### PR TITLE
🗺️ Guide: Update storefront builder link in onboarding success screen

### DIFF
--- a/src/e2e/onboarding_cuj.spec.ts
+++ b/src/e2e/onboarding_cuj.spec.ts
@@ -93,6 +93,7 @@ test.describe('Onboarding Wizard CUJ', () => {
     // 8. Verify it transitions to Live Screen
     await expect(page.getByText("You're Live!")).toBeVisible({ timeout: 15000 });
     await expect(page.getByRole('link', { name: /Open Assistant/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Storefront Builder/i })).toBeVisible();
   });
 
   // Test 2: Ensure validation fails on small name

--- a/src/ui/next/src/app/onboarding/page.test.tsx
+++ b/src/ui/next/src/app/onboarding/page.test.tsx
@@ -526,7 +526,7 @@ describe('OnboardingWizard', () => {
       expect(screen.getByText("You're Live!")).toBeInTheDocument();
       expect(screen.getByText("Your business has been successfully launched.")).toBeInTheDocument();
       expect(screen.getByRole('link', { name: /Open Assistant/i })).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: /Preview Storefront/i })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /Storefront Builder/i })).toBeInTheDocument();
     });
   });
 

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -1228,10 +1228,10 @@ export default function OnboardingWizard() {
                   <IconLabel icon="sparkles">Open Assistant</IconLabel>
                 </a>
                 <a
-                  href="/builder"
+                  href="/website-builder"
                   className="flex w-full items-center justify-center glassmorphism text-[#1D1D1F] dark:text-[#F5F5F7] p-4 rounded-[8px] font-bold shadow-sm active:scale-[0.98] transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)]"
                 >
-                  <IconLabel icon="eye">Preview Storefront</IconLabel>
+                  <IconLabel icon="eye">Storefront Builder</IconLabel>
                 </a>
               </div>
             </div>

--- a/src/ui/next/src/e2e/onboarding.spec.ts
+++ b/src/ui/next/src/e2e/onboarding.spec.ts
@@ -39,6 +39,8 @@ test.describe('OnboardingWizard CUJ', () => {
 
     await page.getByRole('button', { name: 'Launch Store' }).click();
     await expect(page.getByText("You're Live!")).toBeVisible();
+    await expect(page.getByRole('link', { name: /Open Assistant/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Storefront Builder/i })).toBeVisible();
     const storedTenantId = await page.evaluate(() => window.localStorage.getItem('tenant_id'));
     expect(storedTenantId).not.toBeNull();
   });
@@ -72,6 +74,8 @@ test.describe('OnboardingWizard CUJ', () => {
 
     await page.getByRole('button', { name: 'Launch Store' }).click();
     await expect(page.getByText("You're Live!")).toBeVisible();
+    await expect(page.getByRole('link', { name: /Open Assistant/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Storefront Builder/i })).toBeVisible();
     const storedTenantId = await page.evaluate(() => window.localStorage.getItem('tenant_id'));
     expect(storedTenantId).not.toBeNull();
   });
@@ -106,6 +110,8 @@ test.describe('OnboardingWizard CUJ', () => {
 
     await page.getByRole('button', { name: 'Launch Store' }).click();
     await expect(page.getByText("You're Live!")).toBeVisible();
+    await expect(page.getByRole('link', { name: /Open Assistant/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Storefront Builder/i })).toBeVisible();
     const storedTenantId = await page.evaluate(() => window.localStorage.getItem('tenant_id'));
     expect(storedTenantId).not.toBeNull();
   });
@@ -139,6 +145,8 @@ test.describe('OnboardingWizard CUJ', () => {
 
     await page.getByRole('button', { name: 'Launch Store' }).click();
     await expect(page.getByText("You're Live!")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('link', { name: /Open Assistant/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Storefront Builder/i })).toBeVisible();
     const storedTenantId = await page.evaluate(() => window.localStorage.getItem('tenant_id'));
     expect(storedTenantId).not.toBeNull();
   });
@@ -283,6 +291,8 @@ test.describe('OnboardingWizard CUJ', () => {
 
     // Expect it to eventually reach "You're Live!" screen
     await expect(page.getByText("You're Live!")).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('link', { name: /Open Assistant/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Storefront Builder/i })).toBeVisible();
   });
 });
 


### PR DESCRIPTION
This PR updates the storefront builder link in the onboarding success screen to point to `/website-builder` and updates the text to "Storefront Builder". It also updates all corresponding assertions in Playwright and Vitest tests.

---
*PR created automatically by Jules for task [9420522435882722293](https://jules.google.com/task/9420522435882722293) started by @ql-owo-lp*