### PR TITLE
💰 Miser: Fix cost dashboard e2e tests

### DIFF
--- a/src/e2e/cost_dashboard_ui.spec.ts
+++ b/src/e2e/cost_dashboard_ui.spec.ts
@@ -1,48 +1,53 @@
 import { test, expect } from './fixtures';
 
 test.describe('Cost Dashboard & Plan Limits UI', () => {
-  test('should display the cost dashboard and check expected sections', async ({ page }) => {
+  test('should display the cost dashboard and check expected sections', async ({ page, adminUser, loginAs }) => {
+    await loginAs(page, adminUser);
+
     // Navigate to the Cost Dashboard directly
-    await page.goto('/cost-dashboard.html');
+    await page.goto('/cost-dashboard');
 
     // Wait for the main heading to be visible
-    await expect(page.getByRole('heading', { name: 'My Plan' }).first()).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' }).first()).toBeVisible({ timeout: 15000 });
 
     // Verify key sections are present
-    await expect(page.getByText('Total Costs')).toBeVisible();
-    await expect(page.getByText('LLM Usage')).toBeVisible();
+    await expect(page.locator('h2', { hasText: 'Total Costs' })).toBeVisible();
+    await expect(page.locator('span', { hasText: 'LLM Usage' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Storage' }).first()).toBeVisible();
-    await expect(page.getByText('Bandwidth Savings')).toBeVisible();
+    await expect(page.locator('span', { hasText: 'Network & Storage Savings' }).first()).toBeVisible();
 
     // Check if the plan navigation link is present
-    await expect(page.getByRole('link', { name: '← Back to Dashboard' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Back to My Plan' })).toBeVisible();
   });
 
-  test('should display my plan limits and route to pricing', async ({ page }) => {
-    // Go to My Plan page (now combined in cost-dashboard.html)
-    await page.goto('/cost-dashboard.html');
+  test('should display my plan limits and route to pricing', async ({ page, adminUser, loginAs }) => {
+    await loginAs(page, adminUser);
+
+    // Go to My Plan page
+    await page.goto('/plan');
 
     // Wait for the main heading to be visible
-    await expect(page.getByRole('heading', { name: 'My Plan' }).first()).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('h1', { hasText: 'My Plan' }).first()).toBeVisible({ timeout: 15000 });
 
     // Verify data placeholders or limits are populated
-    await expect(page.getByText('Estimated Next Bill')).toBeVisible();
-    await expect(page.getByText('AI actions used this month')).toBeVisible();
+    await expect(page.locator('h2', { hasText: 'Estimated Next Bill:' })).toBeVisible();
+    await expect(page.locator('span', { hasText: 'AI actions used this month' })).toBeVisible();
 
     // Verify actions
-    const upgradeButton = page.getByRole('button', { name: 'Upgrade Plan' });
+    const upgradeButton = page.getByRole('button', { name: 'Upgrade' }).first();
     await expect(upgradeButton).toBeVisible();
 
     // Click on upgrade to ensure it leads to the pricing page
     await upgradeButton.click();
 
     // Expect to land on pricing
-    await expect(page.getByRole('heading', { name: 'Pricing Plans' })).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('h1', { hasText: 'Pricing Plans' })).toBeVisible({ timeout: 15000 });
   });
 
-  test('should verify checkout routing works from pricing', async ({ page }) => {
-    await page.goto('/pricing.html');
-    await expect(page.getByRole('heading', { name: 'Pricing Plans' })).toBeVisible({ timeout: 15000 });
+  test('should verify checkout routing works from pricing', async ({ page, adminUser, loginAs }) => {
+    await loginAs(page, adminUser);
+    await page.goto('/pricing');
+    await expect(page.locator('h1', { hasText: 'Pricing Plans' })).toBeVisible({ timeout: 15000 });
 
     // Ensure the starter upgrade button is visible
     const starterButton = page.getByRole('button', { name: 'Upgrade to Starter via Stripe' });
@@ -52,7 +57,7 @@ test.describe('Cost Dashboard & Plan Limits UI', () => {
     await starterButton.click();
 
     // The redirect logic changes the URL, so we can verify the checkout or error loads
-    await page.waitForURL(/\/checkout\.html\?tier=Starter/);
+    await page.waitForURL(/\/checkout\?tier=Starter/);
     await expect(page.getByText('Plan Upgrade')).toBeVisible({ timeout: 15000 });
   });
 });


### PR DESCRIPTION
Fix cost dashboard e2e tests to reflect new routing and DOM updates

- Updated Playwright assertions in `src/e2e/cost_dashboard_ui.spec.ts` to reflect the new Next.js routes (`/plan` and `/cost-dashboard`) and DOM hierarchy.
- Replaced `.html` test links with clean URLs to match current routing logic.
- Included proper `loginAs` setup steps where necessary to authenticate the adminUser across these pages.

---
*PR created automatically by Jules for task [6224728068544940918](https://jules.google.com/task/6224728068544940918) started by @ql-owo-lp*