### PR TITLE
Fix search bug in Help Center with debounced input

### DIFF
--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -9,14 +9,22 @@ export default function HelpCenterPage() {
   const [articles, setArticles] = useState<{category: string, title: string, desc: string, link: string}[]>([]);
   const [videos, setVideos] = useState<{id: number, title: string, duration: string, video_url: string}[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
 
   useEffect(() => {
-    const url = searchQuery.trim() ? `/api/help/search?q=${encodeURIComponent(searchQuery.trim())}` : '/api/help';
+    const handler = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery);
+    }, 300);
+    return () => clearTimeout(handler);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    const url = debouncedSearchQuery.trim() ? `/api/help/search?q=${encodeURIComponent(debouncedSearchQuery.trim())}` : '/api/help';
     fetch(url)
       .then(res => res.json())
       .then(data => setArticles(Array.isArray(data) ? data : []))
       .catch(console.error);
-  }, [searchQuery]);
+  }, [debouncedSearchQuery]);
 
   useEffect(() => {
     fetch('/api/videos')
@@ -28,7 +36,7 @@ export default function HelpCenterPage() {
   const filteredArticles = articles.filter(a => a.category !== "Advanced");
 
   const filteredVideos = videos.filter(video =>
-    video.title.toLowerCase().includes(searchQuery.toLowerCase())
+    video.title.toLowerCase().includes(debouncedSearchQuery.toLowerCase())
   );
 
   return (


### PR DESCRIPTION
This PR fixes a bug in the Help Center search input where rapid typing triggers a fetch for every character. `page.waitForResponse` in the test suit intercepted the first API response (e.g., matching the letter "m" from "My Store"), leading to the display of irrelevant articles and causing test assertion failures. 

To fix this, a 300ms debounce `debouncedSearchQuery` was added using `setTimeout` within `useEffect`. The API fetch and video filtering now react only to this debounced query, resolving the race condition and allowing all e2e tests to pass successfully.

---
*PR created automatically by Jules for task [4268455796802600228](https://jules.google.com/task/4268455796802600228) started by @ql-owo-lp*