### PR TITLE
chore: apply OHC Aesthetics to dashboards and fix unused import

### DIFF
--- a/deploy/grafana/dashboards/ohc-tenant-cost-miser.json
+++ b/deploy/grafana/dashboards/ohc-tenant-cost-miser.json
@@ -9,6 +9,21 @@
   "liveNow": false,
   "panels": [
     {
+      "type": "text",
+      "title": "OHC Aesthetics",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+      },
+      "transparent": true
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"

--- a/deploy/grafana/dashboards/token_forecast.json
+++ b/deploy/grafana/dashboards/token_forecast.json
@@ -10,6 +10,21 @@
   "liveNow": false,
   "panels": [
     {
+      "type": "text",
+      "title": "OHC Aesthetics",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+      },
+      "transparent": true
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "Prometheus"

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -4128,7 +4128,6 @@ async fn list_ui_bookings_handler(
     axum::extract::Query(query): axum::extract::Query<UiTenantQuery>,
 ) -> axum::response::Response {
     use axum::response::IntoResponse;
-    use sqlx::Row;
     let tenant_id = ui_tenant_id(&query);
     let mobile_optimized = query.mobile_optimized.unwrap_or(false);
 

--- a/src/server/monitoring/dashboards/ohc-tenant-cost-miser.json
+++ b/src/server/monitoring/dashboards/ohc-tenant-cost-miser.json
@@ -9,6 +9,21 @@
   "liveNow": false,
   "panels": [
     {
+      "type": "text",
+      "title": "OHC Aesthetics",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+      },
+      "transparent": true
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"

--- a/src/server/monitoring/dashboards/ohc-token-forecast.json
+++ b/src/server/monitoring/dashboards/ohc-token-forecast.json
@@ -10,6 +10,21 @@
   "liveNow": false,
   "panels": [
     {
+      "type": "text",
+      "title": "OHC Aesthetics",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+      },
+      "transparent": true
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "Prometheus"

--- a/src/server/monitoring/dashboards/standalone_swarm_health.json
+++ b/src/server/monitoring/dashboards/standalone_swarm_health.json
@@ -28,6 +28,21 @@
   "liveNow": false,
   "panels": [
     {
+      "type": "text",
+      "title": "OHC Aesthetics",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+      },
+      "transparent": true
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"

--- a/src/server/monitoring/dashboards/tenant_costs.json
+++ b/src/server/monitoring/dashboards/tenant_costs.json
@@ -25,6 +25,21 @@
   "liveNow": false,
   "panels": [
     {
+      "type": "text",
+      "title": "OHC Aesthetics",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+      },
+      "transparent": true
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"


### PR DESCRIPTION
Applied OHC Aesthetics CSS link to Grafana dashboards and fixed a Rust compiler warning.

---
*PR created automatically by Jules for task [11612868276692340508](https://jules.google.com/task/11612868276692340508) started by @ql-owo-lp*