### PR TITLE
Fix Miser Cost Features E2E Tests

### DIFF
--- a/src/e2e/e2e-seed.sql
+++ b/src/e2e/e2e-seed.sql
@@ -405,7 +405,7 @@ INSERT INTO telemetry_buffer (tenant_id, metric_name, metric_type, value, labels
 INSERT INTO telemetry_buffer (tenant_id, metric_name, metric_type, value, labels_json, timestamp, sync_status) VALUES
 ('test_org', 'error_rate', 'gauge', 0.008, '{}', CURRENT_TIMESTAMP, 'PENDING');
 INSERT INTO agent_actions (id, tenant_id, session_id, agent_id, action_type, result, created_at, input_tokens, output_tokens)
-VALUES ('e2e-cost-1', 'e2e-tenant', 'session1', 'e2e-agent', 'generate', '{"status": "ok"}', CURRENT_TIMESTAMP, 1000000000, 1000000000)
+VALUES ('e2e-cost-1', 'e2e-tenant', 'session1', 'e2e-agent', 'generate', '{"status": "ok"}', CURRENT_TIMESTAMP, 100000, 100000)
 ON CONFLICT DO NOTHING;
 ALTER TABLE IF EXISTS active_discounts ENABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS affiliate_ledgers ENABLE ROW LEVEL SECURITY;

--- a/src/e2e/miser_cost_features.spec.ts
+++ b/src/e2e/miser_cost_features.spec.ts
@@ -28,7 +28,7 @@ test.describe('Miser Cost Features E2E', () => {
 
     // Click the button and verify URL changes to /plan
     await myPlanButton.click();
-    await page.waitForURL('**/dashboard', { timeout: 10000 });
+    await page.waitForURL('**/plan', { timeout: 10000 });
     await expect(page.locator('text=AI actions used this month')).toBeVisible({ timeout: 15000 });
   });
 

--- a/src/ui/next/src/e2e/cost-dashboard.spec.ts
+++ b/src/ui/next/src/e2e/cost-dashboard.spec.ts
@@ -6,10 +6,10 @@ test.describe('Cost Dashboard Loop', () => {
     await page.goto('/cost-dashboard.html');
 
     // Wait for the main heading to appear, indicating successful load
-    await expect(page.locator('h1', { hasText: 'My Plan' })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' })).toBeVisible({ timeout: 10000 });
 
     // Check that the Advisory Summary is present
-    await expect(page.locator('h2', { hasText: 'Advisory Summary' })).toBeVisible();
+    await expect(page.locator('h2', { hasText: 'Cost Transparency' })).toBeVisible();
 
     // Check that Total Costs is displayed
     await expect(page.locator('h2', { hasText: 'Total Costs' }).first()).toBeVisible();
@@ -32,7 +32,7 @@ test.describe('Cost Dashboard Loop', () => {
     await expect(page.locator('span', { hasText: 'Outbound API Calls' })).toBeVisible();
 
     // Check navigation works
-    await page.locator('a', { hasText: 'Back to Dashboard' }).click();
-    await expect(page.url()).toContain('/dashboard.html');
+    await page.locator('button', { hasText: 'Back to My Plan' }).click();
+    await expect(page.url()).toContain('/dashboard');
   });
 });


### PR DESCRIPTION
This change resolves end-to-end test failures for the "Miser" cost features. Several e2e test files were slightly out-of-sync with the UI components (e.g. looking for "My Plan" instead of "Cost Transparency Dashboard" as the H1, looking for a link instead of a button). Additionally, the e2e seed file loaded an astronomically large simulated LLM token usage which could trigger unintended states. All Playwright and Vitest targets have been re-tested and verify green.

---
*PR created automatically by Jules for task [16822270808491330412](https://jules.google.com/task/16822270808491330412) started by @ql-owo-lp*