### PR TITLE
feat: Interactive quote editing before approval

### DIFF
--- a/src/server/api/agents/approvals.rs
+++ b/src/server/api/agents/approvals.rs
@@ -28,6 +28,7 @@ pub struct PaginationQuery {
 #[derive(Deserialize)]
 pub struct DecisionRequest {
     pub approved: bool,
+    pub edited_payload: Option<serde_json::Value>,
 }
 
 #[derive(Serialize)]
@@ -230,7 +231,7 @@ async fn decide_approval(
         None => return (StatusCode::UNAUTHORIZED, Json(DecisionResponse { success: false })).into_response(),
     };
 
-    match orchestrator.decide_approval(&id, &tenant_id, payload.approved).await {
+    match orchestrator.decide_approval(&id, &tenant_id, payload.approved, payload.edited_payload).await {
         Ok(_) => (StatusCode::OK, Json(DecisionResponse { success: true })).into_response(),
         Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, Json(DecisionResponse { success: false })).into_response(),
     }

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -2071,7 +2071,7 @@ impl HubService for MyHubService {
 
         let req = request.into_inner();
 
-        self.dept_orchestrator.decide_approval(&req.task_id, &org_id, req.is_approved).await
+        self.dept_orchestrator.decide_approval(&req.task_id, &org_id, req.is_approved, None).await
             .map_err(|e| Status::internal(e))?;
 
         Ok(Response::new(ApproveTaskResponse {

--- a/src/server/orchestration/departments/approvals_test.rs
+++ b/src/server/orchestration/departments/approvals_test.rs
@@ -54,7 +54,7 @@ mod tests {
 
         let request_id = pending[0].id.clone();
 
-        let res = orchestrator.decide_approval(&request_id, &tenant_id, true).await;
+        let res = orchestrator.decide_approval(&request_id, &tenant_id, true, None).await;
         assert!(res.is_ok());
 
         let pending_after = orchestrator.get_pending_approvals(&tenant_id, None, 100).await;

--- a/src/server/orchestration/departments/flow_test.rs
+++ b/src/server/orchestration/departments/flow_test.rs
@@ -177,7 +177,7 @@ mod tests {
         assert!(has_draft, "Should generate a draft for review");
 
         // 2. Approve the draft
-        let decide_res = orchestrator.decide_approval(&draft_request_id, &tenant_id, true).await;
+        let decide_res = orchestrator.decide_approval(&draft_request_id, &tenant_id, true, None).await;
         assert!(decide_res.is_ok());
 
         // Wait a bit for the approved event to propagate and be processed by the CustomerSuccessAgent

--- a/src/server/orchestration/departments/orchestrator.rs
+++ b/src/server/orchestration/departments/orchestrator.rs
@@ -742,7 +742,7 @@ impl DepartmentOrchestrator {
         results
     }
 
-    pub async fn decide_approval(&self, request_id: &str, tenant_id: &str, approved: bool) -> Result<(), String> {
+    pub async fn decide_approval(&self, request_id: &str, tenant_id: &str, approved: bool, edited_payload: Option<serde_json::Value>) -> Result<(), String> {
         let lock_key = format!("ohc:lock:agent_approval:{}", request_id);
 
         let lock_acquired = self.mesh.acquire_lock(&lock_key, "orchestrator", 60).await;
@@ -762,13 +762,24 @@ impl DepartmentOrchestrator {
             DbStore::Postgres => {
                 let row = if let Ok(mut tx) = self.db.pool.begin().await {
                     if ::server_common::auth_utils::set_org_context(&mut *tx, tenant_id).await.is_ok() {
-                        let updated = sqlx::query("UPDATE agent_approvals SET status = $1, updated_at = $2 WHERE id = $3 AND tenant_id = $4 RETURNING department, payload")
-                            .bind(new_status)
-                            .bind(now)
-                            .bind(request_id)
-                            .bind(tenant_id)
-                            .fetch_optional(&mut *tx)
-                            .await;
+                        let updated = if let Some(ref ep) = edited_payload {
+                            sqlx::query("UPDATE agent_approvals SET status = $1, updated_at = $2, payload = $3 WHERE id = $4 AND tenant_id = $5 RETURNING department, payload")
+                                .bind(new_status)
+                                .bind(now)
+                                .bind(ep)
+                                .bind(request_id)
+                                .bind(tenant_id)
+                                .fetch_optional(&mut *tx)
+                                .await
+                        } else {
+                            sqlx::query("UPDATE agent_approvals SET status = $1, updated_at = $2 WHERE id = $3 AND tenant_id = $4 RETURNING department, payload")
+                                .bind(new_status)
+                                .bind(now)
+                                .bind(request_id)
+                                .bind(tenant_id)
+                                .fetch_optional(&mut *tx)
+                                .await
+                        };
                         let _ = tx.commit().await;
                         updated
                     } else {
@@ -801,13 +812,25 @@ impl DepartmentOrchestrator {
                 }
             }
             DbStore::Sqlite(pool) => {
-                let row = sqlx::query("UPDATE agent_approvals SET status = ?, updated_at = ? WHERE id = ? AND tenant_id = ? RETURNING department, payload")
-                    .bind(new_status)
-                    .bind(now)
-                    .bind(request_id)
-                    .bind(tenant_id)
-                    .fetch_optional(pool)
-                    .await;
+                let row = if let Some(ref ep) = edited_payload {
+                    let ep_str = serde_json::to_string(ep).unwrap_or_default();
+                    sqlx::query("UPDATE agent_approvals SET status = ?, updated_at = ?, payload = ? WHERE id = ? AND tenant_id = ? RETURNING department, payload")
+                        .bind(new_status)
+                        .bind(now)
+                        .bind(ep_str)
+                        .bind(request_id)
+                        .bind(tenant_id)
+                        .fetch_optional(pool)
+                        .await
+                } else {
+                    sqlx::query("UPDATE agent_approvals SET status = ?, updated_at = ? WHERE id = ? AND tenant_id = ? RETURNING department, payload")
+                        .bind(new_status)
+                        .bind(now)
+                        .bind(request_id)
+                        .bind(tenant_id)
+                        .fetch_optional(pool)
+                        .await
+                };
                 match row {
                     Ok(Some(r)) => {
                         use sqlx::Row;
@@ -842,7 +865,9 @@ impl DepartmentOrchestrator {
             ]);
 
             if approved {
-                if let Some(payload) = &original_payload {
+                let payload_to_use = edited_payload.as_ref().or(original_payload.as_ref());
+
+                if let Some(payload) = payload_to_use {
                     if payload.get("feature_type").and_then(|v| v.as_str()) == Some("quote_draft") {
                         let price = payload.get("suggested_price").and_then(|v| v.as_f64()).unwrap_or(0.0);
                         let deposit_amount = (price * 0.20) as i64 * 100;
@@ -1020,7 +1045,7 @@ impl DepartmentOrchestrator {
                 }
 
                 // If this is a stockout restock and price approval, execute the price change and dispatch a job
-                if let Some(payload) = &original_payload {
+                if let Some(payload) = payload_to_use {
                     if payload.get("feature_type").and_then(|v| v.as_str()) == Some("stockout_restock_and_price") {
                         if let Some(product_id) = payload.get("product_id").and_then(|v| v.as_str()) {
                             let new_price = payload.get("new_price").and_then(|v| v.as_f64()).unwrap_or(0.0);
@@ -1063,7 +1088,7 @@ impl DepartmentOrchestrator {
                 }
 
                 // If this is a Smart Pricing approval, execute the price change in the database directly.
-                if let Some(payload) = &original_payload {
+                if let Some(payload) = payload_to_use {
                     if payload.get("context").and_then(|c| c.get("smart_pricing")).and_then(|v| v.as_bool()).unwrap_or(false) {
                         if let Some(product_id) = payload.get("context").and_then(|c| c.get("product_id")).and_then(|v| v.as_str()) {
                             let _discount_amount = payload.get("context").and_then(|c| c.get("discount_amount")).and_then(|v| v.as_f64()).unwrap_or(0.0);

--- a/src/ui/next/src/app/team/components/ApprovalInbox.tsx
+++ b/src/ui/next/src/app/team/components/ApprovalInbox.tsx
@@ -8,7 +8,7 @@ type Props = {
   departmentName: string;
   approvals: ApprovalRequest[];
   onBack: () => void;
-  onApprove: (id: string) => void;
+  onApprove: (id: string, editedPayload?: any) => void;
   onReject: (id: string) => void;
 };
 
@@ -24,6 +24,7 @@ export default function ApprovalInbox({
   const [selectedReview, setSelectedReview] = useState<ApprovalRequest | null>(
     null,
   );
+  const [editedQuote, setEditedQuote] = useState<{ suggested_price: string, scope: string } | null>(null);
 
   const handleToggle = async () => {
     const newValue = !reviewAll;
@@ -628,6 +629,12 @@ export default function ApprovalInbox({
                       onClick={() => {
                         if (payload && (payload.original_message || payload.feature_type === "quote_draft" || payload.feature_type === "ambassador_reply")) {
                           setSelectedReview(req);
+                          if (payload.feature_type === "quote_draft") {
+                            setEditedQuote({
+                              suggested_price: String(payload.suggested_price || ''),
+                              scope: payload.scope || ''
+                            });
+                          }
                         } else {
                           onReject(req.id);
                         }
@@ -639,7 +646,17 @@ export default function ApprovalInbox({
                         : "Reject / Edit"}
                     </button>
                     <button
-                      onClick={() => onApprove(req.id)}
+                      onClick={() => {
+                        if (req.payload?.feature_type === "quote_draft" && editedQuote) {
+                           onApprove(req.id, {
+                             ...req.payload,
+                             suggested_price: parseFloat(editedQuote.suggested_price) || 0,
+                             scope: editedQuote.scope
+                           });
+                        } else {
+                           onApprove(req.id);
+                        }
+                      }}
                       className="flex-1 py-3 px-4 rounded-xl font-bold text-sm bg-[#0066FF] text-white hover:bg-[#0052CC] shadow-md shadow-[#0066FF]/20 active:scale-[0.98] transition-all min-h-[44px] min-w-[44px]"
                     >
                       {req.payload?.feature_type === "case_study"
@@ -682,21 +699,47 @@ export default function ApprovalInbox({
                 </div>
               </div>
 
-              <div className="mb-6">
-                <p className="text-xs text-gray-500 font-medium uppercase tracking-wider mb-1">
-                  Draft
-                </p>
-                <div className="glassmorphism p-3 rounded-xl border border-blue-100 text-sm text-gray-800 italic relative">
-                  {extractPayload(selectedReview.description).payload
-                    ?.generated_response || extractPayload(selectedReview.description).payload?.draft_reply || extractPayload(selectedReview.description).payload?.reply || "N/A"}
+              {extractPayload(selectedReview.description).payload?.feature_type === "quote_draft" ? (
+                <div className="mb-6 space-y-4">
+                  <div>
+                    <label className="block text-xs text-gray-500 font-medium uppercase tracking-wider mb-1">Suggested Price ($)</label>
+                    <input
+                      type="number"
+                      value={editedQuote?.suggested_price || ''}
+                      onChange={(e) => setEditedQuote(prev => prev ? { ...prev, suggested_price: e.target.value } : null)}
+                      className="w-full px-4 py-3 rounded-xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-[#0066FF]/50 bg-white"
+                      data-testid="edit-quote-price"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-gray-500 font-medium uppercase tracking-wider mb-1">Scope of Work</label>
+                    <textarea
+                      value={editedQuote?.scope || ''}
+                      onChange={(e) => setEditedQuote(prev => prev ? { ...prev, scope: e.target.value } : null)}
+                      rows={3}
+                      className="w-full px-4 py-3 rounded-xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-[#0066FF]/50 bg-white resize-none"
+                      data-testid="edit-quote-scope"
+                    />
+                  </div>
                 </div>
-              </div>
+              ) : (
+                <div className="mb-6">
+                  <p className="text-xs text-gray-500 font-medium uppercase tracking-wider mb-1">
+                    Draft
+                  </p>
+                  <div className="glassmorphism p-3 rounded-xl border border-blue-100 text-sm text-gray-800 italic relative">
+                    {extractPayload(selectedReview.description).payload
+                      ?.generated_response || extractPayload(selectedReview.description).payload?.draft_reply || extractPayload(selectedReview.description).payload?.reply || "N/A"}
+                  </div>
+                </div>
+              )}
 
               <div className="flex gap-3">
                 <button
                   onClick={() => {
                     onReject(selectedReview.id);
                     setSelectedReview(null);
+                    setEditedQuote(null);
                   }}
                   className="flex-1 py-3 px-4 rounded-xl font-semibold text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 min-h-[44px] min-w-[44px]"
                 >
@@ -705,19 +748,30 @@ export default function ApprovalInbox({
                 <button
                   onClick={() => {
                     setSelectedReview(null);
+                    setEditedQuote(null);
                   }}
                   className="flex-1 py-3 px-4 rounded-xl font-semibold text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 min-h-[44px] min-w-[44px]"
                 >
-                  Edit
+                  Cancel
                 </button>
                 <button
                   onClick={() => {
-                    onApprove(selectedReview.id);
+                    if (extractPayload(selectedReview.description).payload?.feature_type === "quote_draft" && editedQuote) {
+                      onApprove(selectedReview.id, {
+                         ...extractPayload(selectedReview.description).payload,
+                         suggested_price: parseFloat(editedQuote.suggested_price) || 0,
+                         scope: editedQuote.scope
+                      });
+                    } else {
+                      onApprove(selectedReview.id);
+                    }
                     setSelectedReview(null);
+                    setEditedQuote(null);
                   }}
                   className="flex-1 py-3 px-4 rounded-xl font-bold text-sm bg-[#0066FF] text-white hover:bg-[#0052CC] shadow-md shadow-[#0066FF]/20 active:scale-[0.98] transition-all min-h-[44px] min-w-[44px]"
+                  data-testid="modal-approve-btn"
                 >
-                  Send Draft
+                  {extractPayload(selectedReview.description).payload?.feature_type === "quote_draft" ? "Approve & Send" : "Send Draft"}
                 </button>
               </div>
             </div>

--- a/src/ui/next/src/app/team/page.tsx
+++ b/src/ui/next/src/app/team/page.tsx
@@ -54,17 +54,23 @@ export default function TeamPage() {
     fetchApprovals();
   }, []);
 
-  const handleApprove = async (id: string) => {
+  const handleApprove = async (id: string, editedPayload?: any) => {
     try {
       const token = typeof window !== 'undefined' ? localStorage.getItem('token') || '' : '';
       setApprovals(prev => prev.filter(a => a.id !== id));
+
+      const payload: any = { approved: true };
+      if (editedPayload) {
+        payload.edited_payload = editedPayload;
+      }
+
       const response = await fetch(`/api/agents/approvals/${id}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${token}`
         },
-        body: JSON.stringify({ approved: true })
+        body: JSON.stringify(payload)
       });
       if (!response.ok) fetchApprovals();
     } catch (error) {

--- a/src/ui/next/src/e2e/draft-quote-card.spec.ts
+++ b/src/ui/next/src/e2e/draft-quote-card.spec.ts
@@ -27,12 +27,27 @@ test.describe('Draft Quote Action Card CUJ', () => {
     await expect(page.getByText('Draft Quote: Plumbing Fix for Customer')).toBeVisible();
     await expect(page.getByText('Calculated Total:')).toBeVisible();
 
-    // 5. Tap "Approve & Send"
-    const approveBtn = page.getByRole('button', { name: 'Approve & Send' }).first();
+    // 5. Tap "Edit"
+    const editBtn = page.getByRole('button', { name: 'Edit' }).first();
+    await editBtn.waitFor({ state: 'visible' });
+    await editBtn.click();
+
+    // 6. Edit the price
+    const priceInput = page.getByTestId('edit-quote-price');
+    await expect(priceInput).toBeVisible();
+    await priceInput.fill('350');
+
+    // 7. Edit the scope
+    const scopeInput = page.getByTestId('edit-quote-scope');
+    await expect(scopeInput).toBeVisible();
+    await scopeInput.fill('Updated Plumbing Fix including labor and standard materials plus extra parts.');
+
+    // 8. Tap "Approve & Send" in modal
+    const approveBtn = page.getByTestId('modal-approve-btn');
     await approveBtn.waitFor({ state: 'visible' });
     await approveBtn.click();
 
-    // 6. Optimistic UI update should remove the card from the feed
+    // 9. Optimistic UI update should remove the card from the feed
     await expect(page.getByTestId('quote-draft-card')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
This PR enables the business owner to actively edit drafted quotes (price, scope) prior to approval via the Team Approval Inbox UI, directly addressing the core component of Issue #27841.

**Key Changes:**
1. **Frontend (`ApprovalInbox.tsx`, `team/page.tsx`):** Added specific handling for `quote_draft` features within the Review Modal. When an owner clicks 'Edit', they are presented with inputs to alter the `suggested_price` and `scope`. The `onApprove` callback was upgraded to accept and pass `editedPayload` to the `/api/agents/approvals` endpoints.
2. **Backend (`approvals.rs`, `orchestrator.rs`):** Expanded `DecisionRequest` with an `Option<serde_json::Value>` named `edited_payload`. The `DepartmentOrchestrator::decide_approval` was refactored to override `original_payload` fields with the provided edits and persist them to `quotes`, `projects`, and `agent_approvals`.
3. **E2E Testing:** Re-worked the `draft-quote-card.spec.ts` test to fully execute the edit flow, inputting new data into the text fields and clicking 'Approve & Send'.

**Product-use evidence:** 
- **Persona:** Carlos (Field Service Owner).
- **CUJ:** Login -> View Sales Agent's draft quote on the 375px mobile team page -> Enter Edit mode on quote draft -> Edit the scope to add "extra parts" and increase the price -> Approve.
- **Why?** Pre-drafted quotes are a great start, but owners need control over the final details before sending legal estimates/deposit requests to customers.
- **Verification:** Using `bazel test //...` and `bazel test //src/e2e:playwright` the complete modified CUJ passes automatically.

---
*PR created automatically by Jules for task [696336723466697292](https://jules.google.com/task/696336723466697292) started by @ql-owo-lp*

Resolves #27841