### PR TITLE
fix(helm): resolve mutually exclusive HPA/VPA scaling and enable SPIRE network egress

### DIFF
--- a/deploy/helm/ohc/templates/hpa.yaml
+++ b/deploy/helm/ohc/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.backend.autoscaling.enabled (not .Values.backend.vpa.enabled) }}
+{{- if .Values.backend.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -34,7 +34,7 @@ spec:
           averageUtilization: {{ .Values.backend.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end }}
 ---
-{{- if and .Values.ohcCore.enabled .Values.ohcCore.autoscaling.enabled (not .Values.ohcCore.vpa.enabled) }}
+{{- if and .Values.ohcCore.enabled .Values.ohcCore.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -70,7 +70,7 @@ spec:
           averageUtilization: {{ .Values.ohcCore.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end }}
 ---
-{{- if and .Values.chatwoot.enabled .Values.chatwoot.autoscaling.enabled (not .Values.chatwoot.vpa.enabled) }}
+{{- if and .Values.chatwoot.enabled .Values.chatwoot.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -106,7 +106,7 @@ spec:
           averageUtilization: {{ .Values.chatwoot.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end }}
 ---
-{{- if and .Values.powersync.enabled .Values.powersync.autoscaling.enabled (not .Values.powersync.vpa.enabled) }}
+{{- if and .Values.powersync.enabled .Values.powersync.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deploy/helm/ohc/templates/network-policy.yaml
+++ b/deploy/helm/ohc/templates/network-policy.yaml
@@ -41,6 +41,13 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: spiffe
+      ports:
+        - protocol: TCP
+          port: 8081
+    - to:
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
     - to:
         - namespaceSelector:
@@ -151,6 +158,13 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: spiffe
+      ports:
+        - protocol: TCP
+          port: 8081
+    - to:
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
     - to:
         - namespaceSelector:
@@ -219,6 +233,13 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: spiffe
+      ports:
+        - protocol: TCP
+          port: 8081
+    - to:
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
     - to:
         - namespaceSelector:
@@ -284,6 +305,13 @@ spec:
             matchLabels:
               app: spire-agent
   egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: spiffe
+      ports:
+        - protocol: TCP
+          port: 8081
     - to:
         - namespaceSelector:
             matchLabels:

--- a/deploy/helm/ohc/templates/vpa.yaml
+++ b/deploy/helm/ohc/templates/vpa.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-backend
   updatePolicy:
-    updateMode: {{ if .Values.backend.autoscaling }}{{ if .Values.backend.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}{{ else }}"Auto"{{ end }}
+    updateMode: {{ if .Values.backend.autoscaling }}{{ if .Values.backend.autoscaling.enabled }}"Initial"{{ else }}"Auto"{{ end }}{{ else }}"Auto"{{ end }}
   resourcePolicy:
     containerPolicies:
       - containerName: backend
@@ -32,7 +32,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-core
   updatePolicy:
-    updateMode: {{ if .Values.ohcCore.autoscaling }}{{ if .Values.ohcCore.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}{{ else }}"Auto"{{ end }}
+    updateMode: {{ if .Values.ohcCore.autoscaling }}{{ if .Values.ohcCore.autoscaling.enabled }}"Initial"{{ else }}"Auto"{{ end }}{{ else }}"Auto"{{ end }}
   resourcePolicy:
     containerPolicies:
       - containerName: ohc-core
@@ -53,7 +53,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-chatwoot
   updatePolicy:
-    updateMode: {{ if .Values.chatwoot.autoscaling }}{{ if .Values.chatwoot.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}{{ else }}"Auto"{{ end }}
+    updateMode: {{ if .Values.chatwoot.autoscaling }}{{ if .Values.chatwoot.autoscaling.enabled }}"Initial"{{ else }}"Auto"{{ end }}{{ else }}"Auto"{{ end }}
   resourcePolicy:
     containerPolicies:
       - containerName: chatwoot
@@ -74,7 +74,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-powersync
   updatePolicy:
-    updateMode: {{ if .Values.powersync.autoscaling }}{{ if .Values.powersync.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}{{ else }}"Auto"{{ end }}
+    updateMode: {{ if .Values.powersync.autoscaling }}{{ if .Values.powersync.autoscaling.enabled }}"Initial"{{ else }}"Auto"{{ end }}{{ else }}"Auto"{{ end }}
   resourcePolicy:
     containerPolicies:
       - containerName: powersync


### PR DESCRIPTION
Fixed a bug in the Helm chart where enabling both HPA and VPA resulted in HPA being completely disabled. Now, both resources can correctly be deployed together, with VPA reverting to `"Initial"` mode so it provides deployment estimates without evicting running scaled pods. Additionally, the network policies were updated to explicitly allow the applications (`backend`, `core`, `chatwoot`, `powersync`) to send egress traffic to the `spiffe` namespace on TCP 8081, ensuring SPIRE compliance.

---
*PR created automatically by Jules for task [10798910813705760267](https://jules.google.com/task/10798910813705760267) started by @ql-owo-lp*