### PR TITLE
feat: add Network Cost to Cost Transparency Dashboard

### DIFF
--- a/src/e2e/cost_dashboard.spec.ts
+++ b/src/e2e/cost_dashboard.spec.ts
@@ -92,6 +92,7 @@ test.describe('Cost Dashboard "My Plan" functionality', () => {
     await expect(page.locator('span', { hasText: 'Storage' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Payment Fees' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Bandwidth Savings' }).first()).toBeVisible();
+    await expect(page.locator('span', { hasText: 'Network Cost' }).first()).toBeVisible();
   });
 
   test('Billing checkout session and cancel subscription journey', async ({ page }) => {

--- a/src/ui/tauri/src/ui/cost-dashboard.html
+++ b/src/ui/tauri/src/ui/cost-dashboard.html
@@ -224,6 +224,10 @@
                 <span id="compute-cost" style="font-weight: 500;">$0.00</span>
             </div>
             <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
+                <span style="color: #86868b;">Network Cost</span>
+                <span id="network-cost" style="font-weight: 500;">$0.00</span>
+            </div>
+            <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
                 <span style="color: #86868b;">Email Sends</span>
                 <span id="email-cost" style="font-weight: 500;">$0.00</span>
             </div>
@@ -312,6 +316,7 @@
                 document.getElementById('payment-fees').innerText = formatCents(costData.payment_fees || 0);
                 document.getElementById('bandwidth-savings').innerText = formatCents(costData.bandwidth_savings || 0);
                 document.getElementById('compute-cost').innerText = formatCents(costData.compute_cost || 0);
+                document.getElementById('network-cost').innerText = formatCents(costData.network_cost || 0);
                 document.getElementById('email-cost').innerText = formatCents(costData.email_cost || 0);
                 document.getElementById('api-cost').innerText = formatCents(costData.api_cost || 0);
 


### PR DESCRIPTION
This PR resolves a gap in the Cost Transparency Dashboard. Previously, "Network Cost" was omitted from the cost breakdown section in the UI, even though the API supplied it. 

Changes include:
- Added `Network Cost` alongside the existing breakdowns (Payment Fees, Bandwidth Savings, Compute Usage, etc.) in `src/ui/tauri/src/ui/cost-dashboard.html`.
- Bound the value from the API payload (`costData.network_cost`) appropriately using `formatCents`.
- Updated end-to-end tests (`src/e2e/cost_dashboard.spec.ts`) to explicitly check for the visibility of the new "Network Cost" element in the UI.

The issue was identified via dogfooding/visual inspection of the Cost Transparency layout. All tests pass successfully.

---
*PR created automatically by Jules for task [11867849338824116975](https://jules.google.com/task/11867849338824116975) started by @ql-owo-lp*