### PR TITLE
🛡️ Sentinel: Fix Tenant Isolation for Token Revocation Upserts

### DIFF
--- a/src/server/auth/multitenancy_isolation.rs
+++ b/src/server/auth/multitenancy_isolation.rs
@@ -87,7 +87,7 @@ async fn test_revoke_token_tenant_isolation() {
 
     // Insert an already expired token for the OTHER tenant using raw query
     let expired_time = chrono::Utc::now() - chrono::Duration::hours(1);
-    let _ = sqlx::query("INSERT INTO revoked_tokens (jti, expires_at, tenant_id) VALUES ($1, $2, $3) ON CONFLICT (jti) DO NOTHING")
+    let _ = sqlx::query("INSERT INTO revoked_tokens (jti, expires_at, tenant_id) VALUES ($1, $2, $3) ON CONFLICT (jti, tenant_id) DO NOTHING")
         .bind("other_tenant_expired_token")
         .bind(expired_time)
         .bind(other_tenant)

--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -436,7 +436,7 @@ impl UserRepository for PgUserRepository {
         sqlx::query(
             r#"
             INSERT INTO revoked_tokens (jti, expires_at, tenant_id) VALUES ($1, $2, $3)
-            ON CONFLICT (jti) DO NOTHING
+            ON CONFLICT (jti, tenant_id) DO NOTHING
             "#
         )
         .bind(jti)

--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -358,7 +358,7 @@ impl UserRepository for SqliteUserRepository {
         sqlx::query(
             r#"
             INSERT INTO revoked_tokens (jti, expires_at, tenant_id) VALUES ($1, $2, $3)
-            ON CONFLICT (jti) DO NOTHING
+            ON CONFLICT (jti, tenant_id) DO NOTHING
             "#
         )
         .bind(jti)


### PR DESCRIPTION
Updates the token revocation logic in `postgres_store.rs`, `sqlite_store.rs`, and the corresponding multitenancy test to use the composite constraint `(jti, tenant_id)` in `ON CONFLICT` clauses. This resolves potential cross-tenant collision issues and aligns with the multi-tenant architecture enforcing unique `(jti, tenant_id)` primary keys.

---
*PR created automatically by Jules for task [59969337067707093](https://jules.google.com/task/59969337067707093) started by @ql-owo-lp*