### PR TITLE
💰 Miser: track LLM token cost metrics as ohc_llm_cost_total_cents

### DIFF
--- a/src/server/api/telemetry.rs
+++ b/src/server/api/telemetry.rs
@@ -78,7 +78,7 @@ pub async fn sync_telemetry_handler(Json(batch): Json<Vec<MetricBatchItem>>) -> 
                             "tenant_id": tenant_id.clone(),
                             "model": model_string.clone()
                         });
-                        let _ = ::server_telemetry::buffer_metric_i64(&pool, "ohc_mission_cost_cents", "counter", cost_cents, labels_cents).await;
+                        let _ = ::server_telemetry::buffer_metric_i64(&pool, "ohc_llm_cost_total_cents", "counter", cost_cents, labels_cents).await;
                     });
                 }
             }
@@ -118,7 +118,7 @@ pub async fn sync_telemetry_handler(Json(batch): Json<Vec<MetricBatchItem>>) -> 
                             "tenant_id": tenant_id.clone(),
                             "api": api_string.clone()
                         });
-                        let _ = ::server_telemetry::buffer_metric_i64(&pool, "ohc_mission_cost_cents", "counter", cost_cents, labels_cents).await;
+                        let _ = ::server_telemetry::buffer_metric_i64(&pool, "ohc_llm_cost_total_cents", "counter", cost_cents, labels_cents).await;
                     });
                 }
             }

--- a/src/server/harness/telemetry/store.rs
+++ b/src/server/harness/telemetry/store.rs
@@ -20,7 +20,7 @@ impl ViolationStore {
         let meter = global::meter("ohc.harness.telemetry");
         let violation_counter = meter.u64_counter("ohc_harness_violations_total").build();
         let token_usage_counter = meter.u64_counter("ohc_tenant_token_usage_total").build();
-        let llm_cost_counter = meter.u64_counter("ohc_mission_cost_cents").build();
+        let llm_cost_counter = meter.u64_counter("ohc_llm_cost_total_cents").build();
         let storage_bytes_counter = meter.u64_counter("ohc_storage_bytes_total").build();
         let rate_limit_checks_total = meter.u64_counter("ohc_rate_limit_checks_total").build();
         let rate_limit_exceeded_total = meter.u64_counter("ohc_rate_limit_exceeded_total").build();

--- a/src/server/hub.rs
+++ b/src/server/hub.rs
@@ -90,7 +90,7 @@ impl Hub {
                 let cost_cents = (cost * 100.0).round() as i64;
                 let mut labels_cents = labels.clone();
                 labels_cents["cost_cents"] = serde_json::json!(cost_cents);
-                let _ = ::server_telemetry::buffer_metric_i64(&pool_clone, "ohc_mission_cost_cents", "counter", cost_cents, labels_cents).await;
+                let _ = ::server_telemetry::buffer_metric_i64(&pool_clone, "ohc_llm_cost_total_cents", "counter", cost_cents, labels_cents).await;
             }
         });
 

--- a/src/server/monitoring/dashboards/hybrid_swarm_cost_analytics.json
+++ b/src/server/monitoring/dashboards/hybrid_swarm_cost_analytics.json
@@ -43,7 +43,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(ohc_mission_cost_cents[5m])) by (tenant_id)",
+          "expr": "sum(rate(ohc_llm_cost_total_cents[5m])) by (tenant_id)",
           "legendFormat": "{{tenant_id}}",
           "refId": "A"
         }

--- a/src/server/monitoring/dashboards/ohc-agent-audit.json
+++ b/src/server/monitoring/dashboards/ohc-agent-audit.json
@@ -220,7 +220,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(ohc_mission_cost_cents[5m])) by (tenant_id)",
+          "expr": "sum(rate(ohc_llm_cost_total_cents[5m])) by (tenant_id)",
           "legendFormat": "{{tenant_id}}",
           "range": true,
           "refId": "A"

--- a/src/server/monitoring/dashboards/ohc-kairos-hybrid.json
+++ b/src/server/monitoring/dashboards/ohc-kairos-hybrid.json
@@ -485,7 +485,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(ohc_mission_cost_cents[5m])) by (tenant_id)",
+          "expr": "sum(rate(ohc_llm_cost_total_cents[5m])) by (tenant_id)",
           "legendFormat": "{{tenant_id}}",
           "range": true,
           "refId": "A"

--- a/src/server/monitoring/dashboards/tenant_costs.json
+++ b/src/server/monitoring/dashboards/tenant_costs.json
@@ -125,7 +125,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (organization_id) (increase(ohc_mission_cost_cents[24h])) / 100",
+          "expr": "sum by (organization_id) (increase(ohc_llm_cost_total_cents[24h])) / 100",
           "instant": false,
           "legendFormat": "{{organization_id}}",
           "range": true,

--- a/src/server/pricing/cost_aggregator.rs
+++ b/src/server/pricing/cost_aggregator.rs
@@ -45,7 +45,7 @@ pub fn process_telemetry_rows(rows: Vec<TelemetryRow>) -> Vec<DailyCost> {
             if let Some(daily) = trends.get_mut(&date_str) {
                 let val = row.total.unwrap_or(0.0) as i64;
                 match row.metric_name.as_str() {
-                    "ohc_mission_cost_cents" => daily.llm_cost += val,
+                    "ohc_llm_cost_total_cents" => daily.llm_cost += val,
                     "ohc_storage_rw_cost" => daily.storage_cost += val,
                     "ohc_network_cost_cents" => daily.network_cost += val,
                     "ohc_compute_cost_cents" => daily.compute_cost += val,
@@ -79,7 +79,7 @@ pub async fn aggregate_daily_costs(pool: &PgPool, tenant_id: &str) -> Vec<DailyC
             SUM(value)::FLOAT8 as total
         FROM telemetry_buffer
         WHERE (labels_json::jsonb)->>'tenant_id' = $1
-          AND metric_name IN ('ohc_mission_cost_cents', 'ohc_storage_rw_cost', 'ohc_network_cost_cents', 'ohc_compute_cost_cents', 'ohc_email_send_cost', 'ohc_outbound_api_cost', 'ohc_api_call_cost')
+          AND metric_name IN ('ohc_llm_cost_total_cents', 'ohc_storage_rw_cost', 'ohc_network_cost_cents', 'ohc_compute_cost_cents', 'ohc_email_send_cost', 'ohc_outbound_api_cost', 'ohc_api_call_cost')
           AND timestamp >= CURRENT_DATE - INTERVAL '6 days'
         GROUP BY DATE(timestamp), metric_name
         ORDER BY DATE(timestamp) ASC
@@ -135,7 +135,7 @@ mod tests {
         let rows = vec![
             TelemetryRow {
                 date: Some(today),
-                metric_name: "ohc_mission_cost_cents".to_string(),
+                metric_name: "ohc_llm_cost_total_cents".to_string(),
                 total: Some(500.0),
             },
             TelemetryRow {
@@ -201,7 +201,7 @@ mod tests {
         let rows = vec![
             TelemetryRow {
                 date: None,
-                metric_name: "ohc_mission_cost_cents".to_string(),
+                metric_name: "ohc_llm_cost_total_cents".to_string(),
                 total: Some(500.0),
             },
         ];
@@ -228,7 +228,7 @@ pub async fn aggregate_agent_costs(pool: &PgPool, tenant_id: &str) -> Vec<AgentC
             SUM(value)::FLOAT8 as total
         FROM telemetry_buffer
         WHERE (labels_json::jsonb)->>'tenant_id' = $1
-          AND metric_name = 'ohc_mission_cost_cents'
+          AND metric_name = 'ohc_llm_cost_total_cents'
           AND timestamp >= CURRENT_DATE - INTERVAL '30 days'
         GROUP BY (labels_json::jsonb)->>'agent_id'
         ORDER BY total DESC


### PR DESCRIPTION
**Miser: Standardize LLM Cost Metric**

Updates the `ohc_mission_cost_cents` metric to `ohc_llm_cost_total_cents` across the platform to accurately track LLM token costs for the Principal Cost Engineer objective.

**Product-use evidence:**
Persona: Principal Cost Engineer / Owner
CUJ: Checked Grafana cost dashboards and API metrics and discovered that LLM costs were tracked under a confusing legacy metric name (`ohc_mission_cost_cents`) instead of `ohc_llm_cost_total_cents`. Renaming ensures accurate tracking for billing.

**Superpowers used:** None.

**Interaction Audit:** N/A (Backend metric standardization).

---
*PR created automatically by Jules for task [17648189890245729695](https://jules.google.com/task/17648189890245729695) started by @ql-owo-lp*