### PR TITLE
🗺️ Guide: Fix onboarding schema mismatches

### DIFF
--- a/src/server/services/onboarding/onboarding_agent.rs
+++ b/src/server/services/onboarding/onboarding_agent.rs
@@ -461,7 +461,7 @@ impl OnboardingAgent {
         };
 
         let id = format!("prod-{}", uuid::Uuid::new_v4());
-        sqlx::query("INSERT INTO products (id, organization_id, name, description, price_cents, fulfillment_strategy, metadata) VALUES ($1, $2, $3, $4, $5, $6, $7)")
+        sqlx::query("INSERT INTO products (id, tenant_id, title, description, price_cents, type, metadata) VALUES ($1, $2, $3, $4, $5, $6, $7)")
             .bind(&id)
             .bind(org_id)
             .bind(name)
@@ -2530,7 +2530,7 @@ impl OnboardingAgent {
 
             let hub = self.hub.clone();
             futures.push(tokio::spawn(async move {
-                sqlx::query("INSERT INTO products (id, organization_id, name, description, price_cents, fulfillment_strategy, metadata) VALUES ($1, $2, $3, $4, $5, $6, $7)")
+                sqlx::query("INSERT INTO products (id, tenant_id, title, description, price_cents, type, metadata) VALUES ($1, $2, $3, $4, $5, $6, $7)")
                     .bind(&id)
                     .bind(&org_id)
                     .bind(&name)
@@ -2821,7 +2821,7 @@ mod tests {
         use sqlx::Row;
 
         // Verify products are added
-        let products = sqlx::query("SELECT id, name FROM products WHERE organization_id = $1")
+        let products = sqlx::query("SELECT id, title as name FROM products WHERE tenant_id = $1")
             .bind(&org_id)
             .fetch_all(&agent.db.pool)
             .await
@@ -3047,7 +3047,7 @@ mod tests {
 
         // Test Bakery
         agent.generate_initial_products(org_id, "Home Baker").await.unwrap();
-        let products = sqlx::query("SELECT name FROM products WHERE organization_id = $1")
+        let products = sqlx::query("SELECT title as name FROM products WHERE tenant_id = $1")
             .bind(org_id)
             .fetch_all(&db.pool).await.unwrap();
         assert!(products.iter().any(|p| p.get::<String, _>("name") == "Custom Celebration Cake"));
@@ -3055,7 +3055,7 @@ mod tests {
         // Test Handyman
         let org_id2 = "test-org-handyman";
         agent.generate_initial_products(org_id2, "Handyman").await.unwrap();
-        let products2 = sqlx::query("SELECT name FROM products WHERE organization_id = $1")
+        let products2 = sqlx::query("SELECT title as name FROM products WHERE tenant_id = $1")
             .bind(org_id2)
             .fetch_all(&db.pool).await.unwrap();
         assert!(products2.iter().any(|p| p.get::<String, _>("name") == "Standard Repair Visit"));

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1013,21 +1013,21 @@
         finishBtn.addEventListener('click', () => {
            if (validateStep('step-template')) {
                const req = {
-                   businessType: state.workContext || state.work_context || "Local Service",
-                   companyName: state.businessName,
-                   companyDescription: state.tagline || "",
-                   sellingCategories: state.categories ? [state.categories] : [],
-                   paymentPref: "online",
-                   adminEmail: state.adminEmail || "admin@mybusiness.com",
-                   adminName: state.assistantName || "Admin",
-                   adminPassword: state.adminPassword || "password",
-                   websiteTemplate: state.templateSelection || "Modern",
-                   firstProductName: state.firstOffer || "First Offer",
-                   firstProductPrice: "0.00",
-                   domainChoice: "subdomain",
-                   priceType: "fixed",
+                   business_type: state.workContext || state.work_context || "Local Service",
+                   company_name: state.businessName,
+                   company_description: state.tagline || "",
+                   selling_categories: state.categories ? [state.categories] : [],
+                   payment_pref: "online",
+                   admin_email: state.adminEmail || "admin@mybusiness.com",
+                   admin_name: state.assistantName || "Admin",
+                   admin_password: state.adminPassword || "password",
+                   website_template: state.templateSelection || "Modern",
+                   first_product_name: state.firstOffer || "First Offer",
+                   first_product_price: "0.00",
+                   domain_choice: "subdomain",
+                   price_type: "fixed",
                    location: "Local",
-                   targetAudience: "General"
+                   target_audience: "General"
                };
 
                if (window.__TAURI__ && window.__TAURI__.core) {


### PR DESCRIPTION
This PR fixes the 'Day One' onboarding experience to correctly instantiate a new workspace.

- **Frontend (`src/ui/tauri/src/ui/setup.html`)**: Corrects the `StartOnboardingRequest` payload structure from JS camelCase into `snake_case` properties aligned with the gRPC definition in `hub.proto`.
- **Backend (`src/server/services/onboarding/onboarding_agent.rs`)**: Updates the database insertion logic in `bootstrap_work_context` to use the correct PostgreSQL columns (`tenant_id`, `title`, `type`) for the `products` table, and updates integration tests to query it correctly.

Product-use evidence:
- **Persona:** Small-business owner setting up their workspace
- **UI Flow:** Navigated to Tauri app's `setup.html` flow, entered business type and details, and pressed Launch.
- **Gap observed:** Silent failure at the final step where the payload rejected / database queries failed due to mismatched `businessType` -> `business_type` and `organization_id` vs `tenant_id` column constraints.
- **Result:** After the fix, the app correctly serializes the setup properties and the backend successfully seeds the default agent & products, landing the user in their initialized workspace without friction.

All backend unit tests and Playwright UI E2E tests (`bazelisk test //...` and `bazelisk test //src/e2e:playwright`) pass 100%.

---
*PR created automatically by Jules for task [8779896475356719968](https://jules.google.com/task/8779896475356719968) started by @ql-owo-lp*