### PR TITLE
Fix onboarding test timeout and add glassmorphism border radius

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -582,6 +582,7 @@ body {
   -webkit-backdrop-filter: blur(30px) saturate(210%);
   backdrop-filter: blur(30px) saturate(210%);
   border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 16px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -590,6 +591,7 @@ body {
     -webkit-backdrop-filter: blur(30px) saturate(210%);
   backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
   }
 }
 

--- a/src/ui/next/src/app/onboarding/page.test.tsx
+++ b/src/ui/next/src/app/onboarding/page.test.tsx
@@ -348,7 +348,7 @@ describe('OnboardingWizard', () => {
     await waitFor(() => {
       expect(screen.getByText("Failed to start onboarding")).toBeInTheDocument();
       expect(screen.getByText("Style & Team")).toBeInTheDocument();
-    });
+    }, { timeout: 4000 }); // Increase timeout to allow the 500ms delay to pass
 
     consoleErrorSpy.mockRestore();
   });


### PR DESCRIPTION
Fixes an issue with `waitFor` in `src/ui/next/src/app/onboarding/page.test.tsx` by providing a proper timeout value (4000ms), and addresses a visual styling issue by adding `border-radius: 16px` to the `.glassmorphism` class in `src/ui/next/src/app/globals.css` in accordance to the OHC Premium Design Standards.

---
*PR created automatically by Jules for task [7258531549718713680](https://jules.google.com/task/7258531549718713680) started by @ql-owo-lp*