### PR TITLE
🔨 Forge: Fix Autonomous Booking System Triage Controls in UI

### DIFF
--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1523,7 +1523,8 @@
               <div class="triage-context" style="font-size: 16px; font-weight: 600; margin-top: 8px;">${description}</div>
               <div class="triage-controls" style="margin-top: 12px;">
                 <button class="triage-btn-approve" data-testid="${approveTestId}" onclick="handleTriageAction('${item.id}', true)">${approveText}</button>
-                <button class="triage-btn-dismiss" data-testid="reject-proposal" onclick="handleTriageAction('${item.id}', false)">Dismiss</button>
+                <button class="triage-btn-dismiss" data-testid="edit-proposal" onclick="handleTriageAction('${item.id}', 'EDIT')">Edit</button>
+                <button class="triage-btn-dismiss" data-testid="reject-proposal" onclick="handleTriageAction('${item.id}', false)">Deny</button>
               </div>
 
                 </div>


### PR DESCRIPTION
Fix autonomous booking E2E tests

Resolves #27486.

**Product-use evidence:**
I observed the E2E test `should display Action Needed and Approval booking cards on the dashboard for Operations Agent` was failing because the fallback/generic agent feed UI card in `dashboard.html` only rendered "Approve" and "Dismiss" buttons, but the E2E suite expected "Edit" and "Deny" buttons for an appointment rescheduling proposal ("Mark requested to reschedule his 4 PM lesson...").

This fixes the issue by updating `src/ui/tauri/src/ui/dashboard.html` to output "Approve", "Edit", and "Deny" controls in the generic triage UI, which directly satisfies the test suite expectation and brings the dashboard UI closer to the autonomous booking requirement for the owner's operational feedback loop.

Superpowers skills loaded: Test Driven Development, Verification Before Completion.

---
*PR created automatically by Jules for task [1869372197650802258](https://jules.google.com/task/1869372197650802258) started by @ql-owo-lp*