### PR TITLE
feat: Add public milestone landing page and dynamic OG generation for viral growth loop

### DIFF
--- a/src/ui/next/src/app/business-analytics/page.test.tsx
+++ b/src/ui/next/src/app/business-analytics/page.test.tsx
@@ -1,12 +1,14 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import BusinessAnalytics from './page';
 import { expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { TooltipProvider } from "@/components/TooltipRegistry";
 
 const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
   }),
+  usePathname: () => "/business-analytics",
 }));
 
 beforeEach(() => {
@@ -16,6 +18,7 @@ beforeEach(() => {
   global.window.open = vi.fn();
   // Mock alert
   global.alert = vi.fn();
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })) as any;
 });
 
 afterEach(() => {
@@ -23,39 +26,62 @@ afterEach(() => {
 });
 
 test('renders Business Analytics heading', () => {
-  render(<BusinessAnalytics />);
+  render(
+    <TooltipProvider>
+      <BusinessAnalytics />
+    </TooltipProvider>
+  );
   expect(screen.getByRole('heading', { name: /Business Analytics/i })).toBeInTheDocument();
 });
 
 test('navigates back to dashboard', () => {
-  render(<BusinessAnalytics />);
+  render(
+    <TooltipProvider>
+      <BusinessAnalytics />
+    </TooltipProvider>
+  );
   const backButton = screen.getByText('Back to Dashboard');
-  fireEvent.click(backButton);
-  expect(mockPush).toHaveBeenCalledWith('/dashboard');
+  expect(backButton.closest('a')?.getAttribute('href')).toBe('/dashboard');
 });
 
 test('shows locked predictive AI insights when not pro', () => {
-  render(<BusinessAnalytics />);
+  render(
+    <TooltipProvider>
+      <BusinessAnalytics />
+    </TooltipProvider>
+  );
   expect(screen.getByText('See The Future')).toBeInTheDocument();
   expect(screen.getByText('Unlock Predictions')).toBeInTheDocument();
 });
 
 test('shows predictive AI insights when pro is active', () => {
   localStorage.setItem('pro_plan', 'true');
-  render(<BusinessAnalytics />);
+  render(
+    <TooltipProvider>
+      <BusinessAnalytics />
+    </TooltipProvider>
+  );
   expect(screen.queryByText('See The Future')).not.toBeInTheDocument();
   expect(screen.getByText('Revenue Forecast')).toBeInTheDocument();
 });
 
 test('opens soft paywall modal when clicking Unlock Predictions', () => {
-  render(<BusinessAnalytics />);
+  render(
+    <TooltipProvider>
+      <BusinessAnalytics />
+    </TooltipProvider>
+  );
   const unlockButton = screen.getByText('Unlock Predictions');
   fireEvent.click(unlockButton);
   expect(screen.getByRole('heading', { name: 'Upgrade to Pro' })).toBeInTheDocument();
 });
 
 test('closes soft paywall modal', () => {
-  render(<BusinessAnalytics />);
+  render(
+    <TooltipProvider>
+      <BusinessAnalytics />
+    </TooltipProvider>
+  );
   const unlockButton = screen.getByText('Unlock Predictions');
   fireEvent.click(unlockButton);
   const closeButton = screen.getByText('×');
@@ -64,7 +90,11 @@ test('closes soft paywall modal', () => {
 });
 
 test('upgrades to pro via pricing page', () => {
-  render(<BusinessAnalytics />);
+  render(
+    <TooltipProvider>
+      <BusinessAnalytics />
+    </TooltipProvider>
+  );
   const unlockButton = screen.getByText('Unlock Predictions');
   fireEvent.click(unlockButton);
   const upgradeButton = screen.getByText('Upgrade to Pro ($79/mo)');
@@ -73,7 +103,11 @@ test('upgrades to pro via pricing page', () => {
 });
 
 test('claims trial extension via social share', () => {
-  render(<BusinessAnalytics />);
+  render(
+    <TooltipProvider>
+      <BusinessAnalytics />
+    </TooltipProvider>
+  );
   const unlockButton = screen.getByText('Unlock Predictions');
   fireEvent.click(unlockButton);
   const shareButton = screen.getByText(/Share on X to unlock 7 Days Free/i);
@@ -87,6 +121,10 @@ test('claims trial extension via social share', () => {
 
 test('shows pro view when trial is active', () => {
   localStorage.setItem('trial_active', 'true');
-  render(<BusinessAnalytics />);
+  render(
+    <TooltipProvider>
+      <BusinessAnalytics />
+    </TooltipProvider>
+  );
   expect(screen.queryByText('See The Future')).not.toBeInTheDocument();
 });

--- a/src/ui/next/src/app/cost-dashboard/page.test.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.test.tsx
@@ -3,10 +3,12 @@ import React from 'react';
 import CostDashboardPage from './page';
 import { useRouter } from 'next/navigation';
 import { expect, test, vi, describe, beforeEach, afterEach } from 'vitest';
+import { TooltipProvider } from "@/components/TooltipRegistry";
 
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
-  useRouter: vi.fn()
+  useRouter: vi.fn(),
+  usePathname: () => "/cost-dashboard",
 }));
 
 const mockPush = vi.fn();
@@ -29,7 +31,11 @@ describe('CostDashboardPage', () => {
     // Mock fetch to not resolve immediately
     global.fetch = vi.fn(() => new Promise(() => {})) as any;
 
-    render(<CostDashboardPage />);
+    render(
+      <TooltipProvider>
+        <CostDashboardPage />
+      </TooltipProvider>
+    );
     expect(screen.getByTestId('cost-dashboard-loading')).toBeDefined();
   });
 
@@ -105,7 +111,11 @@ describe('CostDashboardPage', () => {
       return Promise.reject(new Error('not found'));
     }) as any;
 
-    render(<CostDashboardPage />);
+    render(
+      <TooltipProvider>
+        <CostDashboardPage />
+      </TooltipProvider>
+    );
 
     await waitFor(() => {
       expect(screen.queryByTestId('cost-dashboard-loading')).toBeNull();
@@ -122,7 +132,7 @@ describe('CostDashboardPage', () => {
     // Next bill estimated
     expect(screen.getByText('$29.00')).toBeDefined(); // Since Next bill estimated uses formatCurrency which divides by 100
 
-    expect(screen.getByText('Cost Transparency')).toBeDefined();
+    expect(screen.getAllByText('Cost Transparency')[0]).toBeDefined();
     expect(screen.getByText('Period: 2023-10-01 to 2023-10-31')).toBeDefined();
 
     // total revenue
@@ -176,7 +186,11 @@ describe('CostDashboardPage', () => {
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    render(<CostDashboardPage />);
+    render(
+      <TooltipProvider>
+        <CostDashboardPage />
+      </TooltipProvider>
+    );
 
     await waitFor(() => {
       expect(screen.queryByTestId('cost-dashboard-loading')).toBeNull();
@@ -244,7 +258,11 @@ describe('CostDashboardPage', () => {
       return Promise.reject(new Error('not found'));
     }) as any;
 
-    render(<CostDashboardPage />);
+    render(
+      <TooltipProvider>
+        <CostDashboardPage />
+      </TooltipProvider>
+    );
 
     await waitFor(() => {
       expect(screen.queryByTestId('cost-dashboard-loading')).toBeNull();
@@ -287,7 +305,11 @@ describe('CostDashboardPage', () => {
       return Promise.reject(new Error('not found'));
     }) as any;
 
-    render(<CostDashboardPage />);
+    render(
+      <TooltipProvider>
+        <CostDashboardPage />
+      </TooltipProvider>
+    );
 
     await waitFor(() => {
       expect(screen.queryByTestId('cost-dashboard-loading')).toBeNull();
@@ -331,7 +353,11 @@ describe('CostDashboardPage', () => {
       return Promise.reject(new Error('not found'));
     }) as any;
 
-    render(<CostDashboardPage />);
+    render(
+      <TooltipProvider>
+        <CostDashboardPage />
+      </TooltipProvider>
+    );
 
     await waitFor(() => {
       expect(screen.queryByTestId('cost-dashboard-loading')).toBeNull();

--- a/src/ui/next/src/app/integrations/page.test.tsx
+++ b/src/ui/next/src/app/integrations/page.test.tsx
@@ -1,12 +1,22 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/TooltipRegistry";
 import Integrations from "./page";
 
 const push = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
+  usePathname: () => "/integrations",
 }));
+
+const mockIntersectionObserver = vi.fn();
+mockIntersectionObserver.mockReturnValue({
+  observe: () => null,
+  unobserve: () => null,
+  disconnect: () => null
+});
+window.IntersectionObserver = mockIntersectionObserver as any;
 
 describe("Integrations", () => {
   beforeEach(() => {
@@ -24,14 +34,21 @@ describe("Integrations", () => {
       configurable: true,
       value: { assign },
     });
-    (global.fetch as any).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        authorization_url: "https://oauth.example/shippo",
-      }),
+    (global.fetch as any).mockImplementation((url: string) => {
+      if (url === "/api/tooltips") return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          authorization_url: "https://oauth.example/shippo",
+        }),
+      });
     });
 
-    render(<Integrations />);
+    render(
+      <TooltipProvider>
+        <Integrations />
+      </TooltipProvider>
+    );
     fireEvent.click(screen.getAllByRole("button", { name: "Connect" })[4]);
 
     await waitFor(() => {

--- a/src/ui/next/src/app/milestone-share/page.test.tsx
+++ b/src/ui/next/src/app/milestone-share/page.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MilestoneSharePage, { generateMetadata } from './page';
+
+describe('MilestoneSharePage', () => {
+  it('renders the milestone share landing page with correct CTA', () => {
+    render(<MilestoneSharePage searchParams={{ tenant: 'test-tenant', milestone: 'first_sale' }} />);
+
+    // Check if image is rendered with correct src
+    const image = screen.getByAltText('Milestone') as HTMLImageElement;
+    expect(image.src).toContain('/api/v1/growth/milestone/card?milestone_id=first_sale&tenant=test-tenant');
+
+    // Check if CTA exists and points to correct onboarding link
+    const cta = screen.getByText(/Start your own business on OHC/i);
+    expect(cta).toBeDefined();
+    expect((cta as HTMLAnchorElement).href).toContain('/onboarding?ref=test-tenant');
+  });
+
+  it('generateMetadata returns correct OG tags', async () => {
+    const metadata = await generateMetadata({
+      searchParams: {
+        tenant: 'test-tenant',
+        milestone: '100_orders',
+        title: 'Awesome Title',
+        description: 'Awesome Description'
+      }
+    }, {} as any);
+
+    expect(metadata.title).toBe('Awesome Title');
+    expect(metadata.description).toBe('Awesome Description');
+    expect(metadata.openGraph?.images?.[0]).toContain('/api/v1/growth/milestone/card?milestone_id=100_orders&tenant=test-tenant');
+  });
+});

--- a/src/ui/next/src/app/milestone-share/page.tsx
+++ b/src/ui/next/src/app/milestone-share/page.tsx
@@ -1,0 +1,82 @@
+import { Metadata, ResolvingMetadata } from 'next';
+import React from 'react';
+
+type Props = {
+  searchParams: { [key: string]: string | string[] | undefined }
+}
+
+const defaultTargetUrl = '/onboarding';
+
+export async function generateMetadata(
+  { searchParams }: Props,
+  _parent: ResolvingMetadata
+): Promise<Metadata> {
+  const milestoneId = typeof searchParams.milestone === 'string' ? searchParams.milestone : 'first_sale';
+  const tenantId = typeof searchParams.tenant === 'string' ? searchParams.tenant : 'DEFAULT';
+
+  const title = typeof searchParams.title === 'string' ? searchParams.title : 'Milestone Reached! 🏆';
+  const description = typeof searchParams.description === 'string' ? searchParams.description : 'We just hit a massive business milestone on One Human Corp! Start your own business today.';
+  const imageUrl = `/api/v1/growth/milestone/card?milestone_id=${milestoneId}&tenant=${tenantId}`;
+
+  // Hardcode absolute origin for API if possible, otherwise rely on relative, but OG tags typically need absolute URLs.
+  // Next.js will resolve absolute URLs if metadataBase is set, but we can also manually prepend a dummy if needed, though typically OHC provides absolute where possible.
+  // We'll leave it relative; if Next.js needs absolute, we'll assume it's handled or we'll pass full URL from frontend. Let's construct a full URL.
+  // For safety, we'll try to extract host from headers in a real app, but here we can just pass the path and let NextJS handle it if metadataBase is configured, or we require an absolute URL.
+  // In OHC, we'll use a placeholder domain for the test or just relative.
+  const absoluteImageUrl = `https://ohc.app${imageUrl}`; // Fallback for OG
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [absoluteImageUrl],
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [absoluteImageUrl],
+    },
+  };
+}
+
+export default function MilestoneSharePage({ searchParams }: Props) {
+  const milestoneId = typeof searchParams.milestone === 'string' ? searchParams.milestone : 'first_sale';
+  const tenantId = typeof searchParams.tenant === 'string' ? searchParams.tenant : 'DEFAULT';
+
+  const cardUrl = `/api/v1/growth/milestone/card?milestone_id=${milestoneId}&tenant=${tenantId}`;
+  const joinUrl = `/onboarding?ref=${tenantId}`;
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-6 font-sans">
+      <div className="max-w-3xl w-full bg-white rounded-3xl shadow-2xl overflow-hidden border border-gray-100">
+        <div className="w-full aspect-[1200/630] bg-gray-100 relative">
+            <img
+              src={cardUrl}
+              alt="Milestone"
+              className="w-full h-full object-cover"
+              onError={(e) => { e.currentTarget.src = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjAwIiBoZWlnaHQ9IjYzMCI+PHJlY3Qgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0iI2YxZjVmOSIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSI0OCIgZmlsbD0iIzk0YTNiOSIgdGV4dC1hbmNob3I9Im1pZGRsZSI+Q291bGQgbm90IGxvYWQgbWlsZXN0b25lIGNhcmQ8L3RleHQ+PC9zdmc+'; }}
+            />
+        </div>
+
+        <div className="p-8 md:p-12 text-center flex flex-col items-center">
+            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4 tracking-tight">Celebrate this milestone!</h1>
+            <p className="text-lg text-gray-600 mb-8 max-w-xl">
+              This business is powered by One Human Corp. Want to achieve your own milestones? Launch your business online in seconds.
+            </p>
+            <a
+              href={joinUrl}
+              className="inline-flex items-center justify-center px-8 py-4 text-base font-bold text-white bg-indigo-600 hover:bg-indigo-700 rounded-full transition-all shadow-lg hover:shadow-xl hover:-translate-y-0.5"
+            >
+              Start your own business on OHC
+              <svg className="w-5 h-5 ml-2 -mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" /></svg>
+            </a>
+            <p className="mt-4 text-sm text-gray-500 font-medium">Get a $50 credit when you join today.</p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Created `/milestone-share/page.tsx` which exports `generateMetadata` for rich OpenGraph/Twitter card tags utilizing the milestone SVG.
- Created a beautiful responsive landing page that shows the milestone and provides a CTA that points into the onboarding referral loop.
- Updated `/milestones/page.tsx` to output social sharing links that point to the new landing page.
- Added tests for `/milestone-share/page.tsx`.
- Updated existing tests in `milestones/page.test.tsx` to reflect the new `shareTarget`.
- Fixed frontend tests (`business-analytics`, `cost-dashboard`, `integrations`) that were failing due to unmocked `usePathname` for `AppShell` and lack of `TooltipProvider` contexts.

---
*PR created automatically by Jules for task [10026064690781206624](https://jules.google.com/task/10026064690781206624) started by @ql-owo-lp*