### PR TITLE
feat(growth): wire top_product metric to Store Wrapped backend endpoint

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -619,6 +619,7 @@ struct HttpMetricsResponse {
     pending_orders: i64,
     total_sales: f64,
     total_campaigns_sent: i64,
+    top_product: Option<String>,
 }
 
 async fn http_metrics_handler(
@@ -660,7 +661,7 @@ async fn http_metrics_handler(
         return (StatusCode::OK, axum::Json(metrics)).into_response();
     }
 
-    let (active_customers_res, pending_orders_res, sales_res, campaigns_res) = tokio::join!(
+    let (active_customers_res, pending_orders_res, sales_res, campaigns_res, top_product_res) = tokio::join!(
         async {
             match &db.store {
                 crate::db::DbStore::Postgres => sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM users WHERE tenant_id = $1").bind(&tenant_id).fetch_one(&db.pool).await,
@@ -684,6 +685,16 @@ async fn http_metrics_handler(
                 crate::db::DbStore::Postgres => sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM agent_actions WHERE tenant_id = $1 AND action_type = 'growth.campaign_sent'").bind(&tenant_id).fetch_one(&db.pool).await,
                 crate::db::DbStore::Sqlite(pool) => sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM agent_actions WHERE tenant_id = $1 AND action_type = 'growth.campaign_sent'").bind(&tenant_id).fetch_one(pool).await,
             }
+        },
+        async {
+            match &db.store {
+                crate::db::DbStore::Postgres => sqlx::query_scalar::<_, String>(
+                    "SELECT p.title FROM products p JOIN order_items oi ON p.id = oi.product_id JOIN orders o ON oi.order_id = o.id WHERE o.tenant_id = $1 AND p.tenant_id = $1 AND o.status != 'abandoned' GROUP BY p.title ORDER BY SUM(oi.quantity) DESC LIMIT 1"
+                ).bind(&tenant_id).fetch_optional(&db.pool).await,
+                crate::db::DbStore::Sqlite(pool) => sqlx::query_scalar::<_, String>(
+                    "SELECT p.title FROM products p JOIN order_items oi ON p.id = oi.product_id JOIN orders o ON oi.order_id = o.id WHERE o.tenant_id = $1 AND p.tenant_id = $1 AND o.status != 'abandoned' GROUP BY p.title ORDER BY SUM(oi.quantity) DESC LIMIT 1"
+                ).bind(&tenant_id).fetch_optional(pool).await,
+            }
         }
     );
 
@@ -691,8 +702,9 @@ async fn http_metrics_handler(
     let pending_orders = pending_orders_res.unwrap_or(0);
     let total_sales = sales_res.unwrap_or(0.0);
     let total_campaigns_sent = campaigns_res.unwrap_or(0);
+    let top_product = top_product_res.unwrap_or_default();
 
-    let metrics = HttpMetricsResponse { active_customers, pending_orders, total_sales, total_campaigns_sent };
+    let metrics = HttpMetricsResponse { active_customers, pending_orders, total_sales, total_campaigns_sent, top_product };
     cache.set(&cache_key, metrics.clone(), std::time::Duration::from_secs(60)).await;
 
     (


### PR DESCRIPTION
feat(growth): wire top_product metric to Store Wrapped backend endpoint

The Store Wrapped frontend expected the `/api/v1/dashboard/metrics` endpoint to return a `top_product` attribute, but it was currently omitted and falling back to a dummy value ("Signature Blend").

This commit modifies the `http_metrics_handler` by querying the order tables (`orders` joined with `order_items` and `products`) to calculate the top product (by highest cumulative quantity ordered) for the tenant and includes it in the `HttpMetricsResponse` json struct payload. This properly connects the real data to the existing Store Wrapped frontend loop.

---
*PR created automatically by Jules for task [7369051318758138403](https://jules.google.com/task/7369051318758138403) started by @ql-owo-lp*