### PR TITLE
feat: Add min-height to btn-secondary for touch target UX

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -313,6 +313,7 @@
         box-shadow: none;
         border: 1px solid rgba(0, 0, 0, 0.1);
         margin-top: 10px;
+        min-height: 44px !important;
       }
       .btn-secondary:hover {
         background-color: rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
Added `min-height: 44px !important;` rule to the `.btn-secondary` CSS class to ensure mobile touch targets satisfy sizing constraints. Ran all E2E tests to verify regressions.

---
*PR created automatically by Jules for task [5731799750561040574](https://jules.google.com/task/5731799750561040574) started by @ql-owo-lp*