### PR TITLE
fix(ui): update cost dashboard back button to route to /dashboard

### DIFF
--- a/src/e2e/miser_cost_features.spec.ts
+++ b/src/e2e/miser_cost_features.spec.ts
@@ -23,10 +23,10 @@ test.describe('Miser Cost Features E2E', () => {
     await expect(page.locator('#budget-health-alert')).toBeVisible();
 
     // Verify navigation back to My Plan works
-    const myPlanButton = page.locator('button', { hasText: 'Back to My Plan' });
+    const myPlanButton = page.locator('button', { hasText: 'Back to Dashboard' });
     await expect(myPlanButton).toBeVisible();
 
-    // Click the button and verify URL changes to /plan
+    // Click the button and verify URL changes to /dashboard
     await myPlanButton.click();
     await page.waitForURL('**/dashboard', { timeout: 10000 });
     await expect(page.locator('text=AI actions used this month')).toBeVisible({ timeout: 15000 });

--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -116,8 +116,8 @@ export default function CostDashboardPage() {
       <header className="px-4 md:px-6 py-4 flex flex-col md:flex-row items-center justify-between border-b gap-4 sticky top-0 z-50 bg-white/70 backdrop-blur-xl saturate-200 border-b-white/40 shadow-sm">
         <h1 className="text-2xl font-bold font-outfit text-center md:text-left text-gray-900 tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-gray-900 to-gray-600">Cost Transparency Dashboard</h1>
         <div className="flex gap-2">
-            <button onClick={() => router.push('/plan')} className="min-w-[44px] min-h-[44px] px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-800 rounded-xl text-sm font-medium transition-all active:scale-95 shadow-sm flex items-center justify-center">
-            Back to My Plan
+            <button onClick={() => router.push('/dashboard')} className="min-w-[44px] min-h-[44px] px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-800 rounded-xl text-sm font-medium transition-all active:scale-95 shadow-sm flex items-center justify-center">
+            Back to Dashboard
             </button>
         </div>
       </header>


### PR DESCRIPTION
Fixes a bug where the cost dashboard links back to the non-existent `/plan` route instead of `/dashboard`, and updates the button label and corresponding test.

---
*PR created automatically by Jules for task [14039351660019599551](https://jules.google.com/task/14039351660019599551) started by @ql-owo-lp*