### PR TITLE
🔗 Link: [interop improvement] feat(onboarding): implement autonomous zero-click builder backend

### DIFF
--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -351,6 +351,7 @@ where
 .route("/milestone/card", get(handle_get_milestone_card))
         .route("/trial-extension/claim", post(handle_trial_extension_claim))
         .route("/time-savings", get(handle_time_savings))
+        .route("/zero-click-builder/generate", post(handle_zero_click_generate))
         .layer(Extension(GrowthState { pool, hub }))
 }
 
@@ -2173,6 +2174,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_zero_click_generate() {
+        let pool = setup_db().await;
+        if sqlx::query("SELECT 1").execute(&pool).await.is_err() {
+            return;
+        }
+        let (event_tx, _) = tokio::sync::mpsc::channel(100);
+        let hub = Arc::new(crate::hub::Hub::new(event_tx, pool.clone()));
+        let state = GrowthState { pool: pool.clone(), hub };
+
+        let req = ZeroClickGenerateRequest {
+            prompt: "I am a home baker selling cakes.".to_string(),
+        };
+
+        let auth_info = ::server_auth::orchestration::AuthInfo {
+            spiffe_id: format!("spiffe://ohc.app/{}/agent1", "test-tenant-zero"),
+            org_id: "test-tenant-zero".to_string(),
+            agent_id: "owner@test.com".to_string(),
+        };
+
+        // When testing without an LLM mock configured, process_intake returns a mocked success
+        // which has business_name = "Mock Business" and 1 initial product.
+        let res = handle_zero_click_generate(Extension(state.clone()), axum::extract::Extension(auth_info.clone()), Json(req)).await;
+
+        assert!(res.is_ok());
+        let response = res.unwrap().0;
+        assert_eq!(response.name, "Mock Business");
+        assert_eq!(response.url, "mock-business.ohc.app");
+        assert_eq!(response.products_count, 1);
+    }
+
+    #[tokio::test]
     async fn test_waitlist() {
         let req = WaitlistRequest {
             email: "test@example.com".to_string(),
@@ -2606,6 +2638,90 @@ fn escape_html(s: &str) -> String {
         }
     }
     escaped
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct ZeroClickGenerateRequest {
+    pub prompt: String,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct ZeroClickGenerateResponse {
+    pub name: String,
+    pub url: String,
+    pub products_count: usize,
+}
+
+pub async fn handle_zero_click_generate(
+    axum::extract::Extension(state): axum::extract::Extension<GrowthState>,
+    axum::extract::Extension(auth_info): axum::extract::Extension<::server_auth::orchestration::AuthInfo>,
+    axum::Json(req): axum::Json<ZeroClickGenerateRequest>,
+) -> Result<axum::Json<ZeroClickGenerateResponse>, axum::http::StatusCode> {
+    let db = std::sync::Arc::new(crate::db::DB {
+        pool: state.pool.clone(),
+        store: crate::db::DbStore::Postgres,
+    });
+    let agent = crate::services::onboarding::onboarding_agent::OnboardingAgent::new(
+        db,
+        state.hub.clone()
+    );
+
+    let intake_data = agent.process_intake(&req.prompt).await.map_err(|e| {
+        tracing::error!("Intake error: {}", e);
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let first_product = intake_data.initial_products.first();
+    let first_product_name = first_product.map(|p| p.name.clone()).unwrap_or_else(|| "Standard Product".to_string());
+    let first_product_price = first_product.map(|p| p.price.clone()).unwrap_or_else(|| "10.00".to_string());
+
+    let start_req = ::server_ohc::orchestration::StartOnboardingRequest {
+        business_type: intake_data.business_type,
+        company_name: intake_data.business_name.clone(),
+        company_description: req.prompt.clone(),
+        selling_categories: intake_data.categories,
+        payment_pref: "online".to_string(),
+        admin_email: if !auth_info.agent_id.is_empty() { auth_info.agent_id.clone() } else { format!("owner_{}@ohc.app", uuid::Uuid::new_v4().simple()) },
+        admin_name: "Owner".to_string(),
+        admin_password: uuid::Uuid::new_v4().to_string(),
+        website_template: "Modern".to_string(),
+        first_product_name,
+        first_product_price,
+        domain_choice: "subdomain".to_string(),
+        price_type: "fixed".to_string(),
+        location: intake_data.location.unwrap_or_else(|| "Global".to_string()),
+        target_audience: intake_data.target_audience.unwrap_or_else(|| "Everyone".to_string()),
+        initial_products: vec![],
+        ai_agents: vec![],
+        ai_auto_respond: false,
+    };
+
+    let _start_res = agent.start_onboarding(start_req).await.map_err(|e| {
+        tracing::error!("Start onboarding error: {}", e);
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let mut clean_name = String::new();
+    for c in intake_data.business_name.to_lowercase().chars() {
+        if c.is_ascii_alphanumeric() {
+            clean_name.push(c);
+        } else {
+            clean_name.push('-');
+        }
+    }
+    let clean_name = clean_name.trim_matches('-').to_string();
+
+    let url = if clean_name.is_empty() {
+        "my-business.ohc.app".to_string()
+    } else {
+        format!("{}.ohc.app", clean_name)
+    };
+
+    Ok(axum::Json(ZeroClickGenerateResponse {
+        name: intake_data.business_name,
+        url,
+        products_count: intake_data.initial_products.len(),
+    }))
 }
 
 pub async fn handle_embed_widget(


### PR DESCRIPTION
This pull request introduces the backend logic necessary for the "Zero-Click Business Generator" feature.

It exposes a new `/api/v1/growth/zero-click-builder/generate` endpoint which:
1. Receives a natural language prompt from the user about their business.
2. Interacts with the `OnboardingAgent` to extract details via an LLM.
3. Automatically maps these details to a `StartOnboardingRequest` to provision a complete OHC workspace, including setting up an admin email (based on the user's `auth_info.agent_id` or an automatically generated email if anonymous) and random password.

This fully automates the zero-to-one setup flow, closing the functionality gap compared to the previously mocked UI. E2E Playwright tests and unit tests have been added/verified.

---
*PR created automatically by Jules for task [10284061370038186452](https://jules.google.com/task/10284061370038186452) started by @ql-owo-lp*

Resolves #28405