### PR TITLE
test: 💰 Miser: update cost dashboard e2e tests for new api/email metrics

### DIFF
--- a/src/e2e/cost_dashboard.spec.ts
+++ b/src/e2e/cost_dashboard.spec.ts
@@ -91,7 +91,10 @@ test.describe('Cost Dashboard "My Plan" functionality', () => {
     await expect(page.locator('span', { hasText: 'LLM Usage' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Storage' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Payment Fees' }).first()).toBeVisible();
-    await expect(page.locator('span', { hasText: 'Bandwidth Savings' }).first()).toBeVisible();
+    await expect(page.locator('span', { hasText: 'Network & Storage Savings' }).first()).toBeVisible();
+    await expect(page.locator('span', { hasText: 'Compute Usage' })).toBeVisible();
+    await expect(page.locator('span', { hasText: 'Email Sends' })).toBeVisible();
+    await expect(page.locator('span', { hasText: 'Outbound API Calls' })).toBeVisible();
   });
 
   test('Billing checkout session and cancel subscription journey', async ({ page }) => {

--- a/src/e2e/cost_dashboard_ui.spec.ts
+++ b/src/e2e/cost_dashboard_ui.spec.ts
@@ -12,7 +12,9 @@ test.describe('Cost Dashboard & Plan Limits UI', () => {
     await expect(page.getByText('Total Costs')).toBeVisible();
     await expect(page.getByText('LLM Usage')).toBeVisible();
     await expect(page.locator('span', { hasText: 'Storage' }).first()).toBeVisible();
-    await expect(page.getByText('Bandwidth Savings')).toBeVisible();
+    await expect(page.getByText('Network & Storage Savings').first()).toBeVisible();
+    await expect(page.getByText('Email Sends')).toBeVisible();
+    await expect(page.getByText('Outbound API Calls')).toBeVisible();
 
     // Check if the plan navigation link is present
     await expect(page.getByRole('link', { name: '← Back to Dashboard' })).toBeVisible();

--- a/src/e2e/current_app_smoke.ts
+++ b/src/e2e/current_app_smoke.ts
@@ -76,4 +76,12 @@ export async function currentAppSmoke(page: Page, request: APIRequestContext, la
     const networkCost = page.locator('#cost-dashboard-network');
     await expect(networkCost).toBeVisible();
     expect(await networkCost.innerText()).toMatch(/^\$[\d,]+\.\d{2}$/);
+
+    const emailCost = page.locator('#cost-dashboard-email');
+    await expect(emailCost).toBeVisible();
+    expect(await emailCost.innerText()).toMatch(/^\$[\d,]+\.\d{2}$/);
+
+    const apiCost = page.locator('#cost-dashboard-api');
+    await expect(apiCost).toBeVisible();
+    expect(await apiCost.innerText()).toMatch(/^\$[\d,]+\.\d{2}$/);
 }


### PR DESCRIPTION
This PR updates the E2E tests for the Cost Dashboard to reflect the newly integrated metrics: Email Sends and Outbound API Calls. It also fixes a label drift where "Bandwidth Savings" was changed to "Network & Storage Savings".

These changes ensure that the "Miser" cost features are fully covered by the end-to-end automation suite, catching the previously unasserted metrics on the dashboard.

---
*PR created automatically by Jules for task [1458922230021343559](https://jules.google.com/task/1458922230021343559) started by @ql-owo-lp*