### PR TITLE
fix(e2e): update URLs to remove .html suffix for dashboard and pricing

### DIFF
--- a/src/e2e/miser_cost_features.spec.ts
+++ b/src/e2e/miser_cost_features.spec.ts
@@ -6,7 +6,7 @@ test.describe('Miser Cost Features E2E', () => {
     await loginAs(page, adminUser);
 
     // Navigate to the Cost Dashboard
-    await page.goto('/cost-dashboard.html');
+    await page.goto('/cost-dashboard');
     await page.waitForLoadState('networkidle');
 
     // Wait for the main headings
@@ -28,13 +28,13 @@ test.describe('Miser Cost Features E2E', () => {
 
     // Click the button and verify URL changes to /plan
     await myPlanButton.click();
-    await page.waitForURL('**/dashboard.html', { timeout: 10000 });
+    await page.waitForURL('**/dashboard', { timeout: 10000 });
     await expect(page.locator('text=AI actions used this month')).toBeVisible({ timeout: 15000 });
   });
 
   test('Pricing Page displays Free Tier details and "Current Plan" disabled button', async ({ page, adminUser, loginAs }) => {
     await loginAs(page, adminUser);
-    await page.goto('/pricing.html');
+    await page.goto('/pricing');
     await page.waitForLoadState('networkidle');
 
     const freeCard = page.locator('.app-card').filter({ has: page.getByRole('heading', { name: 'Free', exact: true }) });
@@ -52,7 +52,7 @@ test.describe('Miser Cost Features E2E', () => {
 
   test('Pricing Page displays Starter Tier details and navigates to checkout', async ({ page, adminUser, loginAs }) => {
     await loginAs(page, adminUser);
-    await page.goto('/pricing.html');
+    await page.goto('/pricing');
     await page.waitForLoadState('networkidle');
 
     const starterCard = page.locator('.app-card').filter({ has: page.getByRole('heading', { name: 'Starter', exact: true }) });
@@ -73,7 +73,7 @@ test.describe('Miser Cost Features E2E', () => {
 
   test('Pricing Page displays Pro Tier details and navigates to checkout', async ({ page, adminUser, loginAs }) => {
     await loginAs(page, adminUser);
-    await page.goto('/pricing.html');
+    await page.goto('/pricing');
     await page.waitForLoadState('networkidle');
 
     const proCard = page.locator('.app-card').filter({ has: page.getByRole('heading', { name: 'Pro', exact: true }) });
@@ -94,7 +94,7 @@ test.describe('Miser Cost Features E2E', () => {
 
   test('Pricing Page displays Business Tier details and navigates to checkout', async ({ page, adminUser, loginAs }) => {
     await loginAs(page, adminUser);
-    await page.goto('/pricing.html');
+    await page.goto('/pricing');
     await page.waitForLoadState('networkidle');
 
     const businessCard = page.locator('.app-card').filter({ has: page.getByRole('heading', { name: 'Business', exact: true }) });


### PR DESCRIPTION
This commit corrects failing Playwright E2E tests (`test_dashboard_cleanup.spec.ts` and `miser_cost_features.spec.ts`) that were attempting to navigate to direct hardcoded `.html` file paths (e.g., `http://localhost:8080/dashboard.html`) instead of the standard application routes (`/dashboard`, `/setup`, `/cost-dashboard`, `/pricing`).

The application routing operates on pathnames without `.html` suffixes, causing standard browser navigation commands within tests to receive `net::ERR_CONNECTION_REFUSED` or 404 errors when using the explicit `.html` extensions.

This ensures all Playwright UI verification runs can successfully navigate to and evaluate the target pages against the running Next.js/Rust application.

---
*PR created automatically by Jules for task [3605821762833869932](https://jules.google.com/task/3605821762833869932) started by @ql-owo-lp*