### PR TITLE
Wizard: Ensure Onboarding Steps Conform to UX Constraints

### DIFF
--- a/src/e2e/onboarding.spec.ts
+++ b/src/e2e/onboarding.spec.ts
@@ -261,7 +261,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     await expect(generateButton).toBeDisabled();
 
     // We shouldn't see a loading state.
-    const loadingState = page.getByText('Generating...');
+    const loadingState = page.getByText('Building Your Business...');
     await expect(loadingState).not.toBeVisible();
     await expect(page.getByRole('heading', { name: "Tell us about your business" })).toBeVisible();
   });

--- a/src/e2e/operate_business.spec.ts
+++ b/src/e2e/operate_business.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from './fixtures';
 
 test('Maya operates her custom cake business', async ({ page }) => {
-  await page.goto('/website-builder');
+  await page.goto('/onboarding');
   await expect(page.getByRole('heading', { name: '10-Minute Setup Wizard' })).toBeVisible();
   await page.goto('/dashboard');
   await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();

--- a/src/e2e/setup_wizard_comprehensive.spec.ts
+++ b/src/e2e/setup_wizard_comprehensive.spec.ts
@@ -20,7 +20,7 @@ test.describe('Business Setup Wizard Comprehensive Flow', () => {
     }, id);
 
     // We only have the instant build flow now.
-    await page.goto('/website-builder');
+    await page.goto('/onboarding');
     await page.waitForLoadState('networkidle');
 
 
@@ -33,16 +33,16 @@ test.describe('Business Setup Wizard Comprehensive Flow', () => {
 
     await page.getByRole('button', { name: /Generate Storefront/ }).click();
 
-    await expect(page.getByText('Agents are building your store...')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Building Your Business...')).toBeVisible({ timeout: 10000 });
 
     // Verify glassmorphism style is present on loading screen
-    await expect(page.locator('.glassmorphism', { hasText: 'Agents are building your store' }).first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.glassmorphism', { hasText: 'Building Your Business' }).first()).toBeVisible({ timeout: 5000 });
 
-    await expect(page.getByRole('heading', { name: /Success! Your business is live!/ })).toBeVisible({ timeout: 20000 });
+    await expect(page.getByRole('heading', { name: /You're Live!/ })).toBeVisible({ timeout: 20000 });
   });
 
   test('validates empty input in Tell us about your business', async ({ page }) => {
-    await page.goto('/website-builder');
+    await page.goto('/onboarding');
     await page.getByRole('button', { name: /Instant Build/ }).click();
 
     // The textarea starts empty
@@ -54,7 +54,7 @@ test.describe('Business Setup Wizard Comprehensive Flow', () => {
   });
 
   test('clears previous bio input when re-entering Instant Build', async ({ page }) => {
-    await page.goto('/website-builder');
+    await page.goto('/onboarding');
 
     // Enter instant build, fill bio, then go back
     await page.getByRole('button', { name: /Instant Build/ }).click();
@@ -73,7 +73,7 @@ test.describe('Business Setup Wizard Comprehensive Flow', () => {
   });
 
   test('verifies Start My Business navigation is distinct from Instant Build', async ({ page }) => {
-    await page.goto('/website-builder');
+    await page.goto('/onboarding');
     await page.getByRole('button', { name: /Start My Business/ }).click();
     await expect(page.getByRole('heading', { name: 'What kind of business are you building?' })).toBeVisible();
     await expect(page.getByRole('button', { name: /Online Store/ })).toBeVisible();
@@ -81,7 +81,7 @@ test.describe('Business Setup Wizard Comprehensive Flow', () => {
   });
 
   test('Instant Build gracefully handles whitespace-only bio input', async ({ page }) => {
-    await page.goto('/website-builder');
+    await page.goto('/onboarding');
     await page.getByRole('button', { name: /Instant Build/ }).click();
 
     const generateBtn = page.getByRole('button', { name: /Generate Storefront/ });
@@ -95,7 +95,7 @@ test.describe('Business Setup Wizard Comprehensive Flow', () => {
   });
 
   test('Powered by OHC link is visible on step 0', async ({ page }) => {
-    await page.goto('/website-builder');
+    await page.goto('/onboarding');
     const poweredLink = page.getByRole('link', { name: /Powered by OHC/i });
     await expect(poweredLink).toBeVisible();
     await expect(poweredLink).toHaveAttribute('href', '/onboarding?ref=website-builder');

--- a/src/e2e/wizard_cross_device.spec.ts
+++ b/src/e2e/wizard_cross_device.spec.ts
@@ -8,7 +8,7 @@ test.describe('Wizard Cross Device E2E', () => {
       localStorage.setItem('user_id', tenantId);
       localStorage.removeItem('website-builder-storage');
     }, 'storefront');
-    await page.goto('/website-builder');
+    await page.goto('/onboarding');
     await page.waitForLoadState('networkidle');
 
     // 2. Click Start My Business to advance to step 1
@@ -52,7 +52,7 @@ test.describe('Wizard Cross Device E2E', () => {
         localStorage.setItem('user_id', 'storefront');
     }, wizardState);
 
-    await newPage.goto('/website-builder');
+    await newPage.goto('/onboarding');
 
     // 5. Verify the business name and step was properly restored
     await expect(newPage.getByRole('heading', { name: 'Give your business a name' })).toBeVisible();

--- a/src/e2e/wizard_refinement.spec.ts
+++ b/src/e2e/wizard_refinement.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './fixtures';
 
 test.describe('Wizard Refinement E2E', () => {
   test('keeps the setup flow plain-language', async ({ page }) => {
-    await page.goto('/website-builder');
+    await page.goto('/onboarding');
     await expect(page.getByRole('heading', { name: '10-Minute Setup Wizard' })).toBeVisible();
     await page.getByRole('button', { name: 'Instant Build' }).click();
     await expect(page.getByRole('heading', { name: 'Tell us about your business' })).toBeVisible();


### PR DESCRIPTION
* Removed stale `/website-builder` usage in E2E setup wizard tests and replaced with `/onboarding`
* Fixed text assertions in the instant-build e2e spec file and comprehensive setup wizard e2e to match the actual UI (`"Building Your Business..."` and `"You're Live!"`)
* Verified passing test suite locally

---
*PR created automatically by Jules for task [9412666688218842405](https://jules.google.com/task/9412666688218842405) started by @ql-owo-lp*