### PR TITLE
Fix E2E hardcoded database URL and verify_artifacts.sh warnings

### DIFF
--- a/bazel/rules/playwright/playwright_test.sh
+++ b/bazel/rules/playwright/playwright_test.sh
@@ -428,6 +428,7 @@ if [[ -n "${SERVER_BIN:-}" && -x "${SERVER_BIN:-}" ]]; then
     OHC_STANDALONE="false"
     export REDIS_URL="$RD_URL"
   fi
+  export DATABASE_URL="$DB_URL"
   DATABASE_URL="$DB_URL" \
   REDIS_URL="$RD_URL" \
   OHC_STANDALONE_MODE="$OHC_STANDALONE" \

--- a/src/e2e/BUILD.bazel
+++ b/src/e2e/BUILD.bazel
@@ -93,5 +93,6 @@ define_playwright_tests(
 sh_test(
     name = "verify_artifacts_test",
     srcs = ["verify_artifacts.sh"],
+    data = ["//release:all_release_artifacts"],
     tags = ["lint"],
 )

--- a/src/e2e/README.md
+++ b/src/e2e/README.md
@@ -17,7 +17,8 @@ cd src/ui/next
 npm run dev &
 
 # 3. In a third terminal, run the tests
-DATABASE_URL=postgres://ohc:ohc@localhost:5432/ohc npx playwright test src/e2e/viral_growth_loops.spec.ts
+# Note: DATABASE_URL must point to your active test database
+DATABASE_URL=postgres://ohc:ohc@127.0.0.1:<PORT>/ohc npx playwright test src/e2e/viral_growth_loops.spec.ts
 ```
 
 In CI, the tests will fallback to basic smoke verification when appropriate or automatically handle environment orchestration via Bazel.

--- a/src/e2e/db_utils.ts
+++ b/src/e2e/db_utils.ts
@@ -1,7 +1,11 @@
 import { Pool } from 'pg';
 
+if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL is not set in the environment. Tests must run with a valid database.');
+}
+
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL || 'postgres://ohc:ohc@localhost:5432/ohc',
+  connectionString: process.env.DATABASE_URL,
 });
 
 export async function e2eDbQuery(query: string, values?: any[]) {

--- a/src/e2e/global-setup.ts
+++ b/src/e2e/global-setup.ts
@@ -1,9 +1,21 @@
 import { chromium, type FullConfig } from '@playwright/test';
 
+
 export default async function globalSetup(config: FullConfig) {
   const baseURL = config.projects[0]?.use?.baseURL as string | undefined;
   if (!baseURL) {
     throw new Error('Playwright baseURL is required for e2e global setup.');
+  }
+
+  // The Bazel test runner starts a local postgres instance on a random port and exports it via DATABASE_URL
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is not set in the environment. Tests must run with a valid database.');
+  }
+
+  // Ensure there are no hardcoded localhost:5432 ports in use
+  if (databaseUrl.includes('localhost:5432') && process.env.CI) {
+      console.warn('WARNING: Using hardcoded localhost:5432 database URL in CI. This is discouraged.');
   }
 
   // wait for app to be ready

--- a/src/e2e/verify_artifacts.sh
+++ b/src/e2e/verify_artifacts.sh
@@ -3,15 +3,34 @@ set -e
 
 echo "Verifying build artifacts for all platforms..."
 
-# List of artifacts that we expect to be generated.
-# We use find to be flexible with file names and locations.
-ARTIFACTS_DIR="release"
+# In Bazel, tests only see the artifacts built for the target platform.
+# For example, on Linux, we only see Linux artifacts. The Windows
+# ones will not be built and thus will be missing in the runfiles.
+# So we shouldn't emit warnings for cross-platform artifacts missing.
 
-# Check for essential archives
-EXPECTED_ARCHIVES=(
-    "app_tar.tar.gz"
-    "ohc-app-windows.zip"
-)
+ARTIFACTS_DIR="${TEST_SRCDIR}/${TEST_WORKSPACE}/release"
+if [ ! -d "$ARTIFACTS_DIR" ]; then
+    ARTIFACTS_DIR="release"
+fi
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Linux expected artifacts
+    EXPECTED_ARCHIVES=(
+        "ohc-cluster.tar.gz"
+    )
+elif [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* ]]; then
+    # Windows expected artifacts
+    EXPECTED_ARCHIVES=(
+        "ohc-cluster.zip"
+    )
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS expected artifacts
+    EXPECTED_ARCHIVES=(
+        "ohc-cluster.tar.gz"
+    )
+else
+    EXPECTED_ARCHIVES=()
+fi
 
 for arch in "${EXPECTED_ARCHIVES[@]}"; do
     if find "$ARTIFACTS_DIR" -name "$arch" | grep -q .; then
@@ -21,13 +40,19 @@ for arch in "${EXPECTED_ARCHIVES[@]}"; do
     fi
 done
 
-# Check for Linux packages
-if find "$ARTIFACTS_DIR" -name "*.deb" | grep -q .; then
-    echo "PASS: DEB package exists"
-fi
+# Check for Linux packages (only on Linux)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    if find "$ARTIFACTS_DIR" -name "*.deb" | grep -q .; then
+        echo "PASS: DEB package exists"
+    else
+        echo "WARNING: DEB package is missing"
+    fi
 
-if find "$ARTIFACTS_DIR" -name "*.rpm" | grep -q .; then
-    echo "PASS: RPM package exists"
+    # RPM requires rpmbuild, we don't strictly require it to exist and log warning,
+    # because it might be skipped if rpmbuild is not available.
+    if find "$ARTIFACTS_DIR" -name "*.rpm" | grep -q .; then
+        echo "PASS: RPM package exists"
+    fi
 fi
 
 # Check for OCI image artifacts


### PR DESCRIPTION
- Modified `src/e2e/global-setup.ts` to log a warning when `localhost:5432` is found in the `DATABASE_URL`.
- Enforced `DATABASE_URL` check in `src/e2e/db_utils.ts`.
- Updated `bazel/rules/playwright/playwright_test.sh` to properly export `DATABASE_URL` to the e2e scripts.
- Adjusted `src/e2e/verify_artifacts.sh` to check for `ohc-cluster.tar.gz` and `ohc-cluster.zip` according to OS instead of the outdated hardcoded `app_tar.tar.gz`.
- Updated `src/e2e/BUILD.bazel` to include `//release:all_release_artifacts` in the `verify_artifacts_test` test.

---
*PR created automatically by Jules for task [10746428953204114522](https://jules.google.com/task/10746428953204114522) started by @ql-owo-lp*