### PR TITLE
feat(onboarding): Implement strict failure honesty in Instant Build E2E tests

### DIFF
--- a/src/e2e/onboarding.spec.ts
+++ b/src/e2e/onboarding.spec.ts
@@ -81,14 +81,7 @@ test.describe('Onboarding Wizard E2E Flow', () => {
 
     // Step 5: Style & Team
     const styleHeading = page.getByRole('heading', { name: "Style & Team" });
-    try {
-        await expect(styleHeading).toBeVisible({ timeout: 10000 });
-    } catch {
-        const errorHeading2 = page.getByText(/Failed to launch|Failed to fetch|Network Error|Failed to analyze|Backend connection failed/i).first();
-        if (await errorHeading2.isVisible()) {
-            return; // Exit test gracefully if backend is down in CI
-        }
-    }
+    await expect(styleHeading).toBeVisible({ timeout: 30000 });
 
     const nameInputAdmin = page.getByPlaceholder("e.g. Maya Smith");
     await expect(nameInputAdmin).toBeVisible();
@@ -192,8 +185,8 @@ test.describe('Onboarding Wizard E2E Flow', () => {
 });
 
 test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
-  // Test 6: Verifies Instant Build successful generation flow
-  test('Instant Build navigates to step 10 and generates successfully', async ({ page }) => {
+  // Test 1: Verifies Instant Build successful generation flow
+  test('Instant Build successfully creates a fully populated storefront from a valid paragraph', async ({ page }) => {
     await page.goto('/onboarding');
     const setupScreen = page.locator('#setup-screen');
     await expect(setupScreen).toBeVisible({ timeout: 30000 });
@@ -202,34 +195,26 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     await expect(instantBuildButton).toBeVisible();
     await instantBuildButton.click();
 
-    // Verify it navigates to step 10 (Tell us about your business)
     await expect(page.getByRole('heading', { name: "Tell us about your business" })).toBeVisible();
 
     const bioInput = page.getByPlaceholder("e.g. I run a local bakery that sells custom vegan cakes...");
     await expect(bioInput).toBeVisible();
     await expect(bioInput).toHaveClass(/glassmorphism/);
 
-    await bioInput.fill("I run a high-end tech consultation firm specializing in AI.");
+    await bioInput.fill("I run a high-end tech consultation firm specializing in AI in San Francisco.");
 
     const generateButton = page.getByRole('button', { name: 'Generate Storefront' });
     await expect(generateButton).toBeVisible();
-
     await generateButton.click();
 
-    // It relies on a running backend. For tests, wait for the error or success
     await expect(page.locator('#setup-screen')).toBeVisible();
     const successHeading = page.getByRole('heading', { name: "You're Live!" });
-    const errorHeading = page.getByText(/Failed to launch|Failed to fetch|Network Error|Failed to analyze|Backend connection failed/i).first();
 
-    try {
-        await expect(successHeading).toBeVisible({ timeout: 15000 });
-    } catch {
-        await expect(page.getByText(/Failed to launch|Failed to fetch|Network Error|Failed to analyze|Backend connection failed/i).first()).toBeVisible({ timeout: 15000 });
-    }
+    await expect(successHeading).toBeVisible({ timeout: 30000 });
   });
 
-  // Test 7: Verifies Instant Build handles network error gracefully
-  test('Instant Build displays error state gracefully on network failure', async ({ page }) => {
+  // Test 2: Verifies Instant Build handles network error gracefully
+  test('Instant Build gracefully displays an error state on a network failure with proper styling', async ({ page }) => {
     await page.goto('/onboarding');
     const setupScreen = page.locator('#setup-screen');
     await expect(setupScreen).toBeVisible({ timeout: 30000 });
@@ -243,13 +228,6 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     const bioInput = page.getByPlaceholder("e.g. I run a local bakery that sells custom vegan cakes...");
     await bioInput.fill("Will fail network request");
 
-    // Intentionally omit filling out the form completely and bypass network mocked
-    // Wait, without mock, we can cause an error by passing bad data. But to force a true network error,
-    // the system prompts say "no mocking". We can intercept ONLY to abort for a failure simulation
-    // OR use the actual test that checks validation. The user instructions say:
-    // "For nondeterministic external vendors only, use official test-mode credentials or repository-provided local adapters; do not mock internal frontend, API, service, or database calls."
-    // So I should NOT use page.route for ANY internal API.
-    // Let's remove the mock and just see how the real API handles bad input, or we can use Playwright offline mode.
     await page.context().setOffline(true);
 
     const generateButton = page.getByRole('button', { name: 'Generate Storefront' });
@@ -262,9 +240,63 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     await expect(errorBlock).toHaveClass(/border-\[#FF3B30\]\/30/);
 
     // Verify textarea has the red border
-    await expect(bioInput).toHaveClass(/glassmorphism/);
+    await expect(bioInput).toHaveClass(/border-\[#FF3B30\]/);
 
-    // Restore network
+    // Typing clears the error border
+    await bioInput.fill("New text");
+    await expect(bioInput).not.toHaveClass(/border-\[#FF3B30\]/);
+
     await page.context().setOffline(false);
+  });
+
+  // Test 3: Verifies empty input behavior
+  test('Instant Build prevents submission when the input is empty', async ({ page }) => {
+    await page.goto('/onboarding');
+    const instantBuildButton = page.locator('button', { hasText: 'Instant Build' });
+    await instantBuildButton.click();
+
+    const generateButton = page.getByRole('button', { name: 'Generate Storefront' });
+    await generateButton.click();
+
+    // Button click should do nothing if input is empty.
+    // We shouldn't see a loading state.
+    const loadingState = page.getByText('Generating...');
+    await expect(loadingState).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: "Tell us about your business" })).toBeVisible();
+  });
+
+  // Test 4: Smart defaults fallback on partial info
+  test('Instant Build handles partial information appropriately by falling back to smart defaults', async ({ page }) => {
+    await page.goto('/onboarding');
+    const instantBuildButton = page.locator('button', { hasText: 'Instant Build' });
+    await instantBuildButton.click();
+
+    const bioInput = page.getByPlaceholder("e.g. I run a local bakery that sells custom vegan cakes...");
+    // Only provide a generic description
+    await bioInput.fill("I sell things online.");
+
+    const generateButton = page.getByRole('button', { name: 'Generate Storefront' });
+    await generateButton.click();
+
+    const successHeading = page.getByRole('heading', { name: "You're Live!" });
+    await expect(successHeading).toBeVisible({ timeout: 30000 });
+  });
+
+  // Test 5: Mobile responsiveness of the Instant Build component
+  test('Instant Build respects mobile viewport constraints (375px) with valid touch targets for the conversational flow', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/onboarding');
+
+    const instantBuildButton = page.locator('button', { hasText: 'Instant Build' });
+    await instantBuildButton.click();
+
+    const bioInput = page.getByPlaceholder("e.g. I run a local bakery that sells custom vegan cakes...");
+    const box = await bioInput.boundingBox();
+    expect(box?.height).toBeGreaterThanOrEqual(44);
+    expect(box?.width).toBeLessThanOrEqual(375);
+
+    const generateButton = page.getByRole('button', { name: 'Generate Storefront' });
+    const btnBox = await generateButton.boundingBox();
+    expect(btnBox?.height).toBeGreaterThanOrEqual(44);
   });
 });

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -492,8 +492,11 @@ export default function OnboardingWizard() {
               <div className="space-y-4 flex-1 w-full">
                 <textarea
                   value={bio}
-                  onChange={(e) => setBio(e.target.value)}
-                  className="w-full glassmorphism min-h-[44px] min-w-[44px] p-4 focus:ring-2 focus:ring-[#0066FF] focus:border-[#0066FF] outline-none transition-all resize-none text-gray-800 dark:text-[#f5f5f7] shadow-inner rounded-[8px]"
+                  onChange={(e) => {
+                    setBio(e.target.value);
+                    if (error) setError('');
+                  }}
+                  className={`w-full glassmorphism min-h-[44px] min-w-[44px] p-4 border outline-none transition-all resize-none text-gray-800 dark:text-[#f5f5f7] shadow-inner rounded-[8px] ${error ? 'border-[#FF3B30] focus:ring-2 focus:ring-[#FF3B30] focus:border-[#FF3B30]' : 'border-transparent focus:ring-2 focus:ring-[#0066FF] focus:border-[#0066FF]'}`}
                   placeholder="e.g. I run a local bakery that sells custom vegan cakes..."
                   rows={6}
                 />


### PR DESCRIPTION
feat(onboarding): Implement strict failure honesty in Instant Build E2E tests

Resolves #27064

This commit ensures that the Playwright E2E tests for the "Instant Build" onboarding flow do not mask failures. Specifically:
- Refactored the `src/e2e/onboarding.spec.ts` tests into five distinct and stringent verifications as required.
- Removed try-catch blocks in E2E tests that allowed network errors to falsely appear as successful test passes. 
- Added the missing conditionally rendered UI styling for error validation (`border-[#FF3B30]`) on the `textarea` in `src/ui/next/src/app/onboarding/page.tsx` for network failure simulations.
- Verified local functionality using `bazelisk test //...` across the entire codebase to maintain hermetic guarantees.

---
*PR created automatically by Jules for task [8174872973382466109](https://jules.google.com/task/8174872973382466109) started by @ql-owo-lp*