### PR TITLE
Harness Upgrade - LLM-Recoverable ToolMessages for Output Parsing

### DIFF
--- a/src/agents/builtin/output_parser.rs
+++ b/src/agents/builtin/output_parser.rs
@@ -240,7 +240,7 @@ impl<'a, T: DeserializeOwned> RetryWithErrorOutputParser<'a, T> {
                             .map(|tc| crate::types::ToolResult {
                                 tool_call_id: tc.id.clone(),
                                 content: String::new(),
-                                error: detailed_error.clone(),
+                                error: crate::types::ToolResult::new_llm_recoverable(tc.id.clone(), &detailed_error).error,
                             })
                             .collect();
 


### PR DESCRIPTION
In `src/agents/builtin/output_parser.rs`, the fallback mechanism for output parsing was previously propagating generic parsing errors (such as Pydantic validation errors) incorrectly by passing them as a generic `error` string. This change updates `parse_with_prompt_and_strategy` to properly encapsulate the parsing error using `crate::types::ToolResult::new_llm_recoverable()`, which standardizes the self-correcting feedback format. This provides the LLM with precise instructions on how to correct its previous output during retry attempts, fully supporting the "LLM-Recoverable ToolMessages" feature described in the 4-tier error handling mechanic from the Master Catalog. All E2E, unit tests and bazel suites pass successfully.

---
*PR created automatically by Jules for task [11498225711332714205](https://jules.google.com/task/11498225711332714205) started by @ql-owo-lp*