### PR TITLE
🤖 Implementer: Harness Upgrade - Pydantic-first tool schema validation

### DIFF
--- a/src/agents/builtin/tools/aider_pair_programming.rs
+++ b/src/agents/builtin/tools/aider_pair_programming.rs
@@ -1,8 +1,16 @@
 use ohc_builtin_agent_core::types::ToolError;
-use serde_json::{json, Value};
+use serde::Deserialize;
+use serde_json::json;
 use std::sync::Arc;
 
-use super::{Tool, ToolExecutor};
+use super::{Tool, pydantic::{PydanticAdapter, PydanticToolExecutor}};
+
+// SOTA Harness Pattern: Pydantic-first tool schema validation.
+#[derive(Deserialize)]
+struct AiderPairProgrammingArgs {
+    prompt: String,
+    context: Option<String>,
+}
 
 /// SOTA Harness Pattern: Aider: human-in-loop pair programming.
 /// Simulates a pair-programming prompt interaction with a human in the terminal.
@@ -15,10 +23,10 @@ impl AiderPairProgrammingExecutor {
 }
 
 #[async_trait::async_trait]
-impl ToolExecutor for AiderPairProgrammingExecutor {
-    async fn execute(&self, args: Value) -> Result<String, ToolError> {
-        let prompt = args.get("prompt").and_then(|v| v.as_str()).unwrap_or("Review this code");
-        let context = args.get("context").and_then(|v| v.as_str()).unwrap_or("");
+impl PydanticToolExecutor<AiderPairProgrammingArgs> for AiderPairProgrammingExecutor {
+    async fn execute_typed(&self, args: AiderPairProgrammingArgs) -> Result<String, ToolError> {
+        let prompt = args.prompt;
+        let context = args.context.unwrap_or_default();
 
         let msg = format!("Pair Programming Request: {}\nContext: {}", prompt, context);
         Err(ToolError::UserFixable(msg))
@@ -44,7 +52,7 @@ pub fn aider_pair_programming_tool() -> Tool {
             },
             "required": ["prompt"]
         }),
-        execute: Arc::new(AiderPairProgrammingExecutor::new()),
+        execute: Arc::new(PydanticAdapter::new(AiderPairProgrammingExecutor::new())),
     }
 }
 
@@ -55,7 +63,10 @@ mod tests {
     #[tokio::test]
     async fn test_aider_pair_programming() {
         let executor = AiderPairProgrammingExecutor::new();
-        let res = executor.execute(json!({"prompt": "How does this look?", "context": "fn foo() {}"})).await;
+        let res = executor.execute_typed(AiderPairProgrammingArgs {
+            prompt: "How does this look?".to_string(),
+            context: Some("fn foo() {}".to_string()),
+        }).await;
 
         assert!(res.is_err());
         if let Err(ToolError::UserFixable(msg)) = res {

--- a/src/agents/builtin/tools/create_skill.rs
+++ b/src/agents/builtin/tools/create_skill.rs
@@ -1,26 +1,33 @@
 use ohc_builtin_agent_core::types::ToolError;
-use serde_json::{json, Value};
+use serde::Deserialize;
+use serde_json::json;
 use std::sync::Arc;
 
-use super::{Tool, ToolExecutor};
+use super::{Tool, pydantic::{PydanticAdapter, PydanticToolExecutor}};
 
+// SOTA Harness Pattern: Pydantic-first tool schema validation.
+#[derive(Deserialize)]
+struct CreateSkillArgs {
+    name: String,
+    description: String,
+    instruction: String,
+}
 
 struct CreateSkillExecutor {
     // We are mocking persistence for now as LongTermMemory is not exported easily
 }
 
 #[async_trait::async_trait]
-impl ToolExecutor for CreateSkillExecutor {
-    async fn execute(&self, args: Value) -> Result<String, ToolError> {
-        let skill_name = args["name"].as_str().unwrap_or("UnnamedSkill");
-        let description = args["description"].as_str().unwrap_or("");
-        let instruction = args["instruction"].as_str().unwrap_or("");
+impl PydanticToolExecutor<CreateSkillArgs> for CreateSkillExecutor {
+    async fn execute_typed(&self, args: CreateSkillArgs) -> Result<String, ToolError> {
+        let skill_name = args.name;
+        let description = args.description;
+        let instruction = args.instruction;
 
         let _content = format!("Skill: {}\nDescription: {}\nInstruction: {}", skill_name, description, instruction);
-        let _tags = vec!["skill".to_string(), "autonomous".to_string(), skill_name.to_string()];
+        let _tags = vec!["skill".to_string(), "autonomous".to_string(), skill_name.clone()];
 
         if false {
-
             Ok(format!("Successfully created and saved curated skill '{}'. Description: {}. Instruction: {}", skill_name, description, instruction))
         } else {
             // For tests or runs without a memory store
@@ -52,6 +59,6 @@ pub fn create_skill_tool() -> Tool {
             },
             "required": ["name", "description", "instruction"]
         }),
-        execute: Arc::new(CreateSkillExecutor {}),
+        execute: Arc::new(PydanticAdapter::new(CreateSkillExecutor {})),
     }
 }


### PR DESCRIPTION
**Implementation Description:**
- Identified `src/agents/builtin/tools/aider_pair_programming.rs` and `src/agents/builtin/tools/create_skill.rs` as tools still using manual JSON value parsing instead of the SOTA `Pydantic-first` validation.
- Refactored `AiderPairProgrammingExecutor` to implement `PydanticToolExecutor<AiderPairProgrammingArgs>`.
- Refactored `CreateSkillExecutor` to implement `PydanticToolExecutor<CreateSkillArgs>`.
- Updated their tool constructors to use `PydanticAdapter`.
- Updated unit tests to match `execute_typed` parameters.

**Testing instructions:**
1. Run `cargo test` in `src/agents/builtin` to verify all tool tests pass.
2. Verified that `PydanticToolExecutor` natively bubbled up missing fields as an `LlmRecoverable` error instead of panicking on `.unwrap_or`.

---
*PR created automatically by Jules for task [1427794417902666238](https://jules.google.com/task/1427794417902666238) started by @ql-owo-lp*