### PR TITLE
fix(ui): enforce 44px touch targets in unified feed

### DIFF
--- a/src/e2e/test_viewport.spec.ts
+++ b/src/e2e/test_viewport.spec.ts
@@ -23,6 +23,7 @@ test.describe('Unified Agent Feed Viewport Constraint', () => {
         const box = await buttons.nth(i).boundingBox();
         if (box) {
            expect(box.height).toBeGreaterThanOrEqual(44);
+           expect(box.width).toBeGreaterThanOrEqual(44);
         }
     }
   });

--- a/src/e2e/unified_agent_feed.spec.ts
+++ b/src/e2e/unified_agent_feed.spec.ts
@@ -49,6 +49,11 @@ test.describe("Unified Agent Feed Mobile UX", () => {
     // 5. Verify touch targets on the Instagram DM specific button
     const approveIgButton = page.locator('button[data-testid="approve-instagram-dm"]').first();
     await expect(approveIgButton).toBeVisible();
+    const approveIgButtonBox = await approveIgButton.boundingBox();
+    if (approveIgButtonBox) {
+      expect(approveIgButtonBox.width).toBeGreaterThanOrEqual(44);
+      expect(approveIgButtonBox.height).toBeGreaterThanOrEqual(44);
+    }
     await approveIgButton.click();
 
     // The Instagram DM item should optimistically disappear
@@ -57,6 +62,11 @@ test.describe("Unified Agent Feed Mobile UX", () => {
     // Verify touch targets on the default Approve button
     const approveButton = page.locator('button[data-testid="approve-proposal"]').first();
     await expect(approveButton).toBeVisible();
+    const approveButtonBox = await approveButton.boundingBox();
+    if (approveButtonBox) {
+      expect(approveButtonBox.width).toBeGreaterThanOrEqual(44);
+      expect(approveButtonBox.height).toBeGreaterThanOrEqual(44);
+    }
     await approveButton.click();
 
     await expect(page.locator("text=3 new orders to fulfill").first()).not.toBeVisible();
@@ -64,6 +74,11 @@ test.describe("Unified Agent Feed Mobile UX", () => {
     // Test a specific payload button
     const draftButton = page.locator('button[data-testid="approve-draft"]').first();
     await expect(draftButton).toBeVisible();
+    const draftButtonBox = await draftButton.boundingBox();
+    if (draftButtonBox) {
+      expect(draftButtonBox.width).toBeGreaterThanOrEqual(44);
+      expect(draftButtonBox.height).toBeGreaterThanOrEqual(44);
+    }
     await draftButton.click();
 
     await expect(page.locator("text=Draft promo email?").first()).not.toBeVisible();

--- a/src/ui/next/src/e2e/test_viewport.spec.ts
+++ b/src/ui/next/src/e2e/test_viewport.spec.ts
@@ -23,6 +23,7 @@ test.describe('Unified Agent Feed Viewport Constraint', () => {
         const box = await buttons.nth(i).boundingBox();
         if (box) {
            expect(box.height).toBeGreaterThanOrEqual(44);
+           expect(box.width).toBeGreaterThanOrEqual(44);
         }
     }
   });

--- a/src/ui/next/src/e2e/unified_agent_feed_interaction.spec.ts
+++ b/src/ui/next/src/e2e/unified_agent_feed_interaction.spec.ts
@@ -24,6 +24,11 @@ test.describe('Unified Agent Feed Interactive Flow', () => {
     // In case there are no items to approve, we will skip the rest of the assertions safely.
     // In a real E2E environment we would seed this, but this guarantees the script runs.
     if (await approveBtn.isVisible()) {
+        const approveBtnBox = await approveBtn.boundingBox();
+        if (approveBtnBox) {
+           expect(approveBtnBox.height).toBeGreaterThanOrEqual(44);
+           expect(approveBtnBox.width).toBeGreaterThanOrEqual(44);
+        }
         // 2. Expand card to see details
         await editBtn.click();
         const detailsPre = page.locator('pre').first();

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -174,7 +174,7 @@
         justify-content: center;
         align-items: center;
         gap: 8px;
-        min-height: 44px;
+        min-height: 44px; min-width: 44px;
       }
       .btn-primary:hover {
         background-color: #0052cc;
@@ -197,7 +197,7 @@
         justify-content: center;
         align-items: center;
         gap: 8px;
-        min-height: 44px;
+        min-height: 44px; min-width: 44px;
       }
       @media (prefers-color-scheme: dark) {
         .btn-outline {
@@ -286,7 +286,7 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        min-height: 44px; /* touch target size */
+        min-height: 44px; min-width: 44px; /* touch target size */
       }
       button:hover {
         background-color: #0052cc;
@@ -446,7 +446,7 @@
         background: #0066FF;
         font-size: 14px;
         padding: 10px;
-        min-height: 44px;
+        min-height: 44px; min-width: 44px;
       }
       .triage-btn-dismiss {
         flex: 1;
@@ -454,7 +454,7 @@
         color: #1d1d1f;
         font-size: 14px;
         padding: 10px;
-        min-height: 44px;
+        min-height: 44px; min-width: 44px;
         box-shadow: none;
       }
       .triage-btn-dismiss:hover { background: #d1d1d6; }
@@ -1457,8 +1457,8 @@
                   <strong style="margin-top: 8px; display: inline-block;">TikTok:</strong> ${parsedPayload.tiktok || ''}
                 </div>
                 <div class="triage-controls" style="display: flex; gap: 8px;">
-                  <button class="triage-btn-approve" data-testid="approve-btn" onclick="handleTriageAction('${item.id}', true)" style="flex: 1; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Approve & Schedule</button>
-                  <button class="triage-btn-dismiss" onclick="handleTriageAction('${item.id}', false)" style="flex: 1; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Edit Draft</button>
+                  <button class="triage-btn-approve" data-testid="approve-btn" onclick="handleTriageAction('${item.id}', true)" style="flex: 1; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer; min-width: 44px; min-height: 44px;">Approve & Schedule</button>
+                  <button class="triage-btn-dismiss" onclick="handleTriageAction('${item.id}', false)" style="flex: 1; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer; min-width: 44px; min-height: 44px;">Edit Draft</button>
                 </div>
               </div>
             `;
@@ -1481,8 +1481,8 @@
                   ${parsedPayload.draft_reply || ''}
                 </div>
                 <div class="triage-controls" style="display: flex; gap: 8px;">
-                  <button class="triage-btn-approve" data-testid="approve-instagram-dm" onclick="handleTriageAction('${item.id}', 'APPROVED')" style="flex: 1; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Approve Reply</button>
-                  <button class="triage-btn-dismiss" onclick="handleTriageAction('${item.id}', 'DISMISSED')" style="flex: 1; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Edit Draft</button>
+                  <button class="triage-btn-approve" data-testid="approve-instagram-dm" onclick="handleTriageAction('${item.id}', 'APPROVED')" style="flex: 1; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer; min-width: 44px; min-height: 44px;">Approve Reply</button>
+                  <button class="triage-btn-dismiss" onclick="handleTriageAction('${item.id}', 'DISMISSED')" style="flex: 1; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer; min-width: 44px; min-height: 44px;">Edit Draft</button>
                 </div>
               </div>
             `;
@@ -1507,8 +1507,8 @@
                   <strong style="margin-top: 8px; display: inline-block;">TikTok:</strong> ${parsedPayload.tiktok || ''}
                 </div>
                 <div class="triage-controls" style="display: flex; gap: 8px;">
-                  <button class="triage-btn-approve" data-testid="approve-btn" onclick="handleTriageAction('${item.id}', true)" style="flex: 1; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Approve & Schedule</button>
-                  <button class="triage-btn-dismiss" onclick="handleTriageAction('${item.id}', false)" style="flex: 1; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Edit Draft</button>
+                  <button class="triage-btn-approve" data-testid="approve-btn" onclick="handleTriageAction('${item.id}', true)" style="flex: 1; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer; min-width: 44px; min-height: 44px;">Approve & Schedule</button>
+                  <button class="triage-btn-dismiss" onclick="handleTriageAction('${item.id}', false)" style="flex: 1; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer; min-width: 44px; min-height: 44px;">Edit Draft</button>
                 </div>
               </div>
             `;


### PR DESCRIPTION
Ensures 44x44px touch targets are applied correctly across mobile screens, focusing on the Unified Agent Feed, to align with the "Mobile-First Non-Negotiables" requirement. Updated both global classes and inline stylings in `dashboard.html` and strengthened assertions in the relevant `test_viewport` and `unified_agent_feed` E2E scripts to verify width and height.

---
*PR created automatically by Jules for task [15020518902291229754](https://jules.google.com/task/15020518902291229754) started by @ql-owo-lp*