### PR TITLE
Fix UI touch targets in onboarding setup.html and glassmorphism styling in globals.css

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -589,7 +589,7 @@ body {
   .glassmorphism {
     background: rgba(22, 22, 26, 0.7);
     -webkit-backdrop-filter: blur(30px) saturate(210%);
-  backdrop-filter: blur(30px) saturate(210%);
+    backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 16px;
   }

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -500,8 +500,8 @@
         </div>
 
         <div style="display: flex; gap: 10px;">
-            <input type="text" id="chat-input" class="glassmorphism" placeholder="Type a message..." style="margin-bottom: 0; flex-grow: 1;">
-            <button id="chat-send-btn" style="width: auto;">Send</button>
+            <input type="text" id="chat-input" class="glassmorphism" placeholder="Type a message..." style="margin-bottom: 0; flex-grow: 1; min-height: 44px; border-radius: 8px;">
+            <button id="chat-send-btn" style="width: auto; min-height: 44px; min-width: 44px; border-radius: 8px;">Send</button>
         </div>
       </div>
 


### PR DESCRIPTION
Fix UI touch targets in onboarding setup.html and glassmorphism styling in globals.css

- Added min-width and min-height 44px to #chat-send-btn and #chat-input in setup.html
- Fixed globals.css indentation and layout around .glassmorphism

---
*PR created automatically by Jules for task [17254180913112051253](https://jules.google.com/task/17254180913112051253) started by @ql-owo-lp*