### PR TITLE
Fix onboarding duplicate disabled property on button

### DIFF
--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -511,8 +511,6 @@ export default function OnboardingWizard() {
 
               <div className="mt-auto pt-6 w-full">
                 <button
-                  disabled={!bio.trim()}
-                  className="w-full bg-[#0066FF] text-white min-h-[44px] min-w-[44px] p-4 rounded-[8px] font-bold shadow-[0_4px_14px_0_rgba(0,102,255,0.39)] hover:bg-[#0052cc] hover:shadow-[0_6px_20px_rgba(0,102,255,0.23)] active:scale-[0.98] transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] disabled:opacity-50 disabled:cursor-not-allowed"
                   onClick={async () => {
                     if (!bio.trim()) return;
                     setIsLoading(true);


### PR DESCRIPTION
This resolves a React compilation error on the OHC onboarding page caused by a duplicate `disabled` attribute being passed to a button. This was uncovered during the Day 1 Onboarding review and prevents Next.js applications from compiling successfully.

---
*PR created automatically by Jules for task [8902398626971191595](https://jules.google.com/task/8902398626971191595) started by @ql-owo-lp*