### PR TITLE
Update border-radius for OHC Premium Design Standard compliance

### DIFF
--- a/src/ui/tauri/src/ui/pos.html
+++ b/src/ui/tauri/src/ui/pos.html
@@ -24,7 +24,7 @@
         box-sizing: border-box;
         background: rgba(255, 255, 255, 0.65);
         backdrop-filter: blur(30px) saturate(210%);
-        border-radius: 0;
+        border-radius: 16px;
         box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
         text-align: center;
         border-left: 1px solid rgba(255, 255, 255, 0.4);


### PR DESCRIPTION
Updated the border-radius within `src/ui/tauri/src/ui/*.html` to align with the OHC Premium Token library design standards (16px for containers, 8px for controls/buttons).

---
*PR created automatically by Jules for task [10517262449348190923](https://jules.google.com/task/10517262449348190923) started by @wbbsuper*