### PR TITLE
🤖 Implementer: Harness Upgrade - [Context Management: JetBrains Observation Masking]

### DIFF
--- a/src/agents/builtin/observation_masking.rs
+++ b/src/agents/builtin/observation_masking.rs
@@ -28,8 +28,10 @@ impl JetBrainsObservationMasker {
     ) -> bool {
         let mut modified = false;
 
-        // Prevent extremely deep recursion that could blow up the stack
-        if depth > 10 {
+        // More elegant token-budget/byte-budget slicing method.
+        // We allow deeper recursion (up to 100) but reduce the available size limit and element limit proportionally.
+        // Prevent stack overflow with a high hard limit.
+        if depth > 100 {
             match val {
                 Value::Array(arr) => {
                     let len = arr.len();
@@ -48,11 +50,24 @@ impl JetBrainsObservationMasker {
             }
         }
 
+        // Budget reduction at each depth level to ensure total output stays small
+        // We decay the size limit by 20% at each level, but ensure it doesn't drop below a minimum threshold
+        // The element limit decays more gracefully.
+        let mut current_size_limit = size_limit;
+        for _ in 0..depth {
+            current_size_limit = std::cmp::max(10, (current_size_limit * 8) / 10);
+        }
+
+        let mut current_element_limit = element_limit;
+        for _ in 0..depth {
+            current_element_limit = std::cmp::max(1, (current_element_limit * 9) / 10);
+        }
+
         match val {
             Value::String(s) => {
                 let bytes = s.len();
-                if bytes > size_limit {
-                    let preview_chars = std::cmp::max(10, size_limit / 4);
+                if bytes > current_size_limit {
+                    let preview_chars = std::cmp::max(10, current_size_limit / 4);
                     let char_count = s.chars().count();
                     if char_count > preview_chars * 2 {
                         let start_preview: String = s.chars().take(preview_chars).collect();
@@ -71,26 +86,23 @@ impl JetBrainsObservationMasker {
             Value::Array(arr) => {
                 let original_len = arr.len();
 
-                // Adaptive element limit based on depth - deeper structures get truncated more aggressively
-                let current_limit = std::cmp::max(1, element_limit.saturating_sub(depth * 5));
-
-                if original_len > current_limit {
+                if original_len > current_element_limit {
                     // Try to keep a mix of the beginning and end of the array
-                    if current_limit >= 2 {
-                        let half = current_limit / 2;
-                        let mut new_arr = Vec::with_capacity(current_limit + 1);
+                    if current_element_limit >= 2 {
+                        let half = current_element_limit / 2;
+                        let mut new_arr = Vec::with_capacity(current_element_limit + 1);
                         new_arr.extend_from_slice(&arr[..half]);
                         new_arr.push(Value::String(format!(
                             "[... Masked array: {} elements truncated ...]",
-                            original_len - current_limit
+                            original_len - current_element_limit
                         )));
-                        new_arr.extend_from_slice(&arr[original_len - (current_limit - half)..]);
+                        new_arr.extend_from_slice(&arr[original_len - (current_element_limit - half)..]);
                         *arr = new_arr;
                     } else {
-                        arr.truncate(current_limit);
+                        arr.truncate(current_element_limit);
                         arr.push(Value::String(format!(
                             "[Masked array: {} elements truncated]",
-                            original_len - current_limit
+                            original_len - current_element_limit
                         )));
                     }
                     modified = true;
@@ -107,12 +119,9 @@ impl JetBrainsObservationMasker {
                 let mut truncated = false;
                 let mut removed_count = 0;
 
-                // Adaptive element limit based on depth
-                let current_limit = std::cmp::max(1, element_limit.saturating_sub(depth * 5));
-
-                if original_len > current_limit {
+                if original_len > current_element_limit {
                     let keys_to_remove: Vec<String> =
-                        obj.keys().skip(current_limit).cloned().collect();
+                        obj.keys().skip(current_element_limit).cloned().collect();
                     removed_count = keys_to_remove.len();
                     for k in keys_to_remove {
                         obj.remove(&k);


### PR DESCRIPTION
**Harness Upgrade: Context Management: JetBrains Observation Masking**

This PR implements a specific harness upgrade from the MASTER CATALOG: `Context Management: JetBrains Observation Masking`.

*Excerpt from research:*
"Context Management (Preventing Context Rot): Observation Masking (JetBrains' Junie): Hide the raw output of old tools from the prompt, but keep the `tool_calls` themselves visible so the model remembers what it did."

**Implementation Mechanics:**
The existing `JetBrainsObservationMasker::mask_json_value` logic in `src/agents/builtin/observation_masking.rs` utilized a naive hard depth limit (`depth > 10`) and static element counts to perform JSON truncation. When dealing with complex structures, this could completely destroy JSON structural validity or eliminate arrays prematurely.

I refactored the masking algorithm to use a much more robust "token-budget/byte-budget" JSON masking method:
- Recursion depth is safely increased to 100 before hard bailing (preventing stack overflows).
- At each recursion depth, the `size_limit` decays by 20% and the `element_limit` decays by 10%.
- This allows proportional truncation: the top levels of the JSON structure are allowed to retain more keys/elements, while deeper nested elements are aggressively pruned.
- The `[Observation Masked...]` values are still gracefully injected, ensuring we hide the raw output of old tools while perfectly keeping the original `tool_calls` intact in the prompt.

**Testing Instructions:**
Unit tests inside `src/agents/builtin/observation_masking.rs` verify depth, advanced nesting, and large array truncation.
All tests have been run locally via `bazel test //src/agents/builtin/...` and are 100% green.

**Superpowers used:**
None explicitly loaded for this task beyond the Roulette Protocol requirements.

---
*PR created automatically by Jules for task [9372639031832607768](https://jules.google.com/task/9372639031832607768) started by @ql-owo-lp*