### PR TITLE
⚡ Bolt: Fix N+1 query overhead in BookingEngineService

### DIFF
--- a/src/server/services/booking.rs
+++ b/src/server/services/booking.rs
@@ -852,26 +852,39 @@ impl BookingEngineService for NativeBookingService {
         .await
         .map_err(|e| Status::internal(e.to_string()))?;
 
+        let service_ids: Vec<String> = rows.iter().map(|r| r.get("id")).collect();
+
+        // Avoid the query entirely if there are no services
+        let all_reqs = if service_ids.is_empty() {
+            Vec::new()
+        } else {
+            sqlx::query(
+                r#"
+                SELECT service_id, resource_type, quantity
+                FROM service_resource_requirements
+                WHERE service_id = ANY($1)
+                "#,
+            )
+            .bind(&service_ids)
+            .fetch_all(&mut *tx)
+            .await
+            .unwrap_or_default()
+        };
+
+        let mut reqs_map: std::collections::HashMap<String, Vec<::server_ohc::app::ServiceResourceRequirement>> = std::collections::HashMap::new();
+        for r in all_reqs {
+            let s_id: String = r.get("service_id");
+            let req = ::server_ohc::app::ServiceResourceRequirement {
+                resource_type: r.get("resource_type"),
+                quantity: r.get::<i32, _>("quantity") as i32,
+            };
+            reqs_map.entry(s_id).or_default().push(req);
+        }
+
         let mut service_definitions = Vec::new();
         for row in rows {
             let service_id: String = row.get("id");
-
-            let reqs = sqlx::query(
-                r#"
-                SELECT resource_type, quantity
-                FROM service_resource_requirements
-                WHERE service_id = $1
-                "#,
-            )
-            .bind(&service_id)
-            .fetch_all(&mut *tx)
-            .await
-            .unwrap_or_default();
-
-            let resource_requirements = reqs.into_iter().map(|r| ::server_ohc::app::ServiceResourceRequirement {
-                resource_type: r.get("resource_type"),
-                quantity: r.get::<i32, _>("quantity") as i32,
-            }).collect();
+            let resource_requirements = reqs_map.remove(&service_id).unwrap_or_default();
 
             service_definitions.push(::server_ohc::app::ServiceDefinition {
                 id: service_id,


### PR DESCRIPTION
- Loaded Superpowers Skills: `TDD`
- Identified a performance bottleneck (N+1 query) in `BookingEngineService::get_services` where the service sequentially iterated over all returned services to fetch each one's resource requirements.
- Implemented a parallel approach where all services are fetched first, then a single query (`WHERE service_id = ANY($1)`) collects all resource requirements, which are then grouped via a HashMap in memory.
- Tested compilation and verification via `cargo check` and `cargo test -p ohc-mono --lib -- services::booking`, verifying 100% pass for booking services.
- Product-use evidence: Observed an explicit N+1 iteration in `src/server/services/booking.rs` causing latency overhead. Eliminating the loop reduces DB load significantly.

---
*PR created automatically by Jules for task [3603361031111623133](https://jules.google.com/task/3603361031111623133) started by @ql-owo-lp*