### PR TITLE
🎨 Canvas: Refactor Unified Agent Feed E2E Tests

### DIFF
--- a/src/e2e/unified_agent_feed.spec.ts
+++ b/src/e2e/unified_agent_feed.spec.ts
@@ -4,15 +4,15 @@ test.describe("Unified Agent Feed Mobile UX", () => {
   // Use a strictly 375px wide viewport as specified by the issue
   test.use({ viewport: { width: 375, height: 667 } });
 
-  test("Renders and actions can be tapped on 375px mobile screen", async ({
-    page,
-    request,
-  }) => {
-    // 1. Seed some distinct approvals representing different departments,
+  test.beforeEach(async ({ request }) => {
+    // Seed some distinct approvals representing different departments,
     // including the Instagram DM custom cake scenario from the new agent_feed_items table.
     await request.post("/api/e2e/setup", {
       data: {
         query: `
+          DELETE FROM agent_approvals WHERE id IN ('e2e-feed-test-1', 'e2e-feed-test-2');
+          DELETE FROM agent_feed_items WHERE id IN ('e2e-feed-test-3');
+
           INSERT INTO agent_approvals (id, tenant_id, department, description, status, action_risk, payload, created_at, updated_at)
           VALUES
             ('e2e-feed-test-1', 'e2e-tenant', 'operations', '3 new orders to fulfill', 'DRAFT', 'LOW', '{"feature_type": "fulfillment_batch", "message": "3 new orders to fulfill"}'::jsonb, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
@@ -26,14 +26,20 @@ test.describe("Unified Agent Feed Mobile UX", () => {
         `,
       },
     });
+  });
 
-    // 2. Load the dashboard on mobile
-    await page.goto("/dashboard");
-
-    // 3. Ensure the unified feed tab is visible
+  const performLogin = async (page: any) => {
+    await page.goto("/login");
+    await expect(page.getByRole("heading", { name: "Login" })).toBeVisible();
+    await page.getByPlaceholder("Email or Username").first().fill("e2e-user");
+    await page.locator('input[type="password"]').first().fill("password");
+    await page.getByRole("button", { name: "Log In" }).click();
     await expect(page.locator("text=Activity Feed").first()).toBeVisible({ timeout: 15000 });
+  };
 
-    // 4. Verify the seeded cards are rendered
+  test("1. Renders seeded cards and tab navigation on 375px mobile screen", async ({ page }) => {
+    await performLogin(page);
+
     const opsCard = page.locator("text=3 new orders to fulfill").first();
     const marketingCard = page.locator("text=Draft promo email?").first();
     const igCard = page.locator("text=Do you make custom vegan cakes?").first();
@@ -42,29 +48,46 @@ test.describe("Unified Agent Feed Mobile UX", () => {
     await expect(marketingCard).toBeVisible();
     await expect(igCard).toBeVisible();
 
-    // Verify Instagram DM specific UI elements
     await expect(page.locator("text=Instagram DM").first()).toBeVisible();
     await expect(page.locator("text=Yes we do! Here is a booking link").first()).toBeVisible();
+  });
 
-    // 5. Verify touch targets on the Instagram DM specific button
+  test("2. Tapping Approve & Send on Instagram DM dismisses the card", async ({ page }) => {
+    await performLogin(page);
+
     const approveIgButton = page.locator('button[data-testid="approve-instagram-dm"]').first();
     await expect(approveIgButton).toBeVisible();
     await approveIgButton.click();
 
-    // The Instagram DM item should optimistically disappear
     await expect(page.locator("text=Do you make custom vegan cakes?").first()).not.toBeVisible();
+  });
 
-    // Verify touch targets on the default Approve button
+  test("3. Tapping Approve on default proposal dismisses the card", async ({ page }) => {
+    await performLogin(page);
+
     const approveButton = page.locator('button[data-testid="approve-proposal"]').first();
     await expect(approveButton).toBeVisible();
     await approveButton.click();
 
     await expect(page.locator("text=3 new orders to fulfill").first()).not.toBeVisible();
+  });
 
-    // Test a specific payload button
+  test("4. Tapping 'Yes, draft it!' on a draft proposal dismisses the card", async ({ page }) => {
+    await performLogin(page);
+
     const draftButton = page.locator('button[data-testid="approve-draft"]').first();
     await expect(draftButton).toBeVisible();
     await draftButton.click();
+
+    await expect(page.locator("text=Draft promo email?").first()).not.toBeVisible();
+  });
+
+  test("5. Tapping Dismiss on a draft proposal dismisses the card", async ({ page }) => {
+    await performLogin(page);
+
+    const dismissButton = page.locator('button[data-testid="dismiss-draft"]').first();
+    await expect(dismissButton).toBeVisible();
+    await dismissButton.click();
 
     await expect(page.locator("text=Draft promo email?").first()).not.toBeVisible();
   });


### PR DESCRIPTION
Refactored the Playwright End-to-End tests in `src/e2e/unified_agent_feed.spec.ts` to include 5 distinct test cases covering various user journeys like rendering, approvals, drafting, and dismissals of agent feed proposals on a 375px mobile viewport. Also updated the test structure to ensure test isolation by using proper database cleanup in the `test.beforeEach` block, and properly initiating interactions by simulating the real UI login flow instead of direct pre-authenticated navigation.

Resolves #27730

---
*PR created automatically by Jules for task [1784052008399566880](https://jules.google.com/task/1784052008399566880) started by @wbbsuper*