### PR TITLE
fix: update e2e tests to use 'Next' instead of 'Generate My Business'

### DIFF
--- a/src/e2e/onboarding.spec.ts
+++ b/src/e2e/onboarding.spec.ts
@@ -66,7 +66,7 @@ test.describe('Onboarding Wizard E2E Flow', () => {
     await expect(audienceInput).toHaveClass(/min-h-\[44px\]/);
     await expect(audienceInput).toHaveClass(/glassmorphism/);
     await audienceInput.fill("Tech enthusiasts and developers");
-    await page.getByRole('button', { name: 'Generate My Business' }).click();
+    await page.getByRole('button', { name: 'Next' }).click();
 
     // Step 4: Review Details
     await expect(page.getByRole('heading', { name: "Review Details" })).toBeVisible({ timeout: 30000 });

--- a/src/ui/next/e2e/onboarding.spec.ts
+++ b/src/ui/next/e2e/onboarding.spec.ts
@@ -30,7 +30,7 @@ test.describe('Onboarding Flow E2E', () => {
 
     // We expect a short loading process while it talks to the "backend" intake API
     // The intake API is mocked or local, but we just click Generate.
-    await page.click('text=Generate My Business');
+    await page.click('text=Next');
 
     // It should progress to Step 2: Review Details
     await expect(page.getByText('Review Details')).toBeVisible();


### PR DESCRIPTION
- Update `src/e2e/onboarding.spec.ts` and `src/ui/next/e2e/onboarding.spec.ts` to locate the "Next" button instead of "Generate My Business" to match the actual UI text rendered by the Next.js component.
- This resolves an E2E test failure where the test timed out looking for a non-existent button.

---
*PR created automatically by Jules for task [6696465078132171227](https://jules.google.com/task/6696465078132171227) started by @ql-owo-lp*