### PR TITLE
feat: Add chat-image-url to zero-click onboarding flow

### DIFF
--- a/src/e2e/onboarding_chat_cuj.spec.ts
+++ b/src/e2e/onboarding_chat_cuj.spec.ts
@@ -6,7 +6,10 @@ test.describe('Conversational Setup CUJ', () => {
 
   test.beforeEach(async ({ page }) => {
     // Intercept standard setup.html load to serve from filesystem for tests
-    const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
+    let tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
+    if (!fs.existsSync(tauriUiDir)) {
+        tauriUiDir = path.join(process.env.RUNFILES_DIR || process.cwd(), '_main/src/ui/tauri/src/ui');
+    }
     await page.route('**/setup.html', async route => {
       const content = fs.readFileSync(path.join(tauriUiDir, 'setup.html'), 'utf-8');
       await route.fulfill({ contentType: 'text/html', body: content });

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -525,9 +525,12 @@
             <div style="margin-bottom: 10px; color: #333;"><strong>Assistant:</strong> What do you do? (e.g. I make custom vegan cakes in Austin)</div>
         </div>
 
-        <div style="display: flex; gap: 10px;">
-            <input type="text" id="chat-input" data-testid="chat-input" class="glassmorphism" placeholder="Type a message..." style="margin-bottom: 0; flex-grow: 1; min-height: 44px; border-radius: 8px;">
-            <button id="chat-send-btn" data-testid="chat-send-btn" style="width: auto; min-height: 44px; min-width: 44px; border-radius: 8px;">Send</button>
+        <div style="display: flex; flex-direction: column; gap: 10px;">
+            <input type="text" id="chat-image-url" data-testid="chat-image-url" class="glassmorphism" placeholder="Image URL (Optional)" style="margin-bottom: 0; width: 100%; min-height: 44px; border-radius: 8px;">
+            <div style="display: flex; gap: 10px;">
+                <input type="text" id="chat-input" data-testid="chat-input" class="glassmorphism" placeholder="Type a message..." style="margin-bottom: 0; flex-grow: 1; min-height: 44px; border-radius: 8px;">
+                <button id="chat-send-btn" data-testid="chat-send-btn" style="width: auto; min-height: 44px; min-width: 44px; border-radius: 8px;">Send</button>
+            </div>
         </div>
       </div>
 
@@ -1211,12 +1214,22 @@
 
       async function sendChatMessage() {
           const text = chatInputEl.value.trim();
-          if (!text) return;
+          const chatImageEl = document.getElementById('chat-image-url');
+          const imageUrl = chatImageEl ? chatImageEl.value.trim() : '';
+          if (!text && !imageUrl) return;
 
           // Append user message
-          chatMessagesEl.innerHTML += `<div style="margin-bottom: 10px; color: #0066FF;"><strong>You:</strong> ${text}</div>`;
+          let displayMsg = text;
+          if (imageUrl) displayMsg += `<br><span style="font-size: 12px; color: #666;">[Attached Image: ${imageUrl}]</span>`;
+
+          chatMessagesEl.innerHTML += `<div style="margin-bottom: 10px; color: #0066FF;"><strong>You:</strong> ${displayMsg}</div>`;
           chatInputEl.value = '';
-          chatHistory.push({ role: 'user', content: text });
+          if (chatImageEl) chatImageEl.value = '';
+
+          let msgObj = { role: 'user', content: text };
+          if (imageUrl) msgObj.image_url = imageUrl;
+
+          chatHistory.push(msgObj);
           chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
 
           chatSendBtn.disabled = true;


### PR DESCRIPTION
This PR adds the missing `#chat-image-url` input to the conversational agent onboarding flow (`setup.html`) and updates the chat payload generation in JS to pass the optional `image_url` property to the backend. It also patches the E2E test `onboarding_chat_cuj.spec.ts` so that it robustly loads `setup.html` from `RUNFILES_DIR` inside the Bazel sandbox instead of breaking.

**Superpowers Skill Loading Gate:**
- The agent properly audited UI/UX requirements from the Markdown documentation, utilizing the `browser/playwright` and `grep` discovery patterns required before mutating frontend assets.

**Product-use Evidence:**
- **Persona:** Maya (Home Baker)
- **Flow Attempted:** Playwright E2E testing the Conversational Onboarding.
- **CUJ Gap Observed:** The input field (`chat-image-url`) was not present in the HTML DOM, breaking the ability to submit photo uploads in chat.
- **Post-fix flow:** Added the `#chat-image-url` element inside the flex container, updated the `sendChatMessage` function to extract the value and pass it through to the `api/onboarding/chat` POST request. Playwright E2E test successfully loads and executes without the `ENOENT` failure.

**Interaction Audit Table**

| Element Tested | Designed Purpose | Observed Result | Fix Implemented |
|---|---|---|---|
| `#chat-image-url` | Capture multimodal image URLs during onboarding setup chat. | Was completely missing from the markup in `setup.html`. | Appended to DOM right above the chat input box, styled with `glassmorphism`, updated JS handler to capture its value when clicking send. |
| `#chat-send-btn` | Trigger sending chat messages. | Only sent text content. | Modified to detect `image_url`, render the attached URL directly in the UI as a span beneath text, and send the payload appropriately to `api/onboarding/chat`. |

Resolves #27858

---
*PR created automatically by Jules for task [15223477635223450558](https://jules.google.com/task/15223477635223450558) started by @ql-owo-lp*