### PR TITLE
💰 Miser: Fix Upgrade Plan button text in cost dashboard

### DIFF
--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -142,7 +142,7 @@ export default function CostDashboardPage() {
              <button
                onClick={() => router.push('/pricing')}
                className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl text-sm font-medium transition-all shadow-sm">
-               Upgrade
+               Upgrade Plan
              </button>
           </div>
           <div className="app-panel-body">

--- a/src/ui/next/src/app/plan/page.tsx
+++ b/src/ui/next/src/app/plan/page.tsx
@@ -125,7 +125,7 @@ export default function MyPlanPage() {
                 </div>
                 <div className="flex flex-col justify-center mt-2 md:mt-0">
                     <button onClick={() => router.push('/pricing')} className="w-full min-h-[44px] py-3 bg-indigo-600 text-white font-medium rounded-xl hover:bg-indigo-700 transition-colors shadow-sm flex items-center justify-center">
-                        Upgrade
+                        Upgrade Plan
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
Fixes the E2E test `cost_dashboard_ui.spec.ts` failure where it expects a button with the exact text "Upgrade Plan". The UI previously had "Upgrade". Also ensures consistency across the `plan/page.tsx`.

---
*PR created automatically by Jules for task [547611889851258703](https://jules.google.com/task/547611889851258703) started by @ql-owo-lp*