### PR TITLE
fix(ui): parse AI Agent paused message accurately from multiple payload shapes

### DIFF
--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -1223,7 +1223,27 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
                       if (p?.original_payload?.proposed_content?.includes("System is paused")) {
                           return p.original_payload.proposed_content;
                       }
-                      return p?.original_payload?.description || 'Action completed';
+                      if (p?.proposed_action?.proposed_content?.includes("System is paused")) {
+                          return p.proposed_action.proposed_content;
+                      }
+                      if (typeof p?.proposed_action === 'string' && p.proposed_action.includes("System is paused")) {
+                          return p.proposed_action;
+                      }
+                      if (p?.payload?.proposed_content?.includes("System is paused")) {
+                          return p.payload.proposed_content;
+                      }
+                      if (typeof p?.payload === 'string' && p.payload.includes("System is paused")) {
+                          try {
+                            const inner = JSON.parse(p.payload);
+                            if (inner?.proposed_content?.includes("System is paused")) {
+                                return inner.proposed_content;
+                            }
+                          } catch(e) {}
+                      }
+                      if (p?.proposed_content?.includes("System is paused")) {
+                          return p.proposed_content;
+                      }
+                      return p?.original_payload?.description || p?.context_payload?.description || 'Action completed';
                     } catch (e) {
                       return 'Action completed';
                     }


### PR DESCRIPTION
This commit resolves the `ml_resilience.spec.ts` failure where the dashboard feed fell back to showing "Action completed" rather than the actual paused explanation text (e.g. "System is paused. Please manually check..."). 

By probing deeply into the different JSON payload shapes generated by `agent_approvals`—including nested `payload` objects, `proposed_action`, and doubly-stringified payloads—we ensure the warning string surfaces properly in the UI for paused states.

---
*PR created automatically by Jules for task [7878497890242610510](https://jules.google.com/task/7878497890242610510) started by @ql-owo-lp*