### PR TITLE
test: fix cost dashboard e2e test selector

### DIFF
--- a/src/e2e/test_ui.spec.ts
+++ b/src/e2e/test_ui.spec.ts
@@ -6,5 +6,5 @@ test('Cost Soft Limit friendly prompt shows', async ({ page, loginAs, unlimitedA
   await page.waitForLoadState('networkidle');
   // We cannot easily assert the limit reached text without a specific tenant setup in DB.
   // But we must at least assert that the plan page loads fully for the E2E.
-  await expect(page.locator('div.stat-title:has-text("AI actions used this month")').first()).toBeVisible();
+  await expect(page.locator('h3:has-text("AI actions used this month")').first()).toBeVisible();
 });


### PR DESCRIPTION
This PR updates the DOM selector in `src/e2e/test_ui.spec.ts` for the Cost Soft Limit friendly prompt test. The previous selector was incorrectly looking for a `div.stat-title` instead of the actual `h3` element rendered by the `CostDashboardPage` component.

All repo tests and e2e Playwright suites have been verified successfully.

---
*PR created automatically by Jules for task [11643094060722102054](https://jules.google.com/task/11643094060722102054) started by @ql-owo-lp*