### PR TITLE
Fix Wizard Cross Device E2E Test

### DIFF
--- a/src/e2e/wizard_cross_device.spec.ts
+++ b/src/e2e/wizard_cross_device.spec.ts
@@ -6,23 +6,21 @@ test.describe('Wizard Cross Device E2E', () => {
     await page.addInitScript((tenantId) => {
       localStorage.setItem('tenant_id', tenantId);
       localStorage.setItem('user_id', tenantId);
-      localStorage.removeItem('website-builder-storage');
+      localStorage.removeItem('onboarding-storage-v3');
     }, 'storefront');
     await page.goto('/onboarding');
     await page.waitForLoadState('networkidle');
 
     // 2. Click Start My Business to advance to step 1
     await page.getByRole('button', { name: /Start My Business/ }).click();
-    await expect(page.getByRole('heading', { name: 'What kind of business are you building?' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: "What's the name of your business?" })).toBeVisible();
 
-    // 3. Move to step 2 and enter business name
-    await page.getByRole('button', { name: /Online Store/ }).click();
-    await expect(page.getByRole('heading', { name: 'Give your business a name' })).toBeVisible();
-    await page.getByPlaceholder('What is your business called?').fill('Cross Device Wizard');
+    // 3. Enter business name
+    await page.getByPlaceholder(/e\.g\. Maya's Custom Cake/i).fill('Cross Device Wizard');
 
     // Wait until local storage is updated with the business name
     await expect.poll(async () => {
-      const stateStr = await page.evaluate(() => localStorage.getItem('website-builder-storage'));
+      const stateStr = await page.evaluate(() => localStorage.getItem('onboarding-storage-v3'));
       if (!stateStr) return '';
       try {
         const state = JSON.parse(stateStr);
@@ -42,11 +40,11 @@ test.describe('Wizard Cross Device E2E', () => {
     // Inject the exact same local storage state to the new context to test restoration
     // We navigate to dashboard first to have the right origin
     await newPage.goto('/dashboard');
-    const wizardState = await page.evaluate(() => localStorage.getItem('website-builder-storage'));
+    const wizardState = await page.evaluate(() => localStorage.getItem('onboarding-storage-v3'));
 
     await newPage.evaluate((state) => {
         if(state) {
-            localStorage.setItem('website-builder-storage', state);
+            localStorage.setItem('onboarding-storage-v3', state);
         }
         localStorage.setItem('tenant_id', 'storefront');
         localStorage.setItem('user_id', 'storefront');
@@ -55,8 +53,8 @@ test.describe('Wizard Cross Device E2E', () => {
     await newPage.goto('/onboarding');
 
     // 5. Verify the business name and step was properly restored
-    await expect(newPage.getByRole('heading', { name: 'Give your business a name' })).toBeVisible();
-    await expect(newPage.getByPlaceholder('What is your business called?')).toHaveValue('Cross Device Wizard', { timeout: 10000 });
+    await expect(newPage.getByRole('heading', { name: "What's the name of your business?" })).toBeVisible();
+    await expect(newPage.getByPlaceholder(/e\.g\. Maya's Custom Cake/i)).toHaveValue('Cross Device Wizard', { timeout: 10000 });
 
     await newContext.close();
   });


### PR DESCRIPTION
Updates `wizard_cross_device.spec.ts` to correctly test the `v3` onboarding flow. The test previously used old selectors and an outdated LocalStorage key (`website-builder-storage`), which was replaced by `onboarding-storage-v3`. It now correctly asserts using the new UI steps like "What's the name of your business?".

---
*PR created automatically by Jules for task [2010896405824881904](https://jules.google.com/task/2010896405824881904) started by @ql-owo-lp*