### PR TITLE
fix: Resolve Docker Hub Rate Limits & Missing Base Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Because we use local images built from source instead of pulling from Docker Hub
     ```
 2.  Use Docker Compose to launch the stack with the locally built images:
     ```bash
+    # Note: If you encounter Docker Hub rate limits, run the Local Build & Launch flow first:
+    # npx @bazel/bazelisk run //deploy:load_all_images
+    # cd deploy && docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
     cd deploy && docker compose -f docker-compose.yml up -d
     ```
 

--- a/deploy/docker-compose.override.yml
+++ b/deploy/docker-compose.override.yml
@@ -6,3 +6,12 @@ services:
   server:
     pull_policy: never
     image: onehumancorp/server:latest
+
+  postgres:
+    image: ankane/pgvector:v0.5.1
+    command: ["postgres", "-c", "wal_level=logical"]
+
+  valkey:
+    image: public.ecr.aws/docker/library/redis:alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]

--- a/docs/technical/developer/developer-guide.md
+++ b/docs/technical/developer/developer-guide.md
@@ -52,6 +52,16 @@ source deploy/scripts/ohc-mode.sh cloud
 ```
 
 ### 4. Local Development with Docker Compose
+If you encounter Docker Hub unauthenticated pull rate limits or missing `onehumancorp/server:latest` images, use the **Local Build & Launch** flow instead:
+
+```bash
+# Build and load local OCI images
+npx @bazel/bazelisk run //deploy:load_all_images
+
+# Start the stack using the local images
+docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.override.yml up -d --build
+```
+
 ```bash
 docker compose -f deploy/docker-compose.yml up --build
 ```


### PR DESCRIPTION
Fixes the Docker Hub rate limit issue preventing local deployment for dogfooding the UI.

Changes include:
1. Provided documentation for the local-first "Local Build & Launch" flow using the Bazel `load_all_images` script and `docker-compose.override.yml` to build our custom images.
2. Updated the `deploy/docker-compose.override.yml` to use `ankane/pgvector:v0.5.1` (since `pgvector/pgvector:pg15` doesn't exist locally/was restricted) and `public.ecr.aws/docker/library/redis:alpine` as reliable, cacheable fallbacks for local deployment.
3. Overrode the `healthcheck` command for the redis container since `valkey-cli` is not available on the redis fallback image.

Tested via `bazel test //deploy:docker_compose_e2e_test` and locally starting the stack.

---
*PR created automatically by Jules for task [11359612354587129226](https://jules.google.com/task/11359612354587129226) started by @ql-owo-lp*