### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Enforce SPIFFE ID validation on realtime mesh broadcasts

### DIFF
--- a/src/server/auth/grpc.rs
+++ b/src/server/auth/grpc.rs
@@ -115,7 +115,7 @@ fn hmac_token(tok: &str) -> Vec<u8> {
     mac.finalize().into_bytes().to_vec()
 }
 
-fn validate_spiffe_id(id: &str) -> Result<(), Status> {
+pub fn validate_spiffe_id(id: &str) -> Result<(), Status> {
     let lower = id.to_lowercase();
     if lower.contains("%2f") || lower.contains("%25") {
         return Err(Status::permission_denied(format!("invalid SPIFFE ID: encoded slashes: {}", id)));
@@ -185,7 +185,12 @@ mod tests {
 
     #[test]
     fn test_check_token() {
-        let token = "secret_token";
+        // Try to read secret, otherwise set it via env
+        if std::env::var("JWT_SECRET").is_err() {
+            unsafe { std::env::set_var("JWT_SECRET", "test_secret"); }
+        }
+
+        let token = "test_token";
         let hash = hmac_token(token);
         let cfg = AuthConfig { mode: AuthMode::Token(hash) };
 

--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -5,6 +5,7 @@ pub use ::server_oidc as oidc;
 pub mod orchestration;
 pub mod postgres_store;
 pub mod sqlite_store;
+pub mod grpc;
 
 use std::collections::HashMap;
 

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -2177,6 +2177,14 @@ async fn get_pending_approvals(
         &self,
         request: Request<AgentCapabilities>,
     ) -> Result<Response<PublishMessageResponse>, Status> {
+        let md = request.metadata();
+        let spiffe_id = crate::auth::extract_spiffe_id_from_metadata(md)
+            .map_err(|e| Status::unauthenticated(e))?;
+
+        if let Err(e) = crate::auth::grpc::validate_spiffe_id(&spiffe_id) {
+            return Err(e);
+        }
+
         let req = request.into_inner();
         if req.agent_id.is_empty() {
             return Err(Status::invalid_argument("agent_id is required"));
@@ -2211,6 +2219,14 @@ async fn get_pending_approvals(
         &self,
         request: Request<::server_ohc::orchestration::PublishMeshEventRequest>,
     ) -> Result<Response<PublishMessageResponse>, Status> {
+        let md = request.metadata();
+        let spiffe_id = crate::auth::extract_spiffe_id_from_metadata(md)
+            .map_err(|e| Status::unauthenticated(e))?;
+
+        if let Err(e) = crate::auth::grpc::validate_spiffe_id(&spiffe_id) {
+            return Err(e);
+        }
+
         let req = request.into_inner();
         if let Some(event) = req.event {
             self.publish_counter.add(1, &[opentelemetry::KeyValue::new("topic", event.topic.clone())]);
@@ -2252,6 +2268,14 @@ async fn get_pending_approvals(
         &self,
         request: Request<PublishTeammateMeshEventRequest>,
     ) -> Result<Response<PublishMessageResponse>, Status> {
+        let md = request.metadata();
+        let spiffe_id = crate::auth::extract_spiffe_id_from_metadata(md)
+            .map_err(|e| Status::unauthenticated(e))?;
+
+        if let Err(e) = crate::auth::grpc::validate_spiffe_id(&spiffe_id) {
+            return Err(e);
+        }
+
         let req = request.into_inner();
         if req.channel.is_empty() {
             return Err(Status::invalid_argument("channel is required"));


### PR DESCRIPTION
This pull request adds SPIFFE ID validation to the realtime mesh broadcast and capability advertisements within `src/server/lib.rs`.

It ensures multi-tenant isolation by verifying `spiffe_id` before publishing to `advertise_capabilities`, `publish_mesh_event` and `publish_teammate_mesh_event` via grpc interop.

Additionally:
- `validate_spiffe_id` has been made public in `src/server/auth/grpc.rs`
- Fixed an issue causing `test_check_token` to fail in isolated local unit testing due to the `JWT_SECRET` not being properly set when checking mocked tokens.

---
*PR created automatically by Jules for task [2785721614877969170](https://jules.google.com/task/2785721614877969170) started by @ql-owo-lp*