### PR TITLE
⚡ Bolt: [performance improvement] SWR for UI Triage Endpoint

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -70,6 +70,7 @@ mod triage_cache_tests {
         let cache = UI_TRIAGE_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(get_redis_client()));
         // Note: we can't do full integration test easily without db setup, but we verify get/set compiles and runs
         let _ = cache.get("test_key").await;
+        let _ = cache.get_with_swr("test_key").await;
     }
 }
 
@@ -2961,13 +2962,26 @@ pub async fn list_ui_triage_handler(
     axum::extract::Query(query): axum::extract::Query<UiTenantQuery>,
 ) -> axum::response::Response {
     use axum::response::IntoResponse;
-    use sqlx::Row;
     let tenant_id = ui_tenant_id(&query);
     let mobile_optimized = query.mobile_optimized.unwrap_or(false);
 
     let cache_key = format!("ui_triage:{}:mobile:{}", tenant_id, mobile_optimized);
     let cache = UI_TRIAGE_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(get_redis_client()));
-    if let Some(cached) = cache.get(&cache_key).await {
+    if let Some((cached, is_stale)) = cache.get_with_swr(&cache_key).await {
+        if !is_stale {
+            return (axum::http::StatusCode::OK, axum::Json(cached)).into_response();
+        }
+
+        let db_bg = db.clone();
+        let t_bg = tenant_id.clone();
+        let cache_key_bg = cache_key.clone();
+        tokio::spawn(async move {
+            if let Ok(items) = load_ui_triage_from_db(&db_bg, &t_bg, mobile_optimized).await {
+                if let Some(c) = UI_TRIAGE_CACHE.get() {
+                    c.set(&cache_key_bg, items, std::time::Duration::from_secs(10)).await;
+                }
+            }
+        });
         return (axum::http::StatusCode::OK, axum::Json(cached)).into_response();
     }
 


### PR DESCRIPTION
Refactors the UI triage API handler to use `get_with_swr` instead of `.get()` to achieve sub-second latency on the frontend interface using the cache Stale-While-Revalidate pattern. Also resolves unused compiler warnings in `src/server/lib.rs`. All Playwright E2E and Bazel tests passed after the changes.

---
*PR created automatically by Jules for task [5706076417940830626](https://jules.google.com/task/5706076417940830626) started by @ql-owo-lp*