### PR TITLE
chore: Codebase cleanup for console logs and unused code warnings

### DIFF
--- a/src/agents/builtin/tools/repo_map.rs
+++ b/src/agents/builtin/tools/repo_map.rs
@@ -254,7 +254,7 @@ mod tests {
         assert!(result.contains("│ fn helper()"));
 
         assert!(result.contains("📄 utils.py"));
-        println!("RESULT: {}", result); assert!(result.contains("│ def do_something()"));
+        assert!(result.contains("│ def do_something()"));
         assert!(result.contains("│ class Data"));
 
         assert!(result.contains("📄 app.ts"));

--- a/src/server/benchmarks/chaos_bench.rs
+++ b/src/server/benchmarks/chaos_bench.rs
@@ -129,7 +129,7 @@ mod tests {
         // This benchmark asserts that the fundamental timeout utility function
         // guarantees the underlying bounded logic without network drift.
         let start = std::time::Instant::now();
-        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (_tx, _rx) = tokio::sync::oneshot::channel::<()>();
         let result = timeout(Duration::from_millis(500), async {
             tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
             "ok"

--- a/src/server/benchmarks/latency_bench.rs
+++ b/src/server/benchmarks/latency_bench.rs
@@ -643,7 +643,7 @@ mod tests {
     async fn test_ml_resilience_60s_timeout_rule() {
         let start = std::time::Instant::now();
         let timeout_duration = std::time::Duration::from_millis(150);
-        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (_tx, _rx) = tokio::sync::oneshot::channel::<()>();
 
         let result = tokio::time::timeout(timeout_duration, async {
             tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
@@ -657,7 +657,7 @@ mod tests {
     #[tokio::test]
     async fn test_chaos_degradation_network() {
         let start = std::time::Instant::now();
-        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (_tx, _rx) = tokio::sync::oneshot::channel::<()>();
         let result = tokio::time::timeout(std::time::Duration::from_millis(2000), async {
             tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
             "data"

--- a/src/server/orchestration/hybrid_sync/daemon_test.rs
+++ b/src/server/orchestration/hybrid_sync/daemon_test.rs
@@ -377,6 +377,7 @@ async fn test_hybrid_sync_clears_error_on_success() {
     let error: Option<String> = row.try_get("sync_error").unwrap_or(None);
     assert_eq!(status, "SYNCED");
     assert_eq!(error, None, "sync_error should be cleared on success");
+}
 
     #[tokio::test]
     async fn test_hybrid_sync_pos_offline_transactions() {
@@ -442,5 +443,3 @@ async fn test_hybrid_sync_clears_error_on_success() {
             .unwrap();
         assert!(job_row.is_some());
     }
-
-}

--- a/src/ui/next/src/e2e/ai-usage-paywall.spec.ts
+++ b/src/ui/next/src/e2e/ai-usage-paywall.spec.ts
@@ -9,8 +9,6 @@ test.describe('AI Usage Paywall Growth Loop', () => {
       window.localStorage.setItem('tenant', 'test-tenant');
     });
 
-    // Capture console output for debugging
-    page.on('console', msg => console.log('PAGE LOG:', msg.text()));
 
     await page.goto('/ai-usage-paywall');
 


### PR DESCRIPTION
Fixed the following maintainer items:
1. Removed debug console.log from `src/ui/next/src/e2e/ai-usage-paywall.spec.ts`.
2. Prefixed unused `rx` with an underscore `_rx` in `src/server/benchmarks/latency_bench.rs` and `src/server/benchmarks/chaos_bench.rs`.
3. Fixed malformed `#[tokio::test]` block causing an `unused function` warning in `src/server/orchestration/hybrid_sync/daemon_test.rs`.
4. Removed a debug `println!` statement in `src/agents/builtin/tools/repo_map.rs`.

---
*PR created automatically by Jules for task [15330724254005601137](https://jules.google.com/task/15330724254005601137) started by @ql-owo-lp*