### PR TITLE
Fix E2E tests and upgrade dompurify

### DIFF
--- a/src/e2e/business_manager.spec.ts
+++ b/src/e2e/business_manager.spec.ts
@@ -3,13 +3,13 @@ import { test, expect } from './fixtures';
 test.describe('Business Manager UI', () => {
   test('should display dashboard with nav', async ({ page }) => {
     await page.goto('/dashboard');
-    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+    await expect(page.locator('h2', { hasText: /Welcome back/i })).toBeVisible();
     await expect(page.getByRole('navigation', { name: 'Primary' })).toBeVisible();
   });
 
   test('should navigate to agents page', async ({ page }) => {
     await page.goto('/agents');
-    await expect(page.getByRole('heading', { name: 'AI Departments' })).toBeVisible();
+    await expect(page.locator('h1:has-text("Expert Center")')).toBeVisible();
   });
 
   test('should display login page', async ({ page }) => {
@@ -31,17 +31,17 @@ test.describe('Business Manager UI', () => {
 test.describe('Navigation', () => {
   test('should have working nav links', async ({ page }) => {
     await page.goto('/dashboard');
-    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+    await expect(page.locator('h2', { hasText: /Welcome back/i })).toBeVisible();
     const link = page.getByRole('link', { name: 'Agents', exact: true });
     await expect(link).toBeVisible();
     await link.click();
     await page.waitForURL('**/agents**');
-    await expect(page.getByRole('heading', { name: 'AI Departments' })).toBeVisible();
+    await expect(page.locator('h1:has-text("Expert Center")')).toBeVisible();
   });
 
   test('should navigate to dashboard from nav', async ({ page }) => {
     await page.goto('/agents');
     await page.locator('header a[href="/dashboard"]').click();
-    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+    await expect(page.locator('h2', { hasText: /Welcome back/i })).toBeVisible();
   });
 });

--- a/src/ui/next/package-lock.json
+++ b/src/ui/next/package-lock.json
@@ -14,7 +14,7 @@
         "@stripe/terminal-js": "^0.26.0",
         "@testing-library/dom": "^10.4.1",
         "@types/dompurify": "^3.0.5",
-        "dompurify": "^3.0.6",
+        "dompurify": "^3.4.10",
         "framer-motion": "^12.40.0",
         "postcss-loader": "^8.2.1",
         "react": "^18.3.1",
@@ -4039,9 +4039,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/src/ui/next/package.json
+++ b/src/ui/next/package.json
@@ -15,7 +15,7 @@
     "@stripe/terminal-js": "^0.26.0",
     "@testing-library/dom": "^10.4.1",
     "@types/dompurify": "^3.0.5",
-    "dompurify": "^3.0.6",
+    "dompurify": "^3.4.10",
     "framer-motion": "^12.40.0",
     "postcss-loader": "^8.2.1",
     "react": "^18.3.1",


### PR DESCRIPTION
- Fixed failing E2E tests by updating the Playwright locators for headings in `/dashboard` and `/agents` to match the actual UI content.
- Installed `dompurify` and `@types/dompurify` in the `src/ui/next` package using `--legacy-peer-deps` to resolve dependency conflicts.
- Verified that all tests (`bazelisk test //...`) pass successfully.

---
*PR created automatically by Jules for task [14846732446637514339](https://jules.google.com/task/14846732446637514339) started by @ql-owo-lp*