### PR TITLE
feat: Implement Unified Agent Feed UI for Instagram DMs

### DIFF
--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1436,6 +1436,30 @@
             `;
           }
 
+          if (item.event_source === 'instagram_dm' || item.context_payload?.feature_type === 'instagram_dm') {
+            let parsedPayload = item.context_payload || {};
+            return `
+              <div class="triage-item" data-testid="triage-card-${item.id}" id="triage-${item.id}" style="background: rgba(255, 255, 255, 0.4); backdrop-filter: blur(20px); border-radius: 16px; padding: 16px; border: 1px solid rgba(255,255,255,0.6);">
+                <div class="triage-header" style="margin-bottom: 12px;">
+                  <div class="triage-source" style="display: flex; align-items: center; gap: 8px;">
+                    <span style="font-size: 18px;">💬</span> <strong>Instagram DM</strong>
+                  </div>
+                  <div class="triage-priority ${priorityClass}">${item.priority || 'Normal'}</div>
+                </div>
+                <div class="triage-context" style="font-weight: 600; margin-bottom: 12px; font-size: 15px;">
+                  ${parsedPayload.customer_message || 'New message'}
+                </div>
+                <div style="background: rgba(0,0,0,0.03); padding: 12px; border-radius: 12px; margin-bottom: 16px; font-size: 14px; color: #333; font-style: italic;">
+                  ${parsedPayload.draft_reply || ''}
+                </div>
+                <div class="triage-controls" style="display: flex; gap: 8px;">
+                  <button class="triage-btn-approve" data-testid="approve-instagram-dm" onclick="handleTriageAction('${item.id}', 'APPROVED')" style="flex: 1; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Approve Reply</button>
+                  <button class="triage-btn-dismiss" onclick="handleTriageAction('${item.id}', 'DISMISSED')" style="flex: 1; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Edit Draft</button>
+                </div>
+              </div>
+            `;
+          }
+
           if (item.action_type === 'SocialPostDraft') {
             let parsedPayload = {};
             try { parsedPayload = JSON.parse(item.action_payload || '{}'); } catch(e){}


### PR DESCRIPTION
Implemented the `instagram_dm` event source handling in the `dashboard.html` for the new Unified Agent Feed. This allows users to see and directly interact with (Approve/Dismiss) Instagram DMs drafted by the AI assistant directly from the dashboard. This works with the `e2e/unified_agent_feed.spec.ts` E2E Playwright test requirements which verify this UI layout and behavior on a 375px viewport.

**Superpowers used:**
* `using-superpowers`
* `test-driven-development`

**Product-use evidence:**
*   Persona: Maya (Home Baker)
*   Flow Attempted: Checked the main dashboard on mobile resolution.
*   Gap observed: Triage cards for Instagram DMs from the backend feed items were not rendering distinctively from standard proposals.
*   Reason: Maya needs to specifically see Instagram DMs with drafted replies to tap them quickly.
*   Post-fix Flow: Upon viewing the dashboard on mobile resolution with `e2e-seed.sql` backend, the "Instagram DM" cards display nicely with the customer message and drafted reply ready for approval.

**Interaction Audit:**
| Element | Designed Purpose | Observed Result | Fixes |
|---------|-----------------|-----------------|-------|
| Instagram DM Card | Show customer message and draft | Rendered | Added DOM block to `renderTriageItems` |
| "Approve Reply" button | Tap to approve | Call `handleTriageAction` | Verified it renders correctly |

---
*PR created automatically by Jules for task [8343203599150240793](https://jules.google.com/task/8343203599150240793) started by @ql-owo-lp*

Resolves #27079