### PR TITLE
💰 Miser: fix incorrect wait URL in cost features test

### DIFF
--- a/src/e2e/miser_cost_features.spec.ts
+++ b/src/e2e/miser_cost_features.spec.ts
@@ -28,7 +28,7 @@ test.describe('Miser Cost Features E2E', () => {
 
     // Click the button and verify URL changes to /plan
     await myPlanButton.click();
-    await page.waitForURL('**/dashboard', { timeout: 10000 });
+    await page.waitForURL('**/plan', { timeout: 10000 });
     await expect(page.locator('text=AI actions used this month')).toBeVisible({ timeout: 15000 });
   });
 


### PR DESCRIPTION
Updates the `miser_cost_features.spec.ts` test to correctly wait for the `**/plan` URL when clicking the "Back to My Plan" button.

---
*PR created automatically by Jules for task [8679906305235854178](https://jules.google.com/task/8679906305235854178) started by @wbbsuper*