### PR TITLE
🛡️ Sentry: [Fix zero-touch product subscriptions schema consistency and UI hook]

### DIFF
--- a/src/server/api/catalog.rs
+++ b/src/server/api/catalog.rs
@@ -193,14 +193,18 @@ async fn handle_create_product(
             .to_lowercase();
         let discount = payload.subscription_discount.unwrap_or(0);
 
+        let price_cents = (payload.price.parse::<f64>().unwrap_or(0.0) * 100.0).round() as i64;
         let insert_plan = sqlx::query(
-            "INSERT INTO subscription_plans (id, tenant_id, product_id, interval, discount_percentage) VALUES ($1, $2, $3, $4, $5)"
+            "INSERT INTO subscription_plans (id, tenant_id, product_id, interval, discount_percentage, name, price_cents, frequency) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"
         )
         .bind(&plan_id)
         .bind(&tenant_id)
         .bind(&product_id)
         .bind(&interval)
         .bind(discount)
+        .bind(&payload.name)
+        .bind(price_cents)
+        .bind(&interval)
         .execute(&mut *conn)
         .await;
 

--- a/src/server/api/subscription.rs
+++ b/src/server/api/subscription.rs
@@ -60,7 +60,7 @@ async fn get_plans(
     };
 
     let result = sqlx::query(
-        "SELECT sp.id as id, p.title as name, p.description as description, COALESCE(p.price_cents, 0) as amount, sp.interval as interval, sp.status = 'active' as active FROM subscription_plans sp JOIN products p ON sp.product_id = p.id WHERE sp.tenant_id = $1"
+        "SELECT sp.id as id, COALESCE(p.title, sp.name) as name, COALESCE(p.description, sp.description) as description, COALESCE(p.price_cents, sp.price_cents) as amount, COALESCE(sp.interval, sp.frequency) as interval, sp.status = 'active' as active FROM subscription_plans sp LEFT JOIN products p ON sp.product_id = p.id WHERE sp.tenant_id = $1"
     )
     .bind(tenant_id)
     .fetch_all(&mut *conn)

--- a/src/server/db/migrations/123_fix_subscription_plans.sql
+++ b/src/server/db/migrations/123_fix_subscription_plans.sql
@@ -1,0 +1,5 @@
+ALTER TABLE subscription_plans ADD COLUMN IF NOT EXISTS product_id TEXT REFERENCES products(id) ON DELETE CASCADE;
+ALTER TABLE subscription_plans ADD COLUMN IF NOT EXISTS interval TEXT;
+ALTER TABLE subscription_plans ADD COLUMN IF NOT EXISTS interval_count INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE subscription_plans ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active';
+ALTER TABLE subscription_plans ADD COLUMN IF NOT EXISTS discount_percentage INTEGER DEFAULT 0;

--- a/src/ui/next/src/app/products/new/page.tsx
+++ b/src/ui/next/src/app/products/new/page.tsx
@@ -138,10 +138,6 @@ function AutoCatalogContent() {
         interval: subscriptionInterval,
         cutoff: subscriptionCutoff,
       }));
-      setPublished(true);
-      setLoading(false);
-      setPublishingStep(0);
-      return;
     }
 
     try {


### PR DESCRIPTION
This PR addresses the issue of zero-touch automated product subscriptions not being created or correctly retrieved in the API when submitted from the UI. The root cause was a combination of an early return block in the UI, missing required fields when writing to the DB in the catalog endpoint, and a bug in the migration schema due to conflicting table fields across the "legacy" subscription vs zero-touch feature specs.

### Changes
* **Frontend:** Remove early return block in `handlePublish` which previously bypassed calling the `/api/product` endpoint in `subscriptionMode`.
* **Backend Catalog:** Fixed the logic for inserting the subscription plan so it includes both the legacy fields (name, price_cents, frequency) and the new zero-touch fields (product_id, interval). It also correctly handles float rounding to prevent dropping cents.
* **Backend Subscriptions:** The `get_plans` lookup query is rewritten to use a `LEFT JOIN` to the products table. `COALESCE` handles fields depending on whether they exist natively on the plan or the linked product.
* **Migrations:** Add `123_fix_subscription_plans.sql` to explicitly add the new product-linked schema requirements to `subscription_plans` without rewriting history.

---
*PR created automatically by Jules for task [8504180093795596983](https://jules.google.com/task/8504180093795596983) started by @wbbsuper*