### PR TITLE
build: add missing test_delegate_mission tests to bazel group

### DIFF
--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -489,6 +489,11 @@ rust_binary(
 SERVER_LIB_TEST_GROUPS = {
     "agents": [
         "sip::tests::test_delegate_mission_tc2_agents_md",
+        "sip::tests::test_delegate_mission_tc1_no_context_root",
+        "sip::tests::test_delegate_mission_tc6_omni_context_resilience",
+        "sip::tests::test_delegate_mission_tc3_claude_md_fallback",
+        "sip::tests::test_delegate_mission_tc4_grounding_priority",
+        "sip::tests::test_delegate_mission_tc5_missing_files",
     ],
     "core": [
         "analytics::",


### PR DESCRIPTION
This pull request modifies `src/server/BUILD.bazel` to correctly execute all test cases for the "Omni-Context Sub-agent Routing" feature.

### Fix
Several tests in `src/server/sip.rs` (`test_delegate_mission_tc1`, `tc3`, `tc4`, `tc5`, `tc6`) were not grouped in the Bazel `SERVER_LIB_TEST_GROUPS` under "agents", so they were not being run automatically. This commit explicitly adds them next to `test_delegate_mission_tc2_agents_md` ensuring full test suite coverage is executed via `bazel test`.

---
*PR created automatically by Jules for task [15318237681588030572](https://jules.google.com/task/15318237681588030572) started by @wbbsuper*