### PR TITLE
fix: Resolve Playwright test failure for Pricing Branding Growth Loop

### DIFF
--- a/src/e2e/pricing-branding-loop.spec.ts
+++ b/src/e2e/pricing-branding-loop.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Pricing Branding Growth Loop', () => {
     test('Powered by OHC footer is present on Pricing page', async ({ page }) => {

--- a/src/ui/next/src/app/components/PoweredByOHC.tsx
+++ b/src/ui/next/src/app/components/PoweredByOHC.tsx
@@ -39,7 +39,7 @@ export function PoweredByOHC({ tenantId }: PoweredByOHCProps) {
   return (
     <div
       ref={containerRef}
-      className="flex flex-col justify-center items-center mt-8 pb-4 relative"
+      className="powered-by-footer flex flex-col justify-center items-center mt-8 pb-4 relative"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >


### PR DESCRIPTION
This PR fixes a failing Playwright E2E test (`pricing-branding-loop.spec.ts`).

1. **Test Fix**: Updated `src/e2e/pricing-branding-loop.spec.ts` to import `test` and `expect` from the local `./fixtures` file instead of directly from `@playwright/test`.
2. **Component Fix**: Added the missing `powered-by-footer` CSS class to the `PoweredByOHC` component (`src/ui/next/src/app/components/PoweredByOHC.tsx`) to allow the test to successfully locate it.

Both the specific test and the full test suite (`bazel test //...`) have been successfully run and pass.

---
*PR created automatically by Jules for task [13658417824025125731](https://jules.google.com/task/13658417824025125731) started by @ql-owo-lp*