### PR TITLE
fix(queue): enforce RLS context in PgTaskQueue and add concurrency tests

### DIFF
--- a/src/server/orchestration/queue/pg_queue.rs
+++ b/src/server/orchestration/queue/pg_queue.rs
@@ -19,6 +19,7 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
         if jobs.is_empty() { return Ok(()); }
         ::server_telemetry::record_queue_length_sync(jobs.len() as i32, ::server_telemetry::get_deployment_mode());
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
+        ::server_common::auth_utils::set_system_context(&mut *tx).await.map_err(|e| e.to_string())?;
 
         let mut current_depths = std::collections::HashMap::new();
 
@@ -92,12 +93,14 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
     }
 
     async fn enqueue(&self, job: Job) -> Result<(), String> {
+        let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
+        ::server_common::auth_utils::set_org_context(&mut *tx, &job.tenant_id).await.map_err(|e| e.to_string())?;
         ::server_telemetry::record_queue_length_sync(1, ::server_telemetry::get_deployment_mode());
         let payload_json: serde_json::Value = serde_json::from_str(&job.payload).unwrap_or(serde_json::Value::Null);
 
         let count_row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM ohc_job_queue WHERE tenant_id = $1 AND status = 'PENDING'")
             .bind(&job.tenant_id)
-            .fetch_one(&*self.pool)
+            .fetch_one(&mut *tx)
             .await
             .unwrap_or((0,));
 
@@ -118,10 +121,11 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
         .bind(payload_json)
         .bind(next_retry_at)
         .bind(&job.tenant_id)
-        .execute(&*self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| e.to_string())?;
 
+        tx.commit().await.map_err(|e| e.to_string())?;
         Ok(())
     }
 
@@ -131,6 +135,7 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
         }
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
+        ::server_common::auth_utils::set_system_context(&mut *tx).await.map_err(|e| e.to_string())?;
 
         let role_placeholders = roles.iter().enumerate().map(|(i, _)| format!("${}", i + 1)).collect::<Vec<_>>().join(",");
         let query_str = format!(
@@ -190,9 +195,11 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
     }
 
     async fn complete(&self, job_id: &str) -> Result<(), String> {
+        let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
+        ::server_common::auth_utils::set_system_context(&mut *tx).await.map_err(|e| e.to_string())?;
         let row = sqlx::query("UPDATE ohc_job_queue SET status = 'COMPLETED', updated_at = CURRENT_TIMESTAMP WHERE id = $1 RETURNING updated_at, next_retry_at")
             .bind(job_id)
-            .fetch_optional(&*self.pool)
+            .fetch_optional(&mut *tx)
             .await
             .map_err(|e| e.to_string())?;
 
@@ -204,11 +211,13 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
             let latency = (updated - next_retry_at).num_milliseconds() as f64 / 1000.0;
             ::server_telemetry::record_task_processing_latency(::server_telemetry::get_deployment_mode(), latency);
         }
+        tx.commit().await.map_err(|e| e.to_string())?;
         Ok(())
     }
 
     async fn fail(&self, job_id: &str, _reason: &str) -> Result<(), String> {
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
+        ::server_common::auth_utils::set_system_context(&mut *tx).await.map_err(|e| e.to_string())?;
 
         let row = sqlx::query("SELECT retry_count, max_retries, tenant_id, payload FROM ohc_job_queue WHERE id = $1 FOR UPDATE")
             .bind(job_id)

--- a/src/server/orchestration/queue/pg_queue_test.rs
+++ b/src/server/orchestration/queue/pg_queue_test.rs
@@ -120,3 +120,75 @@ async fn test_pg_fail_max_retries_dead_letter() {
     assert_eq!(dl_payload, "{\"test\":\"payload\"}");
     assert_eq!(dl_error_message, "test reason");
 }
+
+#[tokio::test]
+async fn test_pg_queue_concurrent_workers() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    if std::env::var("OHC_DATABASE_URL").is_err() {
+        return;
+    }
+
+    let database_url = std::env::var("OHC_DATABASE_URL").unwrap();
+    let pool = PgPoolOptions::new()
+        .max_connections(20)
+        .connect(&database_url)
+        .await
+        .unwrap();
+
+    let queue = Arc::new(PgTaskQueue::new(Arc::new(pool.clone())));
+
+    // Clean queue
+    sqlx::query("DELETE FROM ohc_job_queue").execute(&pool).await.unwrap();
+
+    // Enqueue 100 jobs
+    let mut jobs = Vec::new();
+    for i in 0..100 {
+        jobs.push(Job {
+            id: format!("job-concurrent-{}", i),
+            tenant_id: "concurrent_tenant".to_string(),
+            parent_task_id: "parent-1".to_string(),
+            job_type: "concurrent-role".to_string(),
+            payload: "{}".to_string(),
+            status: "PENDING".to_string(),
+            retry_count: 0,
+            max_retries: 3,
+            next_retry_at: Utc::now(),
+            locked_until: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        });
+    }
+    queue.enqueue_batch(jobs).await.unwrap();
+
+    let processed_count = Arc::new(AtomicUsize::new(0));
+    let mut workers = Vec::new();
+
+    for _ in 0..5 {
+        let q = queue.clone();
+        let count = processed_count.clone();
+        workers.push(tokio::spawn(async move {
+            loop {
+                let job = q.dequeue(vec!["concurrent-role".to_string()], 0, 0).await.unwrap();
+                match job {
+                    Some(j) => {
+                        q.complete(&j.id).await.unwrap();
+                        count.fetch_add(1, Ordering::SeqCst);
+                    }
+                    None => break, // No more jobs
+                }
+            }
+        }));
+    }
+
+    for w in workers {
+        w.await.unwrap();
+    }
+
+    assert_eq!(processed_count.load(Ordering::SeqCst), 100, "Exactly 100 jobs should be executed");
+
+    // Verify 0 duplicates or pending jobs
+    let remaining: (i64,) = sqlx::query_as("SELECT count(*) FROM ohc_job_queue WHERE status = 'PENDING'")
+        .fetch_one(&pool).await.unwrap();
+    assert_eq!(remaining.0, 0, "There should be no pending jobs left");
+}


### PR DESCRIPTION
Enforces Row Level Security (RLS) across `PgTaskQueue` interactions.
`PgTaskQueue`'s queue interactions are executed in explicit transactions with correct RLS configurations (`set_org_context` and `set_system_context`).

A concurrent test has also been introduced demonstrating the multi-worker robustness pulling from an isolated tenant safely.

---
*PR created automatically by Jules for task [1801882164935313266](https://jules.google.com/task/1801882164935313266) started by @ql-owo-lp*

Resolves #27610