### PR TITLE
fix: use tenants table instead of organizations and correct id column

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -585,7 +585,7 @@ mod department_tier_usage_tests {
         // Start a transaction so we can rollback and not pollute the DB
         let mut tx = pool.begin().await.unwrap();
 
-        sqlx::query("INSERT INTO organizations (id, name, plan_tier) VALUES ($1, 'Test Tenant', 'Free') ON CONFLICT DO NOTHING")
+        sqlx::query("INSERT INTO tenants (id, name, plan_tier) VALUES ($1, 'Test Tenant', 'Free') ON CONFLICT DO NOTHING")
             .bind(&tenant_id)
             .execute(&mut *tx)
             .await
@@ -616,7 +616,7 @@ mod department_tier_usage_tests {
 
         // Teardown
         sqlx::query("DELETE FROM agent_departments WHERE tenant_id = $1").bind(&tenant_id).execute(&pool).await.unwrap();
-        sqlx::query("DELETE FROM organizations WHERE id = $1").bind(&tenant_id).execute(&pool).await.unwrap();
+        sqlx::query("DELETE FROM tenants WHERE id = $1").bind(&tenant_id).execute(&pool).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/server/api/billing_webhook.rs
+++ b/src/server/api/billing_webhook.rs
@@ -487,7 +487,7 @@ pub async fn stripe_webhook_handler(
 
                 let res = match &webhook_state.db.store {
                     DbStore::Sqlite(pool) => {
-                        sqlx::query("UPDATE tenants SET tier = ? WHERE tenant_id = ?")
+                        sqlx::query("UPDATE tenants SET tier = ? WHERE id = ?")
                             .bind(tier_string)
                             .bind(tenant_id)
                             .execute(pool)
@@ -495,7 +495,7 @@ pub async fn stripe_webhook_handler(
                             .map(|_| ())
                     }
                     DbStore::Postgres => {
-                        sqlx::query("UPDATE tenants SET tier = $1 WHERE tenant_id = $2")
+                        sqlx::query("UPDATE tenants SET tier = $1 WHERE id = $2")
                             .bind(tier_string)
                             .bind(tenant_id)
                             .execute(&webhook_state.db.pool)
@@ -530,7 +530,7 @@ pub async fn stripe_webhook_handler(
                 // Update DB
                 let res = match &webhook_state.db.store {
                     DbStore::Sqlite(pool) => {
-                        sqlx::query("UPDATE tenants SET tier = ? WHERE tenant_id = ?")
+                        sqlx::query("UPDATE tenants SET tier = ? WHERE id = ?")
                             .bind("Free")
                             .bind(tenant_id)
                             .execute(pool)
@@ -538,7 +538,7 @@ pub async fn stripe_webhook_handler(
                             .map(|_| ())
                     }
                     DbStore::Postgres => {
-                        sqlx::query("UPDATE tenants SET tier = $1 WHERE tenant_id = $2")
+                        sqlx::query("UPDATE tenants SET tier = $1 WHERE id = $2")
                             .bind("Free")
                             .bind(tenant_id)
                             .execute(&webhook_state.db.pool)


### PR DESCRIPTION
Replaced references to `organizations` with `tenants` in `billing_api.rs` to fix tests, and corrected the `UPDATE tenants` queries in `billing_webhook.rs` to use `WHERE id = ` instead of `WHERE tenant_id = `.

---
*PR created automatically by Jules for task [4795799323987024438](https://jules.google.com/task/4795799323987024438) started by @ql-owo-lp*