### PR TITLE
fix(pricing): render next bill correctly with formatting

### DIFF
--- a/src/server/benchmarks/chaos_bench.rs
+++ b/src/server/benchmarks/chaos_bench.rs
@@ -129,7 +129,7 @@ mod tests {
         // This benchmark asserts that the fundamental timeout utility function
         // guarantees the underlying bounded logic without network drift.
         let start = std::time::Instant::now();
-        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (_tx, _rx) = tokio::sync::oneshot::channel::<()>();
         let result = timeout(Duration::from_millis(500), async {
             tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
             "ok"

--- a/src/server/benchmarks/latency_bench.rs
+++ b/src/server/benchmarks/latency_bench.rs
@@ -640,7 +640,7 @@ mod tests {
     async fn test_ml_resilience_60s_timeout_rule() {
         let start = std::time::Instant::now();
         let timeout_duration = std::time::Duration::from_millis(150);
-        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (_tx, _rx) = tokio::sync::oneshot::channel::<()>();
 
         let result = tokio::time::timeout(timeout_duration, async {
             tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
@@ -654,7 +654,7 @@ mod tests {
     #[tokio::test]
     async fn test_chaos_degradation_network() {
         let start = std::time::Instant::now();
-        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (_tx, _rx) = tokio::sync::oneshot::channel::<()>();
         let result = tokio::time::timeout(std::time::Duration::from_millis(2000), async {
             tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
             "data"

--- a/src/ui/next/src/app/plan/page.tsx
+++ b/src/ui/next/src/app/plan/page.tsx
@@ -46,7 +46,7 @@ export default function MyPlanPage() {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'USD',
-    }).format(amount);
+    }).format(amount / 100);
   };
 
   if (loading) {


### PR DESCRIPTION
The estimated next bill was incorrectly rendering because the `next_bill_estimated` backend value is in cents, while the `formatCurrency` function was rendering it strictly as dollars (e.g. `$29,900` instead of `$299`).
Fixed `formatCurrency(amount)` inside `MyPlanPage` to correctly calculate `amount / 100` before passing to `Intl.NumberFormat`.

---
*PR created automatically by Jules for task [3986577002107742029](https://jules.google.com/task/3986577002107742029) started by @wbbsuper*