### PR TITLE
fix(tauri): capture and persist organization_id during onboarding

### DIFF
--- a/src/e2e/tauri_onboarding.spec.ts
+++ b/src/e2e/tauri_onboarding.spec.ts
@@ -40,10 +40,7 @@ test.describe('Tauri Onboarding Wizard Flow', () => {
               sessionStorage.setItem('mockState', JSON.stringify({ ...currentState, ...args.state }));
               return null;
             } else if (cmd === 'start_onboarding') {
-              return null;
-            }
-            if (cmd === "start_onboarding") {
-              return null;
+              return { success: true, message: "OK", organization_id: "test-org" };
             }
             if (cmd === 'process_intake') {
               return {
@@ -336,7 +333,7 @@ test.describe('Tauri Dashboard UI and UX Improvements', () => {
               return "https://cloud.ohc.network/invite/mock-test";
             }
             if (cmd === "start_onboarding") {
-              return null;
+              return { success: true, message: "OK", organization_id: "test-org" };
             }
             if (cmd === 'process_intake') {
               return {

--- a/src/ui/tauri/src/lib.rs
+++ b/src/ui/tauri/src/lib.rs
@@ -191,8 +191,15 @@ async fn process_intake(input: String, _app_handle: tauri::AppHandle) -> Result<
     }
 }
 
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+struct StartOnboardingResponse {
+    success: bool,
+    message: String,
+    organization_id: String,
+}
+
 #[tauri::command]
-async fn start_onboarding(req: StartOnboardingRequest, _app_handle: tauri::AppHandle) -> Result<(), String> {
+async fn start_onboarding(req: StartOnboardingRequest, _app_handle: tauri::AppHandle) -> Result<StartOnboardingResponse, String> {
     let backend_url = std::env::var("BACKEND_URL").unwrap_or_else(|_| "http://127.0.0.1:18789".to_string());
     let url = format!("{}/api/onboarding/start", backend_url);
 
@@ -204,9 +211,15 @@ async fn start_onboarding(req: StartOnboardingRequest, _app_handle: tauri::AppHa
         .header("Content-Type", "application/json")
         .json(&req);
 
-    let _ = request.send().await;
+    let res = request.send().await.map_err(|err| err.to_string())?;
 
-    Ok(())
+    if !res.status().is_success() {
+        return Err(format!("Failed to start onboarding: {}", res.status()));
+    }
+
+    let resp_data = res.json::<StartOnboardingResponse>().await.map_err(|err| err.to_string())?;
+
+    Ok(resp_data)
 }
 
 #[tauri::command]

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1277,7 +1277,12 @@
 
 
                   if (window.__TAURI__ && window.__TAURI__.core) {
-                      await goToStep('step-loading'); window.__TAURI__.core.invoke("start_onboarding", { req });
+                      await goToStep('step-loading');
+                      const startData = await window.__TAURI__.core.invoke("start_onboarding", { req });
+                      if (startData && startData.organization_id) {
+                          localStorage.setItem('tenant_id', startData.organization_id);
+                          localStorage.setItem('tenant', startData.organization_id);
+                      }
                       localStorage.setItem('has_onboarded', 'true');
                       window.location.href = "success.html";
                       return;
@@ -1392,7 +1397,11 @@
 
 
                   if (window.__TAURI__ && window.__TAURI__.core) {
-                      await window.__TAURI__.core.invoke("start_onboarding", { req });
+                      const startData = await window.__TAURI__.core.invoke("start_onboarding", { req });
+                      if (startData && startData.organization_id) {
+                          localStorage.setItem('tenant_id', startData.organization_id);
+                          localStorage.setItem('tenant', startData.organization_id);
+                      }
                       localStorage.setItem('has_onboarded', 'true');
                       window.location.href = "success.html";
                   } else {
@@ -1543,7 +1552,11 @@
                if (window.__TAURI__ && window.__TAURI__.core) {
                  finishBtn.disabled = true;
                  goToStep('step-loading');
-                 window.__TAURI__.core.invoke("start_onboarding", { req }).then(() => {
+                 window.__TAURI__.core.invoke("start_onboarding", { req }).then((startData) => {
+                   if (startData && startData.organization_id) {
+                       localStorage.setItem('tenant_id', startData.organization_id);
+                       localStorage.setItem('tenant', startData.organization_id);
+                   }
                    localStorage.setItem('has_onboarded', 'true');
                    window.location.href = "success.html";
                  }).catch((err) => {


### PR DESCRIPTION
Fixes the Tauri app onboarding by capturing the `organization_id` missing in the start onboarding API call. Updates Rust struct definitions and frontend JS storage implementations to match the web flow.

---
*PR created automatically by Jules for task [5740652659944871724](https://jules.google.com/task/5740652659944871724) started by @ql-owo-lp*