### PR TITLE
chore: refactor setup wizard text from 'Admin' to 'Owner'

### DIFF
--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -443,10 +443,10 @@ export default function OnboardingWizard() {
   const handleStartOnboarding = async () => {
     const errors: Record<string, string> = {};
     if (!adminName.trim()) {
-      errors.adminName = 'Admin Name is required';
+      errors.adminName = 'Owner Name is required';
     }
     if (!adminEmail.trim()) {
-      errors.adminEmail = 'Admin Email is required';
+      errors.adminEmail = 'Owner Email is required';
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(adminEmail)) {
       errors.adminEmail = 'Please enter a valid email address';
     }
@@ -1274,7 +1274,7 @@ export default function OnboardingWizard() {
                   <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-2">Account Setup</label>
                   <div className="space-y-3 mb-4">
                     <div>
-                      <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Admin Name</label>
+                      <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Owner Name</label>
                       <input
                         type="text"
 
@@ -1285,7 +1285,7 @@ export default function OnboardingWizard() {
                           const val = e.target.value;
                           setAdminName(val);
                           if (!val.trim()) {
-                            setValidationErrors(prev => ({ ...prev, adminName: 'Admin Name is required' }));
+                            setValidationErrors(prev => ({ ...prev, adminName: 'Owner Name is required' }));
                           } else {
                             setValidationErrors(prev => { const { adminName, ...rest } = prev; return rest; });
                           }
@@ -1296,7 +1296,7 @@ export default function OnboardingWizard() {
                       {validationErrors.adminName && <p className="text-[#FF3B30] text-xs mt-1">{validationErrors.adminName}</p>}
                     </div>
                     <div>
-                      <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Admin Email</label>
+                      <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Owner Email</label>
                       <input
                         type="email"
 
@@ -1308,7 +1308,7 @@ export default function OnboardingWizard() {
                           const val = e.target.value;
                           setAdminEmail(val);
                           if (!val.trim()) {
-                            setValidationErrors(prev => ({ ...prev, adminEmail: 'Admin Email is required' }));
+                            setValidationErrors(prev => ({ ...prev, adminEmail: 'Owner Email is required' }));
                           } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val)) {
                             setValidationErrors(prev => ({ ...prev, adminEmail: 'Please enter a valid email address' }));
                           } else {
@@ -1323,7 +1323,7 @@ export default function OnboardingWizard() {
                       {validationErrors.adminEmail && <p className="text-[#FF3B30] text-xs mt-1">{validationErrors.adminEmail}</p>}
                     </div>
                     <div>
-                      <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Admin Password</label>
+                      <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Owner Password</label>
                       <input
                         type="password"
                         enterKeyHint="done"

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -655,10 +655,10 @@
 
       <!-- Step 5: Admin Setup -->
       <div class="step" id="step-admin">
-        <h1>Admin Credentials</h1>
-        <p>Set up your login details.</p>
+        <h1>Owner Profile</h1>
+        <p>How should we address you?</p>
 
-        <input type="email" id="admin-email" data-testid="admin-email" class="glassmorphism" placeholder="admin@mybusiness.com" inputmode="email" autocomplete="email" />
+        <input type="email" id="admin-email" data-testid="admin-email" class="glassmorphism" placeholder="owner@mybusiness.com" inputmode="email" autocomplete="email" />
         <div id="email-error" class="error-msg" aria-live="polite">Please enter a valid email address.</div>
 
         <input type="password" id="admin-password" data-testid="admin-password" class="glassmorphism" placeholder="Password (min 8 chars)" autocomplete="new-password" />
@@ -1023,7 +1023,7 @@
 
               if (emailVal === '' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailVal)) {
                   errors.adminEmail.style.display = 'block';
-                  errors.adminEmail.innerText = emailVal === '' ? 'Admin Email is required' : 'Please enter a valid email address.';
+                  errors.adminEmail.innerText = emailVal === '' ? 'Owner Email is required' : 'Please enter a valid email address.';
                   inputs.adminEmail.style.borderColor = '#FF3B30';
                   stepValid = false;
               } else {


### PR DESCRIPTION
This PR modifies the onboarding UI steps to use a more user-friendly 'Owner Profile' rather than the technical 'Admin Credentials', adhering to the non-technical owner/operator mandate.

It updates:
* `setup.html` in the Tauri app
* `page.tsx` in the legacy Next.js app

All changes have passed `bazel test //...` and `bazel test //src/e2e:playwright` without any regressions.

---
*PR created automatically by Jules for task [14106636725698797050](https://jules.google.com/task/14106636725698797050) started by @wbbsuper*