### PR TITLE
chore: Enforce missing RLS and cleanup tmp usage

### DIFF
--- a/src/agents/builtin/tools/hybrid_blob.rs
+++ b/src/agents/builtin/tools/hybrid_blob.rs
@@ -25,7 +25,7 @@ impl HybridBlobManager {
         let is_cloud = !s3_endpoint.is_empty();
 
         let local_dir = if !is_cloud {
-            let tmp_dir = env::var("OHC_BLOB_DIR").unwrap_or_else(|_| "/tmp/ohc_blobs".to_string());
+            let tmp_dir = env::var("OHC_BLOB_DIR").unwrap_or_else(|_| std::env::temp_dir().join("ohc_blobs").to_string_lossy().into_owned());
             let path = PathBuf::from(tmp_dir);
             if let Err(e) = fs::create_dir_all(&path).await {
                 tracing::error!("Failed to create local blob directory: {}", e);
@@ -203,7 +203,7 @@ pub fn hybrid_blob_tool() -> Tool {
     let is_cloud = !s3_endpoint.is_empty();
 
     let local_dir = if !is_cloud {
-        let tmp_dir = env::var("OHC_BLOB_DIR").unwrap_or_else(|_| "/tmp/ohc_blobs".to_string());
+        let tmp_dir = env::var("OHC_BLOB_DIR").unwrap_or_else(|_| std::env::temp_dir().join("ohc_blobs").to_string_lossy().into_owned());
         let path = PathBuf::from(tmp_dir);
         // We do synchronous dir creation here since this is tool init
         if let Err(e) = std::fs::create_dir_all(&path) {

--- a/src/agents/builtin/tools/restic.rs
+++ b/src/agents/builtin/tools/restic.rs
@@ -16,7 +16,7 @@ impl ToolExecutor for ResticExecutor {
             .as_str()
             .ok_or_else(|| ToolError::LlmRecoverable("restic: action is required (snapshot, restore, status)".to_string()))?;
 
-        let repo = std::env::var("RESTIC_REPOSITORY").unwrap_or_else(|_| "/tmp/restic-repo".to_string());
+        let repo = std::env::var("RESTIC_REPOSITORY").unwrap_or_else(|_| std::env::temp_dir().join("restic-repo").to_string_lossy().into_owned());
         let password = std::env::var("RESTIC_PASSWORD").unwrap_or_else(|_| "dummy_password".to_string());
 
         let timeout = Duration::from_secs(300);
@@ -47,6 +47,17 @@ impl ToolExecutor for ResticExecutor {
             _ => return Err(ToolError::LlmRecoverable("Invalid action. Allowed: snapshot, restore, status".to_string()))
         }
 
+        let target_path_fallback = std::env::temp_dir().join("restore").to_string_lossy().into_owned();
+        let target_string = if action == "restore" {
+            if let Some(t) = args["target"].as_str() {
+                t.to_string()
+            } else {
+                target_path_fallback
+            }
+        } else {
+            String::new()
+        };
+
         let mut full_args = vec!["-r", repo.as_str()];
 
         match action {
@@ -56,8 +67,7 @@ impl ToolExecutor for ResticExecutor {
             }
             "restore" => {
                 let snapshot_id = args["snapshot_id"].as_str().unwrap_or("latest");
-                let target = args["target"].as_str().unwrap_or("/tmp/restore");
-                full_args.extend(vec!["restore", snapshot_id, "--target", target]);
+                full_args.extend(vec!["restore", snapshot_id, "--target", &target_string]);
             }
             "status" => {
                 full_args.extend(vec!["snapshots"]);

--- a/src/server/migrations/131_enforce_missing_rls.sql
+++ b/src/server/migrations/131_enforce_missing_rls.sql
@@ -1,0 +1,53 @@
+-- +goose Up
+-- Migration 131: Enforce Missing Row Level Security Policies for specific tables
+
+DO $$
+BEGIN
+    IF to_regclass('business_milestones') IS NOT NULL THEN
+        ALTER TABLE IF EXISTS business_milestones ENABLE ROW LEVEL SECURITY;
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_policies
+            WHERE schemaname = current_schema()
+              AND tablename = 'business_milestones'
+              AND policyname = 'tenant_isolation_business_milestones'
+        ) THEN
+            CREATE POLICY tenant_isolation_business_milestones ON business_milestones
+                USING (tenant_id::text = current_setting('app.current_tenant', true))
+                WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+        END IF;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF to_regclass('shared_tasks_decomposition') IS NOT NULL THEN
+        ALTER TABLE IF EXISTS shared_tasks_decomposition ENABLE ROW LEVEL SECURITY;
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_policies
+            WHERE schemaname = current_schema()
+              AND tablename = 'shared_tasks_decomposition'
+              AND policyname = 'tenant_isolation_shared_tasks_decomposition'
+        ) THEN
+            CREATE POLICY tenant_isolation_shared_tasks_decomposition ON shared_tasks_decomposition
+                USING (organization_id::text = current_setting('app.current_tenant', true))
+                WITH CHECK (organization_id::text = current_setting('app.current_tenant', true));
+        END IF;
+    END IF;
+END $$;
+
+-- +goose Down
+DO $$
+BEGIN
+    IF to_regclass('business_milestones') IS NOT NULL THEN
+        DROP POLICY IF EXISTS tenant_isolation_business_milestones ON business_milestones;
+        ALTER TABLE IF EXISTS business_milestones DISABLE ROW LEVEL SECURITY;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF to_regclass('shared_tasks_decomposition') IS NOT NULL THEN
+        DROP POLICY IF EXISTS tenant_isolation_shared_tasks_decomposition ON shared_tasks_decomposition;
+        ALTER TABLE IF EXISTS shared_tasks_decomposition DISABLE ROW LEVEL SECURITY;
+    END IF;
+END $$;


### PR DESCRIPTION
Addresses codebase health issues:
1. Enforces PostgreSQL Row Level Security (RLS) on `business_milestones` and `shared_tasks_decomposition` tables that were missing it.
2. Replaces hardcoded `/tmp` paths in `src/agents/builtin/tools/hybrid_blob.rs` and `src/agents/builtin/tools/restic.rs` with cross-platform `std::env::temp_dir()`.

---
*PR created automatically by Jules for task [13005042991185614522](https://jules.google.com/task/13005042991185614522) started by @ql-owo-lp*