### PR TITLE
feat(booking): implement reserve_time_slot endpoint

### DIFF
--- a/src/e2e/ui/booking.spec.ts
+++ b/src/e2e/ui/booking.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Booking time slot reservation', () => {
+  test('should submit booking request and show success', async ({ page }) => {
+    // Navigate to booking page directly. The test database has the default tenant populated.
+    await page.goto('/booking?tenant=default-store&service_id=service-1');
+
+    // Fill out form
+    await page.fill('input[type="text"]', 'John Doe');
+    await page.fill('input[type="email"]', 'john@example.com');
+    await page.fill('input[type="date"]', '2025-01-01');
+
+    // Wait for slots to appear
+    await page.waitForSelector('text=09:00 AM');
+
+    // Select slot
+    await page.click('text=09:00 AM');
+
+    // Submit
+    await page.click('button[type="submit"]');
+
+    await expect(page.locator('text=Request Sent!')).toBeVisible();
+    await expect(page.locator('button', { hasText: 'Submit Another Request' })).toBeVisible();
+  });
+});

--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -70,6 +70,7 @@ SERVER_RS_SRCS = [
     "//src/server/api:shipping.rs",
     "//src/server/api/booking:mod.rs",
     "//src/server/api/booking:request.rs",
+    "//src/server/api/booking:reserve_time_slot.rs",
     "//src/server/api/agents:approvals.rs",
     "//src/server/api/agents:chat.rs",
     "//src/server/api/agents:hire.rs",

--- a/src/server/api/booking/BUILD.bazel
+++ b/src/server/api/booking/BUILD.bazel
@@ -3,7 +3,8 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 exports_files(
     [
         "mod.rs",
-        "request.rs"
+        "request.rs",
+        "reserve_time_slot.rs"
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/server/api/booking/mod.rs
+++ b/src/server/api/booking/mod.rs
@@ -1,1 +1,2 @@
 pub mod request;
+pub mod reserve_time_slot;

--- a/src/server/api/booking/reserve_time_slot.rs
+++ b/src/server/api/booking/reserve_time_slot.rs
@@ -1,0 +1,132 @@
+use axum::{
+    extract::{Extension, Json},
+    response::IntoResponse,
+    http::StatusCode,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct ReserveTimeSlotPayload {
+    pub tenant_id: String,
+    pub product_id: String,
+    pub customer_id: String,
+    pub start_time: String,
+    pub end_time: String,
+    #[serde(default)]
+    pub requires_deposit: bool,
+    pub timezone: Option<String>,
+    pub description: Option<String>,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+pub struct ReserveTimeSlotResponse {
+    pub success: bool,
+    pub booking_id: Option<String>,
+    pub deposit_stripe_link: Option<String>,
+}
+
+pub async fn handle_reserve_time_slot(
+    headers: axum::http::HeaderMap,
+    user: Option<Extension<::server_common::Claims>>,
+    Json(payload): Json<ReserveTimeSlotPayload>,
+) -> impl IntoResponse {
+    let tenant_id = match headers.get("x-tenant-id").and_then(|h| h.to_str().ok()) {
+        Some(t) if !t.trim().is_empty() => t.to_string(),
+        _ => payload.tenant_id.clone(),
+    };
+    if tenant_id.is_empty() {
+        return (axum::http::StatusCode::UNAUTHORIZED, axum::Json(serde_json::json!({"error": "unauthorized"}))).into_response();
+    }
+
+    let port = std::env::var("PORT").unwrap_or_else(|_| "18789".to_string());
+    let url = format!("http://127.0.0.1:{}", port);
+
+    let mut client = match ::server_ohc::app::booking_engine_service_client::BookingEngineServiceClient::connect(url).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("Failed to connect to BookingEngineService: {}", e);
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({"error": "backend connection failed"}))).into_response();
+        }
+    };
+
+    let req = ::server_ohc::app::ReserveTimeSlotRequest {
+        tenant_id: tenant_id.clone(),
+        customer_id: payload.customer_id,
+        product_id: payload.product_id,
+        start_time: payload.start_time,
+        end_time: payload.end_time,
+        requires_deposit: payload.requires_deposit,
+        timezone: payload.timezone.unwrap_or_else(|| "UTC".to_string()),
+    };
+
+    let mut tonic_req = tonic::Request::new(req);
+
+    let spiffe_id = if let Some(Extension(claims)) = user {
+        claims.sub
+    } else {
+        "".to_string()
+    };
+
+    if !spiffe_id.is_empty() {
+        if let Ok(m) = spiffe_id.parse() {
+            tonic_req.metadata_mut().insert("x-spiffe-id", m);
+        }
+    }
+
+    tonic_req.extensions_mut().insert(::server_auth::orchestration::AuthInfo {
+        org_id: tenant_id,
+        agent_id: spiffe_id.clone(),
+        spiffe_id: spiffe_id,
+    });
+
+    match client.reserve_time_slot(tonic_req).await {
+        Ok(resp) => {
+            let data = resp.into_inner();
+            (
+                StatusCode::OK,
+                Json(ReserveTimeSlotResponse {
+                    success: true,
+                    booking_id: Some(data.booking_id),
+                    deposit_stripe_link: Some(data.deposit_stripe_link),
+                }),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!("Failed to reserve time slot: {:?}", e);
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ReserveTimeSlotResponse {
+                    success: false,
+                    booking_id: None,
+                    deposit_stripe_link: None,
+                }),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+
+    #[tokio::test]
+    async fn test_handle_reserve_time_slot_unauthorized() {
+        let headers = HeaderMap::new();
+        let payload = Json(ReserveTimeSlotPayload {
+            tenant_id: "".to_string(),
+            product_id: "".to_string(),
+            customer_id: "".to_string(),
+            start_time: "".to_string(),
+            end_time: "".to_string(),
+            requires_deposit: false,
+            timezone: None,
+            description: None,
+        });
+
+        let resp = handle_reserve_time_slot(headers, None, payload).await.into_response();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -5535,6 +5535,7 @@ async fn create_ui_bom_item_handler(
         .nest("/api/v1/quotes", api::quotes::router().with_state(db.pool.clone()))
         .nest("/api/v1/work-intake/submit", api::agents::client_intake::router(dept_orchestrator.clone()))
         .nest("/api/v1/booking/request", api::booking::request::router(dept_orchestrator.clone()))
+        .route("/api/v1/booking/reserve_time_slot", axum::routing::post(api::booking::reserve_time_slot::handle_reserve_time_slot))
         .nest("/api/agents/mission", api::agents::mission::handoff::router(std::sync::Arc::new(crate::sip::SipDB::new(db.pool.clone(), "default".to_string()))))
         .route("/api/telemetry/sync", axum::routing::post(api::telemetry::sync_telemetry_handler))
         .route("/api/v1/chaos/report", axum::routing::get(api::chaos::get_chaos_report_handler).with_state(db.pool.clone()))

--- a/src/ui/next/src/app/api/v1/booking/reserve_time_slot/route.test.ts
+++ b/src/ui/next/src/app/api/v1/booking/reserve_time_slot/route.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./route";
+
+describe("POST /api/v1/booking/reserve_time_slot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, booking_id: "test-booking" }),
+      status: 200,
+    });
+    process.env.BACKEND_URL = "http://backend.internal";
+  });
+
+  it("proxies reserve time slot request to backend", async () => {
+    const req = new Request("http://localhost/api/v1/booking/reserve_time_slot", {
+      method: "POST",
+      headers: {
+        "x-tenant-id": "test-tenant",
+      },
+      body: JSON.stringify({
+        tenant_id: "test-tenant",
+        product_id: "test-product",
+        customer_id: "test-customer",
+        start_time: "2024-01-01T10:00:00Z",
+        end_time: "2024-01-01T11:00:00Z",
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.success).toBe(true);
+
+    expect(global.fetch).toHaveBeenCalledWith("http://backend.internal/api/v1/booking/reserve_time_slot", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-tenant-id": "test-tenant",
+      },
+      body: JSON.stringify({
+        tenant_id: "test-tenant",
+        product_id: "test-product",
+        customer_id: "test-customer",
+        start_time: "2024-01-01T10:00:00Z",
+        end_time: "2024-01-01T11:00:00Z",
+      }),
+    });
+  });
+});

--- a/src/ui/next/src/app/api/v1/booking/reserve_time_slot/route.ts
+++ b/src/ui/next/src/app/api/v1/booking/reserve_time_slot/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const backendUrl = process.env.BACKEND_URL || 'http://127.0.0.1:18789';
+  const tenantId = req.headers.get('x-tenant-id') || 'default';
+  const authHeader = req.headers.get('authorization');
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'x-tenant-id': tenantId,
+  };
+  if (authHeader) {
+    headers.authorization = authHeader;
+  }
+
+  try {
+    const body = await req.json();
+    const res = await fetch(`${backendUrl}/api/v1/booking/reserve_time_slot`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (res.ok) {
+      return NextResponse.json(await res.json());
+    }
+
+    return NextResponse.json({ error: 'Failed to create booking request' }, { status: res.status });
+  } catch {
+    return NextResponse.json({ error: 'Backend connection failed' }, { status: 500 });
+  }
+}

--- a/src/ui/next/src/app/booking/page.tsx
+++ b/src/ui/next/src/app/booking/page.tsx
@@ -50,10 +50,10 @@ function BookingForm() {
       if (data.deposit_stripe_link) {
         setCheckoutUrl(data.deposit_stripe_link);
       }
+      setSubmitted(true);
+    } else {
+        alert("Failed to reserve time slot. Please try again.");
     }
-
-    // In local dev/testing, we just simulate success if the fetch fails (due to no grpc backend in ui tests)
-    setSubmitted(true);
   };
 
   if (submitted) {


### PR DESCRIPTION
Added the missing `/api/v1/booking/reserve_time_slot` REST endpoint on the Rust backend, proxying it to the internal `BookingEngineService` using tonic. The NextJS frontend now correctly proxies its requests to this real backend rather than using local fallback states. Removed mocked logic in the React UI, and added proper unit/E2E testing.

---
*PR created automatically by Jules for task [11954001054990921169](https://jules.google.com/task/11954001054990921169) started by @ql-owo-lp*