### PR TITLE
fix: UI UX Translucent glass, colors and state persist syncing

### DIFF
--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -333,7 +333,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
       };
 
       ws.onerror = (err) => {
-        console.error("Websocket error:", err);
+        if (process.env.NODE_ENV !== "test") { console.error("Websocket error:", err); }
       };
     };
 

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -330,8 +330,8 @@ export default function OnboardingWizard() {
     } catch (err: any) {
       console.error(err);
       setError(err.message || 'An error occurred processing details');
-      setStep(1); syncStateToBackend({ step: 1 });
-      setChatStep(3); syncStateToBackend({ chatStep: 3 });
+      setStep(1); setChatStep(1); syncStateToBackend({ step: 1, chatStep: 1 });
+
     } finally {
       setIsLoading(false);
     }
@@ -578,7 +578,7 @@ export default function OnboardingWizard() {
               <div className="flex flex-col gap-4 w-full">
                 <button
                   className="w-full bg-[#0066FF] text-white p-4 font-bold rounded-[8px] shadow-[0_4px_14px_0_rgba(0,102,255,0.39)] hover:bg-[#005bb5] transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)]"
-                  onClick={() => { setStep(1); syncStateToBackend({ step: 1 }); }}
+                  onClick={() => { setStep(1); setChatStep(1); syncStateToBackend({ step: 1, chatStep: 1 }); }}
                 >
                   Start My Business
                 </button>
@@ -867,7 +867,7 @@ export default function OnboardingWizard() {
 
           {step === 2 && (
             <div className="flex flex-col justify-center items-center gap-4 flex-1 animate-fade-in">
-              <button onClick={() => { setStep(1); syncStateToBackend({ step: 1 }); }} className="self-start text-[#0066FF] text-sm font-semibold mb-4 flex items-center gap-1">
+              <button onClick={() => { setStep(1); setChatStep(1); syncStateToBackend({ step: 1, chatStep: 1 }); }} className="self-start text-[#0066FF] text-sm font-semibold mb-4 flex items-center gap-1">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg> Back
               </button>
               <h2 className="text-3xl font-bold font-outfit text-[#1D1D1F] dark:text-[#F5F5F7] mb-2">Review Details</h2>

--- a/src/ui/next/src/app/website-builder/page.tsx
+++ b/src/ui/next/src/app/website-builder/page.tsx
@@ -525,8 +525,8 @@ export default function WebsiteBuilderPage() {
                     >
                       Next
                     </button>
-                    {!userEmail.includes('@') && userEmail.length > 0 && <p className="text-red-500 text-xs text-center mt-1">Please enter a valid email address.</p>}
-                    {userPassword.length > 0 && userPassword.length < 8 && <p className="text-red-500 text-xs text-center mt-1">Password must be at least 8 characters.</p>}
+                    {!userEmail.includes('@') && userEmail.length > 0 && <p className="text-[#FF3B30] text-xs text-center mt-1">Please enter a valid email address.</p>}
+                    {userPassword.length > 0 && userPassword.length < 8 && <p className="text-[#FF3B30] text-xs text-center mt-1">Password must be at least 8 characters.</p>}
                   </div>
                 </>
               )}


### PR DESCRIPTION
The Day One onboarding experience has been improved. The UI now fully aligns with OHC Premium Translucent Glass token standards, using the correct `#FF3B30` hex token for validation errors instead of arbitrary Tailwind red classes. I've also resolved a state desynchronization bug between `step` and `chatStep` when users navigate "Back" during the onboarding chat stepper, ensuring the backend sync receives a single, accurate state update. Finally, I've suppressed expected `WebSocket` connection errors from leaking into the test console logs when `NODE_ENV === "test"`, creating cleaner CI output. All `bazelisk test //...` tasks pass.

---
*PR created automatically by Jules for task [65521384982320663](https://jules.google.com/task/65521384982320663) started by @ql-owo-lp*