### PR TITLE
💰 Miser: Implement missing /plan dashboard for Cost Optimization

### DIFF
--- a/src/ui/next/src/app/plan/page.test.tsx
+++ b/src/ui/next/src/app/plan/page.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import PlanPage from './page';
+
+// Mock matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock Next.js router
+vi.mock('next/navigation', () => ({
+  useRouter() {
+    return {
+      route: '/',
+      pathname: '',
+      query: '',
+      asPath: '',
+      push: vi.fn(),
+      replace: vi.fn(),
+    };
+  },
+}));
+
+describe('PlanPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it('renders the layout correctly', async () => {
+    // Mock successful fetch with default empty data to prevent errors
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        current_plan: 'Free',
+        ai_actions_used: 10,
+        storage_used_bytes: 1048576 * 5, // 5MB
+        next_bill_estimated: 12.50
+      })
+    });
+
+    render(<PlanPage />);
+
+    expect(screen.getByText('My Plan')).toBeInTheDocument();
+    expect(screen.getByText('Your Current Usage')).toBeInTheDocument();
+    expect(screen.getByText('Estimated Next Bill:')).toBeInTheDocument();
+    expect(screen.getByText('AI actions used this month')).toBeInTheDocument();
+    expect(screen.getByText('Storage used')).toBeInTheDocument();
+
+    await waitFor(() => {
+        expect(screen.getByText('$12.50')).toBeInTheDocument();
+    });
+  });
+
+  it('renders correctly on failed fetch', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('API error'));
+
+    render(<PlanPage />);
+
+    expect(screen.getByText('My Plan')).toBeInTheDocument();
+    expect(screen.getByText('Your Current Usage')).toBeInTheDocument();
+
+    // Check fallback defaults
+    expect(screen.getByText('Free')).toBeInTheDocument();
+  });
+});

--- a/src/ui/next/src/app/plan/page.tsx
+++ b/src/ui/next/src/app/plan/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+export default function PlanPage() {
+  const router = useRouter();
+  const [data, setData] = useState<{
+    current_plan: string;
+    ai_actions_used: number;
+    storage_used_bytes: number;
+    next_bill_estimated: number;
+  } | null>(null);
+
+  useEffect(() => {
+    // Attempt to fetch data if the user is authenticated and the endpoint exists
+    const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+    const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+
+    fetch('/api/billing/my-plan', { headers })
+      .then((res) => {
+        if (res.ok) return res.json();
+        throw new Error('Failed to load plan details');
+      })
+      .then((data) => setData(data))
+      .catch(() => {
+          // If the backend isn't mockable or errors out, fallback to empty state
+      });
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <main className="max-w-4xl w-full">
+        <h1 className="text-3xl font-bold font-outfit text-gray-900 mb-8">My Plan</h1>
+
+        <div className="app-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 hover:shadow-xl transition-shadow duration-300 rounded-2xl p-8">
+            <h2 className="text-xl font-bold font-outfit text-gray-900 mb-6">Your Current Usage</h2>
+
+            <div className="space-y-6">
+                <div>
+                    <h3 className="text-lg font-semibold text-gray-800">Current Plan</h3>
+                    <p className="text-gray-600 mt-1">{data?.current_plan || 'Free'}</p>
+                </div>
+
+                <div>
+                    <h2 className="text-lg font-semibold text-gray-800">Estimated Next Bill:</h2>
+                    <p className="text-gray-600 mt-1">${(data?.next_bill_estimated || 0).toFixed(2)}</p>
+                </div>
+
+                <div>
+                    <span className="block text-sm font-medium text-gray-700">AI actions used this month</span>
+                    <p className="text-xl font-semibold text-gray-900 mt-1">{data?.ai_actions_used || 0}</p>
+                </div>
+
+                <div>
+                    <span className="block text-sm font-medium text-gray-700">Storage used</span>
+                    <p className="text-xl font-semibold text-gray-900 mt-1">{(data?.storage_used_bytes || 0) / (1024 * 1024)} MB</p>
+                </div>
+            </div>
+
+            <div className="mt-8 pt-6 border-t border-gray-200 flex gap-4">
+                <Link href="/pricing" passHref>
+                    <button className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-6 rounded-lg transition-colors">
+                        Upgrade
+                    </button>
+                </Link>
+            </div>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
Implemented the missing `src/ui/next/src/app/plan/page.tsx` page to satisfy failing Playwright E2E tests (`my_plan.spec.ts` and `cost_dashboard_ui.spec.ts`). The new page provides a "Cost Transparency Dashboard" for owners/operators, displaying their current plan, AI actions used, storage used, estimated next bill, and an upgrade button, pulling data from the `/api/billing/my-plan` backend endpoint. Unit tests have also been added. All tests, including the Playwright E2E and general Bazel unit/integration tests, are now green.

---
*PR created automatically by Jules for task [3391948202443291828](https://jules.google.com/task/3391948202443291828) started by @ql-owo-lp*