### PR TITLE
Fix: update agent feed redis topic prefix

### DIFF
--- a/src/server/api/agent_feed.rs
+++ b/src/server/api/agent_feed.rs
@@ -105,7 +105,7 @@ async fn handle_feed_socket(socket: WebSocket, tenant_id: String) {
         }
     };
 
-    let topic = format!("ohc:feed:{}", tenant_id);
+    let topic = format!("agent_feed:{}", tenant_id);
     if let Err(e) = pubsub_conn.subscribe(&topic).await {
         tracing::error!("Failed to subscribe to topic {}: {}", topic, e);
         let _ = sender.send(WsMessage::Text("{\"error\":\"Failed to subscribe\"}".into())).await;
@@ -239,7 +239,7 @@ async fn create_feed_item(
 
             // Publish to Redis Pub/Sub
             let client = get_redis_client();
-            let topic = format!("ohc:feed:{}", tenant_id);
+            let topic = format!("agent_feed:{}", tenant_id);
             if let Ok(payload_json) = serde_json::to_string(&item) {
                 // In background task, to not block response
                 tokio::spawn(async move {
@@ -423,7 +423,7 @@ mod tests {
 
                 // Publish mock message to redis channel
                 let mut conn = client.get_multiplexed_async_connection().await.unwrap();
-                let topic = "ohc:feed:test_ws_tenant";
+                let topic = "agent_feed:test_ws_tenant";
                 let payload = "{\"mock\":\"data\"}";
                 let _: () = redis::cmd("PUBLISH").arg(topic).arg(payload).query_async(&mut conn).await.unwrap();
 


### PR DESCRIPTION
Resolves #27721

- Changed the redis pub/sub topic prefix from `ohc:feed:{tenant_id}` to `agent_feed:{tenant_id}` in `src/server/api/agent_feed.rs`.
- Fixed the corresponding `topic` usage in `test_websocket_feed` inside `src/server/api/agent_feed.rs`.
- Verified all backend unit tests pass (`cargo test agent_feed` and `bazel test //...`).
- Verified that Playwright E2E tests (`bazel test //src/e2e:playwright`) run properly and pass without issues.

**Product-use evidence:**
I identified through the code review that the problem described in Issue #27721 was caused by the redis publish/subscribe channels not matching across different services. By using `agent_feed:{tenant_id}`, the unified agent feed now reliably streams real-time events to the connected client. I verified these changes natively via both the e2e test suite provided and manual review of the topics logic.

**Superpowers loaded:** None explicitly defined for this operation aside from standards.
**Interaction audit:** N/A (No frontend interaction logic was manually modified, handled implicitly via backend WebSocket topic correction).

---
*PR created automatically by Jules for task [2393605141122171325](https://jules.google.com/task/2393605141122171325) started by @wbbsuper*