### PR TITLE
feat(billing): integrate stripe checkout in pricing page and make llm prompt cache ttl configurable

### DIFF
--- a/src/agents/builtin/local_provider.rs
+++ b/src/agents/builtin/local_provider.rs
@@ -13,12 +13,12 @@ pub struct LocalLLMProvider {
 }
 
 impl LocalLLMProvider {
-    pub fn new(endpoint: String, embed_endpoint: String, model: String) -> Self {
+    pub fn new(endpoint: String, embed_endpoint: String, model: String, cache_ttl: Duration) -> Self {
         LocalLLMProvider {
             endpoint,
             embed_endpoint,
             model,
-            cache: PromptCache::new(Duration::from_secs(600)), // 10 minute TTL
+            cache: PromptCache::new(cache_ttl),
             client: reqwest::Client::new(),
         }
     }
@@ -30,7 +30,11 @@ impl LocalLLMProvider {
             .unwrap_or_else(|_| "http://127.0.0.1:11434/api/embeddings".to_string());
         let model = std::env::var("OHC_LOCAL_MODEL_NAME")
             .unwrap_or_else(|_| "llama3".to_string());
-        Self::new(endpoint, embed_endpoint, model)
+        let ttl_secs = std::env::var("OHC_PROMPT_CACHE_TTL")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(600); // 10 minute TTL default
+        Self::new(endpoint, embed_endpoint, model, Duration::from_secs(ttl_secs))
     }
 
     pub async fn reason(&self, prompt: &str) -> Result<String, String> {

--- a/src/ui/next/src/app/pricing/page.test.tsx
+++ b/src/ui/next/src/app/pricing/page.test.tsx
@@ -19,9 +19,21 @@ vi.mock('../components/PoweredByOHC', () => ({
 describe('PricingPage', () => {
   const mockPush = vi.fn();
 
+  let originalWindowLocation: any;
+
   beforeEach(() => {
     vi.clearAllMocks();
     (useRouter as any).mockReturnValue({ push: mockPush });
+    global.fetch = vi.fn();
+
+    // Mock window.location.href
+    originalWindowLocation = window.location;
+    delete (window as any).location;
+    window.location = { ...originalWindowLocation, href: '' } as any;
+  });
+
+  afterEach(() => {
+    window.location = originalWindowLocation;
   });
 
   it('renders the pricing page', () => {
@@ -33,11 +45,46 @@ describe('PricingPage', () => {
     expect(screen.getByText('Business')).toBeDefined();
   });
 
-  it('navigates to checkout when upgrading to Starter', () => {
+  it('initiates checkout session when upgrading to Starter', async () => {
+    const mockCheckoutUrl = 'https://checkout.stripe.com/pay/test_session_123';
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ checkout_url: mockCheckoutUrl }),
+    });
+
     render(<PricingPage />);
     const upgradeButton = screen.getByText('Upgrade to Starter via Stripe');
     fireEvent.click(upgradeButton);
-    expect(mockPush).toHaveBeenCalledWith('/checkout?tier=Starter');
+
+    // Wait for the async logic to finish
+    await vi.waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/billing/create-checkout-session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ tier: 'Starter' }),
+      });
+      expect(window.location.href).toBe(mockCheckoutUrl);
+    });
+  });
+
+  it('handles upgrade errors gracefully', async () => {
+    (global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
+    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<PricingPage />);
+    const upgradeButton = screen.getByText('Upgrade to Starter via Stripe');
+    fireEvent.click(upgradeButton);
+
+    await vi.waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(alertMock).toHaveBeenCalledWith('Failed to initiate upgrade. Please try again.');
+    });
+
+    alertMock.mockRestore();
+    consoleSpy.mockRestore();
   });
 
   it('renders the PoweredByOHC component', () => {

--- a/src/ui/next/src/app/pricing/page.tsx
+++ b/src/ui/next/src/app/pricing/page.tsx
@@ -9,8 +9,28 @@ import { PoweredByOHC } from '../components/PoweredByOHC';
 export default function PricingPage() {
   const router = useRouter();
 
-  const handleUpgrade = (tier: string) => {
-    router.push('/checkout?tier=' + tier);
+  const handleUpgrade = async (tier: string) => {
+    try {
+      const response = await fetch('/api/billing/create-checkout-session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ tier }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to create checkout session');
+      }
+
+      const data = await response.json();
+      if (data.checkout_url) {
+        window.location.href = data.checkout_url;
+      }
+    } catch (error) {
+      console.error('Error upgrading plan:', error);
+      alert('Failed to initiate upgrade. Please try again.');
+    }
   };
 
   return (


### PR DESCRIPTION
This PR resolves several Cost Engineer & Miser issues:

1. **Pricing Page Checkout**: Integrates the `Starter`, `Pro`, and `Business` tier upgrade buttons on the `/pricing` page with the `create_checkout_session` API. Users are now redirected directly to the Stripe checkout instead of a local page route. 
2. **LLM Prompt Cache Optimization**: Removes hardcoded 10-minute prompt cache TTL inside `LocalLLMProvider` to use a configurable `OHC_PROMPT_CACHE_TTL` from the environment, maximizing token efficiency per tier requirements.

Extensive unit tests and E2E tests have been run locally to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [7560369230229749445](https://jules.google.com/task/7560369230229749445) started by @wbbsuper*