### PR TITLE
🚀 Nova: [Share & Save Viral Loop in Checkout]

### DIFF
--- a/src/e2e/share-and-save.spec.ts
+++ b/src/e2e/share-and-save.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { adminPage } from './fixtures';
+
+test.describe('Share & Save Viral Loop in Checkout', () => {
+  test('User sees Share & Save widget, shares, and gets discount', async ({ page }) => {
+    // 1. Navigate to the checkout page directly
+    await page.goto('/checkout');
+    await page.waitForLoadState('networkidle');
+
+    // 2. Verify the Share & Save widget is visible
+    const widget = page.getByTestId('share-and-save-widget');
+    await expect(widget).toBeVisible();
+    await expect(widget.getByText('Share & Save 10%')).toBeVisible();
+
+    // 3. Verify the initial total ($45.00)
+    await expect(page.getByText('$45.00').first()).toBeVisible();
+
+    // 4. Click the "Share on X" button
+    // Intercept window.open to prevent actually opening a new tab in the test
+    await page.evaluate(() => {
+      window.open = () => null;
+    });
+    await widget.getByTestId('share-x-btn').click();
+
+    // 5. Verify the success state is shown
+    const successWidget = page.getByTestId('share-and-save-success');
+    await expect(successWidget).toBeVisible();
+    await expect(successWidget.getByText('Discount Applied!')).toBeVisible();
+
+    // 6. Verify the total is updated with the 10% discount ($45.00 * 0.9 = $40.50)
+    await expect(page.getByText('$40.50').first()).toBeVisible();
+  });
+});

--- a/src/ui/next/next-env.d.ts
+++ b/src/ui/next/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/ui/next/src/app/checkout/page.tsx
+++ b/src/ui/next/src/app/checkout/page.tsx
@@ -6,6 +6,7 @@ import { WithTooltip } from "../../components/TooltipRegistry";
 import { PoweredByOHC } from "../components/PoweredByOHC";
 import { OneTapReferral } from "../components/OneTapReferral";
 import { PostPurchaseShareWidget } from "../components/PostPurchaseShareWidget";
+import { ShareAndSaveWidget } from "../components/ShareAndSaveWidget";
 
 
 function CheckoutContent() {
@@ -20,6 +21,7 @@ function CheckoutContent() {
   const [tenant, setTenant] = useState("my-store");
   const [checkoutStatus, setCheckoutStatus] = useState("");
   const [isMercadoPagoProcessing, setIsMercadoPagoProcessing] = useState(false);
+  const [shareDiscountApplied, setShareDiscountApplied] = useState(false);
 
   useEffect(() => {
     if (typeof localStorage !== "undefined") {
@@ -296,11 +298,17 @@ function CheckoutContent() {
             </p>
           </div>
 
+          <ShareAndSaveWidget
+            tenantId={tenant}
+            discountPercentage={10}
+            onShareComplete={() => setShareDiscountApplied(true)}
+          />
+
           {deliveryFee !== null && (
              <div className="flex justify-between items-center pt-2 border-t border-gray-100">
                <span className="font-semibold text-gray-700">Total with Delivery</span>
                <span className="text-xl font-bold font-outfit text-gray-900">
-                 ${((45.00 + deliveryFee) * (useLoyaltyPoints && loyaltyDiscount ? (1 - loyaltyDiscount) : 1)).toFixed(2)}
+                 ${(((45.00 + deliveryFee) * (useLoyaltyPoints && loyaltyDiscount ? (1 - loyaltyDiscount) : 1)) * (shareDiscountApplied ? 0.9 : 1)).toFixed(2)}
                </span>
              </div>
           )}
@@ -308,7 +316,7 @@ function CheckoutContent() {
              <div className="flex justify-between items-center pt-2 border-t border-gray-100">
                <span className="font-semibold text-gray-700">Total</span>
                <span className="text-xl font-bold font-outfit text-gray-900">
-                 ${(45.00 * (useLoyaltyPoints && loyaltyDiscount ? (1 - loyaltyDiscount) : 1)).toFixed(2)}
+                 ${((45.00 * (useLoyaltyPoints && loyaltyDiscount ? (1 - loyaltyDiscount) : 1)) * (shareDiscountApplied ? 0.9 : 1)).toFixed(2)}
                </span>
              </div>
           )}

--- a/src/ui/next/src/app/components/ShareAndSaveWidget.test.tsx
+++ b/src/ui/next/src/app/components/ShareAndSaveWidget.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ShareAndSaveWidget } from './ShareAndSaveWidget';
+import React from 'react';
+
+Object.assign(window, {
+  open: vi.fn(),
+});
+
+describe('ShareAndSaveWidget', () => {
+  const mockOnShareComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders correctly with discount percentage', () => {
+    render(<ShareAndSaveWidget tenantId="test-tenant" discountPercentage={15} onShareComplete={mockOnShareComplete} />);
+
+    expect(screen.getByText('Share & Save 15%')).toBeDefined();
+    expect(screen.getByText(/Share our store with your friends/)).toBeDefined();
+    expect(screen.getByTestId('share-x-btn')).toBeDefined();
+    expect(screen.getByTestId('share-wa-btn')).toBeDefined();
+  });
+
+  it('handles X (Twitter) share and applies discount optimistically', () => {
+    render(<ShareAndSaveWidget tenantId="test-tenant" discountPercentage={10} onShareComplete={mockOnShareComplete} />);
+
+    const xButton = screen.getByTestId('share-x-btn');
+    fireEvent.click(xButton);
+
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining('twitter.com/intent/tweet'),
+      '_blank'
+    );
+    expect(mockOnShareComplete).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('share-and-save-success')).toBeDefined();
+    expect(screen.getByText('Discount Applied!')).toBeDefined();
+  });
+
+  it('handles WhatsApp share and applies discount optimistically', () => {
+    render(<ShareAndSaveWidget tenantId="test-tenant" discountPercentage={20} onShareComplete={mockOnShareComplete} />);
+
+    const waButton = screen.getByTestId('share-wa-btn');
+    fireEvent.click(waButton);
+
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining('wa.me/'),
+      '_blank'
+    );
+    expect(mockOnShareComplete).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('share-and-save-success')).toBeDefined();
+    expect(screen.getByText(/20% discount/)).toBeDefined();
+  });
+});

--- a/src/ui/next/src/app/components/ShareAndSaveWidget.tsx
+++ b/src/ui/next/src/app/components/ShareAndSaveWidget.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import React, { useState } from 'react';
+
+interface ShareAndSaveWidgetProps {
+  tenantId: string;
+  discountPercentage: number;
+  onShareComplete: () => void;
+}
+
+export function ShareAndSaveWidget({ tenantId, discountPercentage, onShareComplete }: ShareAndSaveWidgetProps) {
+  const [isShared, setIsShared] = useState(false);
+  const referralLink = `${typeof window !== 'undefined' ? window.location.origin : ''}/onboarding?ref=${tenantId}&source=checkout_share_save`;
+  const shareText = `Check out this awesome store! ${referralLink}`;
+
+  const handleShare = (platform: 'twitter' | 'whatsapp') => {
+    let shareUrl = '';
+    if (platform === 'twitter') {
+      shareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`;
+    } else if (platform === 'whatsapp') {
+      shareUrl = `https://wa.me/?text=${encodeURIComponent(shareText)}`;
+    }
+
+    window.open(shareUrl, '_blank');
+
+    // Optimistically apply discount after user clicks share
+    setIsShared(true);
+    onShareComplete();
+  };
+
+  if (isShared) {
+    return (
+      <div className="mb-6 p-4 rounded-xl glassmorphism border border-green-200/50 dark:border-green-800/30 bg-gradient-to-r from-green-50/80 to-emerald-50/80 dark:from-green-900/20 dark:to-emerald-900/20 shadow-sm" data-testid="share-and-save-success">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 bg-green-100 dark:bg-green-800/50 rounded-full flex items-center justify-center shrink-0">
+            <span className="text-green-600 dark:text-green-400 font-bold text-lg">✓</span>
+          </div>
+          <div>
+            <h3 className="text-sm font-bold font-outfit text-gray-900 dark:text-white">Discount Applied!</h3>
+            <p className="text-xs text-gray-600 dark:text-gray-300">
+              Thanks for sharing. Your {discountPercentage}% discount has been added to your order.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6 p-5 rounded-xl glassmorphism border border-indigo-200/60 dark:border-indigo-800/60 bg-white/40 dark:bg-black/20 backdrop-blur-md relative overflow-hidden group" data-testid="share-and-save-widget">
+      <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4">
+        <div className="w-12 h-12 bg-indigo-100 dark:bg-indigo-900/50 rounded-full flex items-center justify-center shrink-0 shadow-sm border border-indigo-200 dark:border-indigo-800 group-hover:scale-110 transition-transform">
+          <span className="text-xl">🎁</span>
+        </div>
+        <div className="flex-1 text-center sm:text-left">
+          <h3 className="text-base font-bold font-outfit text-gray-900 dark:text-white mb-1">
+            Share & Save {discountPercentage}%
+          </h3>
+          <p className="text-xs text-gray-600 dark:text-gray-300 mb-3">
+            Share our store with your friends on social media to instantly unlock a {discountPercentage}% discount on this order!
+          </p>
+          <div className="flex flex-col sm:flex-row gap-2">
+            <button
+              onClick={() => handleShare('twitter')}
+              className="flex-1 py-2 px-3 bg-black hover:bg-gray-800 text-white rounded-lg font-bold text-xs shadow-sm transition-all flex items-center justify-center gap-2"
+              data-testid="share-x-btn"
+            >
+              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.008 5.94H5.078z"/></svg>
+              Share on X
+            </button>
+            <button
+              onClick={() => handleShare('whatsapp')}
+              className="flex-1 py-2 px-3 bg-[#25D366] hover:bg-[#1ebd5a] text-white rounded-lg font-bold text-xs shadow-sm transition-all flex items-center justify-center gap-2"
+              data-testid="share-wa-btn"
+            >
+              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51a12.8 12.8 0 0 0-.57-.01c-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413Z"/></svg>
+              WhatsApp
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
**Persona & Context:** Maya (Home Baker) wants to increase her organic reach and incentivize sales.

**Observed UX Gap:** The checkout page has a post-purchase share widget, but offering a discount *before* purchase is a much stronger driver for both immediate conversion and viral acquisition. 

**Solution:**
Implemented a "Share & Save" pre-checkout viral loop widget.
1. Created `ShareAndSaveWidget` that prompts users to share the store on X or WhatsApp.
2. Integrated the widget into the checkout page.
3. Optimistically applies a 10% discount to the order total when the user shares.
4. Includes full unit test coverage and an E2E Playwright test proving the end-to-end flow.

This implements a high-priority product-led growth (PLG) feature directly addressing the mission to acquire new users and turn them into advocates.

---
*PR created automatically by Jules for task [17124109380317643109](https://jules.google.com/task/17124109380317643109) started by @ql-owo-lp*