### PR TITLE
feat: Implement Actionable Inbox for Unified Triage and Draft Agent

### DIFF
--- a/src/e2e/actionable_inbox.spec.ts
+++ b/src/e2e/actionable_inbox.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from './fixtures';
+import { e2eDbQuery } from './db_utils';
+
+test.describe('Actionable Inbox UX flow for owners on mobile', () => {
+  test.use({ viewport: { width: 375, height: 667 } });
+
+  test('Receives a message, triage generates a draft, and owner can approve via dashboard feed', async ({ page }) => {
+    const tenantId = 'e2e-tenant';
+    const message = 'Can I get a custom vegan cake for this weekend?';
+
+    const webhookResponse = await page.request.post('/api/inbox/webhook', {
+      data: {
+        tenant_id: tenantId,
+        source: 'Instagram DM',
+        sender_id: 'maya_bakes',
+        message: message,
+      }
+    });
+
+    expect(webhookResponse.ok()).toBeTruthy();
+
+    await page.waitForTimeout(2000);
+
+    await page.goto('/dashboard.html');
+
+    // We should see an Instagram DM actionable item.
+    await expect(page.locator("text=Instagram DM").first()).toBeVisible({ timeout: 15000 });
+
+    // Check that we see the customer message
+    await expect(page.getByText('Can I get a custom vegan cake for this weekend?').first()).toBeVisible();
+
+    // Check for the Approve & Send button
+    const approveBtn = page.getByTestId('approve-instagram-dm').first();
+    await expect(approveBtn).toBeVisible();
+
+    await approveBtn.click();
+
+    // The message should disappear. Wait for it to disappear.
+    await expect(page.getByText('Can I get a custom vegan cake for this weekend?').first()).not.toBeVisible();
+  });
+});

--- a/src/server/workers/message_triage_worker.rs
+++ b/src/server/workers/message_triage_worker.rs
@@ -116,10 +116,11 @@ Analyze the following incoming customer message.
 Message from {}: '{}'
 Source: {}
 
-Please extract the context, priority, and decide if the request needs a Quote, a Booking, or a General Reply.
+Please extract the context, priority, and decide if the request needs a Quote, a Booking, or a General Reply. Note if the source is Instagram DM, whatsapp or similar, explicitly mention the feature type as instagram_dm.
 Output JSON format:
 {{
     \"priority\": \"High\" or \"Medium\" or \"Low\",
+    \"feature_type\": \"instagram_dm\" or \"general\",
     \"context_summary\": \"A short one sentence summary of the request.\",
     \"action_type\": \"Draft Reply\" or \"Draft Quote\" or \"Draft Booking\",
     \"action_payload\": \"The draft reply, or quote details, or booking details.\"
@@ -131,6 +132,7 @@ Output JSON format:
 
             let mut extracted = serde_json::json!({
                 "priority": "Medium",
+                "feature_type": "general",
                 "context_summary": "Customer inquiry",
                 "action_type": "Draft Reply",
                 "action_payload": "Thanks for reaching out! We will review this and get back to you soon."
@@ -162,12 +164,16 @@ Output JSON format:
             }
 
             let priority = extracted.get("priority").and_then(|v| v.as_str()).unwrap_or("Medium");
+            let feature_type = extracted.get("feature_type").and_then(|v| v.as_str()).unwrap_or("general");
             let context_summary = extracted.get("context_summary").and_then(|v| v.as_str()).unwrap_or("Customer inquiry");
             let action_type = extracted.get("action_type").and_then(|v| v.as_str()).unwrap_or("Draft Reply");
             let action_payload = extracted.get("action_payload").and_then(|v| v.as_str()).unwrap_or("Thanks for reaching out! We will review this and get back to you soon.");
 
-            let triage_item_id = Uuid::new_v4().to_string();
-            let action_id = Uuid::new_v4().to_string();
+            let agent_feed_item_id = Uuid::new_v4().to_string();
+            let mut event_source = source.to_string();
+            if feature_type == "instagram_dm" || source.to_lowercase().contains("instagram") {
+                event_source = "instagram_dm".to_string();
+            }
 
             // Get actual customer_id if exists in payload, otherwise empty string or NULL logic
             let customer_id_val = payload.get("customer_id").and_then(|v| v.as_str());
@@ -181,32 +187,26 @@ Output JSON format:
                         .execute(&self.db.pool).await;
 
                     if let Err(e) = sqlx::query(
-                        "INSERT INTO triage_items (id, tenant_id, customer_id, source, priority, context, status) VALUES ($1, $2, $3, $4, $5, $6, 'pending')"
+                        "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, 'PENDING_APPROVAL', NOW(), NOW())"
                     )
-                    .bind(&triage_item_id)
+                    .bind(&agent_feed_item_id)
                     .bind(&tenant_id)
-                    .bind(customer_id_val)
-                    .bind(&source)
-                    .bind(&priority)
-                    .bind(&context_summary)
+                    .bind(&event_source)
+                    .bind(serde_json::json!({
+                        "customer_message": customer_message,
+                        "feature_type": event_source,
+                        "priority": priority,
+                        "context": context_summary,
+                        "inbox_message_id": message_id,
+                        "customer_id": customer_id_val
+                    }))
+                    .bind(serde_json::json!({
+                        "action_type": action_type,
+                        "draft_reply": action_payload,
+                        "inbox_message_id": message_id
+                    }))
                     .execute(&self.db.pool).await {
-                        tracing::error!("Failed to insert triage item: {}", e);
-                        let _ = sqlx::query("UPDATE ohc_job_queue SET status = 'FAILED', updated_at = NOW() WHERE id = $1")
-                            .bind(&job_id)
-                            .execute(&self.db.pool).await;
-                        return Ok(false);
-                    }
-
-                    if let Err(e) = sqlx::query(
-                        "INSERT INTO triage_proposed_actions (id, triage_item_id, tenant_id, action_type, payload) VALUES ($1, $2, $3, $4, $5)"
-                    )
-                    .bind(&action_id)
-                    .bind(&triage_item_id)
-                    .bind(&tenant_id)
-                    .bind(&action_type)
-                    .bind(&action_payload)
-                    .execute(&self.db.pool).await {
-                        tracing::error!("Failed to insert triage action: {}", e);
+                        tracing::error!("Failed to insert agent feed item: {}", e);
                         let _ = sqlx::query("UPDATE ohc_job_queue SET status = 'FAILED', updated_at = NOW() WHERE id = $1")
                             .bind(&job_id)
                             .execute(&self.db.pool).await;
@@ -225,32 +225,26 @@ Output JSON format:
                         .execute(sqlite_pool).await;
 
                     if let Err(e) = sqlx::query(
-                        "INSERT INTO triage_items (id, tenant_id, customer_id, source, priority, context, status) VALUES (?, ?, ?, ?, ?, ?, 'pending')"
+                        "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'PENDING_APPROVAL', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
                     )
-                    .bind(&triage_item_id)
+                    .bind(&agent_feed_item_id)
                     .bind(&tenant_id)
-                    .bind(customer_id_val)
-                    .bind(&source)
-                    .bind(&priority)
-                    .bind(&context_summary)
+                    .bind(&event_source)
+                    .bind(serde_json::json!({
+                        "customer_message": customer_message,
+                        "feature_type": event_source,
+                        "priority": priority,
+                        "context": context_summary,
+                        "inbox_message_id": message_id,
+                        "customer_id": customer_id_val
+                    }).to_string())
+                    .bind(serde_json::json!({
+                        "action_type": action_type,
+                        "draft_reply": action_payload,
+                        "inbox_message_id": message_id
+                    }).to_string())
                     .execute(sqlite_pool).await {
-                        tracing::error!("Failed to insert triage item (SQLite): {}", e);
-                        let _ = sqlx::query("UPDATE ohc_job_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE id = ?")
-                            .bind(&job_id)
-                            .execute(sqlite_pool).await;
-                        return Ok(false);
-                    }
-
-                    if let Err(e) = sqlx::query(
-                        "INSERT INTO triage_proposed_actions (id, triage_item_id, tenant_id, action_type, payload) VALUES (?, ?, ?, ?, ?)"
-                    )
-                    .bind(&action_id)
-                    .bind(&triage_item_id)
-                    .bind(&tenant_id)
-                    .bind(&action_type)
-                    .bind(&action_payload)
-                    .execute(sqlite_pool).await {
-                        tracing::error!("Failed to insert triage action (SQLite): {}", e);
+                        tracing::error!("Failed to insert agent feed item (SQLite): {}", e);
                         let _ = sqlx::query("UPDATE ohc_job_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE id = ?")
                             .bind(&job_id)
                             .execute(sqlite_pool).await;

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1482,23 +1482,26 @@
 
           if (item.event_source === 'instagram_dm' || item.context_payload?.feature_type === 'instagram_dm') {
             let parsedPayload = item.context_payload || {};
+            let proposedAction = item.proposed_action || {};
+            let draftReply = proposedAction.draft_reply || parsedPayload.draft_reply || '';
             return `
-              <div class="triage-item" data-testid="triage-card-${item.id}" id="triage-${item.id}" style="background: rgba(255, 255, 255, 0.4); backdrop-filter: blur(20px); border-radius: 16px; padding: 16px; border: 1px solid rgba(255,255,255,0.6);">
-                <div class="triage-header" style="margin-bottom: 12px;">
-                  <div class="triage-source" style="display: flex; align-items: center; gap: 8px;">
-                    <span style="font-size: 18px;">💬</span> <strong>Instagram DM</strong>
+              <div class="triage-item glassmorphism" data-testid="triage-card-${item.id}" id="triage-${item.id}" style="background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(30px) saturate(210%); border-radius: 16px; padding: 16px; border: 1px solid rgba(255,255,255,0.4);">
+                <div class="triage-header" style="margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center;">
+                  <div class="triage-source" style="display: flex; align-items: center; gap: 8px; font-weight: 600;">
+                    <span style="font-size: 18px;">💬</span> <strong style="color: #1D1D1F; font-family: Outfit, sans-serif;">Instagram DM</strong>
                   </div>
-                  <div class="triage-priority ${priorityClass}">${item.priority || 'Normal'}</div>
+                  <div class="triage-priority" style="font-size: 12px; font-weight: 600; color: #0066FF; background: rgba(0, 102, 255, 0.1); padding: 4px 8px; border-radius: 8px;">${item.priority || 'Action Needed'}</div>
                 </div>
-                <div class="triage-context" style="font-weight: 600; margin-bottom: 12px; font-size: 15px;">
-                  ${parsedPayload.customer_message || 'New message'}
+                <div class="triage-context" style="font-weight: 500; margin-bottom: 12px; font-size: 15px; color: #1D1D1F;">
+                  "${parsedPayload.customer_message || 'New message'}"
                 </div>
-                <div style="background: rgba(0,0,0,0.03); padding: 12px; border-radius: 12px; margin-bottom: 16px; font-size: 14px; color: #333; font-style: italic;">
-                  ${parsedPayload.draft_reply || ''}
+                <div style="background: rgba(0, 102, 255, 0.05); padding: 12px; border-radius: 12px; margin-bottom: 16px; font-size: 14px; color: #1D1D1F; border: 1px solid rgba(0, 102, 255, 0.1);">
+                  <div style="font-size: 10px; font-weight: 700; color: #0066FF; text-transform: uppercase; margin-bottom: 4px;">Draft Reply</div>
+                  ${draftReply}
                 </div>
                 <div class="triage-controls" style="display: flex; gap: 8px;">
-                  <button class="triage-btn-approve" data-testid="approve-instagram-dm" onclick="handleTriageAction('${item.id}', 'APPROVED')" style="flex: 1; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Approve Reply</button>
-                  <button class="triage-btn-dismiss" onclick="handleTriageAction('${item.id}', 'DISMISSED')" style="flex: 1; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer;">Edit Draft</button>
+                  <button class="triage-btn-approve" data-testid="approve-instagram-dm" onclick="handleTriageAction('${item.id}', 'APPROVED')" style="flex: 1; min-height: 44px; background: #0066FF; color: white; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: opacity 0.2s;">Approve & Send</button>
+                  <button class="triage-btn-dismiss" onclick="handleTriageAction('${item.id}', 'DISMISSED')" style="flex: 1; min-height: 44px; background: rgba(0,0,0,0.05); color: #1d1d1f; padding: 12px; border-radius: 12px; font-weight: 600; border: none; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: background 0.2s;">Dismiss</button>
                 </div>
               </div>
             `;


### PR DESCRIPTION
This PR fulfills GitHub Issue #27680: Implement 'Actionable Inbox': Unified Triage & Draft Agent for Owners.

It enhances the `message_triage_worker.rs` to detect when a message is an `instagram_dm` vs a `general` message and output this feature type. Furthermore, it creates pending approval items directly inside the `agent_feed_items` DB via Postgres or SQLite with the appropriate `event_source` and `context_payload` values.

This PR also updates the frontend `dashboard.html` to consume this feed and visually render the pending actionable items according to the Apple / Ubiquiti macOS glassmorphism standards alongside 'Approve & Send' / 'Dismiss' buttons. E2E Playwright tests were added and validated against the implementation.

Resolves #27680

---
*PR created automatically by Jules for task [16381018764390963088](https://jules.google.com/task/16381018764390963088) started by @wbbsuper*