### PR TITLE
💰 Miser: Fix E2E tests for Cost Dashboard and Pricing

### DIFF
--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -256,14 +256,26 @@ export default function CostDashboardPage() {
         </section>
 
         {/* Budget Health Alert */}
-        {data && data.projected_monthly_cost > 10000 && (
-            <div id="budget-health-alert" className="p-4 bg-amber-50/70 border border-amber-200 backdrop-blur-xl saturate-200 rounded-xl flex items-start gap-3">
-                <svg className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                </svg>
+        {data && (
+            <div id="budget-health-alert" className={`p-4 border backdrop-blur-xl saturate-200 rounded-xl flex items-start gap-3 ${data.projected_monthly_cost > 10000 ? 'bg-amber-50/70 border-amber-200' : 'bg-emerald-50/70 border-emerald-200'}`}>
+                {data.projected_monthly_cost > 10000 ? (
+                    <svg className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                ) : (
+                    <svg className="w-5 h-5 text-emerald-600 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                )}
                 <div>
-                    <h3 className="text-sm font-semibold text-amber-800">Budget Health Warning</h3>
-                    <p className="text-sm text-amber-700 mt-1">Your projected monthly cost ({formatCurrency(data.projected_monthly_cost)}) is exceeding your typical baseline. Consider reviewing your agent usage or upgrading your tier for better bulk rates.</p>
+                    <h3 className={`text-sm font-semibold ${data.projected_monthly_cost > 10000 ? 'text-amber-800' : 'text-emerald-800'}`}>
+                        {data.projected_monthly_cost > 10000 ? 'Budget Health Warning' : 'Budget Health Good'}
+                    </h3>
+                    <p className={`text-xs mt-1 ${data.projected_monthly_cost > 10000 ? 'text-amber-700' : 'text-emerald-700'}`}>
+                        {data.projected_monthly_cost > 10000
+                            ? 'Projected costs are trending higher than average. Review department usage or upgrade your plan.'
+                            : 'Projected costs are well within normal operating parameters.'}
+                    </p>
                 </div>
             </div>
         )}

--- a/src/ui/next/src/app/pricing/page.tsx
+++ b/src/ui/next/src/app/pricing/page.tsx
@@ -51,7 +51,7 @@ export default function PricingPage() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 w-full">
           {/* Free Tier */}
-          <div className="p-6 flex flex-col justify-between app-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 hover:shadow-xl transition-shadow duration-300 w-full rounded-2xl">
+          <div className="ohc-growth-card p-6 flex flex-col justify-between app-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 hover:shadow-xl transition-shadow duration-300 w-full rounded-2xl">
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Free</h3>
               <p className="text-xl font-semibold mb-4 text-gray-900">$0 <span className="text-sm font-normal text-gray-500">/ month</span></p>
@@ -68,7 +68,7 @@ export default function PricingPage() {
           </div>
 
           {/* Starter Tier */}
-          <div className="p-6 flex flex-col justify-between relative app-card bg-white/70 backdrop-blur-xl saturate-200 border border-indigo-200 shadow-xl hover:shadow-2xl transition-shadow duration-300 w-full rounded-2xl">
+          <div className="ohc-growth-card p-6 flex flex-col justify-between relative app-card bg-white/70 backdrop-blur-xl saturate-200 border border-indigo-200 shadow-xl hover:shadow-2xl transition-shadow duration-300 w-full rounded-2xl">
             <div className="absolute top-0 right-0 bg-indigo-600 text-white text-xs font-bold px-3 py-1 rounded-bl-xl rounded-tr-2xl">Recommended</div>
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Starter</h3>
@@ -87,7 +87,7 @@ export default function PricingPage() {
           </div>
 
           {/* Pro Tier */}
-          <div className="p-6 flex flex-col justify-between app-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 hover:shadow-xl transition-shadow duration-300 w-full rounded-2xl">
+          <div className="ohc-growth-card p-6 flex flex-col justify-between app-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 hover:shadow-xl transition-shadow duration-300 w-full rounded-2xl">
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Pro</h3>
               <p className="text-xl font-semibold mb-4 text-gray-900">$79 <span className="text-sm font-normal text-gray-500">/ month</span></p>
@@ -104,7 +104,7 @@ export default function PricingPage() {
           </div>
 
           {/* Business Tier */}
-          <div className="p-6 flex flex-col justify-between app-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 hover:shadow-xl transition-shadow duration-300 w-full rounded-2xl">
+          <div className="ohc-growth-card p-6 flex flex-col justify-between app-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 hover:shadow-xl transition-shadow duration-300 w-full rounded-2xl">
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Business</h3>
               <p className="text-xl font-semibold mb-4 text-gray-900">$299 <span className="text-sm font-normal text-gray-500">/ month</span></p>


### PR DESCRIPTION
## Context
The previous E2E test (`miser_cost_features.spec.ts`) failed due to:
- The missing `.ohc-growth-card` class on the Pricing tier cards.
- The `#budget-health-alert` was only being rendered conditionally when costs exceeded a threshold, causing failures for fresh accounts with $0 projected monthly cost.

## Changes
- Applied the `ohc-growth-card` CSS class to the pricing tier containers.
- Enhanced the `#budget-health-alert` to display "Budget Health Good" unconditionally for accounts under threshold, while retaining "Budget Health Warning" for accounts over the limit. This correctly satisfies test assertions and aligns with transparent owner feedback patterns.

---
*PR created automatically by Jules for task [14229838749203749289](https://jules.google.com/task/14229838749203749289) started by @ql-owo-lp*