### PR TITLE
fix: Dynamic parsing of E2E test intake data fallback

### DIFF
--- a/src/server/services/onboarding/onboarding_agent.rs
+++ b/src/server/services/onboarding/onboarding_agent.rs
@@ -171,9 +171,26 @@ Your response:",
             Some(m) => m,
             None => {
                 // E2E Test / Local adapter mock fallback when no LLM is configured
+                let mut mock_name = "Mock Business".to_string();
+                let mut mock_type = "Mock Type".to_string();
+
+                for line in input.lines() {
+                    if line.starts_with("Business Name: ") {
+                        mock_name = line.trim_start_matches("Business Name: ").trim().to_string();
+                    } else if line.starts_with("What we sell: ") {
+                        let desc = line.trim_start_matches("What we sell: ").trim();
+                        if desc.chars().count() > 30 {
+                            let truncated: String = desc.chars().take(27).collect();
+                            mock_type = format!("{}...", truncated);
+                        } else {
+                            mock_type = desc.to_string();
+                        }
+                    }
+                }
+
                 return Ok(IntakeData {
-                    business_name: "Mock Business".to_string(),
-                    business_type: "Mock Type".to_string(),
+                    business_name: mock_name,
+                    business_type: mock_type,
                     categories: vec!["physical".to_string()],
                     initial_products: vec![
                         IntakeProduct {


### PR DESCRIPTION
- Modified the local mock fallback in `process_intake` within `src/server/services/onboarding/onboarding_agent.rs` to parse input text and dynamically populate the `business_name` and `business_type`.
- Applied truncation at 27 characters safely to prevent byte-indexing crashes on UTF-8 strings. 
- Ensured all CUJs (Maya the Baker, Carlos the Handyman, etc) pass correctly because the expected frontend state now aligns with the generated E2E payload strings.

---
*PR created automatically by Jules for task [12093666551905746527](https://jules.google.com/task/12093666551905746527) started by @wbbsuper*