### PR TITLE
fix(db): add missing `department_dead_letters` sqlite schema

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -981,6 +981,16 @@ impl DB {
                         _sync_status TEXT DEFAULT 'pending',
                         version INTEGER DEFAULT 1
                     );
+                    CREATE TABLE IF NOT EXISTS department_dead_letters (
+                        id TEXT PRIMARY KEY,
+                        tenant_id TEXT NOT NULL,
+                        event_type TEXT NOT NULL,
+                        department TEXT NOT NULL,
+                        payload TEXT NOT NULL,
+                        error_message TEXT NOT NULL,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    );
+
                     CREATE TABLE IF NOT EXISTS department_tasks (
                         id TEXT PRIMARY KEY,
                         tenant_id TEXT NOT NULL,


### PR DESCRIPTION
Fixes an issue where running local workflows with SQLite caused crashes due to the missing `department_dead_letters` table.

---
*PR created automatically by Jules for task [17262418011005624201](https://jules.google.com/task/17262418011005624201) started by @ql-owo-lp*