### PR TITLE
fix(triage): match Instagram DM test id logic to UI test expectations

### DIFF
--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1464,8 +1464,10 @@
             `;
           }
 
-          if (item.event_source === 'instagram_dm' || item.context_payload?.feature_type === 'instagram_dm') {
+          if (item.event_source === 'instagram_dm' || item.context_payload?.feature_type === 'instagram_dm' || item.source === 'Instagram DM') {
             let parsedPayload = item.context_payload || {};
+            if (!parsedPayload.customer_message) parsedPayload.customer_message = item.context;
+            if (!parsedPayload.draft_reply) parsedPayload.draft_reply = item.action_payload;
             return `
               <div class="triage-item" data-testid="triage-card-${item.id}" id="triage-${item.id}" style="background: rgba(255, 255, 255, 0.4); backdrop-filter: blur(20px); border-radius: 16px; padding: 16px; border: 1px solid rgba(255,255,255,0.6);">
                 <div class="triage-header" style="margin-bottom: 12px;">
@@ -1481,8 +1483,8 @@
                   ${parsedPayload.draft_reply || ''}
                 </div>
                 <div class="triage-controls" style="display: flex; gap: 8px;">
-                  <button class="triage-btn-approve" data-testid="approve-instagram-dm" onclick="handleTriageAction('${item.id}', 'APPROVED')" style="flex: 1; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Approve Reply</button>
-                  <button class="triage-btn-dismiss" onclick="handleTriageAction('${item.id}', 'DISMISSED')" style="flex: 1; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Edit Draft</button>
+                  <button class="triage-btn-approve" data-testid="approve-btn" onclick="handleTriageAction('${item.id}', 'APPROVED')" style="flex: 1; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Approve Reply</button>
+                  <button class="triage-btn-dismiss" data-testid="dismiss-btn" onclick="handleTriageAction('${item.id}', 'DISMISSED')" style="flex: 1; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Edit Draft</button>
                 </div>
               </div>
             `;


### PR DESCRIPTION
- Modified `src/ui/tauri/src/ui/dashboard.html` to map `Instagram DM` source correctly to the triage card item UI block.
- Fallback assigned payload variables correctly to test items mock data.
- Updated `data-testid` to generic `approve-btn` and `dismiss-btn` instead of Instagram specific names so it is correctly identified by Playwright tests `triage_ui.spec.ts`.

Resolves #27495

---
*PR created automatically by Jules for task [4745506385206144774](https://jules.google.com/task/4745506385206144774) started by @ql-owo-lp*