### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Enforce tenant isolation in workspace search

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -439,11 +439,18 @@ impl DB {
                 }
             }
             DbStore::Postgres => {
+                // To maintain strict tenant isolation and follow the global pattern,
+                // we set the local tenant context before executing the search queries.
+                let mut tx = self.pool.begin().await.map_err(|e| format!("DB Error: {}", e))?;
+                ::server_common::auth_utils::set_org_context(&mut *tx, tenant_id)
+                    .await
+                    .map_err(|e| format!("DB Error: {}", e))?;
+
                 // Search Customers
                 let customer_rows = sqlx::query("SELECT id, name, email FROM customers WHERE tenant_id = $1 AND (name ILIKE $2 OR email ILIKE $2) LIMIT 10")
                     .bind(tenant_id)
                     .bind(&query_lower)
-                    .fetch_all(&self.pool)
+                    .fetch_all(&mut *tx)
                     .await
                     .map_err(|e| format!("DB Error: {}", e))?;
 
@@ -465,7 +472,7 @@ impl DB {
                 let order_rows = sqlx::query("SELECT id, status, CAST(total_amount AS DOUBLE PRECISION) as total_amount FROM orders WHERE tenant_id = $1 AND (id ILIKE $2 OR status ILIKE $2) LIMIT 10")
                     .bind(tenant_id)
                     .bind(&query_lower)
-                    .fetch_all(&self.pool)
+                    .fetch_all(&mut *tx)
                     .await
                     .map_err(|e| format!("DB Error: {}", e))?;
 
@@ -487,7 +494,7 @@ impl DB {
                 let message_rows = sqlx::query("SELECT id, source, content FROM inbox_messages WHERE tenant_id = $1 AND (content ILIKE $2 OR source ILIKE $2) LIMIT 10")
                     .bind(tenant_id)
                     .bind(&query_lower)
-                    .fetch_all(&self.pool)
+                    .fetch_all(&mut *tx)
                     .await
                     .map_err(|e| format!("DB Error: {}", e))?;
 
@@ -509,6 +516,8 @@ impl DB {
                         route: format!("/inbox/{}", id),
                     });
                 }
+
+                tx.commit().await.map_err(|e| format!("DB Error: {}", e))?;
             }
         }
 


### PR DESCRIPTION
The `search_workspace` function for the Postgres backend was missing tenant isolation enforcement via `set_org_context`. This meant it relied solely on the `WHERE tenant_id = $1` clause without setting the application context, which could potentially bypass RLS policies or other context-dependent checks.

This fix opens a transaction, sets the organization context using `auth_utils::set_org_context`, and executes the queries within that transaction. This mirrors the pattern used throughout the rest of the application to ensure strict tenant data isolation.

All tests (backend and Playwright E2E) have been run and pass.

**Superpowers used:**
* Investigated related changes by identifying files importing and using `set_org_context`.

**UI Interaction Audit:**
No UI changes were made in this PR; this is purely a backend security hardening fix. The `search_workspace` endpoint was returning expected data previously and continues to do so but is now securely sandboxed per-tenant.

---
*PR created automatically by Jules for task [18414901872792149467](https://jules.google.com/task/18414901872792149467) started by @wbbsuper*