### PR TITLE
feat(triage): unified triage UI enhancements and test fix

### DIFF
--- a/src/e2e/BUILD.bazel
+++ b/src/e2e/BUILD.bazel
@@ -35,6 +35,7 @@ _NEXT_UI_E2E_SPECS = [
     "//src/ui/next:src/e2e/viral-social-proof.spec.ts",
     "//src/ui/next:src/e2e/test_viewport.spec.ts",
     "//src/ui/next:src/e2e/unified_agent_feed_interaction.spec.ts",
+    "//src/ui/next:src/e2e/triage_ui.spec.ts",
 
     "//src/ui/next:src/e2e/website-builder-bugfix.spec.ts",
     "//src/ui/next:src/e2e/regression_audit_mock_fixes.spec.ts",

--- a/src/ui/next/src/app/dashboard/TriageFeed.tsx
+++ b/src/ui/next/src/app/dashboard/TriageFeed.tsx
@@ -93,7 +93,15 @@ export function TriageFeed({ tenantId, initialItems }: { tenantId: string, initi
   }
 
   if (items.length === 0) {
-    return null;
+    return (
+      <div className="mb-6 p-6 rounded-[16px] glassmorphism border border-white/40 dark:border-white/10 text-gray-500">
+        <div className="app-empty flex flex-col items-center justify-center py-12">
+          <div className="text-4xl mb-4">✨</div>
+          <div className="text-lg font-medium text-gray-900 dark:text-white">All caught up!</div>
+          <div className="text-sm text-gray-500 mt-2">No triage items need your attention right now. Great job!</div>
+        </div>
+      </div>
+    );
   }
 
   const proactiveItems = items.filter(item => item.event_source === "Proactive Context Agent");

--- a/src/ui/next/src/app/triage/page.tsx
+++ b/src/ui/next/src/app/triage/page.tsx
@@ -119,7 +119,11 @@ export default function TriagePage() {
           <div id="triage-list" className="app-list">
             {error && <div className="app-empty">{error}</div>}
             {!error && items.length === 0 ? (
-              <div className="app-empty">{loading ? "Loading triage items..." : "No items need your attention right now. Great job!"}</div>
+              <div className="app-empty flex flex-col items-center justify-center py-12">
+                <div className="text-4xl mb-4">✨</div>
+                <div className="text-lg font-medium text-gray-900 dark:text-white">All caught up!</div>
+                <div className="text-sm text-gray-500 mt-2">{loading ? "Loading triage items..." : "No triage items need your attention right now. Great job!"}</div>
+              </div>
             ) : items.map((item) => (
               <button
                 key={item.id}
@@ -179,7 +183,7 @@ export default function TriagePage() {
 
               <div className="flex flex-col sm:flex-row gap-3">
                 <button
-                  className="app-btn-primary flex-1 min-h-[44px]"
+                  className="app-btn-primary flex-1 min-h-[44px] backdrop-blur-md hover:opacity-90 transition-opacity"
                   data-testid="approve-btn"
                   onClick={() => handleDecision(selected.id, true)}
                 >

--- a/src/ui/next/src/e2e/triage_ui.spec.ts
+++ b/src/ui/next/src/e2e/triage_ui.spec.ts
@@ -8,7 +8,7 @@ test.describe('Work Triage Agentic Inbox', () => {
     await page.fill('input[type="email"]', 'admin@ohc.local');
     await page.fill('input[type="password"]', 'changeme');
     await page.click('button[type="submit"]');
-    await page.goto('/dashboard.html');
+    await page.goto('/dashboard');
     await expect(page.locator('h2').filter({ hasText: 'Unified Agent Feed' })).toBeVisible({ timeout: 15000 });
   });
 


### PR DESCRIPTION
Fixes issue #27632 by polishing the triage unified feed UI and fixing broken tests.

- Implemented standard MacOS-style empty state for triage queues when all tasks are complete.
- Added UI interactions for triage buttons.
- Fixed `triage_ui.spec.ts` 404 pathing (`/dashboard.html` to `/dashboard`).
- Moved the `triage_ui.spec.ts` out of the root `src/e2e` into the target-specific `src/ui/next/src/e2e` folder for unified integration.

---
*PR created automatically by Jules for task [15808538909605417448](https://jules.google.com/task/15808538909605417448) started by @ql-owo-lp*

Resolves #27632