### PR TITLE
Fix compiler warnings by removing unused import and enum variant

### DIFF
--- a/src/server/auth/grpc.rs
+++ b/src/server/auth/grpc.rs
@@ -4,7 +4,6 @@ use sha2::Sha256;
 
 #[derive(Debug, Clone)]
 enum AuthMode {
-    Disabled,
     Token(Vec<u8>), // HMAC-SHA256 of expected token
     SPIFFE { allowed_id: Option<String> },
 }
@@ -30,7 +29,6 @@ impl AuthConfig {
 
     pub fn authenticate(&self, req: &Request<()>) -> Result<(), Status> {
         match &self.mode {
-            AuthMode::Disabled => Ok(()),
             AuthMode::Token(expected_hash) => self.check_token(req, expected_hash),
             AuthMode::SPIFFE { allowed_id } => self.check_spiffe(req, allowed_id.as_deref()),
         }

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -4128,7 +4128,6 @@ async fn list_ui_bookings_handler(
     axum::extract::Query(query): axum::extract::Query<UiTenantQuery>,
 ) -> axum::response::Response {
     use axum::response::IntoResponse;
-    use sqlx::Row;
     let tenant_id = ui_tenant_id(&query);
     let mobile_optimized = query.mobile_optimized.unwrap_or(false);
 


### PR DESCRIPTION
Removed unused `sqlx::Row` import and unused `AuthMode::Disabled` variant to clean up compiler warnings.

---
*PR created automatically by Jules for task [14986493365313794351](https://jules.google.com/task/14986493365313794351) started by @ql-owo-lp*