### PR TITLE
fix: UI glassmorphism style drift in dark mode

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -206,8 +206,9 @@ body {
   .app-card {
     background: rgba(22, 22, 26, 0.7);
     -webkit-backdrop-filter: blur(30px) saturate(210%);
-  backdrop-filter: blur(30px) saturate(210%);
+    backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
   }
 }
 
@@ -225,8 +226,9 @@ body {
   .app-panel {
     background: rgba(22, 22, 26, 0.7);
     -webkit-backdrop-filter: blur(30px) saturate(210%);
-  backdrop-filter: blur(30px) saturate(210%);
+    backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
   }
 }
 


### PR DESCRIPTION
This PR ensures that `.app-card` and `.app-panel` components correctly preserve their `border-radius: 16px` property and proper `backdrop-filter` indentation in the `@media (prefers-color-scheme: dark)` variant inside `globals.css`.

This resolves the `lens_audit.spec.ts` testing regression and styling drift observed in dark mode layouts across the dashboard UI. All tests (including //src/e2e:playwright) have been verified locally.

---
*PR created automatically by Jules for task [9972792265999484211](https://jules.google.com/task/9972792265999484211) started by @ql-owo-lp*