### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Fix tenant data access bug in workspace search

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -480,11 +480,14 @@ impl DB {
                 }
             }
             DbStore::Postgres => {
+                let mut tx = self.pool.begin().await.map_err(|e| format!("DB Error: {}", e))?;
+                ::server_common::auth_utils::set_org_context(&mut *tx, tenant_id).await.map_err(|e| format!("DB Error: {}", e))?;
+
                 // Search Customers
                 let customer_rows = sqlx::query("SELECT id, name, email FROM customers WHERE tenant_id = $1 AND (name ILIKE $2 OR email ILIKE $2) ORDER BY id ASC LIMIT 10")
                     .bind(tenant_id)
                     .bind(&query_lower)
-                    .fetch_all(&self.pool)
+                    .fetch_all(&mut *tx)
                     .await
                     .map_err(|e| format!("DB Error: {}", e))?;
 
@@ -506,7 +509,7 @@ impl DB {
                 let order_rows = sqlx::query("SELECT id, status, CAST(total_amount AS DOUBLE PRECISION) as total_amount FROM orders WHERE tenant_id = $1 AND (id ILIKE $2 OR status ILIKE $2) ORDER BY id ASC LIMIT 10")
                     .bind(tenant_id)
                     .bind(&query_lower)
-                    .fetch_all(&self.pool)
+                    .fetch_all(&mut *tx)
                     .await
                     .map_err(|e| format!("DB Error: {}", e))?;
 
@@ -529,7 +532,7 @@ impl DB {
                 let message_rows = sqlx::query("SELECT id, source, content FROM inbox_messages WHERE tenant_id = $1 AND (content ILIKE $2 OR source ILIKE $2) ORDER BY id ASC LIMIT 10")
                     .bind(tenant_id)
                     .bind(&query_lower)
-                    .fetch_all(&self.pool)
+                    .fetch_all(&mut *tx)
                     .await
                     .map_err(|e| format!("DB Error: {}", e))?;
 
@@ -551,6 +554,8 @@ impl DB {
                         route: format!("/inbox/{}", id),
                     });
                 }
+
+                tx.commit().await.map_err(|e| format!("DB Error: {}", e))?;
             }
         }
 


### PR DESCRIPTION
Fixes a critical data access issue in `src/server/db.rs` where the `search_workspace` method for PostgreSQL could not read data from RLS-protected tables. 

**Root Cause:**
`search_workspace` was using `.fetch_all(&self.pool)` directly. The `PgPoolOptions::before_acquire` lifecycle hook automatically resets `app.current_tenant` to `''` when checking out a connection to prevent tenant bleed. Because the tenant wasn't actively injected into the session config before issuing the query, Postgres evaluated the read against an empty string and returned no records for `customers`, `orders`, and `inbox_messages`.

**Solution:**
* Modified `search_workspace` to begin a dedicated transaction `let mut tx = self.pool.begin().await...`
* Leveraged existing helper `::server_common::auth_utils::set_org_context(&mut *tx, tenant_id).await` to inject the proper tenant context.
* Updated `customer`, `order`, and `message` queries to use `&mut *tx`.
* Completed `tx.commit()`.

Tested with `bazel test //...` and `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"` resolving the issue without regressions.

---
*PR created automatically by Jules for task [7148862845316170138](https://jules.google.com/task/7148862845316170138) started by @ql-owo-lp*