### PR TITLE
chore: remove unused imports and clippy warnings in rust code

### DIFF
--- a/src/agents/builtin/tools/create_skill.rs
+++ b/src/agents/builtin/tools/create_skill.rs
@@ -25,7 +25,7 @@ impl PydanticToolExecutor<CreateSkillArgs> for CreateSkillExecutor {
         let instruction = args.instruction;
 
         let _content = format!("Skill: {}\nDescription: {}\nInstruction: {}", skill_name, description, instruction);
-        let _tags = vec!["skill".to_string(), "autonomous".to_string(), skill_name.clone()];
+        let _tags = ["skill".to_string(), "autonomous".to_string(), skill_name.clone()];
 
         if false {
             Ok(format!("Successfully created and saved curated skill '{}'. Description: {}. Instruction: {}", skill_name, description, instruction))

--- a/src/agents/builtin/tools/find.rs
+++ b/src/agents/builtin/tools/find.rs
@@ -82,11 +82,10 @@ impl FindExecutor {
 
             let mut include = true;
 
-            if let Some(f_name) = name_filter {
-                if !file_name.contains(f_name) && !glob_match(f_name, &file_name) {
+            if let Some(f_name) = name_filter
+                && !file_name.contains(f_name) && !glob_match(f_name, &file_name) {
                     include = false;
                 }
-            }
 
             if let Some(f_type) = type_filter {
                 if f_type == "f" && !metadata.is_file() {

--- a/src/agents/builtin/tools/glob.rs
+++ b/src/agents/builtin/tools/glob.rs
@@ -30,7 +30,7 @@ impl PydanticToolExecutor<GlobArgs> for GlobExecutor {
         let safe_base = base_dir.strip_prefix("/").unwrap_or(base_dir);
         let safe_pattern = pattern.strip_prefix("/").unwrap_or(pattern);
 
-        let mut full_pattern = if safe_base == "." || safe_base == "" {
+        let mut full_pattern = if safe_base == "." || safe_base.is_empty() {
             safe_pattern.to_string()
         } else {
             format!("{}/{}", safe_base.trim_end_matches('/'), safe_pattern)

--- a/src/agents/builtin/tools/hybrid_blob.rs
+++ b/src/agents/builtin/tools/hybrid_blob.rs
@@ -113,11 +113,10 @@ impl BlobManager for HybridBlobManager {
             let local_dir = self.local_dir.as_ref().ok_or("Local directory not configured")?;
             let path = local_dir.join(&safe_key);
 
-            if let Some(parent) = path.parent() {
-                if let Err(e) = fs::create_dir_all(parent).await {
+            if let Some(parent) = path.parent()
+                && let Err(e) = fs::create_dir_all(parent).await {
                     return Err(format!("Failed to create directories for blob: {}", e));
                 }
-            }
 
             let mut file = fs::File::create(&path).await.map_err(|e| format!("Failed to create file: {}", e))?;
             file.write_all(data).await.map_err(|e| format!("Failed to write data: {}", e))?;

--- a/src/agents/builtin/tools/read.rs
+++ b/src/agents/builtin/tools/read.rs
@@ -45,8 +45,8 @@ impl PydanticToolExecutor<ReadArgs> for ReadExecutor {
         let mut result_lines = Vec::new();
         let mut line_count = 0;
 
-        let req_start = args.start_line.map(|n| n.saturating_sub(1) as usize);
-        let req_end = args.end_line.map(|n| n as usize);
+        let req_start = args.start_line.map(|n| n.saturating_sub(1));
+        let req_end = args.end_line.map(|n| n);
 
         if let (Some(s), Some(e)) = (req_start, req_end) {
             if s >= e {

--- a/src/agents/builtin/tools/runner.rs
+++ b/src/agents/builtin/tools/runner.rs
@@ -216,8 +216,8 @@ impl CommandRunner for SandboxedCommandRunner {
         current_dir: Option<&Path>,
         envs: Vec<(String, String)>,
     ) -> io::Result<Output> {
-        if Self::should_use_container_backend() {
-            if let Some(runtime) = Self::find_container_runtime() {
+        if Self::should_use_container_backend()
+            && let Some(runtime) = Self::find_container_runtime() {
                 let container_args = Self::container_args(
                     program,
                     args,
@@ -230,7 +230,6 @@ impl CommandRunner for SandboxedCommandRunner {
                 cmd.args(&container_args);
                 return cmd.output().await;
             }
-        }
 
         static BWRAP_AVAILABLE: OnceLock<bool> = OnceLock::new();
         let is_bwrap_available = *BWRAP_AVAILABLE.get_or_init(|| {

--- a/src/agents/builtin/tools/subagent.rs
+++ b/src/agents/builtin/tools/subagent.rs
@@ -220,11 +220,10 @@ impl PydanticToolExecutor<SubagentArgs> for SubagentExecutor {
             let output = self.runner.run("git", &["worktree", "add", "-b", &branch_name, &worktree_dir], None, vec![]).await;
             if let Err(e) = output {
                 return Err(ToolError::LlmRecoverable(format!("Failed to create git worktree: {}", e)));
-            } else if let Ok(out) = output {
-                if !out.status.success() {
+            } else if let Ok(out) = output
+                && !out.status.success() {
                     return Err(ToolError::LlmRecoverable(format!("git worktree add failed: {}", String::from_utf8_lossy(&out.stderr))));
                 }
-            }
 
             let worktree_task = format!(
                 "You are a subagent running in an isolated git worktree (branch: {}). Your task is: {}\n\nCRITICAL INSTRUCTION: You MUST return a 1k-2k token condensed summary of your findings and actions. Do not return your full context loop.",

--- a/src/server/api/omnichannel_webhook.rs
+++ b/src/server/api/omnichannel_webhook.rs
@@ -219,7 +219,7 @@ pub async fn handle_omnichannel_webhook(
 mod tests {
     use super::*;
     use crate::db::DB;
-    use crate::db::get_pool;
+
     use sqlx::SqlitePool;
 
     #[tokio::test]

--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -56,12 +56,11 @@ pub enum AuthMode {
 ///   OHC_AGENT_TOKEN                – enables token mode
 ///   OHC_AGENT_SPIFFE_ID            – restricts SPIFFE ID (enables SPIFFE mode)
 pub fn auth_mode_from_env() -> AuthMode {
-    if let Ok(tok) = env::var("OHC_AGENT_TOKEN") {
-        if !tok.is_empty() {
+    if let Ok(tok) = env::var("OHC_AGENT_TOKEN")
+        && !tok.is_empty() {
             let hash = hmac_token(&tok);
             return AuthMode::Token { token_hash: hash };
         }
-    }
     AuthMode::Spiffe {
         allowed_id: env::var("OHC_AGENT_SPIFFE_ID").unwrap_or_default(),
     }
@@ -155,23 +154,19 @@ impl Store {
                 }
 
                 let secret_path = ::server_config::get_safe_user_dir().join(".ohc_jwt_secret");
-                if secret_path.exists() {
-                    if let Ok(bytes) = std::fs::read(&secret_path) {
-                        if bytes.len() >= 32 {
+                if secret_path.exists()
+                    && let Ok(bytes) = std::fs::read(&secret_path)
+                        && bytes.len() >= 32 {
                             return bytes;
                         }
-                    }
-                }
 
                 let sqlite_key_opt = std::env::var("OHC_SQLITE_KEY").ok().or_else(|| {
                     let secret_path = ::server_config::get_safe_user_dir().join(".ohc_sqlite_key");
-                    if secret_path.exists() {
-                        if let Ok(bytes) = std::fs::read_to_string(&secret_path) {
-                            if !bytes.trim().is_empty() {
+                    if secret_path.exists()
+                        && let Ok(bytes) = std::fs::read_to_string(&secret_path)
+                            && !bytes.trim().is_empty() {
                                 return Some(bytes.trim().to_string());
                             }
-                        }
-                    }
                     None
                 });
 
@@ -203,12 +198,11 @@ impl Store {
 
                     // Ensure permissions are strictly 0o600
                     use std::os::unix::fs::PermissionsExt;
-                    if let Ok(mut perms) = std::fs::metadata(&secret_path).map(|m| m.permissions()) {
-                        if perms.mode() & 0o777 != 0o600 {
+                    if let Ok(mut perms) = std::fs::metadata(&secret_path).map(|m| m.permissions())
+                        && perms.mode() & 0o777 != 0o600 {
                             perms.set_mode(0o600);
                             let _ = std::fs::set_permissions(&secret_path, perms);
                         }
-                    }
                 }
                 #[cfg(not(unix))]
                 {
@@ -366,11 +360,10 @@ impl Store {
             return Err("account disabled".to_string());
         }
 
-        if let Some(ref user_org) = user.organization_id {
-            if !org_id.is_empty() && user_org != org_id {
+        if let Some(ref user_org) = user.organization_id
+            && !org_id.is_empty() && user_org != org_id {
                 return Err("invalid credentials".to_string());
             }
-        }
 
         if verify(password, &user.password_hash).unwrap_or(false) {
             Ok(user.clone())
@@ -433,14 +426,13 @@ impl Store {
 
         let u = users.get_mut(id).ok_or_else(|| "user not found".to_string())?;
 
-        if !org_id.is_empty() {
-             if u.organization_id.as_deref() != Some(org_id) {
+        if !org_id.is_empty()
+             && u.organization_id.as_deref() != Some(org_id) {
                  return Err("user not found".to_string());
              }
-        }
 
-        if let Some(email) = email_ptr {
-            if email != u.email {
+        if let Some(email) = email_ptr
+            && email != u.email {
                 let org = u.organization_id.clone().unwrap_or_default();
                 let email_key = TenantKey { org_id: org, key: email.clone() };
                 if by_email.contains_key(&email_key) {
@@ -450,7 +442,6 @@ impl Store {
                 u.email = email;
                 by_email.insert(email_key, id.to_string());
             }
-        }
 
         if let Some(r) = roles {
             u.roles = r;
@@ -475,11 +466,10 @@ impl Store {
 
         let u = users.get(id).ok_or_else(|| "user not found".to_string())?;
 
-        if !org_id.is_empty() {
-             if u.organization_id.as_deref() != Some(org_id) {
+        if !org_id.is_empty()
+             && u.organization_id.as_deref() != Some(org_id) {
                  return Err("user not found".to_string());
              }
-        }
 
         let org = u.organization_id.clone().unwrap_or_default();
         by_name.remove(&TenantKey { org_id: org.clone(), key: u.username.clone() });
@@ -505,13 +495,12 @@ impl Store {
             let now = Utc::now();
             revoked.retain(|_, v| *v > now);
         }
-        if let Some(client) = &self.redis_client {
-            if let Ok(mut conn) = client.get_multiplexed_tokio_connection().await {
+        if let Some(client) = &self.redis_client
+            && let Ok(mut conn) = client.get_multiplexed_tokio_connection().await {
                 let ttl = (exp.timestamp() - Utc::now().timestamp()).max(1);
                 let redis_key = format!("revoked_token:{}", jti);
                 let _: redis::RedisResult<()> = redis::AsyncCommands::set_ex(&mut conn, &redis_key, "1", ttl as u64).await;
             }
-        }
     }
 
     pub async fn is_revoked(&self, jti: &str, org_id: &str) -> bool {
@@ -521,21 +510,19 @@ impl Store {
 
         {
             let revoked = self.revoked.read().unwrap();
-            if let Some(exp) = revoked.get(jti) {
-                 if *exp > Utc::now() {
+            if let Some(exp) = revoked.get(jti)
+                 && *exp > Utc::now() {
                      return true;
                  }
-            }
         }
-        if let Some(client) = &self.redis_client {
-            if let Ok(mut conn) = client.get_multiplexed_tokio_connection().await {
+        if let Some(client) = &self.redis_client
+            && let Ok(mut conn) = client.get_multiplexed_tokio_connection().await {
                 let redis_key = format!("revoked_token:{}", jti);
                 let exists: redis::RedisResult<bool> = redis::AsyncCommands::exists(&mut conn, &redis_key).await;
                 if let Ok(true) = exists {
                     return true;
                 }
             }
-        }
         false
     }
 
@@ -561,8 +548,8 @@ impl Store {
     }
 
     pub async fn validate_token(&self, _token: &str) -> Result<Claims, String> {
-        if let Ok(header) = jsonwebtoken::decode_header(_token) {
-            if header.alg == jsonwebtoken::Algorithm::RS256 {
+        if let Ok(header) = jsonwebtoken::decode_header(_token)
+            && header.alg == jsonwebtoken::Algorithm::RS256 {
                 let oidc_cfg_internal = self.oidc_cfg.read().unwrap().clone();
                 let oidc_cfg = crate::oidc::OIDCConfig {
                     issuer_url: oidc_cfg_internal.issuer_url,
@@ -583,7 +570,6 @@ impl Store {
                     return Ok(claims);
                 }
             }
-        }
 
         let validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::HS256);
             let token_data = jsonwebtoken::decode::<Claims>(
@@ -721,9 +707,9 @@ impl AuthService for AuthServiceServerImpl {
             req.password,
             vec![ROLE_VIEWER.to_string()],
             req.organization_id.clone(),
-        ).map_err(|e| Status::internal(e))?;
+        ).map_err(Status::internal)?;
 
-        let token = self.store.issue_token(&user).map_err(|e| Status::internal(e))?;
+        let token = self.store.issue_token(&user).map_err(Status::internal)?;
 
         Ok(Response::new(LoginResponse {
              token,
@@ -732,9 +718,9 @@ impl AuthService for AuthServiceServerImpl {
     }
 
     async fn logout(&self, request: Request<EmptyRequest>) -> Result<Response<EmptyResponse>, Status> {
-        if let Some(auth_info) = request.extensions().get::<AuthInfo>() {
-            if let Some(auth_header) = request.metadata().get("authorization") {
-                if let Ok(auth_str) = auth_header.to_str() {
+        if let Some(auth_info) = request.extensions().get::<AuthInfo>()
+            && let Some(auth_header) = request.metadata().get("authorization")
+                && let Ok(auth_str) = auth_header.to_str() {
                     let token = if auth_str.to_lowercase().starts_with("bearer ") {
                         &auth_str[7..]
                     } else {
@@ -747,8 +733,6 @@ impl AuthService for AuthServiceServerImpl {
                         self.store.revoke_token(claims.jti, exp, &auth_info.org_id).await;
                     }
                 }
-            }
-        }
         Ok(Response::new(EmptyResponse {}))
     }
 
@@ -799,7 +783,7 @@ impl AuthService for AuthServiceServerImpl {
             "temp".to_string(),
             vec![],
             req.organization_id.clone(),
-        ).map_err(|e| Status::internal(e))?;
+        ).map_err(Status::internal)?;
         Ok(Response::new(UserProto {
             id: user.id,
             username: user.username,
@@ -840,7 +824,7 @@ impl AuthService for AuthServiceServerImpl {
         let req = request.into_inner();
 
         let user = self.store.update_user(&req.id, req.email, Some(req.roles), req.active, &org_id)
-            .map_err(|e| Status::internal(e))?;
+            .map_err(Status::internal)?;
 
         Ok(Response::new(UserProto {
             id: user.id,
@@ -861,7 +845,7 @@ impl AuthService for AuthServiceServerImpl {
             .ok_or_else(|| Status::unauthenticated("Missing AuthInfo"))?;
 
         self.store.delete_user(&request.get_ref().id, &org_id)
-            .map_err(|e| Status::internal(e))?;
+            .map_err(Status::internal)?;
 
         Ok(Response::new(EmptyResponse {}))
     }

--- a/src/server/auth/orchestration.rs
+++ b/src/server/auth/orchestration.rs
@@ -41,11 +41,10 @@ pub fn authorize_register_agent(auth: &AuthInfo, req: &RegisterAgentRequest) -> 
 }
 
 pub fn authorize_publish_message(auth: &AuthInfo, req: &PublishMessageRequest) -> Result<(), Status> {
-    if let Some(msg) = &req.message {
-        if auth.agent_id != msg.from_agent {
+    if let Some(msg) = &req.message
+        && auth.agent_id != msg.from_agent {
             return Err(Status::permission_denied(format!("SPIFFE ID {} cannot publish as agent {}", auth.spiffe_id, msg.from_agent)));
         }
-    }
     Ok(())
 }
 

--- a/src/server/benchmarks/chaos_bench.rs
+++ b/src/server/benchmarks/chaos_bench.rs
@@ -2,7 +2,7 @@
 mod tests {
     use std::sync::Arc;
     use std::sync::atomic::Ordering;
-    use tokio::time::{sleep, Duration, timeout};
+    use tokio::time::{Duration, timeout};
 
     // Note: this represents Chaos tests focusing on parity constraints.
     // They don't test actual network unreliability, but rather

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -149,11 +149,10 @@ impl ModeEnforcer for StandaloneModeEnforcer {
             default_sqlite_url
         };
 
-        if let Some(redis_url) = &cfg.redis_url {
-            if !redis_url.is_empty() {
+        if let Some(redis_url) = &cfg.redis_url
+            && !redis_url.is_empty() {
                 tracing::info!("standalone: REDIS_URL is ignored in standalone desktop builds; using embedded NATS");
             }
-        }
 
         let sqlite_url = if let Some(key) = &cfg.sqlite_encryption_key {
             if !key.is_empty() {
@@ -179,15 +178,14 @@ impl ModeEnforcer for StandaloneModeEnforcer {
                 use std::os::unix::fs::PermissionsExt;
 
                 let db_path = sqlite_url.strip_prefix("sqlite://").unwrap_or(sqlite_url.as_str()).split('?').next().unwrap_or("ohc-standalone.db");
-                if let Some(parent) = std::path::Path::new(db_path).parent() {
-                    if !parent.as_os_str().is_empty() {
+                if let Some(parent) = std::path::Path::new(db_path).parent()
+                    && !parent.as_os_str().is_empty() {
                         #[cfg(unix)] use std::os::unix::fs::DirBuilderExt;
                         let mut builder = std::fs::DirBuilder::new();
                         builder.recursive(true);
                         #[cfg(unix)] builder.mode(0o700);
                         let _ = builder.create(parent);
                     }
-                }
                 match OpenOptions::new()
                     .read(true)
                     .write(true)

--- a/src/server/pricing/budget.rs
+++ b/src/server/pricing/budget.rs
@@ -36,7 +36,7 @@ impl BudgetManager {
         }
 
         let mut current_bits = self.current.load(Ordering::Relaxed);
-        let mut final_current = f64::from_bits(current_bits);
+        let final_current;
         loop {
             let current = f64::from_bits(current_bits);
             let next = current + amount;


### PR DESCRIPTION
* Fixed an unused variable warning in `src/server/pricing/budget.rs` by letting `final_current` be correctly initialized within the loop.
* Removed unused import `crate::db::get_pool` in `src/server/api/omnichannel_webhook.rs`.
* Removed unused import `sleep` in `src/server/benchmarks/chaos_bench.rs`.
* Fixed 12 clippy warnings in `ohc_builtin_agent_tools`, 1 warning in `server_config`, and 8 warnings in `server_auth` across multiple files.
* Verified using `cargo test` and `bazelisk test //...` which pass locally.

---
*PR created automatically by Jules for task [17281154133309054125](https://jules.google.com/task/17281154133309054125) started by @ql-owo-lp*