### PR TITLE
fix: Update triage cache invalidation keys to include mobile variants

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -2984,6 +2984,10 @@ pub async fn create_ui_triage_item_handler(
                 return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({"error": e.to_string()}))).into_response();
             }
 
+            let cache = UI_TRIAGE_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(get_redis_client()));
+            cache.invalidate(&format!("ui_triage:{}:mobile:false", tenant_id)).await;
+            cache.invalidate(&format!("ui_triage:{}:mobile:true", tenant_id)).await;
+
             (axum::http::StatusCode::CREATED, axum::Json(serde_json::json!({"id": new_id, "status": "success"}))).into_response()
         }
         crate::db::DbStore::Sqlite(_) => {
@@ -3205,8 +3209,8 @@ pub async fn update_ui_triage_action_handler(
                 Ok(_) => {
                     let _ = tx.commit().await;
                     let cache = UI_TRIAGE_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(get_redis_client()));
-                    let cache_key = format!("ui_triage:{}", tenant_id);
-                    cache.invalidate(&cache_key).await;
+                    cache.invalidate(&format!("ui_triage:{}:mobile:false", tenant_id)).await;
+                    cache.invalidate(&format!("ui_triage:{}:mobile:true", tenant_id)).await;
                     (axum::http::StatusCode::OK, axum::Json(serde_json::json!({"status": "success"}))).into_response()
                 },
                 Err(e) => {


### PR DESCRIPTION
Fixes UI triage list not updating when actions are performed due to outdated cache invalidation keys that didn't include the `mobile:true`/`mobile:false` suffix. Added missing invalidation to the create item handler as well.

---
*PR created automatically by Jules for task [8760545389353917202](https://jules.google.com/task/8760545389353917202) started by @wbbsuper*