### PR TITLE
🧹 Cleaner: Remove debug console.log statements from workflow UI routes

### DIFF
--- a/src/ui/next/src/app/agents/page.tsx
+++ b/src/ui/next/src/app/agents/page.tsx
@@ -1130,7 +1130,6 @@ function WorkflowsPanel({ workflows, setWorkflows }: { workflows: WorkflowRecord
 
         if (wfRes.ok) {
            const wfData = await wfRes.json();
-           console.log("Visual workflow result:", wfData);
            setWorkflows(current => [{
                id: Date.now().toString(),
                name,

--- a/src/ui/next/src/app/api/workflow/run/route.ts
+++ b/src/ui/next/src/app/api/workflow/run/route.ts
@@ -5,7 +5,6 @@ export const runtime = 'nodejs';
 export async function POST(request: NextRequest) {
   try {
     const payload = await request.json();
-    console.log("Visual workflow api received:", payload);
 
     let graphNodes: any[] = [];
     let graphEdges: any[] = [];


### PR DESCRIPTION
This PR removes a couple of leftover `console.log` debugging statements from the frontend application under `src/ui/next/src/app/agents/page.tsx` and `src/ui/next/src/app/api/workflow/run/route.ts`. 

The removal is a routine maintenance step to clean up debug noise and prevent any unintended information from being printed out to logs in production.

All backend tests and frontend Playwright E2E tests have been run and passed 100%.

---
*PR created automatically by Jules for task [10046770305441498757](https://jules.google.com/task/10046770305441498757) started by @ql-owo-lp*