### PR TITLE
fix: handle row-level security for queue operations and add concurrent tests

### DIFF
--- a/src/server/orchestration/queue/pg_queue.rs
+++ b/src/server/orchestration/queue/pg_queue.rs
@@ -131,6 +131,7 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
         }
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
+        ::server_common::auth_utils::set_system_context(&mut *tx).await.map_err(|e| e.to_string())?;
 
         let role_placeholders = roles.iter().enumerate().map(|(i, _)| format!("${}", i + 1)).collect::<Vec<_>>().join(",");
         let query_str = format!(
@@ -190,9 +191,11 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
     }
 
     async fn complete(&self, job_id: &str) -> Result<(), String> {
+        let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
+        ::server_common::auth_utils::set_system_context(&mut *tx).await.map_err(|e| e.to_string())?;
         let row = sqlx::query("UPDATE ohc_job_queue SET status = 'COMPLETED', updated_at = CURRENT_TIMESTAMP WHERE id = $1 RETURNING updated_at, next_retry_at")
             .bind(job_id)
-            .fetch_optional(&*self.pool)
+            .fetch_optional(&mut *tx)
             .await
             .map_err(|e| e.to_string())?;
 
@@ -204,11 +207,13 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
             let latency = (updated - next_retry_at).num_milliseconds() as f64 / 1000.0;
             ::server_telemetry::record_task_processing_latency(::server_telemetry::get_deployment_mode(), latency);
         }
+        tx.commit().await.map_err(|e| e.to_string())?;
         Ok(())
     }
 
     async fn fail(&self, job_id: &str, _reason: &str) -> Result<(), String> {
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
+        ::server_common::auth_utils::set_system_context(&mut *tx).await.map_err(|e| e.to_string())?;
 
         let row = sqlx::query("SELECT retry_count, max_retries, tenant_id, payload FROM ohc_job_queue WHERE id = $1 FOR UPDATE")
             .bind(job_id)

--- a/src/server/orchestration/queue/pg_queue_test.rs
+++ b/src/server/orchestration/queue/pg_queue_test.rs
@@ -120,3 +120,69 @@ async fn test_pg_fail_max_retries_dead_letter() {
     assert_eq!(dl_payload, "{\"test\":\"payload\"}");
     assert_eq!(dl_error_message, "test reason");
 }
+
+#[tokio::test]
+async fn test_pg_concurrent_dequeue() {
+    if std::env::var("OHC_DATABASE_URL").is_err() {
+        return;
+    }
+
+    let database_url = std::env::var("OHC_DATABASE_URL").unwrap();
+    let pool = PgPoolOptions::new()
+        .max_connections(20)
+        .connect(&database_url)
+        .await
+        .unwrap();
+
+    let queue = Arc::new(PgTaskQueue::new(Arc::new(pool.clone())));
+
+    // Clean up before test
+    sqlx::query("DELETE FROM ohc_job_queue").execute(&pool).await.unwrap();
+
+    // Enqueue 100 jobs
+    let mut jobs = Vec::new();
+    for i in 0..100 {
+        jobs.push(Job {
+            id: format!("job-concurrent-{}", i),
+            tenant_id: "test_org".to_string(),
+            parent_task_id: "parent-1".to_string(),
+            job_type: "concurrent-role".to_string(),
+            payload: "{}".to_string(),
+            status: "PENDING".to_string(),
+            retry_count: 0,
+            max_retries: 3,
+            next_retry_at: Utc::now() - chrono::Duration::seconds(10),
+            locked_until: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        });
+    }
+    queue.enqueue_batch(jobs).await.unwrap();
+
+    // Spin up 5 workers
+    let mut handles = Vec::new();
+    let processed_count = Arc::new(tokio::sync::Mutex::new(0));
+
+    for _ in 0..5 {
+        let q = queue.clone();
+        let count_ref = processed_count.clone();
+        handles.push(tokio::spawn(async move {
+            loop {
+                let job_opt = q.dequeue(vec!["concurrent-role".to_string()], 0, 0).await.unwrap();
+                if let Some(job) = job_opt {
+                    q.complete(&job.id).await.unwrap();
+                    let mut c = count_ref.lock().await;
+                    *c += 1;
+                } else {
+                    break;
+                }
+            }
+        }));
+    }
+
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    assert_eq!(*processed_count.lock().await, 100);
+}


### PR DESCRIPTION
Resolves #27610

Added `set_system_context` to `PgTaskQueue` methods so background workers running on their own connections can bypass Row Level Security to perform queue coordination across all tenants. 

Also added `test_pg_concurrent_dequeue` to ensure there are no race conditions when scaling up multiple queue workers against the Postgres DB queue implementation.

---
*PR created automatically by Jules for task [5293142853734880775](https://jules.google.com/task/5293142853734880775) started by @ql-owo-lp*