### PR TITLE
🗺️ Guide: [Agent Feed Unification]

### DIFF
--- a/src/server/domain/repository/agent_feed_repo.rs
+++ b/src/server/domain/repository/agent_feed_repo.rs
@@ -58,9 +58,42 @@ impl AgentFeedRepository {
     }
 
     pub async fn list(&self, tenant_id: &str, limit: i64, offset: i64) -> Result<Vec<AgentFeedItem>, sqlx::Error> {
-        let items = sqlx::query_as::<_, AgentFeedItem>(
-            "SELECT * FROM agent_feed_items WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3"
-        )
+        let query = r#"
+            SELECT
+                id,
+                tenant_id,
+                event_source,
+                context_payload,
+                proposed_action,
+                lifecycle_state,
+                created_at,
+                updated_at
+            FROM agent_feed_items
+            WHERE tenant_id = $1
+
+            UNION ALL
+
+            SELECT
+                id,
+                tenant_id,
+                department as event_source,
+                jsonb_build_object('description', description) as context_payload,
+                payload as proposed_action,
+                CASE
+                    WHEN status = 'DRAFT' THEN 'PENDING_APPROVAL'
+                    WHEN status = 'REJECTED' THEN 'DISMISSED'
+                    ELSE status
+                END as lifecycle_state,
+                created_at,
+                updated_at
+            FROM agent_approvals
+            WHERE tenant_id = $1 AND status IN ('DRAFT', 'PAUSED', 'APPROVED', 'REJECTED', 'DISMISSED')
+
+            ORDER BY created_at DESC
+            LIMIT $2 OFFSET $3
+        "#;
+
+        let items = sqlx::query_as::<_, AgentFeedItem>(query)
         .bind(tenant_id)
         .bind(limit)
         .bind(offset)


### PR DESCRIPTION
This pull request fixes an issue in the Unified Agent Feed logic that caused items from the `agent_approvals` table not to be surfaced via `/api/agent-feed`. 

The fix modifies the core query in `AgentFeedRepository` to perform a `UNION ALL` against both `agent_feed_items` and `agent_approvals` natively at the database level. `agent_approvals` schemas and statuses are safely cast within the query to match `AgentFeedItem` structure (e.g. mapping `DRAFT` status to `PENDING_APPROVAL`), so `LIMIT` and `OFFSET` clauses continue to correctly paginate the unified results.

This ensures proper rendering of actions and drafts on the frontend Unified Feed on the dashboard, making sure owners do not miss critical notifications, fulfilling the "OneHumanCorp (OHC): Owner Work Assistant" unified agent feed capabilities logic.

All corresponding `playwright` E2E checks successfully pass.

Product-use evidence:
- Persona: Business Owner (Maya/Admin)
- Attempted Flow: Used `playwright` UI test flow to login and land on the Unified Agent Feed dashboard on a 375px mobile breakpoint.
- Gap: The items from the `agent_approvals` table originally missing on the `/api/agent-feed` payload resulting in an incomplete dashboard feed queue.
- User need: Requires an actionable and visible queue of pending requests across multiple tables seamlessly.
- Post-fix UI: All items from both tables now correctly render dynamically onto the agent feed on mobile resolutions.

---
*PR created automatically by Jules for task [13050244313476971473](https://jules.google.com/task/13050244313476971473) started by @ql-owo-lp*