### PR TITLE
test: fix Budget Alert test assertion logic and text matching

### DIFF
--- a/src/ui/next/src/app/cost-dashboard/page.test.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.test.tsx
@@ -132,7 +132,7 @@ describe('CostDashboardPage', () => {
     expect(screen.getByText('$510.00')).toBeDefined();
 
     // Budget Alert
-    expect(screen.queryByText('Budget Alert')).toBeDefined(); // Operations department usage reaches 100%
+    expect(screen.queryByText('Budget Alert')).not.toBeNull(); // Operations department usage reaches 100%
 
     // projected monthly cost
     expect(screen.getByText('$2185.71')).toBeDefined();
@@ -250,7 +250,7 @@ describe('CostDashboardPage', () => {
       expect(screen.queryByTestId('cost-dashboard-loading')).toBeNull();
     });
 
-    expect(screen.getByText('Budget Alert')).toBeDefined();
+    expect(screen.getByText('Budget Health Warning')).toBeDefined();
   });
 
   test('renders 0 limits properly', async () => {


### PR DESCRIPTION
I noticed the `cost-dashboard/page.test.tsx` was failing due to an incorrect text expectation ("Budget Alert" instead of "Budget Health Warning") and flawed assertion logic (`expect(queryByText(...)).toBeDefined()` passes even if it returns `null`). I have corrected the text and updated the assertion to use `not.toBeNull()`. All tests, including the `cost-dashboard` UI tests and backend pricing tests, are now passing successfully.

---
*PR created automatically by Jules for task [2726580081214456547](https://jules.google.com/task/2726580081214456547) started by @wbbsuper*