### PR TITLE
test: Restore missing test db helper pools

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -50,6 +50,24 @@ pub struct DB {
 }
 
 
+#[cfg(test)]
+pub async fn create_sqlite_pool_for_test() -> sqlx::SqlitePool {
+    let db_id = uuid::Uuid::new_v4().to_string();
+    let uri = format!("sqlite:file:{}?mode=memory&cache=shared", db_id);
+    sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(2)
+        .connect(&uri)
+        .await
+        .unwrap()
+}
+
+#[cfg(test)]
+pub async fn create_dummy_pg_pool() -> sqlx::PgPool {
+    sqlx::postgres::PgPoolOptions::new()
+        .connect_lazy("postgres://postgres:postgres@localhost:5432/test")
+        .unwrap()
+}
+
 #[derive(serde::Serialize)]
 pub struct SearchResult {
     pub id: String,


### PR DESCRIPTION
**Description:**
Restores the `create_sqlite_pool_for_test` and `create_dummy_pg_pool` helper functions that were unintentionally dropped from `src/server/db.rs` during a prior UI refinement pass (`e83c162a`), which broke compilation for several integration tests in the `server_orchestration_test` suite.

The functions are safely restored with `#[cfg(test)]` guards to prevent leakage into production binary.

**Testing:**
Ran `bazelisk test //src/server/...` and all tests now compile and pass.

---
*PR created automatically by Jules for task [7148456594262339296](https://jules.google.com/task/7148456594262339296) started by @ql-owo-lp*