### PR TITLE
fix(orchestration): ensure sqlite compatibility with agent_missions queue SKIP LOCKED pattern

### DIFF
--- a/src/server/benchmarks/chaos_bench.rs
+++ b/src/server/benchmarks/chaos_bench.rs
@@ -129,7 +129,7 @@ mod tests {
         // This benchmark asserts that the fundamental timeout utility function
         // guarantees the underlying bounded logic without network drift.
         let start = std::time::Instant::now();
-        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (_tx, _rx) = tokio::sync::oneshot::channel::<()>();
         let result = timeout(Duration::from_millis(500), async {
             tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
             "ok"

--- a/src/server/benchmarks/latency_bench.rs
+++ b/src/server/benchmarks/latency_bench.rs
@@ -643,7 +643,7 @@ mod tests {
     async fn test_ml_resilience_60s_timeout_rule() {
         let start = std::time::Instant::now();
         let timeout_duration = std::time::Duration::from_millis(150);
-        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (_tx, _rx) = tokio::sync::oneshot::channel::<()>();
 
         let result = tokio::time::timeout(timeout_duration, async {
             tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
@@ -657,7 +657,7 @@ mod tests {
     #[tokio::test]
     async fn test_chaos_degradation_network() {
         let start = std::time::Instant::now();
-        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (_tx, _rx) = tokio::sync::oneshot::channel::<()>();
         let result = tokio::time::timeout(std::time::Duration::from_millis(2000), async {
             tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
             "data"

--- a/src/server/orchestration/hybrid_sync/daemon_test.rs
+++ b/src/server/orchestration/hybrid_sync/daemon_test.rs
@@ -377,9 +377,10 @@ async fn test_hybrid_sync_clears_error_on_success() {
     let error: Option<String> = row.try_get("sync_error").unwrap_or(None);
     assert_eq!(status, "SYNCED");
     assert_eq!(error, None, "sync_error should be cleared on success");
+}
 
-    #[tokio::test]
-    async fn test_hybrid_sync_pos_offline_transactions() {
+#[tokio::test]
+async fn test_hybrid_sync_pos_offline_transactions() {
         let sqlite_pool = sqlx::sqlite::SqlitePoolOptions::new()
             .connect("sqlite::memory:")
             .await
@@ -443,4 +444,3 @@ async fn test_hybrid_sync_clears_error_on_success() {
         assert!(job_row.is_some());
     }
 
-}

--- a/src/server/sip.rs
+++ b/src/server/sip.rs
@@ -204,7 +204,13 @@ impl SipDB {
                     .await?;
 
                 // Prioritize backlog by bumping updated_at for oldest pending missions
-                sqlx::query("UPDATE agent_missions SET updated_at = CURRENT_TIMESTAMP WHERE id IN (SELECT id FROM agent_missions WHERE status = 'PENDING' AND tenant_id = $1 ORDER BY created_at ASC LIMIT 10 FOR UPDATE SKIP LOCKED) RETURNING id")
+                let is_standalone = crate::is_standalone_runtime();
+                let query_str = if is_standalone {
+                    "UPDATE agent_missions SET updated_at = CURRENT_TIMESTAMP WHERE id IN (SELECT id FROM agent_missions WHERE status = 'PENDING' AND tenant_id = $1 ORDER BY created_at ASC LIMIT 10) RETURNING id"
+                } else {
+                    "UPDATE agent_missions SET updated_at = CURRENT_TIMESTAMP WHERE id IN (SELECT id FROM agent_missions WHERE status = 'PENDING' AND tenant_id = $1 ORDER BY created_at ASC LIMIT 10 FOR UPDATE SKIP LOCKED) RETURNING id"
+                };
+                sqlx::query(query_str)
                     .bind(&self.org_id)
                     .execute(&mut *tx)
                     .await?;


### PR DESCRIPTION
This PR resolves a critical issue where the Standalone runtime (using SQLite) would panic when `prune_stale_missions` attempts to execute a PostgreSQL-specific `SKIP LOCKED` query on the `agent_missions` queue.

By utilizing `crate::is_standalone_runtime()`, the codebase now correctly falls back to a standard `LIMIT 10` execution in SQLite, while preserving the robust `FOR UPDATE SKIP LOCKED` behavior in Cloud environments.

Additionally, this PR cleans up multiple obsolete warning signals and dead code, including:
- Unused variables (`rx`) in `latency_bench.rs` and `chaos_bench.rs`.
- Extraneous test configurations in `daemon_test.rs`.

All changes have been successfully validated using local Bazel testing, maintaining a completely green suite in both local and test environments.

---
*PR created automatically by Jules for task [16064770280812463237](https://jules.google.com/task/16064770280812463237) started by @ql-owo-lp*