### PR TITLE
chore: Remove dead code, unused imports, and unused SQLite test DB pools

### DIFF
--- a/src/server/integrations/registry.rs
+++ b/src/server/integrations/registry.rs
@@ -1,6 +1,4 @@
 use std::sync::RwLock;
-#[allow(unused_imports)]
-use ::server_ohc::orchestration::*;
 use chrono::Utc;
 
 pub struct IntegrationCredentials {

--- a/src/server/orchestration/health.rs
+++ b/src/server/orchestration/health.rs
@@ -106,10 +106,6 @@ mod tests {
             return;
         }
 
-        let _pool = sqlx::sqlite::SqlitePoolOptions::new().max_connections(1)
-            .connect_lazy("sqlite::memory:")
-            .unwrap();
-
         // We use casting to bypass postgres/sqlite types to instantiate a generic hub for test
         // Since Hub takes a PgPool, we have to supply one to construct it, even if unused in this isolated test
         let pg_pool = sqlx::postgres::PgPoolOptions::new()
@@ -169,10 +165,6 @@ mod tests {
             return;
         }
 
-        let _pool = sqlx::sqlite::SqlitePoolOptions::new().max_connections(1)
-            .connect_lazy("sqlite::memory:")
-            .unwrap();
-
         let pg_pool = sqlx::postgres::PgPoolOptions::new()
             .connect_lazy("postgres://dummy")
             .unwrap();
@@ -209,10 +201,6 @@ mod tests {
         if !db_url.starts_with("sqlite") && std::env::var("OHC_DATABASE_URL").is_err() {
             return;
         }
-
-        let _pool = sqlx::sqlite::SqlitePoolOptions::new().max_connections(1)
-            .connect_lazy("sqlite::memory:")
-            .unwrap();
 
         let pg_pool = sqlx::postgres::PgPoolOptions::new()
             .connect_lazy("postgres://dummy")

--- a/src/server/services/agent_memory/service.rs
+++ b/src/server/services/agent_memory/service.rs
@@ -1,9 +1,9 @@
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 use std::collections::HashMap;
 use tokio::sync::OnceCell;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use ohc_builtin_agent::memory_store::VectorRepository;
+
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct EpisodicMemory {
@@ -17,17 +17,16 @@ pub struct AgentMemoryService {
     redis_client: Option<redis::Client>,
     redis_conn: OnceCell<redis::aio::MultiplexedConnection>,
     fallback_cache: RwLock<HashMap<String, EpisodicMemory>>,
-    #[allow(dead_code)]
-    vector_repo: Option<Arc<VectorRepository>>,
+
 }
 
 impl AgentMemoryService {
-    pub fn new(redis_client: Option<redis::Client>, vector_repo: Option<Arc<VectorRepository>>) -> Self {
+    pub fn new(redis_client: Option<redis::Client>) -> Self {
         Self {
             redis_client,
             redis_conn: OnceCell::new(),
             fallback_cache: RwLock::new(HashMap::new()),
-            vector_repo,
+
         }
     }
 
@@ -113,7 +112,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_save_and_retrieve_fallback() {
-        let service = AgentMemoryService::new(None, None);
+        let service = AgentMemoryService::new(None);
 
         let tenant_id = "tenant_a";
         let session_id = "session_123";
@@ -129,7 +128,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tenant_isolation() {
-        let service = AgentMemoryService::new(None, None);
+        let service = AgentMemoryService::new(None);
 
         let tenant_a = "tenant_a";
         let tenant_b = "tenant_b";
@@ -146,7 +145,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tenant_isolation_malicious_key_manipulation() {
-        let service = AgentMemoryService::new(None, None);
+        let service = AgentMemoryService::new(None);
 
         let tenant_a = "tenant_a";
         let tenant_b = "tenant_b";

--- a/src/server/services/chat/service.rs
+++ b/src/server/services/chat/service.rs
@@ -1,6 +1,4 @@
 use tonic::{Request, Response, Status};
-#[allow(unused_imports)]
-use ::server_ohc::orchestration::*;
 use ::server_ohc::orchestration::chat_service_server::ChatService;
 use crate::integrations::registry::IntegrationsRegistry;
 


### PR DESCRIPTION
chore: Remove dead code, unused imports, and unused SQLite test DB pools

- Removes unused `vector_repo` from `AgentMemoryService` along with the `#[allow(dead_code)]` attribute in `src/server/services/agent_memory/service.rs`.
- Updates `AgentMemoryService::new` function and all associated call sites in tests to match the new signature.
- Removes `#[allow(unused_imports)]` and the corresponding actual unused imports (`use ::server_ohc::orchestration::*;`) from `src/server/integrations/registry.rs` and `src/server/services/chat/service.rs`.
- Removes unused in-memory SQLite connection pools (`_pool`) in `src/server/orchestration/health.rs` tests.
- All code compiles warning-free and passes the full test suite via Bazel.

---
*PR created automatically by Jules for task [9478851913057697446](https://jules.google.com/task/9478851913057697446) started by @ql-owo-lp*