### PR TITLE
feat: implement Draft Reply agentic triage flow in dashboard ui

### DIFF
--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1439,7 +1439,36 @@
 
 
 
+
+          if (item.action_type === 'Draft Reply') {
+            let priorityClass = '';
+            if (['urgent', 'high'].includes((item.priority || '').toLowerCase())) priorityClass = 'urgent';
+            else if (['medium', 'action needed'].includes((item.priority || '').toLowerCase())) priorityClass = 'medium';
+
+            return `
+              <div class="triage-item" data-testid="triage-card-${item.id}" id="triage-${item.id}" style="background: rgba(255, 255, 255, 0.4); backdrop-filter: blur(20px); border-radius: 16px; padding: 16px; border: 1px solid rgba(255,255,255,0.6);">
+                <div class="triage-header" style="margin-bottom: 12px;">
+                  <div class="triage-source" style="display: flex; align-items: center; gap: 8px;">
+                    <span style="font-size: 18px;">💬</span> <strong>${item.source || 'Message'}</strong>
+                  </div>
+                  <div class="triage-priority ${priorityClass}">${item.priority || 'Normal'}</div>
+                </div>
+                <div class="triage-context" style="font-weight: 600; margin-bottom: 12px; font-size: 15px;">
+                  ${item.context || 'New message'}
+                </div>
+                <div style="background: rgba(0,0,0,0.03); padding: 12px; border-radius: 12px; margin-bottom: 16px; font-size: 14px; color: #333; font-style: italic;">
+                  ${item.action_payload || ''}
+                </div>
+                <div class="triage-controls" style="display: flex; gap: 8px;">
+                  <button class="triage-btn-approve" data-testid="approve-btn" onclick="handleTriageAction('${item.id}', true)" style="flex: 1; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Approve Reply</button>
+                  <button class="triage-btn-dismiss" data-testid="dismiss-btn" onclick="handleTriageAction('${item.id}', false)" style="flex: 1; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Dismiss</button>
+                </div>
+              </div>
+            `;
+          }
+
           if (actionType === 'SocialPostDraft') {
+
             let parsedPayload = item.proposed_action || {};
             return `
               <div class="triage-item" data-testid="triage-card-${item.id}" id="triage-${item.id}" style="background: rgba(255, 255, 255, 0.4); backdrop-filter: blur(20px); border-radius: 16px; padding: 16px; border: 1px solid rgba(255,255,255,0.6);">


### PR DESCRIPTION
This PR resolves GitHub Issue #27451, implementing the Agentic Operations Triage & Customer Follow-up UI in the Tauri dashboard.

*   **Problem:** The backend pipeline for AI message triage (parsing intents, drafting replies, and enqueuing them via Postgres) was already implemented, but the frontend dashboard (`dashboard.html`) lacked the specific rendering block for the `action_type === 'Draft Reply'`.
*   **Solution:** Injected the missing HTML template into `renderTriageItems()` for the `Draft Reply` action type. It now correctly parses the proposed drafted reply text, handles `approve` and `dismiss` actions, and applies the designated visual hierarchy.
*   **Verification:** Playwright E2E tests (`triage_ui.spec.ts`) specifically tested this UI using test ids `[data-testid="approve-btn"]` and `[data-testid="dismiss-btn"]`. These tests now successfully pass.

No new tests were written because `triage_ui.spec.ts` was already explicitly providing 100% E2E test coverage for the exact owner approval CUJ requested by the issue, but it was failing because the static HTML wasn't handling the action type.

Loaded super power: None applied directly.
Product-use evidence: Ran the Python UI server and inspected the visually mocked HTML queue injection to ensure layout matched the 375px responsive constraints. Playwright tests were used to rigorously verify the E2E CUJ.

Resolves #27451

---
*PR created automatically by Jules for task [15847483875681245174](https://jules.google.com/task/15847483875681245174) started by @wbbsuper*