### PR TITLE
🗺️ Guide: Fix Setup Wizard Playwright E2E Path Resolution

### DIFF
--- a/src/e2e/setup.spec.ts
+++ b/src/e2e/setup.spec.ts
@@ -2,12 +2,27 @@ import { test, expect } from '@playwright/test';
 import * as path from 'path';
 import * as fs from 'fs';
 
+function getSetupHtmlContent() {
+  const possiblePaths = [
+    'src/ui/tauri/src/ui/setup.html',
+    path.join(process.env.SOURCE_REPO_ROOT || '', 'src/ui/tauri/src/ui/setup.html'),
+    path.join(process.env.RUNFILES_DIR || '', 'mono/src/ui/tauri/src/ui/setup.html'),
+    path.join(__dirname, '../../ui/tauri/src/ui/setup.html')
+  ];
+
+  for (const p of possiblePaths) {
+    if (p && fs.existsSync(p)) {
+      return fs.readFileSync(p, 'utf-8');
+    }
+  }
+  throw new Error(`Could not find setup.html. Tried: \n${possiblePaths.join('\n')}\nCWD: ${process.cwd()}\nENV: ${Object.keys(process.env).join(',')}`);
+}
+
 test.describe('OHC Setup Wizard Flow', () => {
 
   test.beforeEach(async ({ page }) => {
-      const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
       await page.route('**/setup.html', async route => {
-          const content = fs.readFileSync(path.join(tauriUiDir, 'setup.html'), 'utf-8');
+          const content = getSetupHtmlContent();
           await route.fulfill({ contentType: 'text/html', body: content });
       });
   });
@@ -119,9 +134,8 @@ test.describe('OHC Setup Wizard Flow', () => {
 test.describe('OHC Setup Wizard Form Configuration', () => {
 
   test.beforeEach(async ({ page }) => {
-      const tauriUiDir = require('path').join(process.cwd(), 'src/ui/tauri/src/ui');
       await page.route('**/setup.html', async route => {
-          const content = require('fs').readFileSync(require('path').join(tauriUiDir, 'setup.html'), 'utf-8');
+          const content = getSetupHtmlContent();
           await route.fulfill({ contentType: 'text/html', body: content });
       });
   });

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -636,7 +636,7 @@
         <h1>Admin Credentials</h1>
         <p>Set up your login details.</p>
 
-        <input type="email" id="admin-email" class="glassmorphism" placeholder="admin@mybusiness.com" inputmode="email" autocomplete="email" />
+        <input type="email" id="admin-email" class="glassmorphism" placeholder="" inputmode="email" autocomplete="email" />
         <div id="email-error" class="error-msg">Please enter a valid email address.</div>
 
         <input type="password" id="admin-password" class="glassmorphism" placeholder="Password (min 8 chars)" autocomplete="new-password" />


### PR DESCRIPTION
This PR fixes the E2E tests for the onboarding flow by ensuring `setup.html` is accurately located within the Bazel test sandbox using fallback paths (`process.env.SOURCE_REPO_ROOT`, `process.env.RUNFILES_DIR`, `__dirname`). It also removes a hardcoded email placeholder in the `setup.html` input.

**Product-use evidence:**
During onboarding flow validation via `bazel test //src/e2e:playwright_setup_spec_ts`, a persistent `ENOENT` error occurred due to missing `setup.html`. The updated paths properly read the file, and all E2E tests have been verified passing in the sandbox.

---
*PR created automatically by Jules for task [1398310910230498263](https://jules.google.com/task/1398310910230498263) started by @ql-owo-lp*