### PR TITLE
fix: resolve `/ui/quote.html` 404 in E2E test

### DIFF
--- a/src/e2e/ui/agentic_quoting.spec.ts
+++ b/src/e2e/ui/agentic_quoting.spec.ts
@@ -45,7 +45,7 @@ test.describe('Agentic Quoting Engine (Mobile First)', () => {
     await page.setViewportSize({ width: 375, height: 667 });
 
     // 2. Owner navigates to the quote draft page (simulating clicking "Edit" from dashboard)
-    await page.goto(`/ui/quote.html?id=${quoteId}&mode=owner`);
+    await page.goto(`/api/ui/quote.html?id=${quoteId}&mode=owner`);
 
     // Verify it loads with correct amounts
     await expect(page.locator('#quote-total')).toHaveText('$150.00');
@@ -75,7 +75,7 @@ test.describe('Agentic Quoting Engine (Mobile First)', () => {
     await page.waitForURL('**/dashboard**');
 
     // 5. Customer navigates to quote page
-    await page.goto(`/ui/quote.html?id=${quoteId}&mode=customer`);
+    await page.goto(`/api/ui/quote.html?id=${quoteId}&mode=customer`);
 
     // Verify it loads in action required state
     await expect(page.locator('#quote-status')).toHaveText('Action Required');

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -5558,6 +5558,9 @@ async fn create_ui_bom_item_handler(
         .route("/api/ui/help_article.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/help_article.html"))
         }))
+        .route("/api/ui/quote.html", axum::routing::get(|| async {
+            axum::response::Html(include_str!("../ui/tauri/src/ui/quote.html"))
+        }))
         .route("/api/ui/api-docs.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/api-docs.html"))
         }))


### PR DESCRIPTION
Fix for the `agentic_quoting.spec.ts` E2E test failing due to `ui/quote.html` returning a 404.

* Added the missing route `/api/ui/quote.html` in `src/server/lib.rs` to correctly serve the static `quote.html` asset.
* Updated `src/e2e/ui/agentic_quoting.spec.ts` to navigate to the new `/api/ui/quote.html` route.

---
*PR created automatically by Jules for task [16806148392857644815](https://jules.google.com/task/16806148392857644815) started by @ql-owo-lp*