### PR TITLE
feat(ui): Refine Actionable Inbox Triage Page and E2E Tests

### DIFF
--- a/src/ui/next/src/app/triage/page.tsx
+++ b/src/ui/next/src/app/triage/page.tsx
@@ -104,13 +104,13 @@ export default function TriagePage() {
     >
       {actionStatus && <div className="mb-4 app-badge good" role="status">{actionStatus}</div>}
 
-      <div className="mb-6 p-6 rounded-[16px] glassmorphism border border-white/40 dark:border-white/10">
+      <div className="mb-6 p-6 rounded-[16px] border border-white/40 dark:border-white/10 shadow-sm" style={{ background: "rgba(255, 255, 255, 0.65)", backdropFilter: "blur(30px) saturate(210%)" }}>
         <h2 className="text-2xl font-bold font-outfit text-[#1D1D1F] dark:text-[#F5F5F7] mb-2">Action Center</h2>
         <p className="text-gray-600 dark:text-gray-400">Review AI-prepared actions and reply drafts across all channels.</p>
       </div>
 
       <div className="app-grid two grid grid-cols-1 lg:grid-cols-[1.5fr_0.8fr] gap-6">
-        <section className="app-panel glassmorphism backdrop-blur-md bg-white/60 dark:bg-black/40 border border-white/20">
+        <section className="app-panel rounded-[16px] border border-white/40 shadow-sm flex flex-col" style={{ background: "rgba(255, 255, 255, 0.65)", backdropFilter: "blur(30px) saturate(210%)" }}>
           <div className="app-panel-header">
             <div>
               <div className="app-panel-title">Triage Queue</div>
@@ -118,7 +118,13 @@ export default function TriagePage() {
           </div>
           <div id="triage-list" className="app-list">
             {error && <div className="app-empty">{error}</div>}
-            {!error && items.length === 0 ? (
+            {loading ? (
+              <div className="p-6 space-y-4">
+                <div className="h-4 bg-gray-200 rounded animate-pulse w-3/4"></div>
+                <div className="h-4 bg-gray-200 rounded animate-pulse w-1/2"></div>
+                <div className="h-4 bg-gray-200 rounded animate-pulse w-5/6"></div>
+              </div>
+            ) : !error && items.length === 0 ? (
               <div className="app-empty flex flex-col items-center justify-center py-12">
                 <div className="text-4xl mb-4">✨</div>
                 <div className="text-lg font-medium text-gray-900 dark:text-white">All caught up!</div>
@@ -130,8 +136,8 @@ export default function TriagePage() {
                 type="button"
                 data-testid={`triage-card-${item.id}`}
                 onClick={() => setSelectedId(item.id)}
-                className="app-list-item w-full text-left min-h-[44px]"
-                style={{ background: selected?.id === item.id ? "rgba(255, 255, 255, 0.5)" : "transparent" }}
+                className="app-list-item w-full text-left min-h-[44px] rounded-[8px] transition-colors"
+                style={{ background: selected?.id === item.id ? "rgba(0, 102, 255, 0.05)" : "transparent" }}
               >
                 <div className="min-w-0">
                   <div className="app-list-title">{item.source || "Unknown Source"}</div>
@@ -143,11 +149,17 @@ export default function TriagePage() {
           </div>
         </section>
 
-        <section className="app-panel glassmorphism backdrop-blur-md bg-white/60 dark:bg-black/40 border border-white/20">
+        <section className="app-panel rounded-[16px] border border-white/40 shadow-sm flex flex-col" style={{ background: "rgba(255, 255, 255, 0.65)", backdropFilter: "blur(30px) saturate(210%)" }}>
           <div className="app-panel-header">
             <div className="app-panel-title">Triage Detail</div>
           </div>
-          {!selected ? (
+          {loading ? (
+            <div className="p-6 space-y-4">
+              <div className="h-4 bg-gray-200 rounded animate-pulse w-3/4"></div>
+              <div className="h-4 bg-gray-200 rounded animate-pulse w-1/2"></div>
+              <div className="h-20 bg-gray-200 rounded animate-pulse w-full"></div>
+            </div>
+          ) : !selected ? (
             <div className="app-empty">Select a triage item to review it.</div>
           ) : (
             <div className="app-panel-body">
@@ -157,25 +169,25 @@ export default function TriagePage() {
               </div>
               <div className="mb-4">
                 <div className="app-metric-label">Context</div>
-                <div className="mt-2 rounded-md border border-gray-200 dark:border-white/10 bg-white/50 dark:bg-black/20 p-3 text-sm leading-6 text-[#1D1D1F] dark:text-[#F5F5F7]">
+                <div className="mt-2 rounded-[8px] border border-gray-200 dark:border-white/10 bg-white/50 dark:bg-black/20 p-3 text-sm leading-6 text-[#1D1D1F] dark:text-[#F5F5F7]">
                   {selected.context || "No context"}
                 </div>
               </div>
               {selected.action_type && (
                 <div className="mb-6">
                   <div className="app-metric-label">Proposed Action: {selected.action_type}</div>
-                  <div className="mt-2 rounded-md border border-blue-200 dark:border-blue-900/30 bg-blue-50/50 dark:bg-blue-900/20 p-4 text-sm leading-6 text-blue-900 dark:text-blue-100 font-medium whitespace-pre-wrap">
+                  <div className="mt-2 rounded-[8px] border border-blue-200 dark:border-blue-900/30 bg-blue-50/50 dark:bg-blue-900/20 p-4 text-sm leading-6 text-blue-900 dark:text-blue-100 font-medium whitespace-pre-wrap">
                     {selected.action_payload || "No specific payload"}
                   </div>
                 </div>
               )}
 
               <div className="grid grid-cols-2 gap-3 mb-6">
-                <div className="app-card glassmorphism backdrop-blur-md bg-white/30 dark:bg-black/30 border border-white/20">
+                <div className="app-card rounded-[16px] border border-white/40 shadow-sm" style={{ background: "rgba(255, 255, 255, 0.4)", backdropFilter: "blur(20px)" }}>
                   <div className="app-metric-label">Priority</div>
                   <div className="mt-2"><span className={`app-badge ${badgeTone(selected.priority)}`}>{selected.priority || "Normal"}</span></div>
                 </div>
-                <div className="app-card glassmorphism backdrop-blur-md bg-white/30 dark:bg-black/30 border border-white/20">
+                <div className="app-card rounded-[16px] border border-white/40 shadow-sm" style={{ background: "rgba(255, 255, 255, 0.4)", backdropFilter: "blur(20px)" }}>
                   <div className="app-metric-label">Created</div>
                   <div className="mt-2 text-sm font-semibold text-[#1D1D1F] dark:text-[#F5F5F7]">{new Date(selected.created_at || Date.now()).toLocaleString()}</div>
                 </div>
@@ -183,14 +195,14 @@ export default function TriagePage() {
 
               <div className="flex flex-col sm:flex-row gap-3">
                 <button
-                  className="app-btn-primary flex-1 min-h-[44px] backdrop-blur-md hover:opacity-90 transition-opacity"
+                  className="app-btn-primary flex-1 min-h-[44px] rounded-[8px] font-medium transition-transform active:scale-[0.98] shadow-sm" style={{ background: "#0066FF" }}
                   data-testid="approve-btn"
                   onClick={() => handleDecision(selected.id, true)}
                 >
                   ✨ Approve &amp; Execute
                 </button>
                 <button
-                  className="px-4 py-2 rounded-[16px] border border-white/40 dark:border-white/20 text-[#1D1D1F] dark:text-[#F5F5F7] bg-white/50 dark:bg-black/20 hover:bg-white/80 dark:hover:bg-black/40 flex-1 min-h-[44px] font-medium transition-colors backdrop-blur-md"
+                  className="px-4 py-2 rounded-[8px] border border-gray-200 text-[#1D1D1F] dark:text-[#F5F5F7] bg-white/50 dark:bg-black/20 hover:bg-white/80 dark:hover:bg-black/40 flex-1 min-h-[44px] font-medium transition-all active:scale-[0.98]"
                   data-testid="dismiss-btn"
                   onClick={() => handleDecision(selected.id, false)}
                 >

--- a/src/ui/next/src/e2e/triage_ui.spec.ts
+++ b/src/ui/next/src/e2e/triage_ui.spec.ts
@@ -8,8 +8,8 @@ test.describe('Work Triage Agentic Inbox', () => {
     await page.fill('input[type="email"]', 'admin@ohc.local');
     await page.fill('input[type="password"]', 'changeme');
     await page.click('button[type="submit"]');
-    await page.goto('/dashboard');
-    await expect(page.locator('h2').filter({ hasText: 'Unified Agent Feed' })).toBeVisible({ timeout: 15000 });
+    await page.goto('/triage');
+    await expect(page.locator('h2').filter({ hasText: 'Action Center' })).toBeVisible({ timeout: 15000 });
   });
 
   test('Owner reviews and approves a triage item', async ({ page }) => {


### PR DESCRIPTION
Resolves #27680

### Description
This PR focuses on two main improvements for the 'Actionable Inbox' (Unified Triage) to better match the requested user experience standards and test stability. 

First, it updates the `TriagePage` UI located at `src/ui/next/src/app/triage/page.tsx` with premium design tokens (translucent macOS style backgrounds and blurs, `8px` rounded corners for interactive elements, `16px` for cards). It replaces standard classes with strict design guidelines and includes a skeleton loader pattern to display a beautiful loading state. 

Second, it fixes the E2E tests `src/ui/next/src/e2e/triage_ui.spec.ts` that were incorrectly referencing the `Unified Agent Feed` at the `/dashboard` route, which has moved to the dedicated `Action Center` at `/triage`.

### Changes Made:
- Removed hard-coded CSS classes and applied macOS inline styling to implement the desired translucent frosted glass effect.
- Created `loading` view skeletons for `TriageQueue` and `TriageDetail` blocks.
- Fixed the Playwright `triage_ui.spec.ts` test to correctly navigate to `/triage` and assert visibility on the `Action Center` heading.

---
*PR created automatically by Jules for task [9227008443560187524](https://jules.google.com/task/9227008443560187524) started by @ql-owo-lp*