### PR TITLE
Add checkout URL and Stripe checkout generation to quotes

### DIFF
--- a/src/proto/app.proto
+++ b/src/proto/app.proto
@@ -41,6 +41,7 @@ message Quote {
   int64 total_amount = 4;
   int64 required_deposit = 5;
   int64 expires_at_unix = 6;
+  string checkout_url = 7;
 }
 
 message Invoice {

--- a/src/server/db/migrations/128_quoting_schema_update.sql
+++ b/src/server/db/migrations/128_quoting_schema_update.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS total_amount BIGINT;
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS required_deposit BIGINT;
+ALTER TABLE quotes ADD COLUMN IF NOT EXISTS checkout_url TEXT;
+
+-- +goose Down
+ALTER TABLE quotes DROP COLUMN IF EXISTS total_amount;
+ALTER TABLE quotes DROP COLUMN IF EXISTS required_deposit;
+ALTER TABLE quotes DROP COLUMN IF EXISTS checkout_url;

--- a/src/server/domain/repository/models.rs
+++ b/src/server/domain/repository/models.rs
@@ -345,6 +345,9 @@ pub struct Quote {
     pub customer_id: String,
     pub status: String,
     pub valid_until: Option<DateTime<Utc>>,
+    pub total_amount: Option<i64>,
+    pub required_deposit: Option<i64>,
+    pub checkout_url: Option<String>,
     pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
 }

--- a/src/server/services/booking.rs
+++ b/src/server/services/booking.rs
@@ -1506,14 +1506,20 @@ impl BookingEngineService for NativeBookingService {
 
         crate::common::auth_utils::set_org_context(&mut *tx, &tenant_id).await.map_err(|e| Status::internal(e.to_string()))?;
 
+        let mut total_calc = 0;
+        for item in &req.line_items {
+            total_calc += item.unit_price_cents * item.quantity as i64;
+        }
+
         sqlx::query(
-            "INSERT INTO quotes (id, tenant_id, customer_id, status, required_deposit) VALUES ($1, $2, $3, $4, $5)"
+            "INSERT INTO quotes (id, tenant_id, customer_id, status, required_deposit, total_amount) VALUES ($1, $2, $3, $4, $5, $6)"
         )
         .bind(&quote_id)
         .bind(&tenant_id)
         .bind(uuid::Uuid::parse_str(&req.customer_id).unwrap_or_else(|_| uuid::Uuid::new_v4()))
         .bind("DRAFT")
         .bind(req.required_deposit)
+        .bind(total_calc)
         .execute(&mut *tx)
         .await
         .map_err(|e| Status::internal(e.to_string()))?;

--- a/src/server/services/quoting/mod.rs
+++ b/src/server/services/quoting/mod.rs
@@ -25,6 +25,9 @@ pub struct Quote {
     pub customer_id: Uuid,
     pub status: String,
     pub valid_until: Option<DateTime<Utc>>,
+    pub total_amount: Option<i64>,
+    pub required_deposit: Option<i64>,
+    pub checkout_url: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -173,18 +176,55 @@ async fn approve_quote(
     State(pool): State<PgPool>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Quote>, axum::http::StatusCode> {
-    let quote = sqlx::query_as::<_, Quote>(
+    let mut tx = pool.begin().await.map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let quote_opt = sqlx::query_as::<_, Quote>(
         "UPDATE quotes SET status = 'ACCEPTED', updated_at = NOW() WHERE id = $1 RETURNING *"
     )
     .bind(id)
-    .fetch_optional(&pool)
+    .fetch_optional(&mut *tx)
     .await
-    .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|e| {
+        tracing::error!("Failed to update quote status: {}", e);
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
-    // Integrate Stripe deposit logic here...
+    let quote = match quote_opt {
+        Some(q) => q,
+        None => return Err(axum::http::StatusCode::NOT_FOUND),
+    };
 
-    match quote {
-        Some(q) => Ok(Json(q)),
-        None => Err(axum::http::StatusCode::NOT_FOUND),
-    }
+    let amount_usd = (quote.total_amount.unwrap_or(0) as f64) / 100.0;
+
+    let stripe_api_key = std::env::var("STRIPE_API_KEY").unwrap_or_default();
+    let stripe_client = crate::integrations::stripe::client::StripeClient::new(stripe_api_key);
+
+    let checkout_url = match stripe_client.create_checkout_session(
+        &format!("Quote {}", id),
+        &quote.customer_id.to_string(),
+        amount_usd,
+        false
+    ).await {
+        Ok(url) => url,
+        Err(e) => {
+            tracing::error!("Stripe integration failed: {}", e);
+            return Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+
+    let updated_quote = sqlx::query_as::<_, Quote>(
+        "UPDATE quotes SET checkout_url = $1 WHERE id = $2 RETURNING *"
+    )
+    .bind(&checkout_url)
+    .bind(id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to update quote with checkout url: {}", e);
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    tx.commit().await.map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(updated_quote))
 }


### PR DESCRIPTION
Add checkout_url to the Quote struct, the quotes DB table, and update the quote approval logic to generate and persist a Stripe checkout session URL.

---
*PR created automatically by Jules for task [5673067171405919758](https://jules.google.com/task/5673067171405919758) started by @ql-owo-lp*

Resolves #28020