### PR TITLE
feat: Add Seasonal Promotion Generator and fix Viral Invite Loop fallback

### DIFF
--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -730,6 +730,7 @@
       <div class="ohc-growth-card">
         <h2>Viral Campaigns</h2>
         <p>Acquire new users and grow your audience through viral sharing.</p>
+        <a href="seasonal-promo.html" id="seasonal-promo-link" style="display: inline-block; background-color: rgba(0, 102, 255, 0.1); color: #0066FF; padding: 12px 24px; border-radius: 16px; font-weight: 600; text-decoration: none; text-align: center; width: 100%; box-sizing: border-box; transition: transform 0.1s; margin-bottom: 10px;">Seasonal Promotion Generator ✨</a>
         <a href="giveaway/index.html" id="giveaway-link" style="display: inline-block; background-color: #0066FF; color: white; padding: 12px 24px; border-radius: 16px; font-weight: 600; text-decoration: none; text-align: center; width: 100%; box-sizing: border-box; transition: transform 0.1s; margin-bottom: 10px;">Viral Giveaway Generator</a>
         <a href="share-cards.html" id="share-cards-link" style="display: inline-block; background-color: rgba(0, 102, 255, 0.1); color: #0066FF; padding: 12px 24px; border-radius: 16px; font-weight: 600; text-decoration: none; text-align: center; width: 100%; box-sizing: border-box; transition: transform 0.1s; margin-bottom: 10px;">Social Share Cards ✨</a>
         <a href="work-intake-widget.html" id="work-intake-link" style="display: inline-block; background-color: rgba(0, 102, 255, 0.1); color: #0066FF; padding: 12px 24px; border-radius: 16px; font-weight: 600; text-decoration: none; text-align: center; width: 100%; box-sizing: border-box; transition: transform 0.1s;">Work-Intake Widget 📋</a>
@@ -2063,9 +2064,21 @@ document.addEventListener('DOMContentLoaded', () => {
                 linkInput.value = link;
                 btn.style.display = 'none';
                 container.style.display = 'block';
-              }).catch((err) => {
+              }).catch(async (err) => {
                 console.error(err);
-                linkInput.value = "https://cloud.ohc.network/invite/fallback";
+                try {
+                  const tenantId = localStorage.getItem("tenant_id") || localStorage.getItem("tenant") || "default";
+                  const res = await fetch("/api/v1/growth/cloud-bridge/invite", {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ team_id: tenantId, inviter_id: "owner", invitee_id: "pending" })
+                  });
+                  const data = await res.json();
+                  linkInput.value = data.invite_link || "https://cloud.ohc.network/invite/fallback";
+                } catch(e) {
+                  console.error(e);
+                  linkInput.value = "https://cloud.ohc.network/invite/fallback";
+                }
                 btn.style.display = 'none';
                 container.style.display = 'block';
               });

--- a/src/ui/tauri/src/ui/seasonal-promo.html
+++ b/src/ui/tauri/src/ui/seasonal-promo.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Seasonal Promotion Generator ✨</title>
+  <style>
+    body {
+      font-family: "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background-color: #f5f5f7;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 40px 20px;
+      box-sizing: border-box;
+    }
+    .container {
+      max-width: 450px;
+      width: 100%;
+      background: rgba(255, 255, 255, 0.65);
+      backdrop-filter: blur(30px) saturate(210%);
+      border-radius: 16px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+      padding: 30px;
+      border: 1px solid rgba(255, 255, 255, 0.4);
+    }
+    h1 {
+      color: #1d1d1f;
+      font-size: 24px;
+      font-weight: 700;
+      margin-top: 0;
+      margin-bottom: 20px;
+      text-align: center;
+    }
+    .form-group {
+      margin-bottom: 20px;
+    }
+    label {
+      display: block;
+      font-weight: 600;
+      margin-bottom: 8px;
+      color: #333336;
+    }
+    input[type="text"], input[type="number"] {
+      width: 100%;
+      padding: 12px 16px;
+      border: 1px solid rgba(0, 0, 0, 0.1);
+      border-radius: 12px;
+      font-size: 14px;
+      background: rgba(255, 255, 255, 0.5);
+      box-sizing: border-box;
+      outline: none;
+      transition: border-color 0.2s;
+    }
+    button {
+      background-color: #0066FF;
+      color: white;
+      border: none;
+      padding: 12px 24px;
+      border-radius: 16px;
+      font-weight: 600;
+      cursor: pointer;
+      width: 100%;
+      font-size: 16px;
+      transition: transform 0.1s, background-color 0.2s;
+    }
+    button:hover {
+      background-color: #005ce6;
+    }
+    button:active {
+      transform: scale(0.98);
+    }
+    #promo-result {
+      margin-top: 20px;
+      padding: 20px;
+      border-radius: 12px;
+      background: white;
+      border: 1px solid rgba(0,0,0,0.05);
+      display: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Seasonal Promotion Generator ✨</h1>
+
+    <div class="form-group">
+      <label for="promo-occasion">Occasion</label>
+      <input type="text" id="promo-occasion" placeholder="e.g. Winter Wonderland" />
+    </div>
+
+    <div class="form-group">
+      <label for="promo-discount">Discount %</label>
+      <input type="number" id="promo-discount" placeholder="e.g. 25" />
+    </div>
+
+    <button id="generate-btn">Generate Campaign</button>
+
+    <div id="promo-result"></div>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const occasionInput = document.getElementById('promo-occasion');
+      const discountInput = document.getElementById('promo-discount');
+      const generateBtn = document.getElementById('generate-btn');
+      const resultDiv = document.getElementById('promo-result');
+
+      generateBtn.addEventListener('click', () => {
+        const occasion = occasionInput.value || 'Seasonal';
+        const discount = discountInput.value || '10';
+
+        const codeBase = occasion.replace(/[^A-Za-z]/g, '').toUpperCase();
+        const code = (codeBase.substring(0, 7) + discount).toUpperCase();
+
+        resultDiv.innerHTML = `
+          <h3 style="margin-top: 0; color: #1d1d1f;">${occasion} Special!</h3>
+          <p style="font-size: 24px; font-weight: bold; color: #0066FF; margin: 10px 0;">${discount}% OFF</p>
+          <p style="background: #f5f5f7; padding: 10px; border-radius: 8px; text-align: center; font-family: monospace; font-size: 18px; letter-spacing: 2px;">Use code: ${code}</p>
+          <div style="text-align: center; margin-top: 15px;">
+            <a href="https://ohc.app" style="font-size: 12px; color: #86868b; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a>
+          </div>
+        `;
+        resultDiv.style.display = 'block';
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds the missing "Seasonal Promotion Generator" to the dashboard and implements proper fallback logic for generating team invites when the local Tauri environment is unavailable.

1.  **Viral Invite Loop Fallback:** Ensures the dashboard button properly falls back to calling the remote API `/api/v1/growth/cloud-bridge/invite` when `window.__TAURI__.core.invoke("generate_cloud_bridge_invite")` encounters an error, such as when running in the browser rather than the Tauri application shell.
2.  **Seasonal Promotion Generator:** Implements the `seasonal-promo.html` route as a standalone UI tool within the web app shell to create custom promotional copy and promotional codes based on occasion and discount inputs. The result card displays formatted content ready for the business owner to copy.
3.  **Viral Campaigns Entry Point:** Wires the new generator into the `Viral Campaigns` section of the main dashboard UI (`dashboard.html`).

---
*PR created automatically by Jules for task [2673956959227749594](https://jules.google.com/task/2673956959227749594) started by @wbbsuper*