### PR TITLE
🎥 Lens Audit: fix Help tooltips and documentations UI tests

### DIFF
--- a/src/ui/next/src/e2e/documentation_cuj.spec.ts
+++ b/src/ui/next/src/e2e/documentation_cuj.spec.ts
@@ -19,7 +19,7 @@ test.describe('Documentation User Journey', () => {
     await expect(page.locator('h2', { hasText: 'Payments' })).toBeVisible();
 
     // Verify Videos list loads
-    await expect(page.locator('h3', { hasText: 'Tutorials' })).toBeVisible();
+    await expect(page.locator('h2', { hasText: 'Video Tutorials' })).toBeVisible({ timeout: 10000 });
 
     // Maya searches for "products" to learn how to add products
     await page.fill('input[placeholder="Search for help articles and videos..."]', 'products');

--- a/src/ui/next/src/e2e/documentation_flows.spec.ts
+++ b/src/ui/next/src/e2e/documentation_flows.spec.ts
@@ -21,7 +21,8 @@ test.describe('Documentation Flows', () => {
     await expect(helpBtn).toBeVisible();
 
     // Hover over the help button to trigger the tooltip
-    await helpBtn.hover();
+    await page.locator('#help-btn-tooltip').dispatchEvent('touchstart');
+    await page.waitForTimeout(600); // 500ms for long press
 
     // Verify the tooltip loads with expected content
     // We expect the tooltip to fetch from the API which defaults to "Need help? Click here for guides, videos, and to ask our AI." or the defaultText "Need help? Click here to access our Help Center, Ask AI, Tutorials, and Release Notes."


### PR DESCRIPTION
Fixed failing E2E tests related to documentation flows and tooltip visibility.

* Updated assertion in `documentation_cuj.spec.ts` to expect an `h2` with "Video Tutorials".
* Replaced failing `.hover()` action in `documentation_flows.spec.ts` with a `touchstart` event and timeout to accurately simulate long-press behaviors required for the mobile-first tooltip implementation.

---
*PR created automatically by Jules for task [2677398381570323321](https://jules.google.com/task/2677398381570323321) started by @ql-owo-lp*