### PR TITLE
feat(growth): Add viral loop footer to booking widget

### DIFF
--- a/src/e2e/viral_booking.spec.ts
+++ b/src/e2e/viral_booking.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Viral Booking Footer', () => {
+    test('renders standalone booking page with viral footer and referral loop link', async ({ page }) => {
+        // Step 1: Navigate to standalone booking page directly
+        // Test with a specific tenant id to verify encoding logic
+        await page.goto('/api/ui/booking.html?tenant=test-tenant-123');
+
+        // Verify we are on the booking page
+        await expect(page.locator('text=Request a Service')).toBeVisible();
+
+        // Check for the "⚡ Powered by OHC" footer
+        const brandingLink = page.locator('a:has-text("⚡ Powered by OHC")');
+        await expect(brandingLink).toBeVisible();
+
+        // Validate the referral link structure matches the expected format
+        const href = await brandingLink.getAttribute('href');
+        expect(href).toContain('/api/v1/growth/referrals/click?target=/onboarding&ref=test-tenant-123');
+    });
+});

--- a/src/ui/tauri/src/ui/booking.html
+++ b/src/ui/tauri/src/ui/booking.html
@@ -129,6 +129,9 @@
         <button type="submit" class="btn btn-primary" id="btn-submit">Get a Quote</button>
       </form>
     </div>
+    <div style="text-align: center; margin-top: 12px; font-family: sans-serif; font-size: 12px;">
+      <a href="#" id="branding-link" target="_blank" style="color: #86868b; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a>
+    </div>
   </div>
 
   <div class="mobile-container" id="success-view" style="display: none; align-items: center; justify-content: center; text-align: center;">
@@ -143,6 +146,11 @@
     document.addEventListener('DOMContentLoaded', () => {
       const urlParams = new URLSearchParams(window.location.search);
       const tenantId = urlParams.get('tenant') || 'demo-tenant';
+
+      const brandingLink = document.getElementById('branding-link');
+      if (brandingLink) {
+        brandingLink.href = `/api/v1/growth/referrals/click?target=/onboarding&ref=${encodeURIComponent(tenantId)}`;
+      }
 
 
       // Fetch actual business profile


### PR DESCRIPTION
Added a referral loop to the booking page (`booking.html`) that allows users sharing their booking widget to acquire new customers via the "Powered by OHC" footer. Verified with a new E2E test `viral_booking.spec.ts`.

---
*PR created automatically by Jules for task [12143043309778372856](https://jules.google.com/task/12143043309778372856) started by @ql-owo-lp*