### PR TITLE
feat: Fully implement Omni-Inbox Work Triage Assistant endpoints

### DIFF
--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -22,6 +22,8 @@ pub mod dynamic_workflows;
 pub mod catalog;
 pub mod shipping;
 pub mod meta_webhook;
+pub mod omnichannel_webhook;
+pub mod omni_inbox_webhook;
 pub mod docs;
 pub mod subscription;
 pub mod fulfillment;

--- a/src/server/api/omni_inbox_webhook.rs
+++ b/src/server/api/omni_inbox_webhook.rs
@@ -55,12 +55,12 @@ pub async fn omni_inbox_post_handler(
     // In future iterations we can save customer_id onto the inbox_messages table,
     // but for now we follow the schema which has sender_id.
 
-    // 2. Insert into omni_inbox_messages
+    // 2. Insert into inbox_messages
     let inbox_id = Uuid::new_v4().to_string();
     let insert_result = match &state.db.store {
         crate::db::DbStore::Postgres => {
             sqlx::query(
-                "INSERT INTO omni_inbox_messages (id, tenant_id, source, original_content, translated_content, target_language, status, sender_id, created_at) VALUES ($1, $2, $3, $4, $5, 'English', 'unread', $6, NOW())"
+                "INSERT INTO inbox_messages (id, tenant_id, source, original_content, content, status, sender_id, draft_reply, created_at) VALUES ($1, $2, $3, $4, $5, 'unread', $6, '', NOW())"
             )
             .bind(&inbox_id)
             .bind(&tenant_id)
@@ -73,7 +73,7 @@ pub async fn omni_inbox_post_handler(
         },
         crate::db::DbStore::Sqlite(sqlite_pool) => {
             sqlx::query(
-                "INSERT INTO omni_inbox_messages (id, tenant_id, source, original_content, translated_content, target_language, status, sender_id, created_at) VALUES (?, ?, ?, ?, ?, 'English', 'unread', ?, CURRENT_TIMESTAMP)"
+                "INSERT INTO inbox_messages (id, tenant_id, source, original_content, content, status, sender_id, draft_reply, created_at) VALUES (?, ?, ?, ?, ?, 'unread', ?, '', CURRENT_TIMESTAMP)"
             )
             .bind(&inbox_id)
             .bind(&tenant_id)

--- a/src/server/api/omnichannel_webhook.rs
+++ b/src/server/api/omnichannel_webhook.rs
@@ -82,24 +82,24 @@ pub async fn resolve_identity(db: &crate::db::DB, tenant_id: &str, channel: &str
         let identity_id = Uuid::new_v4().to_string();
         let _ = match &db.store {
             crate::db::DbStore::Postgres => {
-                 sqlx::query("INSERT INTO customer_identities (id, tenant_id, customer_id, channel, channel_identity) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING")
+                 let _ = sqlx::query("INSERT INTO customer_identities (id, tenant_id, customer_id, channel, channel_identity) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING")
                     .bind(&identity_id)
                     .bind(tenant_id)
                     .bind(&id)
                     .bind(channel)
                     .bind(sender_id)
                     .execute(pool)
-                    .await
+                    .await;
             },
             crate::db::DbStore::Sqlite(sqlite_pool) => {
-                 sqlx::query("INSERT OR IGNORE INTO customer_identities (id, tenant_id, customer_id, channel, channel_identity) VALUES (?, ?, ?, ?, ?)")
+                 let _ = sqlx::query("INSERT OR IGNORE INTO customer_identities (id, tenant_id, customer_id, channel, channel_identity) VALUES (?, ?, ?, ?, ?)")
                     .bind(&identity_id)
                     .bind(tenant_id)
                     .bind(&id)
                     .bind(channel)
                     .bind(sender_id)
                     .execute(sqlite_pool)
-                    .await
+                    .await;
             }
         };
         return Some(id);

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -2725,6 +2725,15 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
         .route_layer(axum::middleware::from_fn_with_state(webhook_state.clone(), api::billing_webhook::webhook_security_middleware))
         .with_state(webhook_state);
 
+    let omni_inbox_webhook_state = api::omni_inbox_webhook::OmniInboxWebhookState {
+        hub: hub.clone(),
+        db: db.clone(),
+        orchestrator: dept_orchestrator.clone(),
+    };
+    let omni_webhook_router = axum::Router::new()
+        .route("/api/v1/webhooks/omni_inbox", axum::routing::post(api::omni_inbox_webhook::omni_inbox_post_handler))
+        .with_state(omni_inbox_webhook_state);
+
     let meta_webhook_state = api::meta_webhook::MetaWebhookState {
         hub: hub.clone(),
         db: db.clone(),
@@ -2927,14 +2936,13 @@ pub async fn update_ui_triage_action_handler(
                     if action_type == "Draft Reply" {
                         let new_msg_id = format!("msg-{}", uuid::Uuid::new_v4());
                         let _ = sqlx::query(
-                            "INSERT INTO omni_inbox_messages (id, tenant_id, source, original_content, translated_content, target_language, status) VALUES ($1, $2, $3, $4, $5, $6, $7)"
+                            "INSERT INTO inbox_messages (id, tenant_id, source, original_content, content, status, sender_id, draft_reply, created_at) VALUES ($1, $2, $3, $4, $5, $6, 'system', '', NOW())"
                         )
                         .bind(&new_msg_id)
                         .bind(&tenant_id)
                         .bind("triage-action")
                         .bind(&action_payload)
                         .bind(&action_payload)
-                        .bind("en")
                         .bind("sent")
                         .execute(&mut *tx)
                         .await;
@@ -4945,6 +4953,11 @@ async fn create_ui_bom_item_handler(
         }))
         .merge(webhook_router)
         .merge(relay_webhook_router)
+        .merge(omni_webhook_router)
+        .nest("/api/v1/omnichannel/webhook", api::omnichannel_webhook::router(api::omnichannel_webhook::AppState {
+            orchestrator: dept_orchestrator.clone(),
+            db: db.clone(),
+        }))
         .merge(ohc_builtin_agent::visual_workflow_client::create_router(std::sync::Arc::new(ohc_builtin_agent::visual_workflow_client::VisualWorkflowState {
             default_agent: std::sync::Arc::new(ohc_builtin_agent::agent::Agent::new(std::sync::Arc::new(ohc_builtin_agent::llm::openai::OpenAIClient::new("dummy".to_string())), vec![])),
             tools: vec![],


### PR DESCRIPTION
This commits wires up `/api/v1/omnichannel/webhook` and
`/api/v1/webhooks/omni_inbox` into the main server router. It
harmonizes the inbox insertion logic across both handlers to
use the `inbox_messages` table, allowing the UI to read
all inbound messages and AI drafted responses from one unified source.

Resolves #26893

---
*PR created automatically by Jules for task [548093945223542804](https://jules.google.com/task/548093945223542804) started by @ql-owo-lp*