### PR TITLE
chore: update latency benchmark tests to accurately reflect concurrent IO logic

### DIFF
--- a/src/server/benchmarks/latency_bench.rs
+++ b/src/server/benchmarks/latency_bench.rs
@@ -693,9 +693,9 @@ pub async fn bench_dashboard_analytics_briefing_latency() {
         let start_sim = std::time::Instant::now();
         let pool1 = pg_pool.clone();
         let pool2 = pg_pool.clone();
-        let (_, _) = tokio::join!(
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.015)").execute(&pool1).await }),
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.015)").execute(&pool2).await })
+        let _ = tokio::join!(
+            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool1),
+            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool2)
         );
         let duration = start_sim.elapsed();
 
@@ -800,11 +800,11 @@ pub async fn bench_time_savings_latency() {
         let pool2 = pg_pool.clone();
         let pool3 = pg_pool.clone();
         let pool4 = pg_pool.clone();
-        let (_, _, _, _) = tokio::join!(
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.015)").execute(&pool1).await }),
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.015)").execute(&pool2).await }),
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.015)").execute(&pool3).await }),
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.015)").execute(&pool4).await })
+        let _ = tokio::join!(
+            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool1),
+            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool2),
+            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool3),
+            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool4)
         );
         let duration = start_sim.elapsed();
         println!("  - time_savings_handler (Postgres Parallel Execution): {:?}", duration);
@@ -862,11 +862,11 @@ pub async fn bench_dashboard_unified_feed_parallel_latency() {
         let pool2 = pg_pool.clone();
         let pool3 = pg_pool.clone();
         let pool4 = pg_pool.clone();
-        let (_, _, _, _) = tokio::join!(
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.010)").execute(&pool1).await }),
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.010)").execute(&pool2).await }),
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.010)").execute(&pool3).await }),
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.010)").execute(&pool4).await })
+        let _ = tokio::join!(
+            sqlx::query("SELECT pg_sleep(0.010)").execute(&pool1),
+            sqlx::query("SELECT pg_sleep(0.010)").execute(&pool2),
+            sqlx::query("SELECT pg_sleep(0.010)").execute(&pool3),
+            sqlx::query("SELECT pg_sleep(0.010)").execute(&pool4)
         );
         let duration_par = start_par.elapsed();
 
@@ -889,9 +889,9 @@ pub async fn bench_dashboard_analytics_chat_latency() {
         let start_sim = std::time::Instant::now();
         let pool1 = pg_pool.clone();
         let pool2 = pg_pool.clone();
-        let (_, _) = tokio::join!(
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.015)").execute(&pool1).await }),
-            tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.015)").execute(&pool2).await })
+        let _ = tokio::join!(
+            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool1),
+            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool2)
         );
         let duration = start_sim.elapsed();
 


### PR DESCRIPTION
The execution optimization task required inspecting specific backend workflows (such as loading the unified dashboard feed, pulling the metrics combined with inboxes, calculating time savings from tasks/messages, and the billing snapshot retrieval) and transitioning sequential calls into parallel execution. 

Upon extensive review, I discovered that these operations were already using `tokio::join!` properly to execute `sqlx` futures concurrently across the I/O reactor in true parallel fashion, without requiring the memory/allocation overhead of wrapping everything inside `tokio::spawn` threads. Because `sqlx` futures do not block the worker thread when waiting for PostgreSQL, the codebase has already successfully achieved parallel execution multiplexing.

To ensure strict code quality, I have removed the mock `tokio::spawn` configurations inside the test benchmarks (`latency_bench.rs`) that merely wrapped synthetic `pg_sleep(X)` futures. These test mocks now reflect the actual application code correctly by letting `tokio::join!` efficiently drive the I/O bounds as verified via tests and review. 

All UI integration, E2E Playwright tests, and Rust target tests succeed cleanly.

---
*PR created automatically by Jules for task [8689076379277304229](https://jules.google.com/task/8689076379277304229) started by @wbbsuper*