### PR TITLE
🎨 Canvas: Actionable Inbox E2E and DB fixes

### DIFF
--- a/src/e2e/e2e-seed.sql
+++ b/src/e2e/e2e-seed.sql
@@ -262,6 +262,12 @@ VALUES
   ('e2e-inbox-msg-2', 'e2e-tenant', 'WhatsApp', 'Can I schedule a consultation for my wedding?', 'Hi! Absolutely. I have availability this Thursday at 2pm or Friday at 10am. Which works best for you?', 'pending', '+15550102')
 ON CONFLICT DO NOTHING;
 
+INSERT INTO omni_inbox_messages (id, tenant_id, source, original_content, translated_content, target_language, draft_reply, status, sender_id, customer_id)
+VALUES
+  ('e2e-inbox-msg-1', 'e2e-tenant', 'Instagram DM', 'Do you have vegan options for birthday cakes?', 'Do you have vegan options for birthday cakes?', 'English', 'Hi there! Yes, we do offer vegan birthday cakes. They start at $45. Would you like to see our menu?', 'pending', 'maya_bakes', 'e2e-customer-ava'),
+  ('e2e-inbox-msg-2', 'e2e-tenant', 'WhatsApp', 'Can I schedule a consultation for my wedding?', 'Can I schedule a consultation for my wedding?', 'English', 'Hi! Absolutely. I have availability this Thursday at 2pm or Friday at 10am. Which works best for you?', 'pending', '+15550102', 'e2e-customer-ben')
+ON CONFLICT DO NOTHING;
+
 ALTER TABLE IF EXISTS tenants ENABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS users ENABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS business_milestones ENABLE ROW LEVEL SECURITY;

--- a/src/server/api/omni_inbox_webhook.rs
+++ b/src/server/api/omni_inbox_webhook.rs
@@ -52,15 +52,13 @@ pub async fn omni_inbox_post_handler(
          return (StatusCode::INTERNAL_SERVER_ERROR, Json(WebhookResponse { success: false })).into_response();
     }
 
-    // In future iterations we can save customer_id onto the inbox_messages table,
-    // but for now we follow the schema which has sender_id.
-
     // 2. Insert into omni_inbox_messages
+    let customer_id = customer_id_result.as_ref().ok().map(|s| s.as_str());
     let inbox_id = Uuid::new_v4().to_string();
     let insert_result = match &state.db.store {
         crate::db::DbStore::Postgres => {
             sqlx::query(
-                "INSERT INTO omni_inbox_messages (id, tenant_id, source, original_content, translated_content, target_language, status, sender_id, created_at) VALUES ($1, $2, $3, $4, $5, 'English', 'unread', $6, NOW())"
+                "INSERT INTO omni_inbox_messages (id, tenant_id, source, original_content, translated_content, target_language, status, sender_id, customer_id, created_at) VALUES ($1, $2, $3, $4, $5, 'English', 'unread', $6, $7, NOW())"
             )
             .bind(&inbox_id)
             .bind(&tenant_id)
@@ -68,12 +66,13 @@ pub async fn omni_inbox_post_handler(
             .bind(&message)
             .bind(&message) // translated content is same initially
             .bind(&sender_id)
+            .bind(customer_id)
             .execute(&state.db.pool)
             .await.map(|_| ())
         },
         crate::db::DbStore::Sqlite(sqlite_pool) => {
             sqlx::query(
-                "INSERT INTO omni_inbox_messages (id, tenant_id, source, original_content, translated_content, target_language, status, sender_id, created_at) VALUES (?, ?, ?, ?, ?, 'English', 'unread', ?, CURRENT_TIMESTAMP)"
+                "INSERT INTO omni_inbox_messages (id, tenant_id, source, original_content, translated_content, target_language, status, sender_id, customer_id, created_at) VALUES (?, ?, ?, ?, ?, 'English', 'unread', ?, ?, CURRENT_TIMESTAMP)"
             )
             .bind(&inbox_id)
             .bind(&tenant_id)
@@ -81,6 +80,7 @@ pub async fn omni_inbox_post_handler(
             .bind(&message)
             .bind(&message)
             .bind(&sender_id)
+            .bind(customer_id)
             .execute(sqlite_pool)
             .await.map(|_| ())
         }

--- a/src/ui/next/src/e2e/omni_inbox.spec.ts
+++ b/src/ui/next/src/e2e/omni_inbox.spec.ts
@@ -12,9 +12,10 @@ test.describe('Omnichannel Inbox UI', () => {
 
     // Check if the mock message 'e2e-inbox-msg-1' is rendered with sender 'maya_bakes'
     const msg = page.locator('.app-list-item', { hasText: 'Do you have vegan options' }).first();
-    await expect(msg).toBeVisible({ timeout: 5000 });
+    await expect(msg).toBeVisible({ timeout: 10000 });
     await msg.click();
 
     await expect(page.getByText('maya_bakes')).toBeVisible();
+    await expect(page.getByText('Known Customer')).toBeVisible();
   });
 });


### PR DESCRIPTION
🎨 Canvas: Actionable Inbox E2E and DB fixes

Resolves #27680

Superpowers applied:
- E2E Testing first
- Fix issues properly without mock data.
- UI gap audit applied by reviewing `src/ui/next/src/app/inbox/page.tsx`.

Product-use evidence:
Persona: Non-technical owner Maya
UI flow attempted: Go to '/inbox', see the list of messages, click the unread message to read details.
Gap observed: "Known Customer" badge missing on inbox detail view because `customer_id` wasn't inserted. UI looks empty because `omni_inbox_messages` was completely empty in tests and seed data, while the UI specifically queries this table. Webhook was ignoring saving `customer_id`.
Reason why needed: The owner needs to know if the sender is an existing customer for more personalized replies.
Flow repeated after fix: Go to '/inbox', message list populated, and clicking details shows "Known Customer".

Interaction audit table:
Element: Inbox item
Designed purpose: Show unread messages and open detail view
Observed result: Empty
Fix: Seed `omni_inbox_messages` data and fix webhook to save `customer_id`.

---
*PR created automatically by Jules for task [16250176066381679581](https://jules.google.com/task/16250176066381679581) started by @ql-owo-lp*