### PR TITLE
Implement Tooltip Registry and Documentation Improvements

### DIFF
--- a/src/e2e/tooltip_registry.spec.ts
+++ b/src/e2e/tooltip_registry.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from './fixtures';
+
+test.describe('Tooltip Registry', () => {
+  test('Persona: Admin updates dynamic tooltips', async ({ page }) => {
+    // We append /api/ui/ since this is served via backend in testing
+    await page.goto('/api/ui/tooltip-registry.html');
+    await expect(page.locator('h1')).toHaveText('Tooltip Registry');
+
+    await page.fill('#new-id', 'test-dynamic-id');
+    await page.fill('#new-text', 'My test tooltip text');
+    await page.click('#add-btn');
+
+    await expect(page.locator('input#input-test-dynamic-id')).toHaveValue('My test tooltip text');
+  });
+});

--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -770,3 +770,56 @@ pub async fn get_api_docs_spec() -> Json<serde_json::Value> {
     });
     Json(spec)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::Json as AxumJson;
+    use axum::Json;
+
+    #[tokio::test]
+    async fn test_list_articles() {
+        let res = list_articles().await;
+        assert!(!res.0.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_search_articles_found() {
+        let res = search_articles(axum::extract::Query(SearchQuery { q: "getting".to_string() })).await;
+        assert!(!res.0.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_search_articles_not_found() {
+        let res = search_articles(axum::extract::Query(SearchQuery { q: "unlikelysearchterm123".to_string() })).await;
+        assert!(res.0.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_videos() {
+        let res = list_videos().await;
+        assert!(!res.0.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_tooltips_api() {
+        // Prepare the payload to update a tooltip
+        let payload = TooltipPayload {
+            id: "test-tooltip-id".to_string(),
+            text: "This is a test tooltip".to_string(),
+        };
+
+        // Update the tooltip
+        let res = update_tooltip(AxumJson(payload)).await;
+        assert!(res.0.success);
+
+        // Fetch tooltips and verify the update
+        let tooltips_res = get_tooltips().await;
+        let tooltips = tooltips_res.0;
+
+        assert_eq!(
+            tooltips.get("test-tooltip-id").map(|s| s.as_str()),
+            Some("This is a test tooltip")
+        );
+    }
+}

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -320,6 +320,9 @@
       .action-buttons {
         display: flex;
         gap: 10px;
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
+        background: rgba(255, 255, 255, 0.65);
       }
       .btn-secondary {
         background-color: #e5e5ea;
@@ -735,7 +738,7 @@
           <button class="btn-secondary" id="dashboard-walkthrough-btn" data-tooltip="dashboard-walkthrough-btn" onclick="window.startWalkthrough([{selector: '#dashboard-title', title: 'Welcome', text: 'Welcome to your dashboard! This is your control center.'}, {selector: '#ai-savings-widget', title: 'AI Savings', text: 'Here you can see the time and effort your agents have saved you.'}])">Start Walkthrough</button>
         <div class="action-buttons">
             <button class="btn-secondary" id="copy-btn" data-tooltip="Copy the referral link to your clipboard.">Copy</button>
-            <button class="btn-secondary" id="share-whatsapp-btn">Share on WhatsApp</button>
+            <button class="btn-secondary" id="share-whatsapp-btn" data-tooltip="Share your link via WhatsApp">Share on WhatsApp</button>
             <button class="btn-secondary" id="share-x-btn" style="background-color: #1DA1F2; color: white;">Share on X (Twitter)</button>
           </div>
         </div>
@@ -2328,15 +2331,18 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     document.addEventListener('mouseover', (e) => {
-        const target = e.target.closest('[id]');
-        if (target && target.id && window.OHC_TOOLTIPS[target.id]) {
-            showTooltip(e, window.OHC_TOOLTIPS[target.id]);
+        const target = e.target.closest('[data-tooltip], [id]');
+        if (target) {
+            const text = (window.OHC_TOOLTIPS && target.id && window.OHC_TOOLTIPS[target.id]) || target.getAttribute('data-tooltip');
+            if (text) {
+                showTooltip(e, text);
+            }
         }
     });
 
     document.addEventListener('mouseout', (e) => {
-        const target = e.target.closest('[id]');
-        if (target && target.id && window.OHC_TOOLTIPS[target.id]) {
+        const target = e.target.closest('[data-tooltip], [id]');
+        if (target) {
             hideTooltip();
         }
     });
@@ -2362,7 +2368,7 @@ function initWalkthrough() {
         const bubble = document.createElement('div');
         bubble.id = 'walkthrough-bubble';
         bubble.setAttribute('role', 'dialog');
-        bubble.style.cssText = 'position: fixed; background: white; border-radius: 8px; padding: 16px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); z-index: 99999; max-width: 300px; display: flex; flex-direction: column; gap: 8px; font-family: Outfit, sans-serif;';
+        bubble.style.cssText = 'position: fixed; background: rgba(255, 255, 255, 0.7); backdrop-filter: blur(30px) saturate(210%); -webkit-backdrop-filter: blur(30px) saturate(210%); border: 1px solid rgba(255, 255, 255, 0.5); border-radius: 8px; padding: 16px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); z-index: 99999; max-width: 300px; display: flex; flex-direction: column; gap: 8px; font-family: Outfit, sans-serif;';
         document.body.appendChild(bubble);
 
         function renderStep() {
@@ -2700,7 +2706,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 <li><a href="/help_article.html?id=payments-1" style="color: #0066FF; text-decoration: none; font-size: 14px;">Accepting your first payment</a></li>
             </ul>
             <div style="margin-top: auto; padding-top: 16px; border-top: 1px solid rgba(226, 232, 240, 0.5);">
-                <a href="/api-docs.html" style="color: #64748b; font-size: 13px; text-decoration: none;">API Reference for advanced users</a>
+                <a href="/api-docs.html" style="color: #64748b; font-size: 13px; text-decoration: none; display: block; margin-bottom: 8px;">API Reference for advanced users</a>
+                <a href="/tooltip-registry.html" style="color: #64748b; font-size: 13px; text-decoration: none; display: block;">Tooltip Registry</a>
             </div>
         </div>
 
@@ -2852,15 +2859,18 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     document.addEventListener('mouseover', (e) => {
-        const target = e.target.closest('[id]');
-        if (target && target.id && window.OHC_TOOLTIPS[target.id]) {
-            showTooltip(e, window.OHC_TOOLTIPS[target.id]);
+        const target = e.target.closest('[data-tooltip], [id]');
+        if (target) {
+            const text = (window.OHC_TOOLTIPS && target.id && window.OHC_TOOLTIPS[target.id]) || target.getAttribute('data-tooltip');
+            if (text) {
+                showTooltip(e, text);
+            }
         }
     });
 
     document.addEventListener('mouseout', (e) => {
-        const target = e.target.closest('[id]');
-        if (target && target.id && window.OHC_TOOLTIPS[target.id]) {
+        const target = e.target.closest('[data-tooltip], [id]');
+        if (target) {
             hideTooltip();
         }
     });
@@ -2880,7 +2890,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const bubble = document.createElement('div');
             bubble.id = 'walkthrough-bubble';
             bubble.setAttribute('role', 'dialog');
-            bubble.style.cssText = 'position: fixed; background: white; border-radius: 8px; padding: 16px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); z-index: 99999; max-width: 300px; display: flex; flex-direction: column; gap: 8px; font-family: Outfit, sans-serif;';
+            bubble.style.cssText = 'position: fixed; background: rgba(255, 255, 255, 0.7); backdrop-filter: blur(30px) saturate(210%); -webkit-backdrop-filter: blur(30px) saturate(210%); border: 1px solid rgba(255, 255, 255, 0.5); border-radius: 8px; padding: 16px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); z-index: 99999; max-width: 300px; display: flex; flex-direction: column; gap: 8px; font-family: Outfit, sans-serif;';
             document.body.appendChild(bubble);
 
             function renderStep() {

--- a/src/ui/tauri/src/ui/help.html
+++ b/src/ui/tauri/src/ui/help.html
@@ -977,15 +977,18 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     document.addEventListener('mouseover', (e) => {
-        const target = e.target.closest('[id]');
-        if (target && target.id && window.OHC_TOOLTIPS[target.id]) {
-            showTooltip(e, window.OHC_TOOLTIPS[target.id]);
+        const target = e.target.closest('[data-tooltip], [id]');
+        if (target) {
+            const text = (window.OHC_TOOLTIPS && target.id && window.OHC_TOOLTIPS[target.id]) || target.getAttribute('data-tooltip');
+            if (text) {
+                showTooltip(e, text);
+            }
         }
     });
 
     document.addEventListener('mouseout', (e) => {
-        const target = e.target.closest('[id]');
-        if (target && target.id && window.OHC_TOOLTIPS[target.id]) {
+        const target = e.target.closest('[data-tooltip], [id]');
+        if (target) {
             hideTooltip();
         }
     });
@@ -1130,8 +1133,9 @@ document.addEventListener('DOMContentLoaded', () => {
             width: 380px;
             height: 600px;
             max-height: calc(100vh - 120px);
-            background: rgba(255, 255, 255, 0.85);
-            backdrop-filter: blur(20px);
+            background: rgba(255, 255, 255, 0.7);
+            backdrop-filter: blur(30px) saturate(210%);
+            -webkit-backdrop-filter: blur(30px) saturate(210%);
             border-radius: 16px;
             box-shadow: 0 8px 32px rgba(0,0,0,0.15);
             z-index: 99990;
@@ -1308,7 +1312,7 @@ document.addEventListener('DOMContentLoaded', () => {
     widget.innerHTML = `
         <div id="ohc-floating-help-header">
             <h3>Help Center</h3>
-            <button id="ohc-floating-help-close" aria-label="Close">
+            <button id="ohc-floating-help-close" aria-label="Close" data-tooltip="Close this widget">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
             </button>
         </div>
@@ -1481,15 +1485,18 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     document.addEventListener('mouseover', (e) => {
-        const target = e.target.closest('[id]');
-        if (target && target.id && window.OHC_TOOLTIPS[target.id]) {
-            showTooltip(e, window.OHC_TOOLTIPS[target.id]);
+        const target = e.target.closest('[data-tooltip], [id]');
+        if (target) {
+            const text = (window.OHC_TOOLTIPS && target.id && window.OHC_TOOLTIPS[target.id]) || target.getAttribute('data-tooltip');
+            if (text) {
+                showTooltip(e, text);
+            }
         }
     });
 
     document.addEventListener('mouseout', (e) => {
-        const target = e.target.closest('[id]');
-        if (target && target.id && window.OHC_TOOLTIPS[target.id]) {
+        const target = e.target.closest('[data-tooltip], [id]');
+        if (target) {
             hideTooltip();
         }
     });

--- a/src/ui/tauri/src/ui/tooltip-registry.html
+++ b/src/ui/tauri/src/ui/tooltip-registry.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OHC Tooltip Registry</title>
+    <style>
+        body { font-family: "Outfit", -apple-system, sans-serif; background-color: #f5f5f7; display: flex; justify-content: center; padding: 40px; margin: 0; }
+        .container { background: rgba(255, 255, 255, 0.7); backdrop-filter: blur(30px) saturate(210%); -webkit-backdrop-filter: blur(30px) saturate(210%); border: 1px solid rgba(255, 255, 255, 0.5); border-radius: 16px; padding: 30px; width: 100%; max-width: 600px; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1); }
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { text-align: left; padding: 12px; border-bottom: 1px solid rgba(0,0,0,0.1); font-size: 14px; }
+        input { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; font-family: inherit; font-size: 14px; }
+        button { padding: 8px 16px; background-color: #0066FF; color: white; border: none; border-radius: 6px; cursor: pointer; font-family: inherit; font-weight: 500; font-size: 14px; transition: background-color 0.2s; }
+        button:hover { background-color: #0055cc; }
+        h1 { margin-top: 0; font-size: 24px; color: #1d1d1f; }
+        p { color: #86868b; font-size: 14px; margin-bottom: 20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Tooltip Registry</h1>
+        <p>Update dynamic tooltips. Agents can modify these to assist non-technical users.</p>
+        <table>
+            <thead><tr><th>Element ID</th><th>Tooltip Text</th><th>Action</th></tr></thead>
+            <tbody id="registry-body"></tbody>
+        </table>
+        <div style="margin-top: 20px;">
+            <input id="new-id" placeholder="New Element ID" style="margin-bottom: 10px;" />
+            <input id="new-text" placeholder="Tooltip Text" style="margin-bottom: 10px;" />
+            <button id="add-btn">Add Tooltip</button>
+        </div>
+    </div>
+    <script>
+        async function loadTooltips() {
+            try {
+                const res = await fetch('/api/tooltips');
+                if (!res.ok) return;
+                const data = await res.json();
+                const tbody = document.getElementById('registry-body');
+                tbody.innerHTML = '';
+                for (const [id, text] of Object.entries(data)) {
+                    tbody.innerHTML += `<tr>
+                        <td>${id}</td>
+                        <td><input type="text" id="input-${id}" value="${text.replace(/"/g, '&quot;')}" /></td>
+                        <td><button onclick="update('${id}')">Save</button></td>
+                    </tr>`;
+                }
+            } catch (e) {
+                console.error('Failed to load tooltips', e);
+            }
+        }
+        window.update = async function(id) {
+            const text = document.getElementById('input-' + id).value;
+            try {
+                await fetch('/api/tooltips', {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ id, text })
+                });
+                loadTooltips();
+            } catch (e) {
+                console.error('Failed to update tooltip', e);
+            }
+        };
+        document.getElementById('add-btn').onclick = async () => {
+            const id = document.getElementById('new-id').value;
+            const text = document.getElementById('new-text').value;
+            if (!id || !text) return;
+            try {
+                await fetch('/api/tooltips', {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ id, text })
+                });
+                document.getElementById('new-id').value = '';
+                document.getElementById('new-text').value = '';
+                loadTooltips();
+            } catch (e) {
+                console.error('Failed to add tooltip', e);
+            }
+        };
+        loadTooltips();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
- Implemented the Tooltip Registry page that fetches and updates tooltips.
- Added comprehensive unit tests for `docs.rs` API endpoints.
- Fixed the Tooltips UI component bug so it correctly falls back to `data-tooltip` attribute if the ID is not available in the registry.
- Applied "Premium macOS Translucent Glass" styling to the interactive Walkthrough bubble.
- Added E2E tests for the Tooltip Registry.

---
*PR created automatically by Jules for task [14310820359803294225](https://jules.google.com/task/14310820359803294225) started by @ql-owo-lp*