### PR TITLE
feat: Wire up edge cache invalidator service on server startup

### DIFF
--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -200,6 +200,7 @@ SERVER_RS_SRCS = [
     "//src/server/orchestration/statemachine:mod.rs",
     "//src/server/services:booking.rs",
     "//src/server/services:mod.rs",
+    "//src/server/services:cache_invalidator.rs",
     "//src/server/services:inventory_sync.rs",
     "//src/server/services:inventory/mod.rs",
     "//src/server/services:inventory/service.rs",

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -410,6 +410,8 @@ pub mod services {
     pub mod onboarding;
     pub mod sync;
     pub mod chat;
+    pub mod cache_invalidator;
+
 
     #[cfg(ohc_bazel)]
     pub use ::server_services_b2b as b2b;
@@ -2409,6 +2411,11 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
     // Start AutoDream worker
     let autodream_worker = Arc::new(autodream::AutoDreamWorker::new(db.clone()));
     autodream_worker.start();
+
+    // Start Cache Invalidator
+    tokio::spawn(async move {
+        crate::services::cache_invalidator::start_cache_invalidator().await;
+    });
 
     // Start Memory Consolidation Worker
     let vector_repo = std::sync::Arc::new(match &db.store {

--- a/src/server/services/cache_invalidator.rs
+++ b/src/server/services/cache_invalidator.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+
 use futures::StreamExt;
 use serde::Deserialize;
 use tracing::{info, error, warn};


### PR DESCRIPTION
Fixes the missing edge cache invalidation process. The edge cache invalidator service listens to invalidation events on Redis pub-sub (such as SEO and inventory changes) and invalidates the edge cache immediately. This PR correctly adds the module to `src/server/lib.rs` and `BUILD.bazel` to be built and starts the async worker on server start.

---
*PR created automatically by Jules for task [12827490484780154806](https://jules.google.com/task/12827490484780154806) started by @ql-owo-lp*

Resolves #27206