### PR TITLE
Add Network Cost to Cost Dashboard

### DIFF
--- a/src/e2e/cost_dashboard.spec.ts
+++ b/src/e2e/cost_dashboard.spec.ts
@@ -91,6 +91,7 @@ test.describe('Cost Dashboard "My Plan" functionality', () => {
     await expect(page.locator('span', { hasText: 'LLM Usage' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Storage' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Payment Fees' }).first()).toBeVisible();
+    await expect(page.locator('span', { hasText: 'Network Cost' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Bandwidth Savings' }).first()).toBeVisible();
   });
 

--- a/src/e2e/cost_dashboard_ui.spec.ts
+++ b/src/e2e/cost_dashboard_ui.spec.ts
@@ -12,6 +12,7 @@ test.describe('Cost Dashboard & Plan Limits UI', () => {
     await expect(page.getByText('Total Costs')).toBeVisible();
     await expect(page.getByText('LLM Usage')).toBeVisible();
     await expect(page.locator('span', { hasText: 'Storage' }).first()).toBeVisible();
+    await expect(page.getByText('Network Cost')).toBeVisible();
     await expect(page.getByText('Bandwidth Savings')).toBeVisible();
 
     // Check if the plan navigation button is present

--- a/src/ui/tauri/src/ui/cost-dashboard.html
+++ b/src/ui/tauri/src/ui/cost-dashboard.html
@@ -214,6 +214,10 @@
                 <span id="payment-fees" style="font-weight: 500;">$0.00</span>
             </div>
             <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
+                <span style="color: #86868b;">Network Cost</span>
+                <span id="network-cost" style="font-weight: 500;">$0.00</span>
+            </div>
+            <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
                 <span style="color: #86868b;">Bandwidth Savings</span>
                 <span id="bandwidth-savings" style="font-weight: 500; color: #34C759;">$0.00</span>
             </div>
@@ -308,6 +312,7 @@
                 document.getElementById('llm-cost').innerText = formatCents(costData.llm_cost || 0);
                 document.getElementById('storage-cost').innerText = formatCents(costData.storage_cost || 0);
                 document.getElementById('payment-fees').innerText = formatCents(costData.payment_fees || 0);
+                document.getElementById('network-cost').innerText = formatCents(costData.network_cost || 0);
                 document.getElementById('bandwidth-savings').innerText = formatCents(costData.bandwidth_savings || 0);
                 document.getElementById('compute-cost').innerText = formatCents(costData.compute_cost || 0);
                 document.getElementById('email-cost').innerText = formatCents(costData.email_cost || 0);


### PR DESCRIPTION
Adds `Network Cost` to the cost dashboard and updates tests.

---
*PR created automatically by Jules for task [14698501564377986684](https://jules.google.com/task/14698501564377986684) started by @ql-owo-lp*