### PR TITLE
🤖 Implementer: Harness Upgrade - Context Management: JetBrains Observation Masking

### DIFF
--- a/src/agents/builtin/observation_masking.rs
+++ b/src/agents/builtin/observation_masking.rs
@@ -170,15 +170,27 @@ impl JetBrainsObservationMasker {
                                         .chars()
                                         .skip(char_count - preview_chars)
                                         .collect();
-                                    format!(
+                                    let raw_msg = format!(
                                         "[Observation Masked to save context. Output was {} bytes. Preview: {}...{} The tool call itself remains visible. Use 'RecallObservation' with ID '{}' if you need the full output again.]",
                                         bytes, start_preview, end_preview, tr.tool_call_id
-                                    )
+                                    );
+                                    let content_trimmed = tr.content.trim();
+                                    if content_trimmed.starts_with('{') || content_trimmed.starts_with('[') {
+                                        serde_json::json!({ "error": raw_msg }).to_string()
+                                    } else {
+                                        raw_msg
+                                    }
                                 } else {
-                                    format!(
+                                    let raw_msg = format!(
                                         "[Observation Masked to save context. Output was {} bytes. The tool call itself remains visible. Use 'RecallObservation' with ID '{}' if you need the full output again.]",
                                         bytes, tr.tool_call_id
-                                    )
+                                    );
+                                    let content_trimmed = tr.content.trim();
+                                    if content_trimmed.starts_with('{') || content_trimmed.starts_with('[') {
+                                        serde_json::json!({ "error": raw_msg }).to_string()
+                                    } else {
+                                        raw_msg
+                                    }
                                 };
 
                                 // Return as valid JSON object containing the masked string.


### PR DESCRIPTION
🤖 Implementer: Harness Upgrade - Context Management: JetBrains Observation Masking

This pull request addresses a subtle bug found in the `JetBrainsObservationMasker` (part of the Context Management / observation masking layer). During length truncation on excessively large JSON strings (such as when `size_limit` is exceeded but depth limitations or structural masking fallback to a hard string cutoff), the system would output a formatted text block containing `[Observation Masked...]` along with the first and last portions of the string. Because this slice breaks the original object formatting, it resulted in invalid JSON that subsequently broke downstream orchestrators expecting cleanly parseable JSON data. 

**Fix details:**
We inspect whether the text starts as a structural JSON array/object. If so, we guarantee that the fallback string truncation output remains valid JSON by placing the masked string inside `{"error": "<masked string>"}` using `serde_json::json!()`.

**Quality and Verification:**
- Loaded `superpowers` skills before initiating workflow. 
- Unit test `test_json_fallback_bug` in `masking_tests.rs` passes.
- Bazel targets via `bazelisk test //src/agents/builtin/...` executed successfully.
- End-to-end `bazelisk test //src/e2e:playwright` executed successfully to verify no regressions in broader platform workflows.
- No direct user-facing mobile or desktop frontend interaction was modified.

---
*PR created automatically by Jules for task [12215236197254515688](https://jules.google.com/task/12215236197254515688) started by @ql-owo-lp*