### PR TITLE
Enhance UnifiedAgentFeed mobile UX (375px/44px constraints)

### DIFF
--- a/src/e2e/agent_feed.spec.ts
+++ b/src/e2e/agent_feed.spec.ts
@@ -41,6 +41,9 @@ test.describe('Agentic Unified Intake & Action Feed', () => {
       // Click approve
       const approveBtn = feedCard.getByTestId('feed-approve-btn');
       await expect(approveBtn).toBeVisible();
+      const box = await approveBtn.boundingBox();
+      expect(box?.height).toBeGreaterThanOrEqual(44);
+      expect(box?.width).toBeGreaterThanOrEqual(44);
       await approveBtn.click();
     }
   });

--- a/src/e2e/unified_agent_feed_interaction.spec.ts
+++ b/src/e2e/unified_agent_feed_interaction.spec.ts
@@ -24,6 +24,11 @@ test.describe('Unified Agent Feed Interactive Flow', () => {
     // In case there are no items to approve, we will skip the rest of the assertions safely.
     // In a real E2E environment we would seed this, but this guarantees the script runs.
     if (await approveBtn.isVisible()) {
+        // Verify touch target size
+        const box = await approveBtn.boundingBox();
+        expect(box?.height).toBeGreaterThanOrEqual(44);
+        expect(box?.width).toBeGreaterThanOrEqual(44);
+
         // 2. Expand card to see details
         await editBtn.click();
         const detailsPre = page.locator('pre').first();
@@ -54,6 +59,10 @@ test.describe('Unified Agent Feed Interactive Flow', () => {
     const isVisible = await approveBtn.isVisible({ timeout: 15000 }).catch(() => false);
 
     if (isVisible) {
+      const box = await approveBtn.boundingBox();
+      expect(box?.height).toBeGreaterThanOrEqual(44);
+      expect(box?.width).toBeGreaterThanOrEqual(44);
+
       // Go offline
       await context.setOffline(true);
       await page.evaluate(() => window.dispatchEvent(new Event('offline')));
@@ -86,6 +95,9 @@ test.describe('Unified Agent Feed Interactive Flow', () => {
     const card = page.getByTestId('agent-feed-card').first();
     if (await card.isVisible()) {
         const approveBtn = card.locator('button', { hasText: 'Approve' });
+        const box = await approveBtn.boundingBox();
+        expect(box?.height).toBeGreaterThanOrEqual(44);
+        expect(box?.width).toBeGreaterThanOrEqual(44);
         await approveBtn.click();
         await expect(card).not.toBeVisible({ timeout: 5000 });
     }
@@ -99,6 +111,9 @@ test.describe('Unified Agent Feed Interactive Flow', () => {
     const card = page.getByTestId('agent-feed-card').first();
     if (await card.isVisible()) {
         const dismissBtn = card.locator('button', { hasText: 'Dismiss' });
+        const box = await dismissBtn.boundingBox();
+        expect(box?.height).toBeGreaterThanOrEqual(44);
+        expect(box?.width).toBeGreaterThanOrEqual(44);
         await dismissBtn.click();
         await expect(card).not.toBeVisible({ timeout: 5000 });
     }

--- a/src/ui/next/src/app/components/WorkTriageFeed.tsx
+++ b/src/ui/next/src/app/components/WorkTriageFeed.tsx
@@ -62,7 +62,7 @@ export function WorkTriageFeed({ items, loading, error, onDecision }: { items: T
   }
 
   return (
-    <div className="w-full max-w-[375px] sm:max-w-full mx-auto" data-testid="work-triage-feed">
+    <div className="w-full max-w-[375px] sm:max-w-full mx-auto overflow-hidden" data-testid="work-triage-feed">
       {items.filter(item => item.source === "Proactive Context Agent").map((item) => (
         <div key={item.id} className="mb-6 p-6 rounded-[16px] glassmorphism border border-orange-400/50 dark:border-orange-500/30 bg-orange-50/50 dark:bg-orange-900/10 shadow-lg relative overflow-hidden" data-testid={`triage-card-${item.id}`}>
           <div className="absolute top-0 left-0 w-1 h-full bg-orange-500"></div>

--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -439,7 +439,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
   }
 
   return (
-    <section className="mb-6 w-full max-w-full overflow-hidden sm:max-w-none" aria-label="Unified Agent Feed">
+    <section className="mb-6 w-full max-w-[375px] sm:max-w-none mx-auto overflow-hidden" aria-label="Unified Agent Feed">
       <h2 className="text-2xl font-bold font-outfit text-[#1D1D1F] dark:text-[#F5F5F7] mb-2 hidden md:block">Action Center</h2>
       {isOffline && (
         <div className="mb-4 w-full p-2 glassmorphism rounded-[8px] bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 text-center text-sm font-semibold flex items-center justify-center gap-2">


### PR DESCRIPTION
Resolves #28345

**Product-use evidence:**
- **Persona**: Non-technical owner using the Unified Agent Feed on a mobile device (375px screen).
- **CUJ Gap**: The feed components didn't strictly guarantee they wouldn't overflow horizontally on 375px screens, and testing touch targets for the 1-tap "Approve" action needed programmatic 44x44 bounding box assurances.
- **Fix Rationale**: A real owner needs to use the app entirely on mobile, without side-scrolling, and buttons must be large enough to hit with a thumb consistently (44x44 minimum).
- **Post-fix UI flow**: Navigating to the Action Center, reading proposals, and hitting the Approve/Dismiss buttons. 

**Changes Made:**
1. Applied `max-w-[375px] sm:max-w-none mx-auto overflow-hidden` wrapper styles to `UnifiedAgentFeed.tsx` and `WorkTriageFeed.tsx` to strictly prevent horizontal overflow issues on small devices.
2. Verified all buttons in the UI logic correctly utilize `min-h-[44px] min-w-[44px]`.
3. Updated `agent_feed.spec.ts` and `unified_agent_feed_interaction.spec.ts` to include explicit programmatic bounding-box layout assertions. E2E tests now directly fail if interactive elements do not meet the 44x44px touch target constraints.

**Interaction Audit Table:**
| Element | Designed Purpose | Observed Result (Pre-Fix) | Post-Fix |
|---------|-----------------|--------------------------|----------|
| `approve-proposal` button | 1-Tap approve agent feed | Layout testing not automated for size | Programmatic E2E asserts 44x44px min size. |
| `UnifiedAgentFeed` shell | Contain items on mobile | Potential overflow | Strictly capped to 375px with hidden overflow via tailwind. |
| `WorkTriageFeed` container | Contain triage items | Potential overflow | Strictly capped to 375px with hidden overflow via tailwind. |

---
*PR created automatically by Jules for task [18109136397384398263](https://jules.google.com/task/18109136397384398263) started by @ql-owo-lp*