### PR TITLE
feat(ui): implement image url field for conversational onboarding

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -527,6 +527,7 @@
 
         <div style="display: flex; gap: 10px;">
             <input type="text" id="chat-input" data-testid="chat-input" class="glassmorphism" placeholder="Type a message..." style="margin-bottom: 0; flex-grow: 1; min-height: 44px; border-radius: 8px;">
+            <input type="text" id="chat-image-url" data-testid="chat-image-url" class="glassmorphism" placeholder="Image URL (optional)..." style="margin-bottom: 0; flex-grow: 0.5; min-height: 44px; border-radius: 8px;">
             <button id="chat-send-btn" data-testid="chat-send-btn" style="width: auto; min-height: 44px; min-width: 44px; border-radius: 8px;">Send</button>
         </div>
       </div>
@@ -1207,18 +1208,28 @@
 
       // Chat logic
       const chatInputEl = document.getElementById('chat-input');
+      const chatImageUrlEl = document.getElementById('chat-image-url');
       const chatSendBtn = document.getElementById('chat-send-btn');
       const chatMessagesEl = document.getElementById('chat-messages');
       let chatHistory = [];
 
       async function sendChatMessage() {
           const text = chatInputEl.value.trim();
-          if (!text) return;
+          const imageUrl = chatImageUrlEl ? chatImageUrlEl.value.trim() : '';
+          if (!text && !imageUrl) return;
 
           // Append user message
-          chatMessagesEl.innerHTML += `<div style="margin-bottom: 10px; color: #0066FF;"><strong>You:</strong> ${text}</div>`;
+          let msgHtml = `<div style="margin-bottom: 10px; color: #0066FF;"><strong>You:</strong> ${text}`;
+          if (imageUrl) {
+              msgHtml += `<br/><img src="${imageUrl}" style="max-width: 100px; max-height: 100px; margin-top: 5px; border-radius: 4px;" />`;
+          }
+          msgHtml += `</div>`;
+          chatMessagesEl.innerHTML += msgHtml;
           chatInputEl.value = '';
-          chatHistory.push({ role: 'user', content: text });
+          if (chatImageUrlEl) chatImageUrlEl.value = '';
+          const messageObj = { role: 'user', content: text };
+          if (imageUrl) messageObj.image_url = imageUrl;
+          chatHistory.push(messageObj);
           chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
 
           chatSendBtn.disabled = true;


### PR DESCRIPTION
This PR adds a dedicated image URL input field to the conversational setup flow, addressing a functionality gap for the Autonomous Work Assistant Onboarding feature where users (such as bakers or field services) are meant to be able to build initial product profiles directly from photos. It captures the URL string, previews the image in the chat feed, and attaches the property to the request payload to satisfy the backend `ChatMessage` schema expectations.

Resolves #27858

## Product-use Evidence
- Persona: Maya (Home Baker)
- Workflow Attempted: Conversational Setup flow via browser E2E spec.
- Gap Observed: Missing `#chat-image-url` input field and improperly mapped image property payload.
- Need: Maya needs a way to supply product images directly into the chat flow without being forced into an advanced management console.
- Result: Maya can now input an image URL along with text. Both display correctly in the chat feed, and the payload accurately parses the url.

## Tests Performed
- `bazelisk test //src/e2e:playwright_shard_1_of_1` (passed)
- `bazelisk test //src/e2e:playwright_spec_coverage` (passed)

---
*PR created automatically by Jules for task [12680593723072021828](https://jules.google.com/task/12680593723072021828) started by @wbbsuper*