### PR TITLE
fix: scope viral loop performance metrics to tenant

### DIFF
--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -1643,7 +1643,7 @@ async fn handle_onboarding_metrics(
 ) -> Result<Json<OnboardingMetricsResponse>, StatusCode> {
     let cache_key = "onboarding_metrics";
     let cache = ONBOARDING_METRICS_CACHE.get_or_init(|| HybridCache::new(None));
-    if let Some(cached_resp) = cache.get(cache_key).await {
+    if let Some(cached_resp) = cache.get(&cache_key).await {
         return Ok(Json(cached_resp));
     }
 
@@ -1655,7 +1655,7 @@ async fn handle_onboarding_metrics(
             use sqlx::Row;
             let metrics = rows.into_iter().map(|r| OnboardingMetric { step: r.get("step"), count: r.get::<i64, _>("count") as i32 }).collect();
             let resp = OnboardingMetricsResponse { metrics };
-            cache.set(cache_key, resp.clone(), std::time::Duration::from_secs(60)).await;
+            cache.set(&cache_key, resp.clone(), std::time::Duration::from_secs(60)).await;
             Ok(Json(resp))
         }
         Err(e) => {
@@ -2256,10 +2256,11 @@ mod tests {
 
 async fn handle_aggregated_team_invites_metrics(
     Extension(state): Extension<GrowthState>,
+    axum::extract::Extension(auth_info): axum::extract::Extension<::server_auth::orchestration::AuthInfo>,
 ) -> Result<Json<TeamInvitesMetricsResponse>, StatusCode> {
-    let cache_key = "aggregated_metrics";
+    let cache_key = format!("aggregated_metrics_{}", auth_info.org_id);
     let cache = METRICS_CACHE.get_or_init(|| HybridCache::new(None));
-    if let Some(cached_resp) = cache.get(cache_key).await {
+    if let Some(cached_resp) = cache.get(&cache_key).await {
         return Ok(Json(cached_resp));
     }
 
@@ -2267,14 +2268,16 @@ async fn handle_aggregated_team_invites_metrics(
     let tracker = crate::services::growth::invites::InviteTracker::new(repo);
 
     let pool_clone = state.pool.clone();
+    let org_id_clone = auth_info.org_id.clone();
     let active_referrals_fut = async {
-        sqlx::query_scalar("SELECT COALESCE(SUM(conversions), 0) FROM referrals")
+        sqlx::query_scalar("SELECT COALESCE(SUM(conversions), 0) FROM referrals WHERE tenant_id = $1")
+            .bind(&org_id_clone)
             .fetch_one(&pool_clone)
             .await
             .unwrap_or(0)
     };
 
-    let invites_count_fut = tracker.get_total_invites_count();
+    let invites_count_fut = tracker.get_total_invites_count(&auth_info.org_id);
     let (active_referrals, invites_count_res) = tokio::join!(active_referrals_fut, invites_count_fut);
 
     match invites_count_res {
@@ -2288,7 +2291,7 @@ async fn handle_aggregated_team_invites_metrics(
                     pending_rewards: 0.0,
                 }
             };
-            cache.set(cache_key, resp.clone(), std::time::Duration::from_secs(60)).await;
+            cache.set(&cache_key, resp.clone(), std::time::Duration::from_secs(60)).await;
             Ok(Json(resp))
         },
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),

--- a/src/server/services/growth/invites.rs
+++ b/src/server/services/growth/invites.rs
@@ -121,8 +121,9 @@ impl InviteRepository {
         Ok(())
     }
 
-    pub async fn get_total_invites_count(&self) -> Result<i64, String> {
-        let row = sqlx::query("SELECT COUNT(*) FROM team_invites")
+    pub async fn get_total_invites_count(&self, tenant_id: &str) -> Result<i64, String> {
+        let row = sqlx::query("SELECT COUNT(*) FROM team_invites WHERE tenant_id = $1")
+            .bind(tenant_id)
             .fetch_one(&self.pool)
             .await
             .map_err(|e| e.to_string())?;
@@ -193,8 +194,8 @@ impl InviteTracker {
         self.repo.accept_invite(invite_id).await
     }
 
-    pub async fn get_total_invites_count(&self) -> Result<i64, String> {
-        self.repo.get_total_invites_count().await
+    pub async fn get_total_invites_count(&self, tenant_id: &str) -> Result<i64, String> {
+        self.repo.get_total_invites_count(tenant_id).await
     }
 
     pub async fn record_invites(&self, team_id: &str, inviter_id: &str, invitee_ids: &[String]) -> Result<(), String> {


### PR DESCRIPTION
**Role:** Principal Growth Engineer & Nova (L7)
**Persona Tested:** OHC Business Owner / Growth Operator
**Critical User Journey:** Logging in to check the "Viral Loop Performance" widget on the Dashboard to see total team invites and active referrals.

**Gap Observed:**
The `/api/v1/growth/team-invites/aggregated-metrics` API route was missing the `axum::extract::Extension(auth_info)` parameter and aggregated stats for both `team_invites` and `referrals` globally across *all* tenants, rather than returning the performance of the current owner's tenant. Additionally, the cache key used in `METRICS_CACHE` was a static string (`"aggregated_metrics"`), which meant that data cached for one tenant was incorrectly returned to other tenants viewing the widget.

**What real owner/operator would need the fix:**
Owners expect their dashboard to reflect their own store and team activity. Seeing global platform metrics (total referrals made by all users on OHC) causes immediate distrust and a broken experience, as they do not own those referrals and the numbers would not match their own efforts.

**How it was fixed:**
- Modified `src/server/services/growth/invites.rs` to add a `tenant_id` parameter to `get_total_invites_count()`.
- Added the `AuthInfo` axum extractor to the endpoint `handle_aggregated_team_invites_metrics` in `src/server/api/growth.rs` to securely fetch the current user's `org_id` (`tenant_id`).
- Fixed the inline SQL query inside the endpoint to execute `SELECT COALESCE(SUM(conversions), 0) FROM referrals WHERE tenant_id = $1`.
- Made the `METRICS_CACHE` key tenant-specific by including the `org_id` in the key (e.g. `format!("aggregated_metrics_{}", auth_info.org_id)`).

**Superpowers used:**
The `verification-before-completion` superpower rules were applied by fully running test suites and ensuring that no regressions occurred when applying the changes and checking cache endpoints.

**Tests:**
All Bazel tests for backend (`bazelisk test //...`) and Playwright E2E suites (`bazelisk test //src/e2e:playwright`) were executed and pass, ensuring hermetic testing requirements are fulfilled.

---
*PR created automatically by Jules for task [15108009763650101665](https://jules.google.com/task/15108009763650101665) started by @ql-owo-lp*