### PR TITLE
feat: implement distributed offline-first sync mesh for field operations

### DIFF
--- a/src/e2e/playwright/offline-mesh.spec.ts
+++ b/src/e2e/playwright/offline-mesh.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Distributed Offline-First AI Sync Mesh for Field Service Operations', () => {
+  test('simulates offline mode, generates mutations, comes back online, syncs, and triggers AI agent', async ({ page, context }) => {
+    await page.goto('/login');
+    await page.fill('input[type="email"]', 'test@example.com');
+    await page.fill('input[type="password"]', 'password123');
+    await page.click('button[type="submit"]');
+    await page.waitForURL('/dashboard');
+
+    await page.goto('/field-ops/jobs');
+
+    await context.setOffline(true);
+
+    const firstJobCard = page.locator('.p-5.bg-white').first();
+    await expect(firstJobCard).toBeVisible();
+
+    await firstJobCard.locator('textarea').fill('Replaced the valve');
+
+    const jobDoneButton = firstJobCard.locator('button:has-text("Job Done")');
+    if (await jobDoneButton.isVisible()) {
+      await jobDoneButton.click();
+    } else {
+      const headingToJobButton = firstJobCard.locator('button:has-text("Heading to Job")');
+      if (await headingToJobButton.isVisible()) {
+        await headingToJobButton.click();
+        const startWorkButton = firstJobCard.locator('button:has-text("Start Work")');
+        await startWorkButton.click();
+        await firstJobCard.locator('button:has-text("Job Done")').click();
+      }
+    }
+
+    await expect(firstJobCard.locator('p:has-text("Replaced the valve")')).toBeVisible();
+
+    await context.setOffline(false);
+
+    await page.waitForTimeout(6000);
+
+    await page.goto('/dashboard');
+
+    await expect(page.locator('text=Invoice drafted for Field Job').first()).toBeVisible({ timeout: 15000 });
+  });
+});

--- a/src/server/api/offline_sync.rs
+++ b/src/server/api/offline_sync.rs
@@ -56,18 +56,55 @@ pub async fn offline_sync_handler(
         if mutation.mutation_type.as_deref() == Some("draft_quote") {
             futures.push(Box::pin(async move {
                 let mut db_tx = db_clone.begin().await.unwrap();
-                let _ = sqlx::query(
+                let payload_str = mutation.payload.unwrap_or_default();
+
+                let q1 = sqlx::query(
+                    "INSERT INTO mutation_queue (id, tenant_id, action_type, payload, status)
+                     VALUES ($1, $2, 'draft_quote', $3::jsonb, 'synced')"
+                )
+                .bind(uuid::Uuid::new_v4().to_string())
+                .bind(&tenant_id_clone)
+                .bind(serde_json::json!({"notes": payload_str}).to_string())
+                .execute(&mut *db_tx)
+                .await;
+
+                if let Err(e) = q1 {
+                    tracing::error!("Failed to insert into mutation_queue: {}", e);
+                }
+
+                let batch_id = uuid::Uuid::new_v4().to_string();
+                let q2 = sqlx::query(
+                    "INSERT INTO sync_events (id, tenant_id, batch_id, action_type, payload)
+                     VALUES ($1, $2, $3, 'SyncEvent:JobCompleted', $4::jsonb)"
+                )
+                .bind(uuid::Uuid::new_v4().to_string())
+                .bind(&tenant_id_clone)
+                .bind(&batch_id)
+                .bind(serde_json::json!({"notes": payload_str}).to_string())
+                .execute(&mut *db_tx)
+                .await;
+
+                if let Err(e) = q2 {
+                    tracing::error!("Failed to insert into sync_events: {}", e);
+                }
+
+                let q3 = sqlx::query(
                     "INSERT INTO department_tasks (id, tenant_id, department, event_type, payload, status)
-                     VALUES ($1, $2, 'sales', 'tenant.omnichannel.message.received', $3::jsonb, 'PENDING')"
+                     VALUES ($1, $2, 'operations', 'SyncEvent:JobCompleted', $3::jsonb, 'PENDING')"
                 )
                 .bind(uuid::Uuid::new_v4().to_string())
                 .bind(&tenant_id_clone)
                 .bind(serde_json::json!({
                     "source": "offline_app",
-                    "message": mutation.payload.unwrap_or_default()
+                    "message": payload_str
                 }).to_string())
                 .execute(&mut *db_tx)
                 .await;
+
+                if let Err(e) = q3 {
+                    tracing::error!("Failed to insert into department_tasks: {}", e);
+                }
+
                 db_tx.commit().await.unwrap();
             }) as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>);
             continue;

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -876,6 +876,24 @@ impl DB {
                         version INTEGER DEFAULT 1
                     );
 
+                    CREATE TABLE IF NOT EXISTS mutation_queue (
+                        id TEXT PRIMARY KEY,
+                        tenant_id TEXT NOT NULL,
+                        action_type TEXT NOT NULL,
+                        payload TEXT NOT NULL,
+                        status TEXT NOT NULL DEFAULT 'pending',
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    );
+
+                    CREATE TABLE IF NOT EXISTS sync_events (
+                        id TEXT PRIMARY KEY,
+                        tenant_id TEXT NOT NULL,
+                        batch_id TEXT,
+                        action_type TEXT NOT NULL,
+                        payload TEXT NOT NULL,
+                        synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    );
+
                     CREATE TABLE IF NOT EXISTS orders (
                         id TEXT PRIMARY KEY,
                         tenant_id TEXT,

--- a/src/server/db/migrations/131_mutation_queue_and_sync_events.sql
+++ b/src/server/db/migrations/131_mutation_queue_and_sync_events.sql
@@ -1,0 +1,71 @@
+-- +goose Up
+-- Migration 131: Add mutation_queue and sync_events tables
+
+CREATE TABLE IF NOT EXISTS mutation_queue (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    action_type TEXT NOT NULL,
+    payload JSONB DEFAULT '{}',
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+DO $$
+BEGIN
+    IF to_regclass('mutation_queue') IS NOT NULL THEN
+        ALTER TABLE mutation_queue ENABLE ROW LEVEL SECURITY;
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_policies
+            WHERE schemaname = current_schema()
+                AND tablename = 'mutation_queue'
+                AND policyname = 'tenant_isolation_mutation_queue'
+        ) THEN
+            CREATE POLICY tenant_isolation_mutation_queue ON mutation_queue USING (tenant_id::text = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+        END IF;
+    END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS sync_events (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    batch_id TEXT,
+    action_type TEXT NOT NULL,
+    payload JSONB DEFAULT '{}',
+    synced_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+DO $$
+BEGIN
+    IF to_regclass('sync_events') IS NOT NULL THEN
+        ALTER TABLE sync_events ENABLE ROW LEVEL SECURITY;
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_policies
+            WHERE schemaname = current_schema()
+                AND tablename = 'sync_events'
+                AND policyname = 'tenant_isolation_sync_events'
+        ) THEN
+            CREATE POLICY tenant_isolation_sync_events ON sync_events USING (tenant_id::text = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+        END IF;
+    END IF;
+END
+$$;
+
+-- +goose Down
+DO $$
+BEGIN
+    IF to_regclass('mutation_queue') IS NOT NULL THEN
+        DROP POLICY IF EXISTS tenant_isolation_mutation_queue ON mutation_queue;
+        ALTER TABLE mutation_queue DISABLE ROW LEVEL SECURITY;
+    END IF;
+    IF to_regclass('sync_events') IS NOT NULL THEN
+        DROP POLICY IF EXISTS tenant_isolation_sync_events ON sync_events;
+        ALTER TABLE sync_events DISABLE ROW LEVEL SECURITY;
+    END IF;
+END
+$$;
+
+DROP TABLE IF EXISTS mutation_queue CASCADE;
+DROP TABLE IF EXISTS sync_events CASCADE;

--- a/src/server/workers/department_workers.rs
+++ b/src/server/workers/department_workers.rs
@@ -58,7 +58,7 @@ impl OperationsWorker {
                         SET status = 'IN_PROGRESS', locked_until = $1, updated_at = CURRENT_TIMESTAMP
                         WHERE id = (
                             SELECT id FROM department_tasks
-                            WHERE status = 'PENDING' AND department = 'operations' AND (event_type = 'OrderReceived' OR event_type = 'OrderPlaced' OR event_type = 'InventoryConflictEvent')
+                            WHERE status = 'PENDING' AND department = 'operations' AND (event_type = 'OrderReceived' OR event_type = 'OrderPlaced' OR event_type = 'InventoryConflictEvent' OR event_type = 'SyncEvent:JobCompleted')
                             AND (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP)
                             ORDER BY created_at ASC
                             LIMIT 1
@@ -81,7 +81,7 @@ impl OperationsWorker {
                     let row = sqlx::query(
                         r#"
                         SELECT id, tenant_id, payload, event_type FROM department_tasks
-                        WHERE status = 'PENDING' AND department = 'operations' AND (event_type = 'OrderReceived' OR event_type = 'OrderPlaced' OR event_type = 'InventoryConflictEvent')
+                        WHERE status = 'PENDING' AND department = 'operations' AND (event_type = 'OrderReceived' OR event_type = 'OrderPlaced' OR event_type = 'InventoryConflictEvent' OR event_type = 'SyncEvent:JobCompleted')
                         AND (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP)
                         ORDER BY created_at ASC
                         LIMIT 1
@@ -124,6 +124,99 @@ impl OperationsWorker {
         let processed = task.is_some();
         if let Some((id, tenant_id, payload, event_type)) = task {
             let mut final_status = "COMPLETED";
+
+            if event_type == "SyncEvent:JobCompleted" {
+                let message = payload.get("message").and_then(|v| v.as_str()).unwrap_or("");
+                let prompt = format!("Draft a concise follow-up invoice/quote response based on this job note: '{}'", message);
+                let mut drafted_msg = "Follow-up invoice drafted.".to_string();
+
+                let mut attempts = 0;
+                while attempts < MAX_RETRIES {
+                    let ai_op = async {
+                        if let Ok(mut client) = ::server_ohc::orchestration::hub_service_client::HubServiceClient::connect(std::env::var("OHC_HUB_URL").unwrap_or_else(|_| "http://127.0.0.1:8081".to_string())).await {
+                            let reason_req = ::server_ohc::orchestration::ReasonRequest {
+                                prompt: prompt.clone(),
+                                from_agent_id: "operations".into(),
+                            };
+                            if let Ok(res) = client.reason(tonic::Request::new(reason_req)).await {
+                                return Ok(res.into_inner().content);
+                            }
+                        }
+                        Err("AI call failed".to_string())
+                    };
+
+                    match timeout(AI_AGENT_TIMEOUT, ai_op).await {
+                        Ok(Ok(content)) => {
+                            if !content.is_empty() {
+                                drafted_msg = content;
+                            }
+                            break;
+                        },
+                        _ => {
+                            attempts += 1;
+                            tokio::time::sleep(Duration::from_secs(2u64.pow(attempts as u32))).await;
+                        }
+                    }
+                }
+
+                let invoice_id = Uuid::new_v4().to_string();
+                let feed_id = Uuid::new_v4().to_string();
+                let future_date = (Utc::now() + chrono::Duration::days(7)).timestamp() as i64;
+
+                match &db.store {
+                    crate::db::DbStore::Postgres => {
+                        let _ = sqlx::query(
+                            "INSERT INTO invoices (id, tenant_id, client_id, client_name, status, due_date, total_amount)
+                             VALUES ($1, $2, 'offline_client', 'Field Customer', 'draft', $3, 0)"
+                        )
+                        .bind(&invoice_id)
+                        .bind(&tenant_id)
+                        .bind(future_date)
+                        .execute(&db.pool)
+                        .await;
+
+                        let _ = sqlx::query(
+                            "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state)
+                             VALUES ($1, $2, 'operations_agent', '{}'::jsonb, $3::jsonb, 'pending_review')"
+                        )
+                        .bind(&feed_id)
+                        .bind(&tenant_id)
+                        .bind(serde_json::json!({
+                            "title": "Invoice drafted for Field Job",
+                            "message": drafted_msg
+                        }).to_string())
+                        .execute(&db.pool)
+                        .await;
+
+                        let _ = sqlx::query("UPDATE department_tasks SET status = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2")
+                            .bind(final_status)
+                            .bind(&id)
+                            .execute(&db.pool)
+                            .await;
+                    },
+                    crate::db::DbStore::Sqlite(pool) => {
+                        let _ = sqlx::query(
+                            "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state)
+                             VALUES (?, ?, 'operations_agent', '{}', ?, 'pending_review')"
+                        )
+                        .bind(&feed_id)
+                        .bind(&tenant_id)
+                        .bind(serde_json::json!({
+                            "title": "Invoice drafted for Field Job",
+                            "message": drafted_msg
+                        }).to_string())
+                        .execute(pool)
+                        .await;
+
+                        let _ = sqlx::query("UPDATE department_tasks SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?")
+                            .bind(final_status)
+                            .bind(&id)
+                            .execute(pool)
+                            .await;
+                    }
+                }
+                return Ok(true);
+            }
 
             if event_type == "InventoryConflictEvent" {
                 let transaction_id = payload.get("transaction_id").and_then(|v| v.as_str()).unwrap_or("unknown");

--- a/src/ui/next/next-env.d.ts
+++ b/src/ui/next/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/ui/next/src/app/field-ops/jobs/page.tsx
+++ b/src/ui/next/src/app/field-ops/jobs/page.tsx
@@ -109,7 +109,7 @@ export default function FieldOpsJobsPage() {
 
     handleStatusChange(jobId, 'Completed');
 
-    if (job.notes && !isOffline) {
+    if (job.notes) {
       SyncManager.getInstance().enqueue({
         id: `mutation-${Date.now()}`,
         type: 'draft_quote',

--- a/src/ui/next/src/lib/powersync/AppSchema.ts
+++ b/src/ui/next/src/lib/powersync/AppSchema.ts
@@ -25,7 +25,25 @@ const omniInboxMessages = new Table({
   updated_at: column.text
 });
 
+const mutationQueue = new Table({
+  tenant_id: column.text,
+  action_type: column.text,
+  payload: column.text,
+  status: column.text,
+  created_at: column.text
+});
+
+const syncEvents = new Table({
+  tenant_id: column.text,
+  batch_id: column.text,
+  action_type: column.text,
+  payload: column.text,
+  synced_at: column.text
+});
+
 export const AppSchema = new Schema({
   agent_feed_items: agentFeedItems,
-  omni_inbox_messages: omniInboxMessages
+  omni_inbox_messages: omniInboxMessages,
+  mutation_queue: mutationQueue,
+  sync_events: syncEvents
 });

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Resolves #28036

**Features**
- DB Migrations: added `mutation_queue` and `sync_events` and properly implemented RLS via `tenant_id`.
- Handled backend ingestion logic in `/api/v1/sync/offline` parsing offline mutations securely and issuing `SyncEvent:JobCompleted` payloads.
- Added AI integration in the operations worker `department_workers.rs` mapping `SyncEvent` updates to HubServiceClient interactions which subsequently drafts estimates & invoices on behalf of field ops and publishes them into `agent_feed_items`.
- Configured PowerSync `AppSchema.ts` client definitions and removed online connectivity checks to reliably queue mutations while offline in `app/field-ops/jobs/page.tsx`.
- Playwright E2E covering the field operator journey `offline-mesh.spec.ts`.

**Verification**
- Run `bazel test //...` and `bazel test //src/e2e:playwright` cleanly
- Validated offline storage states through UI mock
- Loaded Superpowers specs

---
*PR created automatically by Jules for task [7577097620011299809](https://jules.google.com/task/7577097620011299809) started by @ql-owo-lp*