### PR TITLE
fix(docs): fix broken getting started link in help chat and unify article title

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -79,7 +79,7 @@ pub async fn update_tooltip(axum::extract::Json(payload): axum::extract::Json<To
 
 pub fn get_articles() -> Vec<HelpArticle> {
     vec![
-        HelpArticle { category: "Getting Started".to_string(), title: "Getting Started".to_string(), desc: "Learn how to easily set up your store and accept your first payment.".to_string(), link: "/help/getting-started-1".to_string() },
+        HelpArticle { category: "Getting Started".to_string(), title: "Getting Started with Your Store".to_string(), desc: "Welcome to OneHumanCorp! Let's get your business online in under 10 minutes.".to_string(), link: "/help/getting-started-1".to_string() },
         HelpArticle { category: "My Store".to_string(), title: "Adding Products".to_string(), desc: "Add products, track what's in stock, and change how your store looks.".to_string(), link: "/help/my-store".to_string() },
         HelpArticle { category: "Payments".to_string(), title: "Getting Paid".to_string(), desc: "Set up how you get paid, view deposits, and handle simple taxes.".to_string(), link: "/help/payments".to_string() },
         HelpArticle { category: "AI Agents".to_string(), title: "Your AI Helpers".to_string(), desc: "Learn how to hire AI helpers and give them tasks to do.".to_string(), link: "/help/ai-agents".to_string() },

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -5297,11 +5297,11 @@ async fn create_ui_bom_item_handler(
             let query = req.message.to_lowercase();
             let mut reply = "I am your AI Help Agent! I specialize in answering questions about OHC features and helping you grow your small business. Check out our Getting Started guide.".to_string();
             let mut link_title = "Read the full article →";
-            let mut link_url = "/help/getting-started";
+            let mut link_url = "/help/getting-started-1";
 
             if query.contains("getting started") {
                 reply = format!("Based on our help center: {}", help_articles[0].1);
-                link_url = "/help/getting-started";
+                link_url = "/help/getting-started-1";
             } else if query.contains("store") {
                 reply = format!("Based on our help center: {}", help_articles[1].1);
                 link_url = "/help/my-store";

--- a/src/ui/next/src/app/help/page.test.tsx
+++ b/src/ui/next/src/app/help/page.test.tsx
@@ -13,7 +13,7 @@ describe('HelpCenterPage', () => {
       if (url === '/api/help') {
         return Promise.resolve({
           json: () => Promise.resolve([
-            { title: "Getting Started", desc: "Learn how to easily set up your store and accept your first payment.", link: "/help/getting-started-1" },
+            { title: "Getting Started with Your Store", desc: "Welcome to OneHumanCorp! Let's get your business online in under 10 minutes.", link: "/help/getting-started-1" },
             { title: "Adding Products", desc: "Add products, track what's in stock, and change how your store looks.", link: "/help/my-store" }
           ])
         });
@@ -22,7 +22,7 @@ describe('HelpCenterPage', () => {
         const urlObj = new URL('http://localhost' + url);
         const q = urlObj.searchParams.get('q')?.toLowerCase() || '';
         const allArticles = [
-            { title: "Getting Started", desc: "Learn how to easily set up your store and accept your first payment.", link: "/help/getting-started-1" },
+            { title: "Getting Started with Your Store", desc: "Welcome to OneHumanCorp! Let's get your business online in under 10 minutes.", link: "/help/getting-started-1" },
             { title: "Adding Products", desc: "Add products, track what's in stock, and change how your store looks.", link: "/help/my-store" }
         ];
         const results = allArticles.filter(a =>
@@ -57,7 +57,7 @@ describe('HelpCenterPage', () => {
     expect(screen.getByText('Help Center')).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(screen.getByText('Getting Started')).toBeInTheDocument();
+      expect(screen.getByText('Getting Started with Your Store')).toBeInTheDocument();
       expect(screen.getByText('Adding Products')).toBeInTheDocument();
     });
   });
@@ -67,14 +67,14 @@ describe('HelpCenterPage', () => {
     render(<TooltipProvider><HelpCenterPage /></TooltipProvider>);
 
     await waitFor(() => {
-      expect(screen.getByText('Getting Started')).toBeInTheDocument();
+      expect(screen.getByText('Getting Started with Your Store')).toBeInTheDocument();
     });
 
     const searchInput = screen.getByPlaceholderText('Search for help articles and videos...');
     await user.type(searchInput, 'products');
 
     await waitFor(() => {
-      expect(screen.queryByText('Getting Started')).not.toBeInTheDocument();
+      expect(screen.queryByText('Getting Started with Your Store')).not.toBeInTheDocument();
       expect(screen.getByText('Adding Products')).toBeInTheDocument();
     });
   });
@@ -84,7 +84,7 @@ describe('HelpCenterPage', () => {
     render(<TooltipProvider><HelpCenterPage /></TooltipProvider>);
 
     await waitFor(() => {
-      expect(screen.getByText('Getting Started')).toBeInTheDocument();
+      expect(screen.getByText('Getting Started with Your Store')).toBeInTheDocument();
     });
 
     const searchInput = screen.getByPlaceholderText('Search for help articles and videos...');
@@ -131,7 +131,7 @@ describe('HelpCenterPage', () => {
     const user = userEvent.setup();
     render(<TooltipProvider><HelpCenterPage /></TooltipProvider>);
     await waitFor(() => {
-      expect(screen.getByText('Getting Started')).toBeInTheDocument();
+      expect(screen.getByText('Getting Started with Your Store')).toBeInTheDocument();
     });
 
     const searchInput = screen.getByPlaceholderText('Search for help articles and videos...');


### PR DESCRIPTION
I fixed a hardcoded `/help/getting-started` broken link in `src/server/lib.rs`'s `/api/chat` route to correctly map to `/help/getting-started-1`.

I also unified the "Getting Started" help article title to "Getting Started with Your Store" in `src/server/api/docs.rs` so that it is consistent with the database and `fallback.ts`.

Lastly, I updated the corresponding frontend tests in `src/ui/next/src/app/help/page.test.tsx` to expect the exact new unified "Getting Started with Your Store" article title.

I have verified `bazel test //...` and Playwright tests locally passing without regression.

---
*PR created automatically by Jules for task [8846070166928252079](https://jules.google.com/task/8846070166928252079) started by @ql-owo-lp*