### PR TITLE
Fix unused import warnings in Rust server tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,8 +1,8 @@
 # Bazel configuration for MCP Any
 
 build --color=yes
-build --config=remote-cache
-build --config=bes
+# build --config=remote-cache
+# build --config=bes
 
 # ── Default: local builds/tests ───────────────────────────────────────────────
 build --jobs=HOST_CPUS
@@ -135,7 +135,7 @@ common:nativelink --jobs=50
 common:nativelink --remote_upload_local_results=false
 common:nativelink --remote_header=x-nativelink-api-key=GZRlHAyqIIcVJw9dJ9n9
 
-common:remote-cache --config=nativelink
+# common:remote-cache --config=nativelink
 common:remote-cache --remote_download_minimal
 common:remote-cache --remote_local_fallback
 common:remote-cache --remote_timeout=10m

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,8 +1,8 @@
 # Bazel configuration for MCP Any
 
 build --color=yes
-# build --config=remote-cache
-# build --config=bes
+build --config=remote-cache
+build --config=bes
 
 # ── Default: local builds/tests ───────────────────────────────────────────────
 build --jobs=HOST_CPUS
@@ -135,7 +135,7 @@ common:nativelink --jobs=50
 common:nativelink --remote_upload_local_results=false
 common:nativelink --remote_header=x-nativelink-api-key=GZRlHAyqIIcVJw9dJ9n9
 
-# common:remote-cache --config=nativelink
+common:remote-cache --config=nativelink
 common:remote-cache --remote_download_minimal
 common:remote-cache --remote_local_fallback
 common:remote-cache --remote_timeout=10m

--- a/src/server/api/omnichannel_webhook.rs
+++ b/src/server/api/omnichannel_webhook.rs
@@ -219,7 +219,7 @@ pub async fn handle_omnichannel_webhook(
 mod tests {
     use super::*;
     use crate::db::DB;
-    use crate::db::get_pool;
+
     use sqlx::SqlitePool;
 
     #[tokio::test]

--- a/src/server/benchmarks/chaos_bench.rs
+++ b/src/server/benchmarks/chaos_bench.rs
@@ -2,7 +2,7 @@
 mod tests {
     use std::sync::Arc;
     use std::sync::atomic::Ordering;
-    use tokio::time::{sleep, Duration, timeout};
+    use tokio::time::{Duration, timeout};
 
     // Note: this represents Chaos tests focusing on parity constraints.
     // They don't test actual network unreliability, but rather

--- a/src/server/telemetry_test.rs
+++ b/src/server/telemetry_test.rs
@@ -39,7 +39,7 @@ mod tests {
     }
 
 
-    use serde_json::{json, Value};
+    use serde_json::json;
     use ::server_telemetry::{redact_interface_pii, buffer_metric};
 
     #[test]


### PR DESCRIPTION
Removed unused imports in `src/server/api/omnichannel_webhook.rs`, `src/server/benchmarks/chaos_bench.rs`, and `src/server/telemetry_test.rs` to fix compiler warnings.

---
*PR created automatically by Jules for task [10467836641011506305](https://jules.google.com/task/10467836641011506305) started by @ql-owo-lp*