### PR TITLE
Fix onboarding UI styling issues and tests

### DIFF
--- a/src/e2e/persona_onboarding.spec.ts
+++ b/src/e2e/persona_onboarding.spec.ts
@@ -8,7 +8,7 @@ test.describe('Persona-Driven Onboarding E2E', () => {
     const fs = require('fs');
     const path = require('path');
     await page.route('**/setup.html', async route => {
-        const fileContent = fs.readFileSync(path.join(process.cwd(), 'src/ui/tauri/src/ui/setup.html'), 'utf-8');
+        const fileContent = fs.readFileSync(path.join(process.env.TEST_WORKSPACE ? path.join(process.env.TEST_SRCDIR, process.env.TEST_WORKSPACE) : process.cwd(), 'src/ui/tauri/src/ui/setup.html'), 'utf-8');
         await route.fulfill({ contentType: 'text/html', body: fileContent });
     });
     await page.goto('http://mock/setup.html');
@@ -72,11 +72,13 @@ test.describe('Persona-Driven Onboarding E2E', () => {
     const fs = require('fs');
     const path = require('path');
     await page.route('**/setup.html', async route => {
-        const fileContent = fs.readFileSync(path.join(process.cwd(), 'src/ui/tauri/src/ui/setup.html'), 'utf-8');
+        const fileContent = fs.readFileSync(path.join(process.env.TEST_WORKSPACE ? path.join(process.env.TEST_SRCDIR, process.env.TEST_WORKSPACE) : process.cwd(), 'src/ui/tauri/src/ui/setup.html'), 'utf-8');
         await route.fulfill({ contentType: 'text/html', body: fileContent });
     });
     await page.goto('http://mock/setup.html');
 
+    await page.locator(".next-step-btn[data-next=\"step-context\"]").click();
+    await expect(page.getByText("How do you work?")).toBeVisible();
     await page.getByText("I'm a Handyman").click();
     await expect(page.getByText("Applied!")).toBeVisible();
     await expect(page.locator('input[value="Local Service"]')).toBeChecked();
@@ -107,11 +109,13 @@ test.describe('Persona-Driven Onboarding E2E', () => {
     const fs = require('fs');
     const path = require('path');
     await page.route('**/setup.html', async route => {
-        const fileContent = fs.readFileSync(path.join(process.cwd(), 'src/ui/tauri/src/ui/setup.html'), 'utf-8');
+        const fileContent = fs.readFileSync(path.join(process.env.TEST_WORKSPACE ? path.join(process.env.TEST_SRCDIR, process.env.TEST_WORKSPACE) : process.cwd(), 'src/ui/tauri/src/ui/setup.html'), 'utf-8');
         await route.fulfill({ contentType: 'text/html', body: fileContent });
     });
     await page.goto('http://mock/setup.html');
 
+    await page.locator(".next-step-btn[data-next=\"step-context\"]").click();
+    await expect(page.getByText("How do you work?")).toBeVisible();
     await page.getByText("I'm a Boutique Owner").click();
     await page.getByText('Next').first().click();
     await expect(page.locator('#business-categories')).toHaveValue('Boutique');
@@ -124,11 +128,13 @@ test.describe('Persona-Driven Onboarding E2E', () => {
     const fs = require('fs');
     const path = require('path');
     await page.route('**/setup.html', async route => {
-        const fileContent = fs.readFileSync(path.join(process.cwd(), 'src/ui/tauri/src/ui/setup.html'), 'utf-8');
+        const fileContent = fs.readFileSync(path.join(process.env.TEST_WORKSPACE ? path.join(process.env.TEST_SRCDIR, process.env.TEST_WORKSPACE) : process.cwd(), 'src/ui/tauri/src/ui/setup.html'), 'utf-8');
         await route.fulfill({ contentType: 'text/html', body: fileContent });
     });
     await page.goto('http://mock/setup.html');
 
+    await page.locator(".next-step-btn[data-next=\"step-context\"]").click();
+    await expect(page.getByText("How do you work?")).toBeVisible();
     await page.getByText("I'm a Tutor").click();
     await page.getByText('Next').first().click();
     await expect(page.locator('#business-categories')).toHaveValue('Tutoring');
@@ -141,7 +147,7 @@ test.describe('Persona-Driven Onboarding E2E', () => {
     const fs = require('fs');
     const path = require('path');
     await page.route('**/setup.html', async route => {
-        const fileContent = fs.readFileSync(path.join(process.cwd(), 'src/ui/tauri/src/ui/setup.html'), 'utf-8');
+        const fileContent = fs.readFileSync(path.join(process.env.TEST_WORKSPACE ? path.join(process.env.TEST_SRCDIR, process.env.TEST_WORKSPACE) : process.cwd(), 'src/ui/tauri/src/ui/setup.html'), 'utf-8');
         await route.fulfill({ contentType: 'text/html', body: fileContent });
     });
     await page.goto('http://mock/setup.html');

--- a/src/e2e/setup.spec.ts
+++ b/src/e2e/setup.spec.ts
@@ -5,7 +5,8 @@ import * as fs from 'fs';
 test.describe('OHC Setup Wizard Flow', () => {
 
   test.beforeEach(async ({ page }) => {
-      const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
+      const workspaceRoot = process.env.TEST_WORKSPACE ? path.join(process.env.TEST_SRCDIR, process.env.TEST_WORKSPACE) : process.cwd();
+      const tauriUiDir = path.join(workspaceRoot, 'src/ui/tauri/src/ui');
       await page.route('**/setup.html', async route => {
           const content = fs.readFileSync(path.join(tauriUiDir, 'setup.html'), 'utf-8');
           await route.fulfill({ contentType: 'text/html', body: content });
@@ -23,7 +24,7 @@ test.describe('OHC Setup Wizard Flow', () => {
     // Check initial UI loading
     await expect(page.locator('h1').first()).toBeVisible();
     // Start My Business
-    await page.locator('.next-step-btn[data-next="step-context"]').click();
+    await page.getByRole('button', { name: "Start My Business" }).click();
     await expect(page.getByText('How do you work?')).toBeVisible();
 
     // Context step
@@ -110,7 +111,7 @@ test.describe('OHC Setup Wizard Flow', () => {
     const btnBox = await page.locator('.next-step-btn').first().boundingBox();
     expect(btnBox?.height).toBeGreaterThanOrEqual(44);
 
-    await page.locator('.next-step-btn[data-next="step-context"]').click();
+    await page.getByRole('button', { name: "Start My Business" }).click();
     const inputbox = await page.locator('.radio-option').first().boundingBox();
     expect(inputbox?.height).toBeGreaterThanOrEqual(44);
   });

--- a/src/e2e/tauri_onboarding.spec.ts
+++ b/src/e2e/tauri_onboarding.spec.ts
@@ -72,6 +72,8 @@ test.describe('Tauri Onboarding Wizard Flow', () => {
     await page.getByRole('button', { name: 'Start Onboarding' }).click();
 
     // Setup page (Step 1: Context)
+    await expect(page.getByRole('heading', { name: "10-Minute Setup Wizard" })).toBeVisible();
+    await page.getByRole('button', { name: "Start My Business" }).click();
     await expect(page.getByRole('heading', { name: "How do you work?" })).toBeVisible();
 
     // Verify validation triggers

--- a/src/ui/next/next-env.d.ts
+++ b/src/ui/next/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -578,6 +578,7 @@ body {
 }
 
 .glassmorphism {
+  border-radius: 16px;
   background: rgba(255, 255, 255, 0.65);
   -webkit-backdrop-filter: blur(30px) saturate(210%);
   backdrop-filter: blur(30px) saturate(210%);
@@ -586,6 +587,7 @@ body {
 
 @media (prefers-color-scheme: dark) {
   .glassmorphism {
+  border-radius: 16px;
     background: rgba(22, 22, 26, 0.7);
     -webkit-backdrop-filter: blur(30px) saturate(210%);
   backdrop-filter: blur(30px) saturate(210%);

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -15,6 +15,7 @@
         height: 100vh;
       }
       .container {
+        border-radius: 16px;
         background: rgba(255, 255, 255, 0.65);
         backdrop-filter: blur(30px) saturate(210%);
         -webkit-backdrop-filter: blur(30px) saturate(210%);
@@ -143,6 +144,7 @@
           background-color: #16161a;
         }
         .container {
+        border-radius: 16px;
           background: rgba(22, 22, 26, 0.7);
           backdrop-filter: blur(30px) saturate(210%);
           -webkit-backdrop-filter: blur(30px) saturate(210%);
@@ -412,6 +414,7 @@
 
       @media (max-width: 768px) {
         .container {
+        border-radius: 16px;
           padding: 20px;
           border-radius: 16px;
           width: 100%;
@@ -423,6 +426,9 @@
       }
 
       @media (max-width: 375px) {
+        body {
+          overflow-x: hidden;
+        }
         .stepper {
           gap: 4px;
         }
@@ -434,6 +440,7 @@
           transform: scale(1.2);
         }
         .container {
+        border-radius: 16px;
           padding: 16px;
         }
         .radio-option {
@@ -2170,6 +2177,7 @@ document.addEventListener('DOMContentLoaded', () => {
             margin-top: 4px;
         }
         #ohc-help-chat-input-container {
+        border-radius: 16px;
             display: flex;
             gap: 8px;
             padding-top: 12px;

--- a/src/ui/tauri/src/ui/success.html
+++ b/src/ui/tauri/src/ui/success.html
@@ -15,6 +15,7 @@
         height: 100vh;
       }
       .container {
+        border-radius: 16px;
         background: rgba(255, 255, 255, 0.65);
         backdrop-filter: blur(30px) saturate(210%);
         padding: 40px;
@@ -62,6 +63,7 @@
           background-color: #16161a;
         }
         .container {
+        border-radius: 16px;
           background: rgba(22, 22, 26, 0.7);
           backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
@@ -479,6 +481,7 @@ document.addEventListener('DOMContentLoaded', () => {
             margin-top: 4px;
         }
         #ohc-help-chat-input-container {
+        border-radius: 16px;
             display: flex;
             gap: 8px;
             padding-top: 12px;


### PR DESCRIPTION
Fixes the E2E tests failing because of missing mock pages when run with Bazel. Also addresses the UI issues related to the 375px mobile view, making sure there is no horizontal scroll, and adds the missing `border-radius` to the glassmorphism.

---
*PR created automatically by Jules for task [12826978216510937292](https://jules.google.com/task/12826978216510937292) started by @ql-owo-lp*