### PR TITLE
feat: support dynamic product pricing in checkout sessions

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -85,7 +85,7 @@ pub fn router<S: Clone + Send + Sync + 'static>(hub: Arc<Hub>) -> axum::Router<S
 
 #[derive(serde::Deserialize)]
 pub struct CreateCheckoutSessionRequest {
-    pub tier: String,
+    pub tier: Option<String>,
     pub is_subscription: Option<bool>,
     pub product_id: Option<String>,
     pub quantity: Option<i32>,
@@ -111,12 +111,34 @@ pub async fn create_checkout_session_handler(
     let body_bytes = axum::body::to_bytes(request.into_body(), 1024 * 64).await.map_err(|_| StatusCode::BAD_REQUEST)?;
     let req: CreateCheckoutSessionRequest = serde_json::from_slice(&body_bytes).map_err(|_| StatusCode::BAD_REQUEST)?;
 
-    let amount_usd = match req.tier.to_lowercase().as_str() {
-        "starter" => 29.0,
-        "pro" => 79.0,
-        "business" => 299.0,
-        _ => return Err(StatusCode::BAD_REQUEST),
-    };
+    let mut amount_usd = 0.0;
+    let mut item_name = "Checkout".to_string();
+
+    if let Some(tier) = &req.tier {
+        amount_usd = match tier.to_lowercase().as_str() {
+            "starter" => 29.0,
+            "pro" => 79.0,
+            "business" => 299.0,
+            _ => return Err(StatusCode::BAD_REQUEST),
+        };
+        item_name = tier.clone();
+    } else if let Some(product_id) = &req.product_id {
+        let mut conn = hub.pool.acquire().await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let row = sqlx::query("SELECT title, price_cents FROM products WHERE id = $1 AND tenant_id = $2")
+            .bind(product_id)
+            .bind(&tenant_id)
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(|_| StatusCode::NOT_FOUND)?;
+        use sqlx::Row;
+        let price_cents: i64 = row.try_get("price_cents").unwrap_or(0);
+        let title: String = row.try_get("title").unwrap_or_else(|_| "Product".to_string());
+        let quantity = req.quantity.unwrap_or(1);
+        amount_usd = (price_cents as f64 / 100.0) * quantity as f64;
+        item_name = title;
+    } else {
+        return Err(StatusCode::BAD_REQUEST);
+    }
 
     let mut acquired_lock_id = "".to_string();
     if let (Some(product_id), Some(quantity)) = (&req.product_id, req.quantity) {
@@ -139,7 +161,7 @@ pub async fn create_checkout_session_handler(
 
     if let Some(client) = &hub.tracker().stripe_client {
         // Assume price_id corresponds to the tier directly or is generated. We pass the tier name as the price_id for now.
-        match client.create_checkout_session(&req.tier, &tenant_id, amount_usd, req.is_subscription.unwrap_or(false)).await {
+        match client.create_checkout_session(&item_name, &tenant_id, amount_usd, req.is_subscription.unwrap_or(false)).await {
             Ok(url) => Ok(Json(CreateCheckoutSessionResponse { checkout_url: url })),
             Err(_) => {
                 // Explicitly release the lock if the stripe session creation fails
@@ -154,7 +176,8 @@ pub async fn create_checkout_session_handler(
         }
     } else {
         // Fallback for tests / missing Stripe config
-        Ok(Json(CreateCheckoutSessionResponse { checkout_url: format!("https://checkout.stripe.com/pay/test_{}_{}", req.tier, tenant_id) }))
+        let fallback_tier = req.tier.clone().unwrap_or_else(|| "product".to_string());
+        Ok(Json(CreateCheckoutSessionResponse { checkout_url: format!("https://checkout.stripe.com/pay/test_{}_{}", fallback_tier, tenant_id) }))
     }
 }
 
@@ -622,13 +645,13 @@ mod department_tier_usage_tests {
     async fn test_create_checkout_session_inventory_lock() {
         // Just verify struct layout and compile.
         let req = CreateCheckoutSessionRequest {
-            tier: "starter".to_string(),
+            tier: Some("starter".to_string()),
             is_subscription: Some(false),
             product_id: Some("prod_123".to_string()),
             quantity: Some(1),
             ttl_seconds: Some(300),
         };
-        assert_eq!(req.tier, "starter");
+        assert_eq!(req.tier.unwrap(), "starter");
         assert_eq!(req.product_id.unwrap(), "prod_123");
     }
 

--- a/src/server/api/catalog.rs
+++ b/src/server/api/catalog.rs
@@ -149,14 +149,16 @@ async fn handle_create_product(
 
     let product_id = uuid::Uuid::new_v4().to_string();
 
+    let price_cents = (payload.price.parse::<f64>().unwrap_or(0.0) * 100.0).round() as i64;
     let insert_product = sqlx::query(
-        "INSERT INTO products (id, tenant_id, title, description, type, inventory_count) VALUES ($1, $2, $3, $4, $5, 100)"
+        "INSERT INTO products (id, tenant_id, title, description, type, price_cents, inventory_count) VALUES ($1, $2, $3, $4, $5, $6, 100)"
     )
     .bind(&product_id)
     .bind(&tenant_id)
     .bind(&payload.name)
     .bind(&payload.description)
     .bind(&payload.item_type)
+    .bind(price_cents)
     .execute(&mut *conn)
     .await;
 
@@ -193,7 +195,6 @@ async fn handle_create_product(
             .to_lowercase();
         let discount = payload.subscription_discount.unwrap_or(0);
 
-        let price_cents = (payload.price.parse::<f64>().unwrap_or(0.0) * 100.0).round() as i64;
         let insert_plan = sqlx::query(
             "INSERT INTO subscription_plans (id, tenant_id, product_id, interval, discount_percentage, name, price_cents, frequency) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"
         )

--- a/src/server/integrations/stripe/client.rs
+++ b/src/server/integrations/stripe/client.rs
@@ -53,7 +53,7 @@ impl StripeClient {
         std::env::var("STRIPE_API_BASE").unwrap_or_else(|_| "https://api.stripe.com".to_string())
     }
 
-    pub async fn create_checkout_session(&self, _price_id: &str, customer_id: &str, amount_usd: f64, is_subscription: bool) -> Result<String, String> {
+    pub async fn create_checkout_session(&self, price_id_or_name: &str, customer_id: &str, amount_usd: f64, is_subscription: bool) -> Result<String, String> {
         let pm = PaymentRouter::optimize_payment_method(amount_usd);
         let savings = PaymentRouter::calculate_fee_savings(amount_usd);
         tracing::info!("💰 Miser telemetry: Payment method optimized. Saved ${} in fees", savings);
@@ -64,12 +64,12 @@ impl StripeClient {
                 let api_key = std::env::var("RAZORPAY_API_KEY").unwrap_or_default();
                 let api_secret = std::env::var("RAZORPAY_API_SECRET").unwrap_or_default();
                 let rzp_client = RazorpayClient::new(api_key, api_secret);
-                return rzp_client.create_checkout_preference(_price_id, customer_id).await;
+                return rzp_client.create_checkout_preference(price_id_or_name, customer_id).await;
             },
             PaymentMethod::MercadoPago => {
                 if let Ok(token) = std::env::var("MERCADOPAGO_ACCESS_TOKEN") {
                     let mp_client = MercadoPagoClient::new(token);
-                    return mp_client.create_checkout_preference(_price_id, customer_id).await;
+                    return mp_client.create_checkout_preference(price_id_or_name, customer_id).await;
                 } else {
                     return Err("Mercado Pago access token is required".to_string());
                 }
@@ -106,7 +106,8 @@ impl StripeClient {
             form.insert("mode".to_string(), "payment".to_string());
         }
         form.insert("line_items[0][price_data][currency]".to_string(), "usd".to_string());
-        form.insert("line_items[0][price_data][product_data][name]".to_string(), "Checkout".to_string());
+        let display_name = if price_id_or_name.trim().is_empty() { "Checkout".to_string() } else { price_id_or_name.to_string() };
+        form.insert("line_items[0][price_data][product_data][name]".to_string(), display_name);
         form.insert("line_items[0][price_data][unit_amount]".to_string(), amount_cents.to_string());
         form.insert("line_items[0][quantity]".to_string(), "1".to_string());
         form.insert("client_reference_id".to_string(), customer_id.to_string());


### PR DESCRIPTION
This PR refactors the billing checkout session API to support dynamic product checkout pricing.
Previously, the endpoint only allowed static subscription tiers (e.g. `starter`, `pro`). Now, if a `product_id` is supplied without a `tier`, the backend queries the DB for the product's actual price and title to render the checkout correctly, resolving an omission for generalized checkouts. The PR also ensures the product creation API properly populates the `price_cents` column. All tests pass successfully.

---
*PR created automatically by Jules for task [1899177960439111215](https://jules.google.com/task/1899177960439111215) started by @ql-owo-lp*