### PR TITLE
fix: resolve cross-device onboarding stepper resume failures

### DIFF
--- a/src/server/api/onboarding/mod.rs
+++ b/src/server/api/onboarding/mod.rs
@@ -74,7 +74,10 @@ async fn get_draft(
     let uid = if user_id.is_empty() { "default".to_string() } else { user_id };
 
     match agent.get_onboarding_state(&tid, &uid).await {
-        Ok(state) => Ok(Json(state)),
+        Ok(state) => {
+            let unwrapped_state = state.get("wizardState").unwrap_or(&state).clone();
+            Ok(Json(unwrapped_state))
+        },
         Err(_) => Ok(Json(serde_json::json!({}))), // fallback
     }
 }
@@ -96,7 +99,9 @@ async fn save_draft(
         .and_then(|s| s.as_i64())
         .unwrap_or(0) as i32;
 
-    match agent.save_onboarding_state(&tid, &uid, step, &payload).await {
+    let state_to_save = payload.get("wizardState").unwrap_or(&payload);
+
+    match agent.save_onboarding_state(&tid, &uid, step, state_to_save).await {
         Ok(_) => Ok(axum::http::StatusCode::OK),
         Err(e) => {
             tracing::error!("Failed to save onboarding draft: {}", e);
@@ -150,7 +155,11 @@ async fn get_state(
     let uid = if user_id.is_empty() { "default".to_string() } else { user_id };
 
     match agent.get_onboarding_state(&tid, &uid).await {
-        Ok(state) => Ok(Json(state)),
+        Ok(state) => {
+            // Unwrap legacy `wizardState` wrapper if it exists for backward compatibility
+            let unwrapped_state = state.get("wizardState").unwrap_or(&state).clone();
+            Ok(Json(unwrapped_state))
+        },
         Err(e) => {
             tracing::error!("Failed to get onboarding state: {}", e);
             Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
@@ -175,7 +184,9 @@ async fn save_state(
         .and_then(|s| s.as_i64())
         .unwrap_or(0) as i32;
 
-    match agent.save_onboarding_state(&tid, &uid, step, &payload).await {
+    let state_to_save = payload.get("wizardState").unwrap_or(&payload);
+
+    match agent.save_onboarding_state(&tid, &uid, step, state_to_save).await {
         Ok(_) => Ok(axum::http::StatusCode::NO_CONTENT),
         Err(e) => {
             tracing::error!("Failed to save onboarding state: {}", e);

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1547,7 +1547,7 @@
               "X-Tenant-ID": tenantId,
               "X-User-ID": userId,
             },
-            body: JSON.stringify({ wizardState: state }),
+            body: JSON.stringify(state),
           }).catch(console.error);
         }
       }
@@ -2198,7 +2198,7 @@
           }
 
           const payload = {
-            wizardState: state,
+            ...state,
             step: currentStepIdx,
             instantBio: document.getElementById("instant-bio")?.value || "",
           };


### PR DESCRIPTION
Fixes the bug where onboarding state couldn't be properly resumed across devices due to inconsistent payload wrapping (using `wizardState`). This fix updates the frontend to always send a flattened state object and ensures the backend continues supporting backwards compatibility by correctly unwrapping older payloads during save and load operations.

---
*PR created automatically by Jules for task [6889657698028284310](https://jules.google.com/task/6889657698028284310) started by @ql-owo-lp*