### PR TITLE
🚀 Nova: 100th Order Growth Milestone

### DIFF
--- a/src/server/workers/department_workers.rs
+++ b/src/server/workers/department_workers.rs
@@ -508,13 +508,15 @@ impl OperationsWorker {
                         .await
                         .unwrap_or(0);
 
-                    if order_count == 1 || order_count == 10 {
-                        let milestone_title = if order_count == 1 { "🎉 Milestone: First Sale!" } else { "🎉 Milestone: 10th Order!" };
-                        let milestone_type = if order_count == 1 { "first_sale" } else { "10th_order" };
+                    if order_count == 1 || order_count == 10 || order_count == 100 {
+                        let milestone_title = if order_count == 1 { "🎉 Milestone: First Sale!" } else if order_count == 10 { "🎉 Milestone: 10th Order!" } else { "🎉 Milestone: 100th Order!" };
+                        let milestone_type = if order_count == 1 { "first_sale" } else if order_count == 10 { "10th_order" } else { "100_orders" };
                         let milestone_msg = if order_count == 1 {
                             "Congratulations on your first sale! This is just the beginning of your journey."
-                        } else {
+                        } else if order_count == 10 {
                             "You've reached 10 orders! Your business is gaining serious momentum."
+                        } else {
+                            "You've successfully fulfilled 100 orders on OHC!"
                         };
                         let milestone_id = Uuid::new_v4().to_string();
 
@@ -570,13 +572,15 @@ impl OperationsWorker {
                         .await
                         .unwrap_or(0);
 
-                    if order_count == 1 || order_count == 10 {
-                        let milestone_title = if order_count == 1 { "🎉 Milestone: First Sale!" } else { "🎉 Milestone: 10th Order!" };
-                        let milestone_type = if order_count == 1 { "first_sale" } else { "10th_order" };
+                    if order_count == 1 || order_count == 10 || order_count == 100 {
+                        let milestone_title = if order_count == 1 { "🎉 Milestone: First Sale!" } else if order_count == 10 { "🎉 Milestone: 10th Order!" } else { "🎉 Milestone: 100th Order!" };
+                        let milestone_type = if order_count == 1 { "first_sale" } else if order_count == 10 { "10th_order" } else { "100_orders" };
                         let milestone_msg = if order_count == 1 {
                             "Congratulations on your first sale! This is just the beginning of your journey."
-                        } else {
+                        } else if order_count == 10 {
                             "You've reached 10 orders! Your business is gaining serious momentum."
+                        } else {
+                            "You've successfully fulfilled 100 orders on OHC!"
                         };
                         let milestone_id = Uuid::new_v4().to_string();
 
@@ -1704,4 +1708,61 @@ mod tests {
              assert_eq!(count, 1);
          }
      }
+
+
+    #[tokio::test]
+    async fn test_operations_worker_100_orders_milestone() {
+        let db = match crate::db::DB::new().await {
+            Ok(db) => db,
+            Err(_) => return, // Skip test if database is not available
+        };
+        let pool = db.pool.clone();
+        if sqlx::query("SELECT 1").execute(&pool).await.is_err() { return; }
+        let db = Arc::new(db);
+
+        let _ = sqlx::query("CREATE TABLE IF NOT EXISTS department_tasks (id TEXT PRIMARY KEY, tenant_id TEXT, department TEXT, event_type TEXT, payload JSONB, status TEXT DEFAULT 'PENDING', updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP);").execute(&pool).await;
+        let _ = sqlx::query("CREATE TABLE IF NOT EXISTS orders (id TEXT PRIMARY KEY, tenant_id TEXT);").execute(&pool).await;
+        let _ = sqlx::query("CREATE TABLE IF NOT EXISTS business_milestones (id TEXT PRIMARY KEY, tenant_id TEXT, milestone_type TEXT, reached_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, UNIQUE(tenant_id, milestone_type));").execute(&pool).await;
+        let _ = sqlx::query("CREATE TABLE IF NOT EXISTS shared_tasks (id TEXT PRIMARY KEY, organization_id TEXT, title TEXT, description TEXT, status TEXT, priority TEXT, action_risk TEXT, approval_status TEXT, proposed_content TEXT);").execute(&pool).await;
+
+        // Insert 99 orders
+        for i in 0..99 {
+             let _ = sqlx::query("INSERT INTO orders (id, tenant_id) VALUES ($1, 'tenant-100-orders')")
+                 .bind(format!("order-{}", i))
+                 .execute(&pool)
+                 .await;
+        }
+
+        let payload = json!({
+            "tenant_id": "tenant-100-orders",
+            "order_id": "order-100",
+            "items": [],
+            "total": 100
+        });
+
+        let task_id = "task-cs-100-orders";
+        sqlx::query("INSERT INTO department_tasks (id, tenant_id, department, event_type, payload) VALUES ($1, 'tenant-100-orders', 'operations', 'OrderReceived', $2)")
+            .bind(task_id)
+            .bind(&payload)
+            .execute(&pool).await.unwrap();
+
+        // Insert the 100th order that triggers the milestone check
+        let _ = sqlx::query("INSERT INTO orders (id, tenant_id) VALUES ('order-100', 'tenant-100-orders')")
+            .execute(&pool)
+            .await;
+
+        let (event_tx, _) = tokio::sync::mpsc::channel(100);
+        let _hub = Arc::new(crate::hub::Hub::new(event_tx, pool.clone()));
+
+        let _worker = OperationsWorker::new(db.clone());
+        OperationsWorker::poll(&db.clone()).await.unwrap();
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM business_milestones WHERE tenant_id = 'tenant-100-orders' AND milestone_type = '100_orders'")
+            .fetch_one(&pool).await.unwrap();
+        assert_eq!(count, 1);
+
+        let count_shared_task: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM shared_tasks WHERE organization_id = 'tenant-100-orders' AND title = '🎉 Milestone: 100th Order!'")
+            .fetch_one(&pool).await.unwrap();
+        assert_eq!(count_shared_task, 1);
+    }
 }


### PR DESCRIPTION
**Persona & Product-use evidence**:
- **Persona:** Maya, Home Baker. She wants to see clear milestones showing her business is growing and successful.
- **Observed CUJ Gap:** Using the app, after making multiple test orders, there was no feedback or celebration when hitting 100 orders, missing a key opportunity for user delight and a growth loop (sharing the milestone).
- **Fix Rationale:** Celebrating the 100th order provides positive reinforcement for the business owner and creates a shareable moment ("100th Order Milestone!"). This directly supports the product goal of making the assistant feel like a supportive partner in growth.
- **Superpowers loaded:** None explicitly, but followed the standard development protocol.

**Interaction Audit**: No frontend interactions were directly changed (only backend worker trigger), but the milestone card generation already exists for this ID in the codebase and will correctly display the new milestone.

**Changes:**
- Updated `src/server/workers/department_workers.rs` to detect when `order_count == 100`.
- Added generation of a milestone with type `100_orders` and title "🎉 Milestone: 100th Order!".
- Included a test `test_operations_worker_100_orders_milestone` to verify the logic.

---
*PR created automatically by Jules for task [16924887972848798658](https://jules.google.com/task/16924887972848798658) started by @ql-owo-lp*