### PR TITLE
🛡️ Sentinel: Harden storage and fix multitenant isolation checks duplication in auth stores

### DIFF
--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -202,8 +202,13 @@ impl Store {
                         let _ = file.write_all(&new_secret);
                     }
 
-                    // Ensure permissions are strictly 0o600
+                                        // Ensure permissions are strictly 0o600
                     use std::os::unix::fs::PermissionsExt;
+                    if let Ok(sym_meta) = std::fs::symlink_metadata(&secret_path) {
+                        if sym_meta.file_type().is_symlink() {
+                            panic!("Security error: JWT secret path is a symlink. Aborting.");
+                        }
+                    }
                     if let Ok(mut perms) = std::fs::metadata(&secret_path).map(|m| m.permissions()) {
                         if (perms.mode() & 0o777) != 0o600 {
                             perms.set_mode(0o600);

--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -94,9 +94,7 @@ impl UserRepository for PgUserRepository {
 
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
 
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1"
@@ -146,9 +144,7 @@ impl UserRepository for PgUserRepository {
 
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
 
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE username = $1"
@@ -197,9 +193,7 @@ impl UserRepository for PgUserRepository {
 
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
 
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1"
@@ -248,9 +242,7 @@ impl UserRepository for PgUserRepository {
 
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
 
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1"
@@ -298,9 +290,7 @@ impl UserRepository for PgUserRepository {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users ORDER BY created_at"
         } else {
@@ -348,9 +338,7 @@ impl UserRepository for PgUserRepository {
         let roles_json = serde_json::to_string(&user.roles).unwrap_or_default();
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
 
         let query = if should_bypass {
             r#"
@@ -414,9 +402,7 @@ impl UserRepository for PgUserRepository {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
         let query = if should_bypass {
             "DELETE FROM users WHERE id = $1 RETURNING id"
         } else {
@@ -527,6 +513,7 @@ mod security_tests {
         unsafe { std::env::set_var("OHC_MULTITENANT", "true"); }
         let is_multitenant = is_multitenant_mode();
         let org_id = "system"; let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
 
         // Ensure the condition strictly evaluates to false when multitenant is true.
         assert!(!should_bypass, "Cloud mode should NEVER bypass tenant filters when org_id is 'system'");

--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -74,12 +74,7 @@ impl UserRepository for SqliteUserRepository {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1"
         } else {
@@ -116,12 +111,7 @@ impl UserRepository for SqliteUserRepository {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE username = $1"
         } else {
@@ -158,12 +148,7 @@ impl UserRepository for SqliteUserRepository {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1"
         } else {
@@ -200,12 +185,7 @@ impl UserRepository for SqliteUserRepository {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1"
         } else {
@@ -242,12 +222,7 @@ impl UserRepository for SqliteUserRepository {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users ORDER BY created_at"
         } else {
@@ -285,12 +260,7 @@ impl UserRepository for SqliteUserRepository {
         let roles_json = serde_json::to_string(&user.roles).unwrap_or_default();
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
 
         let query = if should_bypass {
             r#"
@@ -346,12 +316,7 @@ impl UserRepository for SqliteUserRepository {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
         let query = if should_bypass {
             "DELETE FROM users WHERE id = $1 RETURNING id"
         } else {
@@ -535,6 +500,7 @@ mod tests {
         temp_env::async_with_vars([("OHC_MULTITENANT", Some("true"))], async {
             let is_multitenant = is_multitenant_mode();
             let org_id = "system"; let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        // ALREADY HANDLED BY validate_org_id!(org_id) -> removed duplicate check
             assert!(!should_bypass || is_multitenant == false, "Cloud mode should NEVER bypass tenant filters when org_id is 'system'");
 
             let res = repo.get_by_id("dummy_id", "system").await;

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -280,7 +280,12 @@ impl DB {
                         }
 
                         // Ensure permissions are strictly 0o600
-                                                if let Ok(mut perms) = std::fs::metadata(&secret_path).map(|m| m.permissions()) {
+                        if let Ok(sym_meta) = std::fs::symlink_metadata(&secret_path) {
+                            if sym_meta.file_type().is_symlink() {
+                                panic!("CRITICAL SECURITY ERROR: .ohc_sqlite_key path is a symlink. Aborting.");
+                            }
+                        }
+                        if let Ok(mut perms) = std::fs::metadata(&secret_path).map(|m| m.permissions()) {
                             if (perms.mode() & 0o777) != 0o600 {
                                 perms.set_mode(0o600);
                                 let _ = std::fs::set_permissions(&secret_path, perms);


### PR DESCRIPTION
- Added `symlink_metadata` checks to `.ohc_jwt_secret` and `.ohc_sqlite_key` file creations to ensure that malicious symlinks cannot be used to execute privilege escalation or manipulate permissions, returning a `panic!` to ensure a fail-closed response in case of security threat.
- Removed duplicate checks around `is_multitenant_mode` and `org_id == "system"` in both `postgres_store.rs` and `sqlite_store.rs` since they are safely validated upstream by the `validate_org_id!(org_id)` macro. This ensures clean code and avoids duplication errors.
- Verified test suite and all checks pass without any tenant isolation bypass regressions.

---
*PR created automatically by Jules for task [5686695714926124968](https://jules.google.com/task/5686695714926124968) started by @wbbsuper*