### PR TITLE
feat: Implement checkout success modal referral growth loop

### DIFF
--- a/src/e2e/checkout_success_modal.spec.ts
+++ b/src/e2e/checkout_success_modal.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Checkout Success Modal Growth Loop', () => {
+  test('should not show success modal on normal load', async ({ page }) => {
+    await page.goto('/checkout');
+    await expect(page.locator('text=Payment Successful!')).not.toBeVisible();
+    await expect(page.locator('.one-tap-referral')).not.toBeVisible();
+  });
+
+  test('should show success modal when success=true is passed', async ({ page }) => {
+    await page.goto('/checkout?success=true');
+    await expect(page.locator('text=Payment Successful!')).toBeVisible();
+    await expect(page.locator('.one-tap-referral')).toBeVisible();
+  });
+
+  test('should show success modal when session_id is passed', async ({ page }) => {
+    await page.goto('/checkout?session_id=cs_test_123');
+    await expect(page.locator('text=Payment Successful!')).toBeVisible();
+    await expect(page.locator('.one-tap-referral')).toBeVisible();
+  });
+
+  test('should interact with OneTapReferral inside modal', async ({ page, context }) => {
+    await page.goto('/checkout?success=true');
+    await expect(page.locator('text=Payment Successful!')).toBeVisible();
+
+    // Verify OneTapReferral widget is visible
+    const oneTapWidget = page.locator('.one-tap-referral');
+    await expect(oneTapWidget).toBeVisible();
+    await expect(oneTapWidget.locator('text=Refer & Earn $50')).toBeVisible();
+
+    // Verify Copy Link button works
+    const copyButton = oneTapWidget.locator('button:has-text("Copy Link")');
+    await copyButton.click();
+    await expect(oneTapWidget.locator('button:has-text("Copied!")')).toBeVisible();
+
+    // Verify Dashboard redirect works
+    const dashboardButton = page.locator('button:has-text("Continue to Dashboard")');
+    await dashboardButton.click();
+    await expect(page).toHaveURL('/dashboard');
+  });
+
+  test('should navigate to affiliate onboarding from powered by link', async ({ page }) => {
+    await page.goto('/checkout?success=true');
+    const affiliateLink = page.locator('a:has-text("⚡ Powered by OHC")');
+    await expect(affiliateLink).toHaveAttribute('href', /^\/onboarding\?ref=.*&source=checkout_affiliate/);
+  });
+});

--- a/src/server/integrations/stripe/client.rs
+++ b/src/server/integrations/stripe/client.rs
@@ -97,8 +97,10 @@ impl StripeClient {
         let amount_cents = (amount_usd * 100.0).round() as i64;
 
         let mut form = std::collections::HashMap::new();
-        form.insert("success_url".to_string(), "https://example.com/success".to_string());
-        form.insert("cancel_url".to_string(), "https://example.com/cancel".to_string());
+        let success_url = std::env::var("OHC_FRONTEND_URL").unwrap_or_else(|_| "https://app.onehumancorp.com".to_string()) + "/checkout?success=true&session_id={CHECKOUT_SESSION_ID}";
+        form.insert("success_url".to_string(), success_url);
+        let cancel_url = std::env::var("OHC_FRONTEND_URL").unwrap_or_else(|_| "https://app.onehumancorp.com".to_string()) + "/checkout?canceled=true";
+        form.insert("cancel_url".to_string(), cancel_url);
         if is_subscription {
             form.insert("mode".to_string(), "subscription".to_string());
             form.insert("line_items[0][price_data][recurring][interval]".to_string(), "month".to_string());

--- a/src/ui/next/src/app/checkout/page.tsx
+++ b/src/ui/next/src/app/checkout/page.tsx
@@ -13,6 +13,8 @@ function CheckoutContent() {
   const productId = searchParams?.get("product_id") || "prod_123";
   const quantity = parseInt(searchParams?.get("quantity") || "1", 10);
   const discountParam = searchParams?.get("discount");
+  const successParam = searchParams?.get("success");
+  const sessionIdParam = searchParams?.get("session_id");
   const [isProcessing, setIsProcessing] = useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [tenant, setTenant] = useState("my-store");
@@ -22,8 +24,11 @@ function CheckoutContent() {
   useEffect(() => {
     if (typeof localStorage !== "undefined") {
       setTenant(localStorage.getItem("tenant") || "my-store");
+      if (successParam === "true" || sessionIdParam) {
+        setShowSuccessModal(true);
+      }
     }
-  }, []);
+  }, [successParam, sessionIdParam]);
 
   const [deliveryAddress, setDeliveryAddress] = useState("");
   const [deliveryFee, setDeliveryFee] = useState<number | null>(null);


### PR DESCRIPTION
### Context
The post-purchase `showSuccessModal` inside the checkout page has a nice "OneTapReferral" widget. This feature helps small business owners acquire customers organically. However, previously, it was not being triggered upon successful payment through the backend's Stripe integration, causing users to not be successfully exposed to the referral widget.

### Changes
- In the Stripe backend client integration, instead of setting `https://example.com/success`, append standard `success=true&session_id={CHECKOUT_SESSION_ID}` query parameters to the `OHC_FRONTEND_URL`.
- Adjust `checkout/page.tsx` on the frontend to display the checkout success modal on page load if `successParam === "true"` or a `sessionIdParam` is detected, ensuring the `OneTapReferral` appears automatically.
- Introduces robust E2E test coverage asserting the behavior of the modal display upon return navigation, as well as the functionality inside `OneTapReferral`.

### E2E Tests
Tests added and verified successfully in `src/e2e/checkout_success_modal.spec.ts`. Validated all UI aspects using playwright (`bazel test //...`) and everything is green.

---
*PR created automatically by Jules for task [13984048009021423710](https://jules.google.com/task/13984048009021423710) started by @wbbsuper*