### PR TITLE
✍️ Scribe: Contextual Tooltips Registry Update

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -155,6 +155,18 @@ pub fn get_tooltips_registry() -> &'static RwLock<HashMap<String, String>> {
     m.insert("checkout-plan-upgrade-tooltip".to_string(), "Click here to securely subscribe to the plan.".to_string());
     m.insert("change-vibe-tooltip".to_string(), "Change the theme and colors of your website.".to_string());
     m.insert("help-center-nav-btn".to_string(), "Access the Help Center".to_string());
+    m.insert("search-input".to_string(), "Search our knowledge base for help articles.".to_string());
+    m.insert("nav-store".to_string(), "Your Storefront. This is where you manage what you sell.".to_string());
+    m.insert("nav-agents".to_string(), "AI Helpers. These are your digital employees.".to_string());
+    m.insert("ohc-help-btn".to_string(), "Need help? Click here to access our Help Center and tutorials.".to_string());
+    m.insert("ohc-floating-help-btn".to_string(), "Need help? Click here to access our Help Center and tutorials.".to_string());
+    m.insert("ask-ai-tooltip".to_string(), "Open AI Help Chat to get answers instantly. It can guide you to the right article.".to_string());
+    m.insert("inbox-activity-tooltip".to_string(), "Keep track of recent customer messages. Reply or assign them to an AI agent.".to_string());
+    m.insert("recent-orders-tooltip".to_string(), "View the latest orders placed by your customers.".to_string());
+    m.insert("total-sales-tooltip".to_string(), "Total revenue generated from all your orders.".to_string());
+    m.insert("kairos-nav-link-tooltip".to_string(), "Click here to see what your AI helpers are working on and how they plan.".to_string());
+    m.insert("help-btn-tooltip".to_string(), "Need help? Click here to access our Help Center and tutorials.".to_string());
+    m.insert("pricing-tier-tooltip".to_string(), "Select the plan that best fits your business needs.".to_string());
     m.insert("dashboard-walkthrough-btn".to_string(), "Take a tour of the dashboard".to_string());
     m.insert("pos-walkthrough-btn".to_string(), "Take a tour of Quick Charge POS".to_string());
     m.insert("assistant-walkthrough-btn".to_string(), "Take a tour of the Assistant Workspace".to_string());


### PR DESCRIPTION
The goal of this task was to implement contextual tooltips as part of the documentation and in-app assistance feature. By adding these tooltips directly to the `TOOLTIPS_REGISTRY`, they can be correctly served by the `/api/tooltips` endpoint instead of relying exclusively on fallbacks.

## Changes
- `src/server/lib.rs`: Added mapping for missing tooltips (`search-input`, `nav-store`, `nav-agents`, `ohc-help-btn`, `ohc-floating-help-btn`, `ask-ai-tooltip`, `inbox-activity-tooltip`, `recent-orders-tooltip`, `total-sales-tooltip`, `kairos-nav-link-tooltip`, `help-btn-tooltip`, `pricing-tier-tooltip`).

## Testing
- Ran `bazel test //src/ui/next:next_vitest`.
- Ensured tests passed and checked the Rust binary build using cargo locally.

---
*PR created automatically by Jules for task [9173341892702495399](https://jules.google.com/task/9173341892702495399) started by @ql-owo-lp*