### PR TITLE
🛡️ Sentry: [reliability fix] Fix test hanging and enhance UI coverage

### DIFF
--- a/src/e2e/chaos_report.spec.ts
+++ b/src/e2e/chaos_report.spec.ts
@@ -5,4 +5,23 @@ test('Chaos Report Dashboard should render and display charts', async ({ page })
   await expect(page.locator('text=System Reliability Report')).toBeVisible();
   await expect(page.locator('text=Latency Distribution')).toBeVisible();
   await expect(page.locator('text=Error Rate Over Time')).toBeVisible();
+
+  // Test Theme Toggle Interaction
+  const themeToggle = page.locator('button', { hasText: /Toggle (Dark|Light) Mode/ });
+  await expect(themeToggle).toBeVisible();
+
+  const body = page.locator('body');
+  const initialText = await themeToggle.textContent();
+
+  if (initialText === 'Toggle Light Mode') {
+      await expect(body).toHaveClass(/dark-mode/);
+      await themeToggle.click();
+      await expect(body).toHaveClass(/light-mode/);
+      await expect(themeToggle).toHaveText('Toggle Dark Mode');
+  } else {
+      await expect(body).toHaveClass(/light-mode/);
+      await themeToggle.click();
+      await expect(body).toHaveClass(/dark-mode/);
+      await expect(themeToggle).toHaveText('Toggle Light Mode');
+  }
 });

--- a/src/server/api/offline_sync.rs
+++ b/src/server/api/offline_sync.rs
@@ -241,7 +241,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_offline_sync_unauthorized() {
-        let pool = PgPoolOptions::new().connect_lazy("postgres://localhost/dummy").unwrap();
+        let pool = PgPoolOptions::new().connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let mesh: Arc<dyn MeshTransport> = Arc::new(InProcessTransport::new());
         let state = State((pool, mesh));
 
@@ -254,7 +254,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_offline_sync_success_and_negative_guard() {
-        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/dummy".to_string());
+        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://127.0.0.1:1/dummy".to_string());
         if !database_url.contains("test") {
             return;
         }

--- a/src/server/api/terminal_api.rs
+++ b/src/server/api/terminal_api.rs
@@ -630,7 +630,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_commit_inventory_low_stock() {
-        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/dummy".to_string());
+        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://127.0.0.1:1/dummy".to_string());
         if !database_url.contains("test") {
             return;
         }
@@ -670,7 +670,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_commit_inventory_records_order() {
-        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/dummy".to_string());
+        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://127.0.0.1:1/dummy".to_string());
         if !database_url.contains("test") {
             return;
         }

--- a/src/server/autodream_pipeline/pipeline.rs
+++ b/src/server/autodream_pipeline/pipeline.rs
@@ -324,7 +324,7 @@ mod tests {
             .unwrap();
         }
 
-        let pg_pool = sqlx::PgPool::connect_lazy("postgres://localhost/dummy").unwrap();
+        let pg_pool = sqlx::PgPool::connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let db = Arc::new(DB {
             pool: pg_pool,
             store: DbStore::Sqlite(sqlite_pool.clone()),

--- a/src/server/chaos.rs
+++ b/src/server/chaos.rs
@@ -19,7 +19,7 @@ mod tests {
         let pool = PgPoolOptions::new()
             .acquire_timeout(Duration::from_millis(50))
 
-            .connect_lazy("postgres://localhost/dummy")
+            .connect_lazy("postgres://127.0.0.1:1/dummy")
             .unwrap();
 
         let sip_db = SipDB::new(pool.clone(), "test_org".to_string());
@@ -766,7 +766,7 @@ mod tests {
             );"
         ).execute(&pool).await.unwrap();
 
-        let pg_pool = sqlx::PgPool::connect_lazy("postgres://localhost/dummy").unwrap();
+        let pg_pool = sqlx::PgPool::connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let sip_db = Arc::new(SipDB::new(pg_pool, "system".to_string()));
 
         // Cloud Mode Simulation (100 simultaneous business owners)

--- a/src/server/orchestration/departments/operations_agent.rs
+++ b/src/server/orchestration/departments/operations_agent.rs
@@ -202,7 +202,7 @@ mod tests {
             .await
             .unwrap();
 
-        let pg_pool = sqlx::PgPool::connect_lazy("postgres://localhost/dummy").unwrap();
+        let pg_pool = sqlx::PgPool::connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let db = Arc::new(crate::db::DB {
             pool: pg_pool,
             store: crate::db::DbStore::Sqlite(sqlite_pool),

--- a/src/server/orchestration/handoff.rs
+++ b/src/server/orchestration/handoff.rs
@@ -202,7 +202,7 @@ mod tests {
                         Ok(true)
                     })
                 })
-                .connect_lazy("postgres://localhost/dummy")
+                .connect_lazy("postgres://127.0.0.1:1/dummy")
                 .unwrap(),
             store: DbStore::Sqlite(pool.clone()),
         });
@@ -301,7 +301,7 @@ mod tests {
                         Ok(true)
                     })
                 })
-                .connect_lazy("postgres://localhost/dummy")
+                .connect_lazy("postgres://127.0.0.1:1/dummy")
                 .unwrap(),
             store: DbStore::Sqlite(pool.clone()),
         });
@@ -444,7 +444,7 @@ mod tests {
                         Ok(true)
                     })
                 })
-                .connect_lazy("postgres://localhost/dummy")
+                .connect_lazy("postgres://127.0.0.1:1/dummy")
                 .unwrap(),
             store: DbStore::Sqlite(pool.clone()),
         });
@@ -525,7 +525,7 @@ mod tests {
             .unwrap();
 
         let db = std::sync::Arc::new(crate::db::DB {
-            pool: sqlx::postgres::PgPoolOptions::new().connect_lazy("postgres://localhost/dummy").unwrap(),
+            pool: sqlx::postgres::PgPoolOptions::new().connect_lazy("postgres://127.0.0.1:1/dummy").unwrap(),
             store: crate::db::DbStore::Sqlite(pool.clone()),
         });
 
@@ -582,7 +582,7 @@ mod tests {
             .unwrap();
 
         let db = std::sync::Arc::new(crate::db::DB {
-            pool: sqlx::postgres::PgPoolOptions::new().connect_lazy("postgres://localhost/dummy").unwrap(),
+            pool: sqlx::postgres::PgPoolOptions::new().connect_lazy("postgres://127.0.0.1:1/dummy").unwrap(),
             store: crate::db::DbStore::Sqlite(pool.clone()),
         });
 
@@ -616,7 +616,7 @@ mod tests {
             .unwrap();
 
         let db = std::sync::Arc::new(crate::db::DB {
-            pool: sqlx::postgres::PgPoolOptions::new().connect_lazy("postgres://localhost/dummy").unwrap(),
+            pool: sqlx::postgres::PgPoolOptions::new().connect_lazy("postgres://127.0.0.1:1/dummy").unwrap(),
             store: crate::db::DbStore::Sqlite(pool.clone()),
         });
 

--- a/src/server/orchestration/state/parity_test.rs
+++ b/src/server/orchestration/state/parity_test.rs
@@ -17,7 +17,7 @@ mod parity_tests {
 
         // Run migrations/schema setup for SQLite
         let db = DB {
-            pool: PgPoolOptions::new().connect_lazy("postgres://localhost/dummy").unwrap(),
+            pool: PgPoolOptions::new().connect_lazy("postgres://127.0.0.1:1/dummy").unwrap(),
             store: DbStore::Sqlite(sqlite_pool),
         };
         db.run_migrations().await.unwrap();

--- a/src/server/services/agent/service.rs
+++ b/src/server/services/agent/service.rs
@@ -330,7 +330,7 @@ mod tests {
             .acquire_timeout(std::time::Duration::from_secs(1))
             .connect(database_url).await.unwrap();
 
-        let pg_pool = sqlx::PgPool::connect_lazy("postgres://localhost/dummy").unwrap();
+        let pg_pool = sqlx::PgPool::connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let db = Arc::new(crate::db::DB { pool: pg_pool, store: crate::db::DbStore::Sqlite(pool.clone()) });
 
         let (tx, _rx) = tokio::sync::mpsc::channel(100);

--- a/src/server/services/ops/service.rs
+++ b/src/server/services/ops/service.rs
@@ -466,7 +466,7 @@ mod tests {
             .acquire_timeout(std::time::Duration::from_secs(1))
             .connect(database_url).await.unwrap();
 
-        let pg_pool = sqlx::PgPool::connect_lazy("postgres://localhost/dummy").unwrap();
+        let pg_pool = sqlx::PgPool::connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let db = Arc::new(crate::db::DB { pool: pg_pool, store: crate::db::DbStore::Sqlite(pool) });
 
         let (tx, _rx) = tokio::sync::mpsc::channel(100);

--- a/src/server/services/subscription/service.rs
+++ b/src/server/services/subscription/service.rs
@@ -521,7 +521,7 @@ mod tests {
             .connect("sqlite::memory:")
             .await
             .unwrap();
-        let pg_pool = sqlx::PgPool::connect_lazy("postgres://localhost/dummy").unwrap();
+        let pg_pool = sqlx::PgPool::connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let db = Arc::new(crate::db::DB {
             pool: pg_pool,
             store: crate::db::DbStore::Sqlite(sqlite_pool),

--- a/src/server/services/sync/power_sync_test.rs
+++ b/src/server/services/sync/power_sync_test.rs
@@ -53,7 +53,7 @@ mod tests {
         let db = Arc::new(DB {
             pool: sqlx::postgres::PgPoolOptions::new()
 
-                .connect_lazy("postgres://localhost/dummy").unwrap(),
+                .connect_lazy("postgres://127.0.0.1:1/dummy").unwrap(),
             store: DbStore::Sqlite(pool.clone()),
         });
 
@@ -107,7 +107,7 @@ mod tests {
         let db = Arc::new(DB {
             pool: sqlx::postgres::PgPoolOptions::new()
 
-                .connect_lazy("postgres://localhost/dummy").unwrap(),
+                .connect_lazy("postgres://127.0.0.1:1/dummy").unwrap(),
             store: DbStore::Sqlite(pool.clone()),
         });
 
@@ -160,7 +160,7 @@ mod tests {
         let db = Arc::new(DB {
             pool: sqlx::postgres::PgPoolOptions::new()
 
-                .connect_lazy("postgres://localhost/dummy").unwrap(),
+                .connect_lazy("postgres://127.0.0.1:1/dummy").unwrap(),
             store: DbStore::Sqlite(pool.clone()),
         });
 

--- a/src/server/services/sync/service.rs
+++ b/src/server/services/sync/service.rs
@@ -368,7 +368,7 @@ mod tests {
     async fn test_hybrid_sync_missions_empty() {
         // We can test empty payloads without DB!
         let pool = sqlx::postgres::PgPoolOptions::new()
-            .connect_lazy("postgres://localhost/dummy").unwrap();
+            .connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let service = MySyncService::new(pool);
         let req = Request::new(HybridSyncMissionsRequest { payloads: vec![] });
         let resp = service.hybrid_sync_missions(req).await.unwrap();
@@ -379,7 +379,7 @@ mod tests {
     #[tokio::test]
     async fn test_power_sync_push() {
         let pool = sqlx::postgres::PgPoolOptions::new()
-            .connect_lazy("postgres://localhost/dummy").unwrap();
+            .connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let service = MySyncService::new(pool);
         let req = Request::new(PowerSyncPushRequest { payload: "[]".to_string() });
         let resp = service.power_sync_push(req).await.unwrap();
@@ -400,7 +400,7 @@ mod tests {
         // This is safe since we only check that it doesn't panic.
         #[allow(unused_variables)]
         let pool = sqlx::postgres::PgPoolOptions::new()
-            .connect_lazy("postgres://localhost/dummy").unwrap();
+            .connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let service = MySyncService::new(pool);
         let req = Request::new(PowerSyncPullRequest {});
         let resp = service.power_sync_pull(req).await;
@@ -410,7 +410,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_power_sync_push_and_pull() {
-        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/dummy".to_string());
+        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://127.0.0.1:1/dummy".to_string());
         if !database_url.contains("test") {
             // Only run e2e flow if real test db is available. Dummy will fail.
             return;
@@ -460,7 +460,7 @@ mod tests {
     #[tokio::test]
     async fn test_sync_mcp_deltas_empty() {
         let pool = sqlx::postgres::PgPoolOptions::new()
-            .connect_lazy("postgres://localhost/dummy").unwrap();
+            .connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let service = MySyncService::new(pool);
         let mut req = Request::new(SyncMcpDeltasRequest { tenant_id: "org1".to_string(), deltas: vec![] });
         req.metadata_mut().insert("x-spiffe-id", "spiffe://ohc/org/org1/agent/agent1".parse().unwrap());
@@ -471,7 +471,7 @@ mod tests {
     #[tokio::test]
     async fn test_sync_escalation_empty() {
         let pool = sqlx::postgres::PgPoolOptions::new()
-            .connect_lazy("postgres://localhost/dummy").unwrap();
+            .connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let service = MySyncService::new(pool);
         let req = Request::new(SyncEscalationRequest { payloads: vec![] });
         let resp = service.sync_escalation(req).await.unwrap();
@@ -481,7 +481,7 @@ mod tests {
     #[tokio::test]
     async fn test_vector_sync() {
         let pool = sqlx::postgres::PgPoolOptions::new()
-            .connect_lazy("postgres://localhost/dummy").unwrap();
+            .connect_lazy("postgres://127.0.0.1:1/dummy").unwrap();
         let service = MySyncService::new(pool);
         let req = Request::new(VectorSyncRequest {});
         let resp = service.vector_sync(req).await.unwrap();

--- a/src/server/services/sync/telemetry_sync.rs
+++ b/src/server/services/sync/telemetry_sync.rs
@@ -189,10 +189,10 @@ mod tests {
     #[tokio::test]
     async fn bench_telemetry_sync_parallel() {
         // If we are in the Bazel sandbox without an active HTTP mock or DB, just exit cleanly to avoid timeouts
-        let db_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/dummy".to_string());
+        let db_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://127.0.0.1:1/dummy".to_string());
 
         // Fast fail for tests
-        if db_url.contains("dummy") || db_url == "postgres://localhost/dummy" {
+        if db_url.contains("dummy") || db_url == "postgres://127.0.0.1:1/dummy" {
             return;
         }
 

--- a/src/server/sip.rs
+++ b/src/server/sip.rs
@@ -515,7 +515,7 @@ mod tests {
 
     // Helper to get a dummy pgpool for testing
     async fn setup_dummy_pool() -> PgPool {
-        let db_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/dummy".to_string());
+        let db_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://127.0.0.1:1/dummy".to_string());
         sqlx::postgres::PgPoolOptions::new()
             .acquire_timeout(std::time::Duration::from_millis(50))
             .connect_lazy(&db_url)
@@ -665,7 +665,7 @@ mod tests {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(1)
             .acquire_timeout(std::time::Duration::from_millis(10))
-            .connect_lazy("postgres://localhost/dummy")
+            .connect_lazy("postgres://127.0.0.1:1/dummy")
             .unwrap();
 
         let sip_db = SipDB::new(pool, "test_org".to_string());
@@ -770,7 +770,7 @@ mod tests {
         let dummy_pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(1)
             .acquire_timeout(std::time::Duration::from_millis(10))
-            .connect_lazy("postgres://localhost/dummy")
+            .connect_lazy("postgres://127.0.0.1:1/dummy")
             .unwrap();
 
         let sip_db_dummy = SipDB::new(dummy_pool, "test_org".to_string());

--- a/src/server/workers/pos_conflict_worker.rs
+++ b/src/server/workers/pos_conflict_worker.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pos_conflict_worker() {
-        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/dummy".to_string());
+        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://127.0.0.1:1/dummy".to_string());
         if !database_url.contains("test") {
             return;
         }

--- a/src/server/workers/pos_sync_worker.rs
+++ b/src/server/workers/pos_sync_worker.rs
@@ -375,7 +375,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pos_sync_worker_logic() {
-        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/dummy".to_string());
+        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://127.0.0.1:1/dummy".to_string());
         if !database_url.contains("test") {
             return;
         }
@@ -438,7 +438,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pos_sync_worker_low_stock() {
-        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/dummy".to_string());
+        let database_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://127.0.0.1:1/dummy".to_string());
         if !database_url.contains("test") {
             return;
         }


### PR DESCRIPTION
This PR addresses test instabilities during the Sentry chaos parity checks and optimizes E2E coverage for the chaos report. 

### Implementation details:
1. **Fix localhost connection tests**: Switched out `postgres://localhost/dummy` with `postgres://127.0.0.1:1/dummy` in dummy test connections. This resolves issues where tests might hang on systems running local PostgreSQL by failing fast with a `Connection Refused` error.
2. **Enhance UI Test Coverage**: Added Playwright E2E coverage in `src/e2e/chaos_report.spec.ts` to assert the interaction and state change (dark/light mode) of the theme toggle button.
3. Verified the codebase remains fully covered and all Bazel E2E tests are 100% passing successfully.

---
*PR created automatically by Jules for task [11385353701421896304](https://jules.google.com/task/11385353701421896304) started by @ql-owo-lp*