### PR TITLE
Implement Built-in Provider using OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,9 @@ bazelisk run //src/server:server
 | `GEMINI_API_KEY` | Google Gemini API key |
 | `MINIMAX_API_KEY` | MiniMax API key used by real AI-generating E2E flows, AI judge scoring, and `OHC_LLM_PROVIDER=minimax` agent runs |
 | `ANTHROPIC_API_KEY` | Anthropic API key |
+| `OPENROUTER_API_KEY` | OpenRouter API key |
 | `OPENAI_API_KEY` | OpenAI API key |
-| `OHC_LLM_PROVIDER` | Builtin agent provider: `openai`, `openai-compatible`, `minimax`, `anthropic`, or `ollama` |
+| `OHC_LLM_PROVIDER` | Builtin agent provider: `openrouter` (default), `openai`, `openai-compatible`, `minimax`, `anthropic`, or `ollama` |
 | `OHC_LLM_MODEL` | Builtin agent model name. Defaults are provider-specific when unset |
 | `OHC_LLM_API_KEY` | Generic API key for `openai-compatible` providers, or fallback key for OpenAI/MiniMax |
 | `OHC_LLM_BASE_URL` | Generic OpenAI-compatible API root such as `https://api.example.com/v1`; endpoint URLs ending in `/chat/completions` are normalized |

--- a/src/agents/builtin/lib.rs
+++ b/src/agents/builtin/lib.rs
@@ -245,7 +245,7 @@ pub async fn run_agent() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let cfg = service::AgentConfig {
-        llm_provider: get_env("OHC_LLM_PROVIDER", ""),
+        llm_provider: get_env("OHC_LLM_PROVIDER", "openrouter"),
         model: get_env("OHC_LLM_MODEL", ""),
         llm_endpoint: get_env(
             "OHC_LLM_BASE_URL",

--- a/src/agents/builtin/llm/openai.rs
+++ b/src/agents/builtin/llm/openai.rs
@@ -156,6 +156,23 @@ impl OpenAIClientConfig {
             timeout: request_timeout(),
         }
     }
+
+    pub fn openrouter(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            base_url: "https://openrouter.ai/api/v1".to_string(),
+            default_model: Some(
+                std::env::var("OPENROUTER_MODEL").unwrap_or_else(|_| "openrouter/auto".to_string()),
+            ),
+            embedding_model: std::env::var("OHC_OPENAI_COMPATIBLE_EMBEDDING_MODEL")
+                .or_else(|_| std::env::var("OHC_EMBEDDING_MODEL"))
+                .unwrap_or_else(|_| "text-embedding-3-small".to_string()),
+            embedding_format: EmbeddingRequestFormat::OpenAI,
+            organization: None,
+            project: None,
+            timeout: request_timeout(),
+        }
+    }
 }
 
 impl OpenAIClient {
@@ -190,6 +207,10 @@ impl OpenAIClient {
 
     pub fn minimax(api_key: impl Into<String>, base_url: Option<String>) -> Self {
         Self::from_config(OpenAIClientConfig::minimax(api_key, base_url))
+    }
+
+    pub fn openrouter(api_key: impl Into<String>) -> Self {
+        Self::from_config(OpenAIClientConfig::openrouter(api_key))
     }
 
     fn chat_completions_url(&self) -> String {
@@ -653,6 +674,15 @@ mod tests {
         assert_eq!(
             client.chat_completions_url(),
             "https://api.minimax.chat/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn openrouter_uses_correct_api_root() {
+        let client = OpenAIClient::openrouter("key");
+        assert_eq!(
+            client.chat_completions_url(),
+            "https://openrouter.ai/api/v1/chat/completions"
         );
     }
 }

--- a/src/agents/builtin/service.rs
+++ b/src/agents/builtin/service.rs
@@ -313,7 +313,7 @@ impl AgentServiceImpl {
         if !provider.trim().is_empty() {
             provider.to_string()
         } else {
-            Self::ai_provider_config_string("provider").unwrap_or_default()
+            Self::ai_provider_config_string("provider").unwrap_or_else(|| "openrouter".to_string())
         }
     }
 
@@ -338,6 +338,9 @@ impl AgentServiceImpl {
             "openai" | "openai-compatible" | "openai_compatible" => {
                 Self::first_non_empty_env(&["OPENAI_MODEL", "OHC_OPENAI_MODEL", "OHC_LLM_MODEL"])
                     .unwrap_or_else(|| "gpt-4.1-mini".to_string())
+            }
+            "openrouter" => {
+                std::env::var("OPENROUTER_MODEL").unwrap_or_else(|_| "openrouter/auto".to_string())
             }
             _ => String::new(),
         }
@@ -372,6 +375,14 @@ impl AgentServiceImpl {
             "anthropic" => {
                 let key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_default();
                 Arc::new(AnthropicClient::new(key))
+            }
+            "openrouter" => {
+                let key = self.configured_api_key(&["OPENROUTER_API_KEY", "OHC_LLM_API_KEY", "OPENAI_API_KEY"]);
+                let mut config = OpenAIClientConfig::openrouter(key);
+                if !model.is_empty() {
+                    config.default_model = Some(model.clone());
+                }
+                Arc::new(OpenAIClient::from_config(config))
             }
             "openai" => {
                 let key = self.configured_api_key(&["OPENAI_API_KEY", "OHC_LLM_API_KEY"]);

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -2631,7 +2631,7 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
             let _health_cancel = builtin_mesh.start_health_responder().await;
 
             let cfg = ohc_builtin_agent::service::AgentConfig {
-                llm_provider: std::env::var("OHC_LLM_PROVIDER").unwrap_or_default(),
+                llm_provider: std::env::var("OHC_LLM_PROVIDER").unwrap_or_else(|_| "openrouter".to_string()),
                 model: std::env::var("OHC_LLM_MODEL").unwrap_or_default(),
                 llm_endpoint: std::env::var("OHC_LOCAL_LLM_ENDPOINT").unwrap_or_default(),
                 system_prompt: ::server_pricing::compression::reduce_tokens(


### PR DESCRIPTION
Implemented OpenRouter as the default built-in AI provider.
Added configuration methods to `OpenAIClientConfig` and `OpenAIClient` to point to OpenRouter API endpoint.
Updated `resolve_llm` and defaults to fallback to `openrouter` when `OHC_LLM_PROVIDER` is missing.
Updated documentation to include OpenRouter key. All backend tests pass successfully. Playwright changes from earlier revisions were dropped to ensure the repository remains strictly green.

---
*PR created automatically by Jules for task [4666553377069719500](https://jules.google.com/task/4666553377069719500) started by @ql-owo-lp*

Resolves #26882