### PR TITLE
🧙 Wizard: Update UI to adhere to OHC Premium Token styling standards

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -8,6 +8,8 @@
       body {
         font-family: "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
         background-color: #f5f5f7;
+        background-image: linear-gradient(135deg, #e0e8ff 0%, #f5f5f7 50%, #ffe0f0 100%);
+        background-attachment: fixed;
         margin: 0;
         display: flex;
         align-items: center;
@@ -140,6 +142,8 @@
       @media (prefers-color-scheme: dark) {
         body {
           background-color: #16161a;
+          background-image: linear-gradient(135deg, #1a2035 0%, #16161a 50%, #2a1625 100%);
+          background-attachment: fixed;
         }
         .container {
           background: rgba(22, 22, 26, 0.7);
@@ -283,7 +287,7 @@
         border: 1px solid rgba(255, 255, 255, 0.5);
         padding: 12px 16px;
         min-height: 44px !important;
-        border-radius: 16px;
+        border-radius: 8px;
         cursor: pointer;
         transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
       }
@@ -360,7 +364,7 @@
         background: rgba(255, 255, 255, 0.8);
         border: 1px solid rgba(0, 0, 0, 0.05);
         padding: 12px 16px;
-        border-radius: 18px;
+        border-radius: 16px;
         border-bottom-left-radius: 4px;
         font-size: 14px;
         line-height: 1.4;
@@ -1890,7 +1894,7 @@ document.addEventListener('DOMContentLoaded', () => {
         #ohc-help-input {
             flex-grow: 1;
             border: 1px solid rgba(0, 0, 0, 0.2);
-            border-radius: 16px;
+            border-radius: 8px;
             padding: 10px 15px;
             outline: none;
             background: rgba(255, 255, 255, 0.8);
@@ -1903,7 +1907,7 @@ document.addEventListener('DOMContentLoaded', () => {
             border: none;
             width: 40px;
             height: 40px;
-            border-radius: 16px;
+            border-radius: 8px;
             cursor: pointer;
             display: flex;
             align-items: center;


### PR DESCRIPTION
This PR updates the onboarding wizard to strictly follow the OHC Premium Design Standards.

Changes included:
*   Updated `.radio-option` to have an `8px` border radius (was 16px).
*   Updated `.chat-bubble` to have a `16px` border radius (was 18px).
*   Updated `#ohc-help-input` and `#ohc-help-send` to have an `8px` border radius (was 16px).
*   Added a subtle `linear-gradient` to the `body` background for both light and dark themes to properly exhibit the translucent glassmorphism styling (`backdrop-filter`) mandated by the design specs.

---
*PR created automatically by Jules for task [3148789126622454556](https://jules.google.com/task/3148789126622454556) started by @ql-owo-lp*