### PR TITLE
feat: Add Save Draft functionality to the onboarding wizard

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1225,6 +1225,74 @@
               }
           });
       }
+      document.querySelectorAll(".save-draft-btn").forEach(btn => {
+        btn.addEventListener("click", (e) => {
+            const originalText = e.target.innerText;
+            e.target.innerText = "Saving...";
+            e.target.disabled = true;
+
+            const backendUrl = (window.location.origin.includes("localhost") || window.location.protocol === "file:") ? "http://127.0.0.1:18789" : "";
+            const tenantId = localStorage.getItem("tenant_id") || "storefront";
+            const userId = localStorage.getItem("user_id") || "test-user";
+
+            const currentStepEl = document.querySelector(".step.active");
+            let currentStepIdx = 0;
+            if (currentStepEl) {
+                const steps = Array.from(document.querySelectorAll(".step"));
+                currentStepIdx = steps.indexOf(currentStepEl);
+            }
+
+            const payload = {
+                wizardState: state,
+                step: currentStepIdx
+            };
+
+            if (window.__TAURI__ && window.__TAURI__.core) {
+                window.__TAURI__.core.invoke("save_onboarding_state", { state: payload }).then(() => {
+                    e.target.innerText = "Saved!";
+                    setTimeout(() => {
+                        e.target.innerText = originalText;
+                        e.target.disabled = false;
+                    }, 3000);
+                }).catch(err => {
+                    console.error("Failed to save draft", err);
+                    e.target.innerText = "Error!";
+                    setTimeout(() => {
+                        e.target.innerText = originalText;
+                        e.target.disabled = false;
+                    }, 3000);
+                });
+            } else {
+                fetch(`${backendUrl}/api/onboarding/state`, {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "X-Tenant-ID": tenantId,
+                        "X-User-ID": userId
+                    },
+                    body: JSON.stringify(payload)
+                }).then(res => {
+                    if (res.ok) {
+                        e.target.innerText = "Saved!";
+                        setTimeout(() => {
+                            e.target.innerText = originalText;
+                            e.target.disabled = false;
+                        }, 3000);
+                    } else {
+                        throw new Error("Failed to save");
+                    }
+                }).catch(err => {
+                    console.error("Failed to save draft", err);
+                    e.target.innerText = "Error!";
+                    setTimeout(() => {
+                        e.target.innerText = originalText;
+                        e.target.disabled = false;
+                    }, 3000);
+                });
+            }
+        });
+      });
+
 
       if (finishBtn) {
         finishBtn.addEventListener('click', () => {


### PR DESCRIPTION
This PR adds a click event listener for `.save-draft-btn` in `setup.html` that successfully posts the wizard's state to `/api/onboarding/state`. It utilizes Tauri's internal communication layer `window.__TAURI__.core.invoke("save_onboarding_state")` if it exists (for local/desktop application) and falls back to a standard fetch via `POST` if running in the cloud/web browser. 

The state loading mechanism remains untouched and continues to utilize `get_onboarding_state`. E2E functionality has been verified using Playwright locally for 375px resolutions to handle friction points and no-ops as requested.

---
*PR created automatically by Jules for task [8582631840098934385](https://jules.google.com/task/8582631840098934385) started by @ql-owo-lp*