### PR TITLE
chore: fix stagnant mission queue tests and polish dashboard UI to translucent glass

### DIFF
--- a/src/server/sip.rs
+++ b/src/server/sip.rs
@@ -700,6 +700,21 @@ mod tests {
             .await
             .unwrap();
 
+            sqlx::query(
+                "CREATE TABLE IF NOT EXISTS department_dead_letters (
+                    id TEXT PRIMARY KEY,
+                    tenant_id TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    department TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    error_message TEXT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )"
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+
             // Insert initial record
             sqlx::query("INSERT INTO agent_missions (id, status, payload, tenant_id) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING")
                 .bind("test_mission_id")
@@ -1103,6 +1118,21 @@ mod tests {
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     tenant_id TEXT,
                     mission_log TEXT
+                )"
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+
+            sqlx::query(
+                "CREATE TABLE IF NOT EXISTS department_dead_letters (
+                    id TEXT PRIMARY KEY,
+                    tenant_id TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    department TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    error_message TEXT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )"
             )
             .execute(&pool)

--- a/src/ui/next/src/app/dashboard/MorningBriefingCard.tsx
+++ b/src/ui/next/src/app/dashboard/MorningBriefingCard.tsx
@@ -62,7 +62,7 @@ export function MorningBriefingCard({ tenant }: { tenant: string }) {
   };
 
   return (
-    <div className="glassmorphism p-6 rounded-[16px] mb-6 shadow-sm border border-indigo-200/50 bg-gradient-to-br from-indigo-50/50 to-purple-50/50 w-full relative overflow-hidden group">
+    <div className="p-6 rounded-[16px] mb-6 shadow-sm w-full relative overflow-hidden group bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] border border-white/40 dark:bg-[#16161a]/70 dark:backdrop-blur-[30px] dark:backdrop-saturate-[2.1] dark:border-white/10">
       <div className="absolute top-0 right-0 w-24 h-24 bg-white/40 rounded-bl-full -z-10 group-hover:scale-110 transition-transform"></div>
 
       <div className="flex flex-col gap-4">

--- a/src/ui/next/src/app/dashboard/NeighborhoodPulseCard.tsx
+++ b/src/ui/next/src/app/dashboard/NeighborhoodPulseCard.tsx
@@ -51,19 +51,14 @@ export const NeighborhoodPulseCard = ({ tenant }: { tenant: string }) => {
 
   return (
     <div
-      className="glassmorphism p-6 rounded-2xl mb-6 shadow-xl relative overflow-hidden text-white"
-      style={{
-        background: 'linear-gradient(135deg, rgba(99, 102, 241, 0.9), rgba(168, 85, 247, 0.9))',
-        backdropFilter: 'blur(30px) saturate(210%)',
-        border: '1px solid rgba(255, 255, 255, 0.2)'
-      }}
+      className="p-6 rounded-2xl mb-6 shadow-xl relative overflow-hidden text-black dark:text-white bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] border border-white/40 dark:bg-[#16161a]/70 dark:backdrop-blur-[30px] dark:backdrop-saturate-[2.1] dark:border-white/10"
     >
       {/* Decorative pulse element */}
       <div className="absolute top-0 right-0 w-64 h-64 bg-white opacity-10 rounded-full blur-3xl -mr-10 -mt-10 animate-pulse"></div>
 
       <div className="relative z-10">
         <h2 className="text-xl font-bold font-outfit mb-2">Neighborhood Pulse</h2>
-        <p className="text-sm text-indigo-100 mb-6 font-inter">
+        <p className="text-sm text-gray-800 dark:text-gray-200 mb-6 font-inter">
           There are {neighbors.length} OHC businesses in your area. Form a "Main Street Collective" to share customers?
         </p>
 
@@ -71,20 +66,15 @@ export const NeighborhoodPulseCard = ({ tenant }: { tenant: string }) => {
           {neighbors.map(neighbor => (
             <div
               key={neighbor.id}
-              className="flex items-center justify-between p-4 rounded-xl"
-              style={{
-                background: 'rgba(255, 255, 255, 0.15)',
-                backdropFilter: 'blur(30px) saturate(210%)',
-                border: '1px solid rgba(255, 255, 255, 0.2)'
-              }}
+              className="flex items-center justify-between p-4 rounded-xl bg-white/40 dark:bg-black/20 border border-white/30 dark:border-white/5"
             >
               <div>
                 <h3 className="font-semibold">{neighbor.name}</h3>
-                <p className="text-xs text-indigo-100">Complementary Vibe Match</p>
+                <p className="text-xs text-gray-600 dark:text-gray-400">Complementary Vibe Match</p>
               </div>
               <button
                 onClick={() => handleInvite(neighbor.id)}
-                className="px-4 py-2 bg-white text-indigo-600 rounded-lg text-sm font-semibold hover:bg-indigo-50 transition-colors shadow-sm"
+                className="px-4 py-2 bg-[#0066FF] text-white rounded-lg text-sm font-semibold hover:bg-[#0052CC] transition-colors shadow-sm"
               >
                 Invite Partner
               </button>

--- a/src/ui/next/src/app/dashboard/SuccessMilestoneWidget.tsx
+++ b/src/ui/next/src/app/dashboard/SuccessMilestoneWidget.tsx
@@ -37,21 +37,21 @@ export function SuccessMilestoneWidget() {
   };
 
   return (
-    <section className="glassmorphism app-panel mb-6 border-2 border-indigo-200 bg-gradient-to-br from-indigo-50 to-white shadow-lg transform transition-all hover:scale-[1.01]">
-      <div className="app-panel-header border-b border-indigo-100 pb-4">
+    <section className="app-panel mb-6 shadow-lg transform transition-all hover:scale-[1.01] bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] border border-white/40 dark:bg-[#16161a]/70 dark:backdrop-blur-[30px] dark:backdrop-saturate-[2.1] dark:border-white/10 rounded-2xl p-6">
+      <div className="app-panel-header border-b border-gray-200 dark:border-gray-800 pb-4 flex justify-between items-start">
         <div>
-          <h2 className="app-panel-title text-indigo-900 flex items-center gap-2">
+          <h2 className="app-panel-title text-gray-900 dark:text-white flex items-center gap-2 font-bold text-xl">
             <span>🏆</span> {milestone.title}
           </h2>
-          <div className="app-list-subtitle text-indigo-700 font-medium mt-1">{milestone.subtitle}</div>
+          <div className="app-list-subtitle text-gray-700 dark:text-gray-300 font-medium mt-1">{milestone.subtitle}</div>
         </div>
-        <div className="flex items-center gap-2 px-4 py-1.5 bg-green-100 rounded-full border border-green-200 shadow-sm">
-          <span className="text-sm font-bold text-green-700">{milestone.reward}</span>
+        <div className="flex items-center gap-2 px-4 py-1.5 bg-green-100 dark:bg-green-900/30 rounded-full border border-green-200 dark:border-green-800 shadow-sm">
+          <span className="text-sm font-bold text-green-700 dark:text-green-400">{milestone.reward}</span>
         </div>
       </div>
       <div className="app-panel-body pt-5">
-        <div className="bg-white/60 backdrop-blur-sm p-4 rounded-xl border border-indigo-50 mb-4">
-          <p className="text-sm text-gray-700 italic">"{fullShareText}"</p>
+        <div className="bg-white/60 dark:bg-black/20 backdrop-blur-sm p-4 rounded-xl border border-gray-100 dark:border-gray-800 mb-4">
+          <p className="text-sm text-gray-700 dark:text-gray-300 italic">"{fullShareText}"</p>
         </div>
 
         <div className="flex flex-col sm:flex-row gap-3">


### PR DESCRIPTION
This PR addresses the Maintainer Swarm mandate for codebase hygiene and visual polish. It introduces two key improvements:
1. **Test Hygiene:** Injected missing schema setup for `department_dead_letters` into several test fixtures within `src/server/sip.rs` to fix flaky or failing unit tests related to stagnant mission pruning.
2. **Visual Polish:** Updated three dashboard components (`MorningBriefingCard`, `NeighborhoodPulseCard`, `SuccessMilestoneWidget`) to use the mandated macOS Translucent Glass style, stripping out hardcoded inline styles and legacy gradients. All components now correctly support both light and dark mode with high-legibility blur effects.

---
*PR created automatically by Jules for task [12748522273080428941](https://jules.google.com/task/12748522273080428941) started by @ql-owo-lp*