### PR TITLE
🔗 Link: Fix triage payload saving logic

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -2928,7 +2928,6 @@ pub async fn create_ui_triage_item_handler(
 
             if let Some(action_type) = payload.action_type {
                 let action_id = format!("act-{}", uuid::Uuid::new_v4());
-                let action_payload = payload.action_payload.unwrap_or_else(|| "".to_string());
                 if let Err(e) = sqlx::query(
                     "INSERT INTO triage_proposed_actions (id, triage_item_id, tenant_id, action_type, payload) VALUES ($1, $2, $3, $4, $5)"
                 )
@@ -2936,7 +2935,7 @@ pub async fn create_ui_triage_item_handler(
                 .bind(&new_id)
                 .bind(&tenant_id)
                 .bind(&action_type)
-                .bind(&action_payload)
+                .bind(&payload.action_payload)
                 .execute(&mut *tx).await {
                     tracing::error!("Failed to insert triage action: {:?}", e);
                     return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({"error": e.to_string()}))).into_response();


### PR DESCRIPTION
Fix empty action_payload issue when updating action payload to backend database in `/api/ui/triage`.

---
*PR created automatically by Jules for task [5729124170091671240](https://jules.google.com/task/5729124170091671240) started by @wbbsuper*

Resolves #27632