### PR TITLE
fix(booking): fix flaky dynamic pricing test and resolve server compilation errors

### DIFF
--- a/src/server/api/pos.rs
+++ b/src/server/api/pos.rs
@@ -55,7 +55,7 @@ async fn sync_offline_handler(
         pool: hub.pool.clone(),
         store: DbStore::Postgres,
     });
-    let service = MyPosService::new(db);
+    let service = MyPosService::new(db, None);
 
     let mut transactions = Vec::new();
     for mutation in payload.mutations {
@@ -120,9 +120,11 @@ async fn start_session_handler(
         pool: hub.pool.clone(),
         store: DbStore::Postgres,
     });
-    let service = MyPosService::new(db);
+    let service = MyPosService::new(db, None);
 
     let req = StartTerminalSessionRequest {
+        product_id: None,
+        quantity: None,
         tenant_id: tenant_id.clone(),
         device_id: payload.device_id,
     };
@@ -169,7 +171,7 @@ async fn update_session_status_handler(
         pool: hub.pool.clone(),
         store: DbStore::Postgres,
     });
-    let service = MyPosService::new(db);
+    let service = MyPosService::new(db, None);
 
     let req = UpdateTerminalSessionStatusRequest {
         tenant_id: tenant_id.clone(),
@@ -212,7 +214,7 @@ async fn end_session_handler(
         pool: hub.pool.clone(),
         store: DbStore::Postgres,
     });
-    let service = MyPosService::new(db);
+    let service = MyPosService::new(db, None);
 
     let req = EndTerminalSessionRequest {
         tenant_id: tenant_id.clone(),

--- a/src/server/services/booking.rs
+++ b/src/server/services/booking.rs
@@ -321,7 +321,7 @@ mod tests {
         let (time_slot, stripe_link) = result.unwrap();
 
         assert_eq!(quote.status, "approved");
-        assert_eq!(quote.amount, 20000);
+        if time_slot.start_time.hour() >= 17 && time_slot.start_time.hour() <= 20 { assert_eq!(quote.amount, 23000); } else { assert_eq!(quote.amount, 20000); }
         assert!(stripe_link.starts_with("https://checkout.stripe.com/pay/cs_test_"));
         assert!(time_slot.start_time < time_slot.end_time);
     }

--- a/src/server/services/sync/service.rs
+++ b/src/server/services/sync/service.rs
@@ -154,7 +154,7 @@ impl SyncService for MySyncService {
                          tracing::error!("failed to insert sync_event via PowerSync: {}", e);
                     } else {
                         // Dispatch event directly to orchestration if it's Operations Agent
-                        let event = crate::orchestration::departments::types::DepartmentEvent {
+                        let _event = crate::orchestration::departments::types::DepartmentEvent {
                             id: event_id,
                             tenant_id: tenant_id.to_string(),
                             event_type: format!("SyncEvent:{}", action_type),


### PR DESCRIPTION
This PR resolves several issues uncovered during test execution and build phases.

First, it patches a non-deterministic flaky test in `test_approve_quote` within `src/server/services/booking.rs`. The `approve_quote` logic naturally applies a 15% surge price between the hours of 17:00 and 20:00. The test blindly asserted an amount of 20000, which failed if the time fell within that window. The assertion has been dynamically updated based on the `start_time` of the booked slot.

Second, multiple compilation errors in the POS routing logic (`src/server/api/pos.rs`) were fixed. Calls to `MyPosService::new(db)` were missing the `redis_client` parameter. `StartTerminalSessionRequest` missing required enum/option fields were also properly seeded. 

Lastly, a minor unused variable warning `event` was suppressed via an underscore prefix in `src/server/services/sync/service.rs` to ensure an entirely clean compilation step.

---
*PR created automatically by Jules for task [17644987519385721557](https://jules.google.com/task/17644987519385721557) started by @wbbsuper*