### PR TITLE
Fix flaky sleep-based chaos tests

### DIFF
--- a/src/server/benchmarks/chaos_bench.rs
+++ b/src/server/benchmarks/chaos_bench.rs
@@ -30,18 +30,15 @@ mod tests {
 
         // Simulate lag / timeout -> wait for TTL to pass. Poll to avoid
         // scheduler jitter making a loaded test run land on the expiry boundary.
-        tokio::task::yield_now().await;
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(6);
-        let mut acquired2_retry = false;
-        while tokio::time::Instant::now() < deadline {
-            if transport.acquire_lock(&resource, "agent_2", 2).await.unwrap() {
-                acquired2_retry = true;
-                break;
+        let acquired2_retry = tokio::time::timeout(tokio::time::Duration::from_secs(6), async {
+            loop {
+                if transport.acquire_lock(&resource, "agent_2", 2).await.unwrap_or(false) {
+                    return true;
+                }
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
             }
-            // sleep(Duration::from_millis(100)).await;
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        assert!(acquired2_retry);
+        }).await.unwrap_or(false);
+        assert!(acquired2_retry, "Agent 2 failed to acquire lock after wait");
 
         transport.release_lock(&resource, "agent_2").await.unwrap();
     }
@@ -132,12 +129,11 @@ mod tests {
         // This benchmark asserts that the fundamental timeout utility function
         // guarantees the underlying bounded logic without network drift.
         let start = std::time::Instant::now();
-        let slow_operation = async {
-            tokio::task::yield_now().await; sleep(Duration::from_millis(3000)).await;
+        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let result = timeout(Duration::from_millis(500), async {
+            let _ = rx.await;
             "ok"
-        };
-
-        let result = timeout(Duration::from_millis(500), slow_operation).await;
+        }).await;
         assert!(result.is_err()); // Timeout triggers
         assert!(start.elapsed() < Duration::from_millis(2500));
     }

--- a/src/server/benchmarks/latency_bench.rs
+++ b/src/server/benchmarks/latency_bench.rs
@@ -643,9 +643,10 @@ mod tests {
     async fn test_ml_resilience_60s_timeout_rule() {
         let start = std::time::Instant::now();
         let timeout_duration = std::time::Duration::from_millis(150);
+        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
 
         let result = tokio::time::timeout(timeout_duration, async {
-            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            let _ = rx.await;
             Ok::<(), String>(())
         }).await;
 
@@ -656,12 +657,11 @@ mod tests {
     #[tokio::test]
     async fn test_chaos_degradation_network() {
         let start = std::time::Instant::now();
-        let slow_network = async {
-            tokio::task::yield_now().await;
-            tokio::time::sleep(std::time::Duration::from_millis(2050)).await;
+        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let result = tokio::time::timeout(std::time::Duration::from_millis(2000), async {
+            let _ = rx.await;
             "data"
-        };
-        let result = tokio::time::timeout(std::time::Duration::from_millis(2000), slow_network).await;
+        }).await;
         assert!(result.is_err());
         assert!(start.elapsed() < std::time::Duration::from_millis(2500));
     }


### PR DESCRIPTION
The chaos tests (specifically the sleep-based ones mentioned in the backlog like `test_simulate_sql_sync_lag` and `test_graceful_degradation`) were identified as flaky. 
This PR implements fixes for the flaky tests by replacing arbitrary sleeps with channel receivers and timeout mechanisms.
Additionally, addressed the busy wait loop feedback in `test_simulate_sql_sync_lag` by restoring the required polling interval for the lock.

Verified that both backend `bazelisk test //...` and e2e `bazelisk test //src/e2e:playwright` suites now successfully pass with hermetic execution.

---
*PR created automatically by Jules for task [1831471140160297937](https://jules.google.com/task/1831471140160297937) started by @wbbsuper*