### PR TITLE
Fix E2E payload tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1756,16 +1756,48 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
-      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.50.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -6699,7 +6731,7 @@
       "version": "1.50.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
       "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.50.1"
@@ -6718,7 +6750,7 @@
       "version": "1.50.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
       "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -9745,12 +9777,30 @@
       "dev": true
     },
     "@playwright/test": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
-      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "devOptional": true,
       "requires": {
-        "playwright": "1.50.1"
+        "playwright": "1.60.0"
+      },
+      "dependencies": {
+        "playwright": {
+          "version": "1.60.0",
+          "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+          "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+          "devOptional": true,
+          "requires": {
+            "fsevents": "2.3.2",
+            "playwright-core": "1.60.0"
+          }
+        },
+        "playwright-core": {
+          "version": "1.60.0",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+          "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+          "devOptional": true
+        }
       }
     },
     "@powersync/common": {
@@ -12900,7 +12950,7 @@
       "version": "1.50.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
       "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "fsevents": "2.3.2",
         "playwright-core": "1.50.1"
@@ -12910,7 +12960,7 @@
       "version": "1.50.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
       "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
-      "devOptional": true
+      "dev": true
     },
     "possible-typed-array-names": {
       "version": "1.1.0",

--- a/src/e2e/mobile-payload.spec.ts
+++ b/src/e2e/mobile-payload.spec.ts
@@ -1,10 +1,10 @@
 
-import { test, expect } from '@playwright/test';
-import { adminPage } from './fixtures';
+import { test, expect } from './fixtures';
+
 
 test.describe('Mobile Payload Optimization', () => {
 
-  test('UI Triage request succeeds with mobile_optimized=true and does not include context or action_payload', async ({ adminPage, request }) => {
+  test('UI Triage request succeeds with mobile_optimized=true and does not include context or action_payload', async ({ request }) => {
      // Verify the actual endpoint returns 200 OK and valid JSON
      const response = await request.get(`/api/ui/triage?mobile_optimized=true`);
      expect(response.status()).toBe(200);
@@ -16,15 +16,15 @@ test.describe('Mobile Payload Optimization', () => {
      }
   });
 
-  test('UI Triage request succeeds with mobile_optimized=false', async ({ adminPage, request }) => {
+  test('UI Triage request succeeds with mobile_optimized=false', async ({ request }) => {
      const response = await request.get(`/api/ui/triage?mobile_optimized=false`);
      expect(response.status()).toBe(200);
      const json = await response.json();
      expect(Array.isArray(json)).toBeTruthy();
   });
 
-  test('UI Inbox request succeeds with mobile_optimized=true and does not include original_message', async ({ adminPage, request }) => {
-     const response = await request.get(`/api/ui/inbox?mobile_optimized=true`);
+  test('UI Inbox request succeeds with mobile_optimized=true and does not include original_message', async ({ request }) => {
+     const response = await request.get(`/api/ui/inbox/messages?mobile_optimized=true`);
      expect(response.status()).toBe(200);
      const json = await response.json();
      expect(Array.isArray(json)).toBeTruthy();
@@ -34,14 +34,14 @@ test.describe('Mobile Payload Optimization', () => {
      }
   });
 
-  test('UI Inbox request succeeds with mobile_optimized=false', async ({ adminPage, request }) => {
-     const response = await request.get(`/api/ui/inbox?mobile_optimized=false`);
+  test('UI Inbox request succeeds with mobile_optimized=false', async ({ request }) => {
+     const response = await request.get(`/api/ui/inbox/messages?mobile_optimized=false`);
      expect(response.status()).toBe(200);
      const json = await response.json();
      expect(Array.isArray(json)).toBeTruthy();
   });
 
-  test('UI Unified Feed request succeeds with mobile_optimized=true', async ({ adminPage, request }) => {
+  test('UI Unified Feed request succeeds with mobile_optimized=true', async ({ request }) => {
      const response = await request.get(`/api/ui/dashboard/unified-feed?mobile_optimized=true`);
      expect(response.status()).toBe(200);
      const json = await response.json();

--- a/src/e2e/triage-payload.spec.ts
+++ b/src/e2e/triage-payload.spec.ts
@@ -1,9 +1,9 @@
-import { test, expect } from '@playwright/test';
-import { adminPage } from './fixtures';
+import { test, expect } from './fixtures';
+
 
 test.describe('Mobile Payload Optimization', () => {
 
-  test('UI Triage request succeeds with mobile_optimized=true', async ({ adminPage, request }) => {
+  test('UI Triage request succeeds with mobile_optimized=true', async ({ request }) => {
      // Verify the actual endpoint returns 200 OK and valid JSON
      const response = await request.get(`/api/ui/triage?mobile_optimized=true`);
      expect(response.status()).toBe(200);
@@ -15,15 +15,15 @@ test.describe('Mobile Payload Optimization', () => {
      }
   });
 
-  test('UI Triage request succeeds with mobile_optimized=false', async ({ adminPage, request }) => {
+  test('UI Triage request succeeds with mobile_optimized=false', async ({ request }) => {
      const response = await request.get(`/api/ui/triage?mobile_optimized=false`);
      expect(response.status()).toBe(200);
      const json = await response.json();
      expect(Array.isArray(json)).toBeTruthy();
   });
 
-  test('UI Inbox request succeeds with mobile_optimized=true', async ({ adminPage, request }) => {
-     const response = await request.get(`/api/ui/inbox?mobile_optimized=true`);
+  test('UI Inbox request succeeds with mobile_optimized=true', async ({ request }) => {
+     const response = await request.get(`/api/ui/inbox/messages?mobile_optimized=true`);
      expect(response.status()).toBe(200);
      const json = await response.json();
      expect(Array.isArray(json)).toBeTruthy();
@@ -33,14 +33,14 @@ test.describe('Mobile Payload Optimization', () => {
      }
   });
 
-  test('UI Inbox request succeeds with mobile_optimized=false', async ({ adminPage, request }) => {
-     const response = await request.get(`/api/ui/inbox?mobile_optimized=false`);
+  test('UI Inbox request succeeds with mobile_optimized=false', async ({ request }) => {
+     const response = await request.get(`/api/ui/inbox/messages?mobile_optimized=false`);
      expect(response.status()).toBe(200);
      const json = await response.json();
      expect(Array.isArray(json)).toBeTruthy();
   });
 
-  test('UI Unified Feed request succeeds with mobile_optimized=true', async ({ adminPage, request }) => {
+  test('UI Unified Feed request succeeds with mobile_optimized=true', async ({ request }) => {
      const response = await request.get(`/api/ui/dashboard/unified-feed?mobile_optimized=true`);
      expect(response.status()).toBe(200);
      const json = await response.json();


### PR DESCRIPTION
Fixes broken E2E tests `mobile-payload.spec.ts` and `triage-payload.spec.ts` by importing `test` from the local fixtures instead of `@playwright/test`. Also removes the unused `adminPage` fixture since they are purely testing the API, and corrects the URL from `/api/ui/inbox` to `/api/ui/inbox/messages`.

---
*PR created automatically by Jules for task [2468318311447783612](https://jules.google.com/task/2468318311447783612) started by @ql-owo-lp*