### PR TITLE
fix(tests): mock WebSocket to prevent unhandled test errors

### DIFF
--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,3 +1,34 @@
 import '@testing-library/jest-dom/vitest';
 
 if (typeof window !== "undefined") { window.HTMLElement.prototype.scrollIntoView = function () {}; }
+class MockWebSocket {
+  onerror: ((ev: Event) => any) | null = null;
+  onopen: ((ev: Event) => any) | null = null;
+  onmessage: ((ev: MessageEvent) => any) | null = null;
+  onclose: ((ev: CloseEvent) => any) | null = null;
+  readyState: number = 0; // CONNECTING
+  url: string = '';
+
+  constructor(url: string) {
+    this.url = url;
+    setTimeout(() => {
+        this.readyState = 1; // OPEN
+        if (this.onopen) {
+           this.onopen(new Event('open'));
+        }
+    }, 0);
+  }
+  close() {
+      this.readyState = 3; // CLOSED
+      if (this.onclose) {
+          this.onclose(new CloseEvent('close'));
+      }
+  }
+  send() {}
+
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent() { return true; }
+}
+
+global.WebSocket = MockWebSocket as any;


### PR DESCRIPTION
Fix an unhandled `Websocket error: Event { isTrusted: [Getter] }` coming from `vitest` when testing UI components connecting to a WebSocket. I implemented `MockWebSocket` in `setupTests.ts` which provides the lifecycle methods necessary to prevent unhandled errors during test executions. Tested that all test cases pass without regressions.

---
*PR created automatically by Jules for task [14339886608277111496](https://jules.google.com/task/14339886608277111496) started by @ql-owo-lp*