### PR TITLE
feat(growth): implement viral Brand Kit Generator loop

### DIFF
--- a/src/e2e/viral_brand_kit_loop.spec.ts
+++ b/src/e2e/viral_brand_kit_loop.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from './fixtures';
+import { currentAppSmoke } from './current_app_smoke';
+
+test('viral_brand_kit_loop_smoke', async ({ page, request, loginAs, adminUser }) => {
+  await loginAs(page, adminUser);
+  await currentAppSmoke(page, request, 'viral_brand_kit_loop');
+});
+
+test.describe('Viral Brand Kit Loop', () => {
+  test('should display the soft paywall modal and handle share bypass for Brand Kit', async ({ page }) => {
+    // Navigate to dashboard
+    await page.goto('/dashboard.html');
+    await page.waitForLoadState('networkidle');
+
+    // 1. Verify the brand kit generator card is visible
+    const brandKitHeading = page.getByRole('heading', { name: /Brand Kit Generator/i });
+    await expect(brandKitHeading).toBeVisible();
+
+    // 2. Click the enable button for the brand kit
+    // We want the enable button inside the Brand Kit Generator card
+    const brandKitCard = page.locator('.ohc-growth-card').filter({ hasText: 'Brand Kit Generator' });
+    const enableBtn = brandKitCard.getByRole('button', { name: 'Enable', exact: true });
+    await expect(enableBtn).toBeVisible();
+    await enableBtn.click();
+
+    // 3. Verify the soft paywall modal appears
+    const modalHeading = page.getByRole('heading', { name: 'Unlock Advanced Features' });
+    await expect(modalHeading).toBeVisible();
+    await expect(page.getByText('Advanced AI Automations are available on the Pro plan')).toBeVisible();
+
+    // 4. Mock window.open to prevent opening a new tab
+    await page.evaluate(() => {
+        window.open = function(url) {
+            (window as any).lastOpenedShareUrl = url;
+            return window;
+        };
+    });
+
+    // 5. Click the share button to trigger the bypass API call
+    const shareButton = page.getByRole('button', { name: /Share on X to Unlock/i });
+    await expect(shareButton).toBeVisible();
+    await shareButton.click();
+
+    // 6. Verify the loading state
+    await expect(page.getByText(/Verifying Share.../i)).toBeVisible();
+
+    // 7. Verify the success state and modal disappearance
+    await expect(page.getByText('Unlocked!')).toBeVisible({ timeout: 10000 });
+
+    // Verify the correct intent URL was used for the share
+    const sharedUrl = await page.evaluate(() => (window as any).lastOpenedShareUrl);
+    expect(sharedUrl).toContain('Brand%20Kit');
+
+    // The modal should hide and the "Unlocked! Go to settings to view." status should appear
+    await expect(modalHeading).not.toBeVisible({ timeout: 5000 });
+    const statusText = page.getByText('✅ Unlocked! Go to settings to view.');
+    await expect(statusText).toBeVisible();
+  });
+});

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -644,6 +644,18 @@
         <p id="advanced-automations-status" style="display: none; color: #34C759; font-weight: 600; margin-top: 12px;">✅ Enabled</p>
       </div>
 
+      <!-- Viral Brand Kit Loop -->
+      <div class="ohc-growth-card" style="margin-bottom: 20px;">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+          <div>
+            <h2 style="margin-bottom: 4px;">Brand Kit Generator</h2>
+            <p style="margin-top: 0; margin-bottom: 0;">Auto-generate logos, palettes, and typography for your storefront.</p>
+          </div>
+          <button id="enable-brand-kit-btn" style="background-color: #0066FF; color: white; border: none; padding: 10px 16px; border-radius: 16px; cursor: pointer; transition: transform 0.1s;">Enable</button>
+        </div>
+        <p id="brand-kit-status" style="display: none; color: #34C759; font-weight: 600; margin-top: 12px;">✅ Unlocked! Go to settings to view.</p>
+      </div>
+
       <!-- Soft Paywall Modal -->
       <div id="soft-paywall-modal" style="display: none; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.4); z-index: 10000; align-items: center; justify-content: center; backdrop-filter: blur(5px);">
         <div style="background: rgba(255, 255, 255, 0.85); backdrop-filter: blur(30px) saturate(210%); border: 1px solid rgba(255, 255, 255, 0.6); border-radius: 16px; padding: 32px; max-width: 400px; width: 90%; box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15); text-align: center;">
@@ -1034,11 +1046,15 @@
 
         // Soft Paywall Logic
         const enableAutomationsBtn = document.getElementById('enable-advanced-automations-btn');
+        const enableBrandKitBtn = document.getElementById('enable-brand-kit-btn');
+        const brandKitStatus = document.getElementById('brand-kit-status');
         const softPaywallModal = document.getElementById('soft-paywall-modal');
         const softPaywallCloseBtn = document.getElementById('soft-paywall-close-btn');
         const softPaywallShareBtn = document.getElementById('soft-paywall-share-btn');
         const softPaywallStatus = document.getElementById('soft-paywall-status');
         const advancedAutomationsStatus = document.getElementById('advanced-automations-status');
+
+        let currentSoftPaywallTarget = null; // 'automations' or 'brand-kit'
 
         if (enableAutomationsBtn) {
           enableAutomationsBtn.addEventListener('click', async () => {
@@ -1050,6 +1066,20 @@
               enableAutomationsBtn.style.display = 'none';
               advancedAutomationsStatus.style.display = 'block';
             } else {
+              currentSoftPaywallTarget = 'automations';
+              softPaywallModal.style.display = 'flex';
+            }
+          });
+        }
+
+        if (enableBrandKitBtn) {
+          enableBrandKitBtn.addEventListener('click', async () => {
+            const isPro = localStorage.getItem('has_pro') === 'true';
+            if (isPro) {
+              enableBrandKitBtn.style.display = 'none';
+              brandKitStatus.style.display = 'block';
+            } else {
+              currentSoftPaywallTarget = 'brand-kit';
               softPaywallModal.style.display = 'flex';
             }
           });
@@ -1064,7 +1094,12 @@
         if (softPaywallShareBtn) {
           softPaywallShareBtn.addEventListener('click', async () => {
             const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'DEFAULT';
-            const message = `I just discovered Advanced AI Automations on OneHumanCorp! This is going to revolutionize how I work. 🚀 #OneHumanCorp #SmallBiz https://ohc.app/invite/${tenantId}`;
+            let message = '';
+            if (currentSoftPaywallTarget === 'brand-kit') {
+                message = `I'm using OneHumanCorp to auto-generate my Brand Kit! 🎨 #OneHumanCorp #SmallBiz https://ohc.app/invite/${tenantId}`;
+            } else {
+                message = `I just discovered Advanced AI Automations on OneHumanCorp! This is going to revolutionize how I work. 🚀 #OneHumanCorp #SmallBiz https://ohc.app/invite/${tenantId}`;
+            }
             const shareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(message)}`;
 
             // Open share dialog
@@ -1092,8 +1127,22 @@
                 localStorage.setItem('has_pro', 'true');
                 setTimeout(() => {
                   softPaywallModal.style.display = 'none';
-                  enableAutomationsBtn.style.display = 'none';
-                  advancedAutomationsStatus.style.display = 'block';
+                  if (currentSoftPaywallTarget === 'brand-kit') {
+                    if (enableBrandKitBtn && brandKitStatus) {
+                      enableBrandKitBtn.style.display = 'none';
+                      brandKitStatus.style.display = 'block';
+                    }
+                  } else {
+                    if (enableAutomationsBtn && advancedAutomationsStatus) {
+                      enableAutomationsBtn.style.display = 'none';
+                      advancedAutomationsStatus.style.display = 'block';
+                    }
+                  }
+
+                  // Reset state for next use
+                  softPaywallStatus.style.display = 'none';
+                  softPaywallStatus.innerText = 'Verifying...';
+                  softPaywallShareBtn.style.display = 'block';
                 }, 1500);
               } else {
                 softPaywallStatus.innerText = 'Failed to unlock features. Please try again.';


### PR DESCRIPTION
This PR introduces a new viral growth loop targeting owner engagement and acquisition by offering a Brand Kit Generator behind a social share soft paywall. It refactors the existing `dashboard.html` soft paywall modal to handle multiple targets, enabling the user to unlock the new feature by sharing on X. It also adds a comprehensive Playwright E2E test suite to verify the UI interaction, modal bypassing, and specific URL share intent.

---
*PR created automatically by Jules for task [5679451013068550268](https://jules.google.com/task/5679451013068550268) started by @wbbsuper*