### PR TITLE
Fix hanging chaos and benchmark tests

### DIFF
--- a/src/server/benchmarks/chaos_bench.rs
+++ b/src/server/benchmarks/chaos_bench.rs
@@ -131,7 +131,7 @@ mod tests {
         let start = std::time::Instant::now();
         let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
         let result = timeout(Duration::from_millis(500), async {
-            let _ = rx.await;
+            tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
             "ok"
         }).await;
         assert!(result.is_err()); // Timeout triggers

--- a/src/server/benchmarks/latency_bench.rs
+++ b/src/server/benchmarks/latency_bench.rs
@@ -646,7 +646,7 @@ mod tests {
         let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
 
         let result = tokio::time::timeout(timeout_duration, async {
-            let _ = rx.await;
+            tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
             Ok::<(), String>(())
         }).await;
 
@@ -659,7 +659,7 @@ mod tests {
         let start = std::time::Instant::now();
         let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
         let result = tokio::time::timeout(std::time::Duration::from_millis(2000), async {
-            let _ = rx.await;
+            tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
             "data"
         }).await;
         assert!(result.is_err());

--- a/src/server/chaos.rs
+++ b/src/server/chaos.rs
@@ -464,8 +464,8 @@ mod tests {
     let _tracker = crate::telemetry::ChaosRecoveryTracker::new("Standalone");
         // "Verify that mobile/Thin Client features fail-safe when backend latency spikes >2s or connections drop entirely."
         let result = tokio::time::timeout(std::time::Duration::from_millis(50), async {
-            let pending = std::future::pending::<Result<(), String>>();
-            pending.await
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await; let pending = Ok::<(), String>(());
+            pending
         }).await;
 
         assert!(result.is_err(), "Mobile API read operations must fail-safe when backend latency spikes >2s (returning cached data)");
@@ -494,8 +494,8 @@ mod tests {
 
         // 2. Simulate read operation degradation via pending
         let read_result = tokio::time::timeout(timeout_duration, async {
-            let pending = std::future::pending::<Result<String, String>>();
-            pending.await
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await; let pending = Ok::<String, String>("".to_string());
+            pending
         }).await;
 
         // Verify timeout was hit
@@ -511,8 +511,8 @@ mod tests {
 
         // 3. Simulate write operation queueing locally on failure via pending
         let write_result = tokio::time::timeout(timeout_duration, async {
-            let pending = std::future::pending::<Result<(), String>>();
-            pending.await
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await; let pending = Ok::<(), String>(());
+            pending
         }).await;
 
         assert!(write_result.is_err(), "Write operation must timeout after latency spike");
@@ -917,8 +917,8 @@ mod tests {
         let timeout_duration = std::time::Duration::from_millis(50);
 
         let result = tokio::time::timeout(timeout_duration, async {
-            let pending = std::future::pending::<Result<(), String>>();
-            pending.await
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await; let pending = Ok::<(), String>(());
+            pending
         }).await;
 
         assert!(result.is_err(), "Chaos resilience must enforce ML-Resilience timeout rule to prevent cascading failure");
@@ -930,8 +930,8 @@ mod tests {
         let timeout_duration = std::time::Duration::from_millis(50);
 
         let inference_future = async {
-            let pending = std::future::pending::<Result<&str, String>>();
-            pending.await
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await; let pending = Ok::<&str, String>("");
+            pending
         };
 
         let inference_result = tokio::time::timeout(timeout_duration, inference_future).await;


### PR DESCRIPTION
Fix hanging tests caused by pending futures in tokio timeouts

Replaced occurrences of `std::future::pending().await` and blocking `rx.await` blocks within `tokio::time::timeout` scopes across `src/server/chaos.rs`, `src/server/benchmarks/latency_bench.rs`, and `src/server/benchmarks/chaos_bench.rs` with explicit `tokio::time::sleep` delays. This ensures the intended timeouts are tested effectively without risking infinite hangs in the Bazel test runner.

---
*PR created automatically by Jules for task [15115306302605653457](https://jules.google.com/task/15115306302605653457) started by @ql-owo-lp*