### PR TITLE
fix: Format estimated bill in dollars and update Upgrade button

### DIFF
--- a/src/ui/next/src/app/plan/page.tsx
+++ b/src/ui/next/src/app/plan/page.tsx
@@ -46,7 +46,7 @@ export default function MyPlanPage() {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'USD',
-    }).format(amount);
+    }).format(amount / 100);
   };
 
   if (loading) {
@@ -92,7 +92,7 @@ export default function MyPlanPage() {
                 <button
                     onClick={() => router.push('/pricing')}
                     className="w-full sm:w-auto px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl font-medium transition-all shadow-sm text-center">
-                    View Upgrade Plans
+                    Upgrade
                 </button>
                 <button
                     onClick={() => router.push('/cost-dashboard')}

--- a/src/ui/next/src/e2e/plan.spec.ts
+++ b/src/ui/next/src/e2e/plan.spec.ts
@@ -24,10 +24,10 @@ test.describe('My Plan Page Loop', () => {
     await expect(page.locator('h2', { hasText: 'Estimated Next Bill:' })).toBeVisible();
 
     // Check for "Upgrade Plan" or "View Upgrade Plans" buttons
-    await expect(page.locator('button', { hasText: 'View Upgrade Plans' })).toBeVisible();
+    await expect(page.locator('button', { hasText: 'Upgrade' })).toBeVisible();
 
     // Check navigation buttons work correctly
-    await page.locator('button', { hasText: 'View Upgrade Plans' }).click();
+    await page.locator('button', { hasText: 'Upgrade' }).click();
     await expect(page).toHaveURL('/pricing');
   });
 });


### PR DESCRIPTION
This PR addresses a bug where the `next_bill_estimated` was displayed in cents instead of dollars on the "My Plan" page. It also updates the button text from "View Upgrade Plans" to a more direct "Upgrade", as required by the design doc. End-to-end tests have been updated accordingly.

---
*PR created automatically by Jules for task [9613123222688175352](https://jules.google.com/task/9613123222688175352) started by @ql-owo-lp*