### PR TITLE
Feat: Handle Centralized Inventory Checkout Conflicts & Offline POS Sync

### DIFF
--- a/src/server/orchestration/departments/operations_agent.rs
+++ b/src/server/orchestration/departments/operations_agent.rs
@@ -52,8 +52,13 @@ impl Department for OperationsAgent {
         let action_description = match event.event_type.as_str() {
             "tenant.order.created" => "Process Order & Update Inventory".to_string(),
             "LowStockAlert" => {
-                let product_id = event.payload.get("product_id").and_then(|v| v.as_str()).unwrap_or("unknown");
-                format!("Draft a restock order for product {} due to low stock", product_id)
+                let msg = event.payload.get("message").and_then(|v| v.as_str()).unwrap_or("");
+                if !msg.is_empty() {
+                    msg.to_string()
+                } else {
+                    let product_id = event.payload.get("product_id").and_then(|v| v.as_str()).unwrap_or("unknown");
+                    format!("Draft a restock order for product {} due to low stock", product_id)
+                }
             },
             "InventoryConflictEvent" => {
                 // If it's the specific test/simulation message from offline_sync, we forward it exactly.

--- a/src/server/services/inventory/service.rs
+++ b/src/server/services/inventory/service.rs
@@ -306,11 +306,18 @@ impl InventoryService {
 
             if new_stock <= 5 {
                 let job_id = Uuid::new_v4().to_string();
+
+                let message = if new_stock == 0 {
+                    format!("{} sold out. Would you like to draft a restock order?", product_id)
+                } else {
+                    format!("Stock for product {} has dropped to {}.", product_id, new_stock)
+                };
+
                 let job_payload = serde_json::json!({
                     "product_id": product_id,
                     "remaining_stock": new_stock,
                     "threshold": 5,
-                    "message": format!("Stock for product {} has dropped to {}.", product_id, new_stock)
+                    "message": message
                 }).to_string();
 
                 let _ = sqlx::query("INSERT INTO department_tasks (id, tenant_id, department, event_type, payload, status) VALUES ($1, $2, 'operations', 'LowStockAlert', $3::jsonb, 'PENDING')")
@@ -322,7 +329,6 @@ impl InventoryService {
 
                 // Directly notify Operations Agent for real-time monitoring as per Step 3
                 tracing::info!("Real-time stock level monitored: {} drops below threshold. Triggered LowStockAlert for Operations Agent.", product_id);
-
 
                 let action_request_id = Uuid::new_v4().to_string();
                 let action_payload = serde_json::json!({

--- a/src/server/workers/pos_sync_worker.rs
+++ b/src/server/workers/pos_sync_worker.rs
@@ -82,11 +82,18 @@ impl PosSyncWorker {
                         .map_err(|e| e.to_string())?;
 
                     let job_id = uuid::Uuid::new_v4().to_string();
+
+                    let message = if new_stock == 0 {
+                        format!("{} sold out. Would you like to draft a restock order?", product_id)
+                    } else {
+                        format!("Stock for product {} has dropped to {}.", product_id, new_stock)
+                    };
+
                     let job_payload = serde_json::json!({
                         "product_id": product_id,
                         "remaining_stock": new_stock,
                         "threshold": 5,
-                        "message": format!("Stock for product {} has dropped to {}.", product_id, new_stock)
+                        "message": message
                     }).to_string();
                     sqlx::query("INSERT INTO department_tasks (id, tenant_id, department, event_type, payload, status) VALUES ($1, $2, 'operations', 'LowStockAlert', $3::jsonb, 'PENDING')")
                         .bind(job_id).bind(&job.tenant_id).bind(&job_payload).execute(&mut *tx).await
@@ -198,11 +205,18 @@ impl PosSyncWorker {
                                     .map_err(|e| e.to_string())?;
 
                                 let job_id = uuid::Uuid::new_v4().to_string();
+
+                                let message = if new_stock == 0 {
+                                    format!("{} sold out. Would you like to draft a restock order?", product_id)
+                                } else {
+                                    format!("Stock for product {} has dropped to {}.", product_id, new_stock)
+                                };
+
                                 let job_payload = serde_json::json!({
                                     "product_id": product_id,
                                     "remaining_stock": new_stock,
                                     "threshold": 5,
-                                    "message": format!("Stock for product {} has dropped to {}.", product_id, new_stock)
+                                    "message": message
                                 }).to_string();
                                 sqlx::query("INSERT INTO department_tasks (id, tenant_id, department, event_type, payload, status) VALUES ($1, $2, 'operations', 'LowStockAlert', $3::jsonb, 'PENDING')")
                                     .bind(job_id).bind(&job.tenant_id).bind(&job_payload).execute(&mut *tx).await

--- a/src/ui/next/src/app/checkout/page.tsx
+++ b/src/ui/next/src/app/checkout/page.tsx
@@ -112,6 +112,12 @@ function CheckoutContent() {
           quantity: tier ? undefined : quantity
         }),
       });
+      if (response.status === 409) {
+        setCheckoutStatus("Item just sold out.");
+        setIsProcessing(false);
+        return;
+      }
+
       const data = await response.json();
       if (!response.ok || !data.checkout_url) {
         throw new Error(data.message || data.error || "Failed to create checkout session");

--- a/src/ui/next/src/e2e/pos-inventory-sync.spec.ts
+++ b/src/ui/next/src/e2e/pos-inventory-sync.spec.ts
@@ -55,4 +55,56 @@ test.describe('POS Inventory Sync - E2E Race Condition', () => {
 
     expect(commitRes.ok()).toBe(true);
   });
+
+  test('Online checkout UI shows Item just sold out when POS locks item', async ({ page }) => {
+    const tenantId = 'e2e-tenant';
+    const productId = 'e2e-product-cake';
+
+    // 1. Setup tenant info in local storage for checkout page
+    await page.goto('/checkout');
+    await page.evaluate((tenant) => {
+      localStorage.setItem('tenant', tenant);
+      localStorage.setItem('customer_id', 'e2e-customer');
+    }, tenantId);
+
+    // Simulate POS (User B) acquiring lock
+    const reserveRes = await page.request.post('/api/v1/payments/terminal/reserve', {
+        data: {
+            tenant_id: tenantId,
+            product_id: productId,
+            quantity: 1,
+            ttl_seconds: 15
+        },
+        headers: {
+            'x-tenant-id': tenantId
+        }
+    });
+
+    expect(reserveRes.ok()).toBe(true);
+    const lockData = await reserveRes.json();
+    expect(lockData.success).toBe(true);
+
+    // 2. Navigate to checkout page for the locked product
+    await page.goto(`/checkout?product_id=${productId}&quantity=1`);
+
+    // 3. Click the Pay button
+    await page.getByRole('button', { name: 'Pay' }).click();
+
+    // 4. Verify the "Item just sold out" message appears
+    await expect(page.getByText('Item just sold out.')).toBeVisible();
+
+    // Cleanup: Release lock so it doesn't affect other tests if they run concurrently
+    // (Actually the lock will expire in 15 seconds, but let's release it cleanly)
+    await page.request.post('/api/v1/payments/terminal/commit', {
+        data: {
+            tenant_id: tenantId,
+            product_id: productId,
+            quantity: 1,
+            lock_id: lockData.lock_id
+        },
+        headers: {
+            'x-tenant-id': tenantId
+        }
+    });
+  });
 });


### PR DESCRIPTION
- Fixed a race condition where the frontend online checkout didn't gracefully handle the `409` conflict error returned by the backend when an item was locked by a POS checkout or sold out. Now, it displays a clear "Item just sold out." message rather than a generic error.
- Expanded the Operations Agent's behavior inside the `LowStockAlert` event to proactively suggest restocking for out-of-stock items, sending: `"{product_id} sold out. Would you like to draft a restock order?"`.
- E2E tests have been expanded in Playwright to simulate the offline-online lock acquisition race conditions and verify the UI updates accordingly.

---
*PR created automatically by Jules for task [17600052012222188605](https://jules.google.com/task/17600052012222188605) started by @ql-owo-lp*

Resolves #27615