### PR TITLE
fix(orchestration): fix sqlite datetime text-binding bug

### DIFF
--- a/src/server/orchestration/queue/sqlite_queue.rs
+++ b/src/server/orchestration/queue/sqlite_queue.rs
@@ -64,7 +64,7 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
                  .push_bind(job.job_type.clone())
                  .push_bind(job.payload.clone())
                  .push_bind("PENDING")
-                 .push_bind(next_retry_at)
+                 .push_bind(next_retry_at.to_rfc3339())
                  .push_bind(job.tenant_id.clone());
             });
 
@@ -103,7 +103,7 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
         .bind(&job.parent_task_id)
         .bind(&job.job_type)
         .bind(&job.payload)
-        .bind(next_retry_at)
+        .bind(next_retry_at.to_rfc3339())
         .bind(&job.tenant_id)
         .execute(&*self.pool)
         .await
@@ -244,7 +244,7 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
                 let new_next_retry_at = chrono::Utc::now() + chrono::Duration::seconds(backoff_seconds as i64);
                 sqlx::query("UPDATE ohc_job_queue SET status = 'PENDING', retry_count = ?, next_retry_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?")
                     .bind(next_attempt)
-                    .bind(new_next_retry_at)
+                    .bind(new_next_retry_at.to_rfc3339())
                     .bind(job_id)
                     .execute(&mut *tx)
                     .await


### PR DESCRIPTION
Fixed an issue in `sqlite_queue.rs` where `DateTime<Utc>` objects were directly bound to `sqlx` queries without explicit text formatting, causing flaky runtime text-binding issues when used with SQLite's internal date/time functions. The fix ensures `next_retry_at` is consistently formatted using `.to_rfc3339()` before being bound in the `enqueue`, `enqueue_batch`, and `fail` methods. This brings Standalone mode (SQLite) queue handling into full parity with Cloud mode (Postgres). All tests passed, including `test_worker_pool_chaos_timeout`.

---
*PR created automatically by Jules for task [18227341881140190032](https://jules.google.com/task/18227341881140190032) started by @ql-owo-lp*