### PR TITLE
feat(ui): implement Unified Agent Feed Mobile MVP transitions and backend integration

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -3906,7 +3906,7 @@ async fn ui_dashboard_unified_agent_feed_handler(
         let cache_key_bg = cache_key.clone();
         tokio::spawn(async move {
             let (approvals_res, ledger_res) = tokio::join!(
-                tokio::spawn({ let db = db.clone(); let t = t.clone(); async move { load_ui_agent_approvals_from_db(&db, &t).await } }),
+                tokio::spawn({ let db = db.clone(); let t = t.clone(); async move { load_ui_agent_feed_from_db(&db, &t).await } }),
                 tokio::spawn({ let db = db.clone(); let t = t.clone(); async move { load_ui_ledger_from_db(&db, &t).await } })
             );
 
@@ -3916,7 +3916,7 @@ async fn ui_dashboard_unified_agent_feed_handler(
             if mobile_optimized {
                 for item in pending_approvals.iter_mut() {
                     if let Some(obj) = item.as_object_mut() {
-                        obj.remove("payload");
+                        obj.remove("context_payload");
                     }
                 }
                 for item in entries.iter_mut() {
@@ -3939,7 +3939,7 @@ async fn ui_dashboard_unified_agent_feed_handler(
     }
 
     let (approvals_res, ledger_res) = tokio::join!(
-        tokio::spawn({ let db = db.clone(); let t = tenant_id.clone(); async move { load_ui_agent_approvals_from_db(&db, &t).await } }),
+        tokio::spawn({ let db = db.clone(); let t = tenant_id.clone(); async move { load_ui_agent_feed_from_db(&db, &t).await } }),
         tokio::spawn({ let db = db.clone(); let t = tenant_id.clone(); async move { load_ui_ledger_from_db(&db, &t).await } })
     );
 
@@ -3949,7 +3949,7 @@ async fn ui_dashboard_unified_agent_feed_handler(
     if mobile_optimized {
         for item in pending_approvals.iter_mut() {
             if let Some(obj) = item.as_object_mut() {
-                obj.remove("payload");
+                obj.remove("context_payload");
             }
         }
         for item in entries.iter_mut() {

--- a/src/ui/next/next-env.d.ts
+++ b/src/ui/next/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -53,6 +53,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
   const [isOffline, setIsOffline] = useState(false);
   const [offlineActionsCount, setOfflineActionsCount] = useState(0);
   const [queuedActionIds, setQueuedActionIds] = useState<Set<string>>(new Set());
+  const [transitioningId, setTransitioningId] = useState<string | null>(null);
 
   const tenantId = () => {
     if (typeof window === "undefined") return "default";
@@ -311,6 +312,16 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
   };
 
   const handleDecision = async (id: string, approved: boolean) => {
+    if (approved) {
+      setTransitioningId(id);
+      setTimeout(() => {
+        setItems(prev => prev.filter(app => app.id !== id));
+        setTransitioningId(null);
+      }, 500);
+    } else {
+      setItems(prev => prev.filter(app => app.id !== id));
+    }
+
     if (isOffline) {
       // Enqueue offline action
       await enqueueAction({
@@ -323,9 +334,6 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
       setQueuedActionIds(prev => new Set(prev).add(id));
       return;
     }
-
-    // Optimistic UI update
-    setItems(prev => prev.filter(app => app.id !== id));
 
     try {
       await submitDecision(id, approved);
@@ -459,7 +467,10 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
             {items.map((approval) => (
               <div
                 key={approval.id}
-                className="glassmorphism p-5 rounded-[16px] border border-white/40 dark:border-white/10 shadow-sm flex flex-col gap-4"
+                className={`glassmorphism p-5 rounded-[16px] shadow-sm flex flex-col gap-4 relative overflow-hidden transition-all duration-300 ${
+                  transitioningId === approval.id ? 'border-green-500 scale-95 opacity-50 border-2' : 'border border-white/40 dark:border-white/10'
+                }`}
+                data-testid="agent-feed-card"
               >
                 <div className="flex flex-col gap-1">
                   <div className="flex items-center gap-2">

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Resolves #27654

### Product-use evidence
**Persona**: Maya (Home Baker) / Carlos (Field Service Owner)
**Attempted Flow**: Navigating the dashboard from a 375px mobile viewport to view urgent agent actions. Approving a drafted quote or restock action directly from the mobile feed without having to dig through dense table views or graphs.
**CUJ Gap Observed**: The previous Unified Agent Feed did not properly visualize state transitions (the 500ms delay/animation before removing a card) causing abrupt jumps, and there was incomplete migration to the unified backend persistence model (`load_ui_agent_feed_from_db`).
**Need**: Mobile users need immediate, smooth feedback confirming their tap on "Approve" (a green border and slight scale-down) so they know the system received their command before the card disappears. They also need all data securely fetched with the new robust `agent_feed_items` abstraction instead of fragmented legacy `agent_approvals`.

### Implementation Rationale & Fixes
- Added `transitioningId` state to `UnifiedAgentFeed.tsx`. This locally delays the removal of an approved card from the feed array by 500ms, giving the CSS `transition-all duration-300` time to render the `border-green-500 scale-95 opacity-50 border-2` feedback states requested by the design specification.
- Updated `src/server/lib.rs` to substitute legacy calls to `load_ui_agent_approvals_from_db` with `load_ui_agent_feed_from_db`, completing the migration toward the new unified `agent_feed_items` PostgreSQL persistence table. Mobile payload hydration was adjusted to strip `context_payload` where appropriate to keep responses lean for edge delivery.
- Successfully verified `Unified Agent Feed Interactive Flow` E2E test.

---
*PR created automatically by Jules for task [12759904709622015596](https://jules.google.com/task/12759904709622015596) started by @ql-owo-lp*