### PR TITLE
Fix API docs routing and link

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -5620,6 +5620,9 @@ async fn create_ui_bom_item_handler(
         .route("/api/ui/api-docs.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/api-docs.html"))
         }))
+        .route("/api-docs", axum::routing::get(|| async {
+            axum::response::Html(include_str!("../ui/tauri/src/ui/api-docs.html"))
+        }))
         .route("/api/ui/changelog.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/next/public/api/ui/changelog.html"))
         }))

--- a/src/ui/tauri/src/ui/help.html
+++ b/src/ui/tauri/src/ui/help.html
@@ -893,7 +893,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 <h3 style="font-size: 18px; font-weight: bold; color: #78350f; margin: 0;">Advanced Users</h3>
                 <p style="font-size: 14px; color: rgba(146, 64, 14, 0.8); margin: 0;">For users who want to use OHC's APIs directly (e.g., connect a custom checkout).</p>
               </div>
-              <a href="api-docs.html" style="background: #fef3c7; color: #78350f; padding: 10px 24px; border-radius: 12px; font-weight: 600; text-decoration: none; border: 1px solid rgba(252, 211, 77, 0.5); font-size: 14px;">API Documentation</a>
+              <a href="/api-docs" style="background: #fef3c7; color: #78350f; padding: 10px 24px; border-radius: 12px; font-weight: 600; text-decoration: none; border: 1px solid rgba(252, 211, 77, 0.5); font-size: 14px;">API Documentation</a>
             </div>
           </section>
         `;


### PR DESCRIPTION
Fixed the missing route for `/api-docs` by mapping it correctly to the `api-docs.html` file in the Rust API server. Also updated the link in `help.html` to navigate to `/api-docs`. This resolves the Playwright E2E test failures.

---
*PR created automatically by Jules for task [15925543976092371342](https://jules.google.com/task/15925543976092371342) started by @ql-owo-lp*