### PR TITLE
Fix unbounded temp file growth in standalone blob provider

### DIFF
--- a/src/server/agents/mcp/proxy/blob.rs
+++ b/src/server/agents/mcp/proxy/blob.rs
@@ -15,7 +15,7 @@ pub struct LocalBlobProvider {
 impl LocalBlobProvider {
     pub fn new() -> Self {
         Self {
-            base_dir: "/var/tmp/ohc/blobs".to_string(),
+            base_dir: std::env::temp_dir().join("ohc/blobs").to_string_lossy().to_string(),
         }
     }
 
@@ -34,7 +34,7 @@ impl BlobProvider for LocalBlobProvider {
     fn read_blob<'a>(&'a self, path: &'a str) -> std::pin::Pin<Box<dyn std::future::Future<Output = std::io::Result<String>> + Send + 'a>> {
         Box::pin(async move {
             let full_path = self.resolve_path(path)?;
-            fs::read_to_string(full_path).await
+            fs::read_to_string(&full_path).await
         })
     }
 

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -2537,6 +2537,9 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
 
     // Ensure local database permissions are secure in standalone mode
     if is_standalone_runtime() {
+        // Clean up unbounded temp files on startup to prevent unbounded growth synchronously
+        let _ = std::fs::remove_dir_all(std::env::temp_dir().join("ohc"));
+
         // Initialize local tables required for standalone mode
         if let crate::db::DbStore::Sqlite(pool) = &db.store {
             let _ = sqlx::query(


### PR DESCRIPTION
This patch fixes the unbounded growth of temporary files in the Standalone Wrapper (`LocalBlobProvider`) by:

1. Changing the base_dir to `std::env::temp_dir().join("ohc/blobs")` instead of `/var/tmp/ohc/blobs`.
2. Sync cleanup of `std::env::temp_dir().join("ohc")` in `src/server/lib.rs` during standalone initialization.

---
*PR created automatically by Jules for task [3636409928669916015](https://jules.google.com/task/3636409928669916015) started by @ql-owo-lp*