### PR TITLE
fix: Handle POS inventory sync conflicts gracefully (#27615)

### DIFF
--- a/src/server/orchestration/departments/operations_agent.rs
+++ b/src/server/orchestration/departments/operations_agent.rs
@@ -53,7 +53,12 @@ impl Department for OperationsAgent {
             "tenant.order.created" => "Process Order & Update Inventory".to_string(),
             "LowStockAlert" => {
                 let product_id = event.payload.get("product_id").and_then(|v| v.as_str()).unwrap_or("unknown");
-                format!("Draft a restock order for product {} due to low stock", product_id)
+                let remaining_stock = event.payload.get("remaining_stock").and_then(|v| v.as_i64()).unwrap_or(0);
+                if remaining_stock == 0 {
+                    format!("{} sold out. Would you like to draft a restock order?", product_id)
+                } else {
+                    format!("Draft a restock order for product {} due to low stock", product_id)
+                }
             },
             "InventoryConflictEvent" => {
                 // If it's the specific test/simulation message from offline_sync, we forward it exactly.

--- a/src/server/workers/pos_sync_worker.rs
+++ b/src/server/workers/pos_sync_worker.rs
@@ -240,7 +240,7 @@ impl PosSyncWorker {
 
                                 let _ = sqlx::query(
                                     "INSERT INTO department_tasks (id, tenant_id, department, event_type, payload, status)
-                                     VALUES ($1, $2, 'operations', 'LowStockAlert', $3::jsonb, 'PENDING')"
+                                     VALUES ($1, $2, 'operations', 'InventoryConflictEvent', $3::jsonb, 'PENDING')"
                                 )
                                 .bind(&notification_id)
                                 .bind(&job.tenant_id)


### PR DESCRIPTION
In `src/server/workers/pos_sync_worker.rs`, corrected the event payload type from `LowStockAlert` to `InventoryConflictEvent` so that the `operations_agent` properly picks up and evaluates overbookings created during offline Point-Of-Sale synchronization.

In `src/server/orchestration/departments/operations_agent.rs`, refined the logic for `LowStockAlert` so that when `remaining_stock == 0` the alert reads `sold out. Would you like to draft a restock order?` matching the intended outcome described in the CUJ.

Resolves #27615

---
*PR created automatically by Jules for task [5852045845881880940](https://jules.google.com/task/5852045845881880940) started by @ql-owo-lp*