### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Handle user not found explicitly instead of database errors in auth repository

### DIFF
--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -111,10 +111,14 @@ impl UserRepository for PgUserRepository {
             set_org_context(&mut *tx, tenant_id).await.map_err(|e| e.to_string())?;
         }
 
-        let row = if should_bypass {
-            sqlx::query(query).bind(id).fetch_one(&mut *tx).await.map_err(|e| e.to_string())?
+        let row_opt = if should_bypass {
+            sqlx::query(query).bind(id).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query(query).bind(id).bind(org_id).fetch_one(&mut *tx).await.map_err(|e| e.to_string())?
+            sqlx::query(query).bind(id).bind(org_id).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
+        };
+        let row = match row_opt {
+            Some(r) => r,
+            None => return Err("user not found".to_string()),
         };
 
         // Parse roles from JSON string
@@ -159,10 +163,14 @@ impl UserRepository for PgUserRepository {
             set_org_context(&mut *tx, tenant_id).await.map_err(|e| e.to_string())?;
         }
 
-        let row = if should_bypass {
-            sqlx::query(query).bind(username).fetch_one(&mut *tx).await.map_err(|e| e.to_string())?
+        let row_opt = if should_bypass {
+            sqlx::query(query).bind(username).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query(query).bind(username).bind(org_id).fetch_one(&mut *tx).await.map_err(|e| e.to_string())?
+            sqlx::query(query).bind(username).bind(org_id).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
+        };
+        let row = match row_opt {
+            Some(r) => r,
+            None => return Err("user not found".to_string()),
         };
 
         let roles_json: String = row.get("roles");
@@ -206,10 +214,14 @@ impl UserRepository for PgUserRepository {
             set_org_context(&mut *tx, tenant_id).await.map_err(|e| e.to_string())?;
         }
 
-        let row = if should_bypass {
-            sqlx::query(query).bind(email).fetch_one(&mut *tx).await.map_err(|e| e.to_string())?
+        let row_opt = if should_bypass {
+            sqlx::query(query).bind(email).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query(query).bind(email).bind(org_id).fetch_one(&mut *tx).await.map_err(|e| e.to_string())?
+            sqlx::query(query).bind(email).bind(org_id).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
+        };
+        let row = match row_opt {
+            Some(r) => r,
+            None => return Err("user not found".to_string()),
         };
 
         let roles_json: String = row.get("roles");
@@ -253,10 +265,14 @@ impl UserRepository for PgUserRepository {
             set_org_context(&mut *tx, tenant_id).await.map_err(|e| e.to_string())?;
         }
 
-        let row = if should_bypass {
-            sqlx::query(query).bind(sub).fetch_one(&mut *tx).await.map_err(|e| e.to_string())?
+        let row_opt = if should_bypass {
+            sqlx::query(query).bind(sub).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query(query).bind(sub).bind(org_id).fetch_one(&mut *tx).await.map_err(|e| e.to_string())?
+            sqlx::query(query).bind(sub).bind(org_id).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
+        };
+        let row = match row_opt {
+            Some(r) => r,
+            None => return Err("user not found".to_string()),
         };
 
         let roles_json: String = row.get("roles");

--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -85,10 +85,14 @@ impl UserRepository for SqliteUserRepository {
         } else {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1 AND tenant_id = $2"
         };
-        let row = if should_bypass {
-            sqlx::query(query).bind(id).fetch_one(&self.pool).await.map_err(|e| e.to_string())?
+        let row_opt = if should_bypass {
+            sqlx::query(query).bind(id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query(query).bind(id).bind(org_id).fetch_one(&self.pool).await.map_err(|e| e.to_string())?
+            sqlx::query(query).bind(id).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
+        };
+        let row = match row_opt {
+            Some(r) => r,
+            None => return Err("user not found".to_string()),
         };
 
         let roles_json: String = row.get("roles");
@@ -123,10 +127,14 @@ impl UserRepository for SqliteUserRepository {
         } else {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE username = $1 AND tenant_id = $2"
         };
-        let row = if should_bypass {
-            sqlx::query(query).bind(username).fetch_one(&self.pool).await.map_err(|e| e.to_string())?
+        let row_opt = if should_bypass {
+            sqlx::query(query).bind(username).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query(query).bind(username).bind(org_id).fetch_one(&self.pool).await.map_err(|e| e.to_string())?
+            sqlx::query(query).bind(username).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
+        };
+        let row = match row_opt {
+            Some(r) => r,
+            None => return Err("user not found".to_string()),
         };
 
         let roles_json: String = row.get("roles");
@@ -161,10 +169,14 @@ impl UserRepository for SqliteUserRepository {
         } else {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1 AND tenant_id = $2"
         };
-        let row = if should_bypass {
-            sqlx::query(query).bind(email).fetch_one(&self.pool).await.map_err(|e| e.to_string())?
+        let row_opt = if should_bypass {
+            sqlx::query(query).bind(email).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query(query).bind(email).bind(org_id).fetch_one(&self.pool).await.map_err(|e| e.to_string())?
+            sqlx::query(query).bind(email).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
+        };
+        let row = match row_opt {
+            Some(r) => r,
+            None => return Err("user not found".to_string()),
         };
 
         let roles_json: String = row.get("roles");
@@ -199,10 +211,14 @@ impl UserRepository for SqliteUserRepository {
         } else {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1 AND tenant_id = $2"
         };
-        let row = if should_bypass {
-            sqlx::query(query).bind(sub).fetch_one(&self.pool).await.map_err(|e| e.to_string())?
+        let row_opt = if should_bypass {
+            sqlx::query(query).bind(sub).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query(query).bind(sub).bind(org_id).fetch_one(&self.pool).await.map_err(|e| e.to_string())?
+            sqlx::query(query).bind(sub).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
+        };
+        let row = match row_opt {
+            Some(r) => r,
+            None => return Err("user not found".to_string()),
         };
 
         let roles_json: String = row.get("roles");


### PR DESCRIPTION
The agent discovered an issue where database reads in the `auth` module (`get_by_id`, `get_by_username`, `get_by_email`, `get_by_oidc_subject`) were using `sqlx`'s `fetch_one` instead of `fetch_optional`. `fetch_one` raises a database error if no records match, which can lead to unhandled errors mapping to 500s rather than a controlled "user not found" outcome when filtering by `tenant_id`. 

This change modifies both `postgres_store.rs` and `sqlite_store.rs` to use `fetch_optional` and handle the missing record cases with an explicit and friendly `Err("user not found".to_string())` instead. All repository tests pass correctly after these changes.

---
*PR created automatically by Jules for task [2682444727486150765](https://jules.google.com/task/2682444727486150765) started by @ql-owo-lp*