### PR TITLE
Add Hybrid Landing E2E tests and Referral UI Styling

### DIFF
--- a/src/e2e/hybrid_landing_loop.spec.ts
+++ b/src/e2e/hybrid_landing_loop.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Hybrid Landing Page E2E', () => {
+  test('User navigates to Hybrid Landing page and starts cloud trial', async ({ page }) => {
+    await page.goto('/hybrid-landing');
+
+    // Verify main header
+    await expect(page.locator('h1')).toHaveText(/Your Business.\s*Your AI. Your Rules./);
+
+    // Verify cards content
+    await expect(page.locator('text=Local Sovereignty')).toBeVisible();
+    await expect(page.locator('text=Zero Data Leakage:')).toBeVisible();
+
+    await expect(page.locator('text=Cloud Convenience')).toBeVisible();
+    await expect(page.locator('text=Team Collaboration:')).toBeVisible();
+
+    // Verify buttons
+    await expect(page.locator('button:has-text("Download Desktop")')).toBeVisible();
+    const startWebTrial = page.locator('a:has-text("Start Web Trial")');
+    await expect(startWebTrial).toBeVisible();
+
+    // Navigate to dashboard
+    await startWebTrial.click();
+    await expect(page).toHaveURL(/.*\/dashboard|.*\/onboarding/);
+  });
+});

--- a/src/ui/next/src/app/hybrid-landing/page.test.tsx
+++ b/src/ui/next/src/app/hybrid-landing/page.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import HybridLandingPage from './page';
+
+describe('HybridLandingPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the hybrid landing page with two main cards', () => {
+    render(<HybridLandingPage />);
+
+    // Check main headings
+    expect(screen.getByText('OHC Hybrid OS')).toBeDefined();
+
+    // Check card 1: Local Sovereignty
+    expect(screen.getByText('Local Sovereignty')).toBeDefined();
+    expect(screen.getByText(/Zero Data Leakage/i)).toBeDefined();
+    expect(screen.getByText(/Air-Gapped Autonomy/i)).toBeDefined();
+    expect(screen.getByText(/Self-Hosted LLMs/i)).toBeDefined();
+
+    // Check card 2: Cloud Convenience
+    expect(screen.getByText('Cloud Convenience')).toBeDefined();
+    expect(screen.getByText(/Team Collaboration/i)).toBeDefined();
+    expect(screen.getByText(/Anywhere Access/i)).toBeDefined();
+    expect(screen.getByText(/Fully Managed/i)).toBeDefined();
+  });
+
+  it('downloads desktop app when CTA is clicked', async () => {
+    // The handleDownload function calls window.alert
+    const mockAlert = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+    render(<HybridLandingPage />);
+
+    const downloadButton = screen.getByText('Download Desktop');
+    expect(downloadButton).toBeDefined();
+
+    // Click the button
+    fireEvent.click(downloadButton);
+
+    // Verify downloading state
+    expect(screen.getByText('Downloading...')).toBeDefined();
+
+    // Wait for async operations
+    await vi.waitFor(() => {
+        expect(mockAlert).toHaveBeenCalledWith("Desktop App Download Started! (Simulation)");
+    }, { timeout: 2000 });
+
+    // Cleanup mocks
+    mockAlert.mockRestore();
+  });
+
+  it('navigates to dashboard for cloud trial', () => {
+    render(<HybridLandingPage />);
+
+    const startTrialLink = screen.getByText('Start Web Trial');
+    expect(startTrialLink).toBeDefined();
+    // Since it's a Next.js Link component, we check its href attribute
+    expect(startTrialLink.getAttribute('href')).toBe('/dashboard');
+  });
+});

--- a/src/ui/next/src/app/referrals/page.tsx
+++ b/src/ui/next/src/app/referrals/page.tsx
@@ -271,6 +271,14 @@ export default function ReferralsPage() {
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@500;600;700;800&display=swap');
         .font-inter { font-family: 'Inter', sans-serif; }
         .font-outfit { font-family: 'Outfit', sans-serif; }
+        .ohc-growth-card {
+            backdrop-filter: blur(20px) saturate(200%);
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            font-family: 'Outfit', 'Inter', sans-serif;
+            border-radius: 12px;
+            padding: 20px;
+        }
       `}} />
     </div>
   );


### PR DESCRIPTION
Implement tests for the newly added hybrid landing page to test functionality surrounding Local-First vs Cloud-Native acquisition flows, and enhance the referral page by implementing `.ohc-growth-card` glassmorphism specifically for the Cloud Bridge referral loop as requested in the growth audit report.

---
*PR created automatically by Jules for task [6871235874857864385](https://jules.google.com/task/6871235874857864385) started by @ql-owo-lp*