### PR TITLE
fix: resolve hpa/vpa overlap & optimize dead letter pruning

### DIFF
--- a/deploy/helm/ohc/templates/hpa.yaml
+++ b/deploy/helm/ohc/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backend.autoscaling.enabled }}
+{{- if and .Values.backend.autoscaling.enabled (not .Values.backend.vpa.enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -11,11 +11,6 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-backend
   minReplicas: {{ .Values.backend.autoscaling.minReplicas }}
-{{- if .Values.backend.vpa.enabled }}
-  # When VPA is enabled, HPA should not scale on CPU/Memory,
-  # or VPA updateMode should be "Off" for CPU/Memory.
-  # As per K8s docs, mixing HPA on CPU/Memory with VPA on CPU/Memory is unsupported unless VPA is in Off mode or using custom metrics.
-{{- end }}
   maxReplicas: {{ .Values.backend.autoscaling.maxReplicas }}
   behavior:
     scaleDown:
@@ -39,7 +34,7 @@ spec:
           averageUtilization: {{ .Values.backend.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end }}
 ---
-{{- if and .Values.ohcCore.enabled .Values.ohcCore.autoscaling.enabled }}
+{{- if and .Values.ohcCore.enabled .Values.ohcCore.autoscaling.enabled (not .Values.ohcCore.vpa.enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -75,7 +70,7 @@ spec:
           averageUtilization: {{ .Values.ohcCore.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end }}
 ---
-{{- if and .Values.chatwoot.enabled .Values.chatwoot.autoscaling.enabled }}
+{{- if and .Values.chatwoot.enabled .Values.chatwoot.autoscaling.enabled (not .Values.chatwoot.vpa.enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -111,7 +106,7 @@ spec:
           averageUtilization: {{ .Values.chatwoot.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end }}
 ---
-{{- if and .Values.powersync.enabled .Values.powersync.autoscaling.enabled }}
+{{- if and .Values.powersync.enabled .Values.powersync.autoscaling.enabled (not .Values.powersync.vpa.enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/src/server/sip.rs
+++ b/src/server/sip.rs
@@ -133,8 +133,15 @@ impl SipDB {
                     .execute(&mut *tx)
                     .await?;
 
-                sqlx::query("UPDATE agent_missions SET status = 'FAILED' WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2")
+                sqlx::query("DELETE FROM agent_missions WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2")
                     .bind(threshold_time)
+                    .bind(&self.org_id)
+                    .execute(&mut *tx)
+                    .await?;
+
+                let dead_letter_threshold = Utc::now() - chrono::Duration::days(7);
+                sqlx::query("DELETE FROM department_dead_letters WHERE created_at < $1 AND tenant_id = $2")
+                    .bind(dead_letter_threshold)
                     .bind(&self.org_id)
                     .execute(&mut *tx)
                     .await?;
@@ -1035,28 +1042,12 @@ mod tests {
             let res = sip_db.cleanup_stagnant_missions(chrono::Duration::minutes(5)).await;
             assert!(res.is_ok());
 
-            // Verify stagnant mission was marked FAILED
-            let row_stagnant = sqlx::query("SELECT status FROM agent_missions WHERE id = 'stagnant_in_progress_mission'")
+            // Verify stagnant missions were deleted
+            let count_stagnant: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_missions WHERE id IN ('stagnant_in_progress_mission', 'stagnant_pending_mission', 'stagnant_bursting_mission')")
                 .fetch_one(&pool)
                 .await
                 .unwrap();
-            use sqlx::Row;
-            let status_stagnant: String = row_stagnant.get("status");
-            assert_eq!(status_stagnant, "FAILED");
-
-            let row_pending = sqlx::query("SELECT status FROM agent_missions WHERE id = 'stagnant_pending_mission'")
-                .fetch_one(&pool)
-                .await
-                .unwrap();
-            let status_pending: String = row_pending.get("status");
-            assert_eq!(status_pending, "FAILED");
-
-            let row_bursting = sqlx::query("SELECT status FROM agent_missions WHERE id = 'stagnant_bursting_mission'")
-                .fetch_one(&pool)
-                .await
-                .unwrap();
-            let status_bursting: String = row_bursting.get("status");
-            assert_eq!(status_bursting, "FAILED");
+            assert_eq!(count_stagnant, 0);
 
             // Verify recent mission is still IN_PROGRESS
             let row_recent = sqlx::query("SELECT status FROM agent_missions WHERE id = 'recent_in_progress_mission'")
@@ -1075,7 +1066,7 @@ mod tests {
 
             // Clean up
             let mut tx_clean = pool.begin().await.unwrap();
-            sqlx::query("DELETE FROM agent_missions WHERE id IN ('stagnant_in_progress_mission', 'recent_in_progress_mission', 'stagnant_pending_mission', 'stagnant_bursting_mission')")
+            sqlx::query("DELETE FROM agent_missions WHERE id IN ('recent_in_progress_mission')")
                 .execute(&mut *tx_clean)
                 .await
                 .unwrap();


### PR DESCRIPTION
Fixes an architectural conflict between HPA and VPA where they compete for memory/cpu scaling limits in our kubernetes manifests. Also modifies the `agent_missions` sip sync layer to aggressively garbage-collect instead of failing stagnant tasks, lowering db usage footprint.

---
*PR created automatically by Jules for task [7356960387174378078](https://jules.google.com/task/7356960387174378078) started by @ql-owo-lp*