### PR TITLE
🗺️ Guide: Add instant-image-url to onboarding setup

### DIFF
--- a/src/ui/tauri/src/lib.rs
+++ b/src/ui/tauri/src/lib.rs
@@ -168,7 +168,7 @@ struct IntakeData {
 }
 
 #[tauri::command]
-async fn process_intake(input: String, _app_handle: tauri::AppHandle) -> Result<serde_json::Value, String> {
+async fn process_intake(input: String, image_url: Option<String>, _app_handle: tauri::AppHandle) -> Result<serde_json::Value, String> {
     let backend_url = std::env::var("BACKEND_URL").unwrap_or_else(|_| "http://127.0.0.1:18789".to_string());
     let url = format!("{}/api/onboarding/intake", backend_url);
 
@@ -179,7 +179,7 @@ async fn process_intake(input: String, _app_handle: tauri::AppHandle) -> Result<
 
     let response = client.post(&url)
         .header("Content-Type", "application/json")
-        .json(&serde_json::json!({ "description": input }))
+        .json(&serde_json::json!({ "description": input, "image_url": image_url }))
         .send().await
         .map_err(|err| err.to_string())?;
 

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -500,6 +500,7 @@
 
         <textarea id="instant-bio" data-testid="instant-bio" class="glassmorphism" placeholder="e.g. I run a local bakery that sells custom vegan cakes..." rows="6" style="resize: none;"></textarea>
         <div id="instant-error" class="error-msg" aria-live="polite" style="margin-bottom: 20px;"></div>
+        <input type="url" id="instant-image-url" data-testid="instant-image-url" class="glassmorphism" placeholder="Image URL (Optional)" style="margin-top: 10px; margin-bottom: 0; width: 100%; min-height: 44px; border-radius: 8px;">
 
         <div class="btn-group" style="margin-top: 24px;">
           <button id="generate-storefront-btn" data-testid="generate-storefront-btn">Next</button>
@@ -1329,6 +1330,8 @@
       if (generateStorefrontBtn) {
           generateStorefrontBtn.addEventListener('click', async () => {
               const bioInput = instantBioInputEl.value;
+              const imageUrlInput = document.getElementById("instant-image-url");
+              const imageUrl = imageUrlInput ? imageUrlInput.value.trim() : "";
               if (!bioInput.trim()) {
                   instantErrorEl.innerText = "Please tell us about your business.";
                   instantErrorEl.style.display = 'block';
@@ -1351,7 +1354,7 @@
                   let intakeData = null;
 
                   if (window.__TAURI__ && window.__TAURI__.core) {
-                     intakeData = await window.__TAURI__.core.invoke("process_intake", { input: bioInput });
+                     intakeData = await window.__TAURI__.core.invoke("process_intake", { input: bioInput, imageUrl: imageUrl || undefined });
                   } else {
                      const res = await fetch(`${backendUrl}/api/onboarding/intake`, {
                          method: 'POST',
@@ -1360,7 +1363,7 @@
                              'X-Tenant-ID': tenantIdStr,
                              'X-User-ID': userIdStr
                          },
-                         body: JSON.stringify({ description: bioInput })
+                         body: JSON.stringify({ description: bioInput, image_url: imageUrl || undefined })
                      });
                      if (!res.ok) {
                          const errData = await res.json().catch(()=>({}));


### PR DESCRIPTION
Adds an optional image URL input to the instant build onboarding flow in `setup.html`.
Updates both the Javascript fetch fallback and the Tauri `process_intake` command to capture and forward the `image_url` to the backend API.

Product-use evidence:
- Persona: Maya - Home Baker
- Goal: Create a new storefront using the instant build wizard and include an existing logo/image.
- UI Flow Attempted: Opened `setup.html`, clicked "Instant Build", typed a bio, and wanted to provide an image URL.
- CUJ Gap Observed: The `instant-image-url` input field was missing from the UI, even though the backend and E2E tests expected it to be there.
- Reason: Owners often have existing logos or hero images they want to immediately incorporate into their generated site. Without this field, they are forced to manually add it later, increasing friction.
- Post-fix UI Flow: Opened `setup.html`, clicked "Instant Build", typed a bio, entered an image URL into the new input field, and clicked "Next". The URL is now successfully captured and sent to the backend.

---
*PR created automatically by Jules for task [13170138835075061235](https://jules.google.com/task/13170138835075061235) started by @ql-owo-lp*