### PR TITLE
fix(growth): Invalidate tenant specific aggregated metrics cache

### DIFF
--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -1909,10 +1909,10 @@ async fn handle_team_invite_accept(
                 // Note: We invalidate specifically the first page commonly fetched. For robust cache invalidation across all pages, consider tag-based invalidation or shorter TTLs. We will rely on the short 30s TTL for subsequent pages.
                 let cache = TEAM_INVITES_CACHE.get_or_init(|| HybridCache::new(None));
                 cache.invalidate(&format!("{}None", cache_key_prefix)).await;
-            }
 
-            let metrics_cache = METRICS_CACHE.get_or_init(|| HybridCache::new(None));
-            metrics_cache.invalidate("aggregated_metrics").await;
+                let metrics_cache = METRICS_CACHE.get_or_init(|| HybridCache::new(None));
+                metrics_cache.invalidate(&format!("aggregated_metrics_{}", team_id)).await;
+            }
 
             let msg = state.hub.sanitize_hub_event(serde_json::json!({ "type": "growth.team_invite_accepted", "id": req.id }));
             state.hub.append_recent_event(msg);
@@ -1937,7 +1937,7 @@ async fn handle_create_team_invite(
             cache.invalidate(&format!("{}None", cache_key_prefix)).await;
 
             let metrics_cache = METRICS_CACHE.get_or_init(|| HybridCache::new(None));
-            metrics_cache.invalidate("aggregated_metrics").await;
+            metrics_cache.invalidate(&format!("aggregated_metrics_{}", req.team_id)).await;
 
             let msg = state.hub.sanitize_hub_event(serde_json::json!({ "type": "growth.team_invite_created", "team_id": req.team_id, "inviter_id": req.inviter_id, "invitee_id": req.invitee_id }));
             state.hub.append_recent_event(msg);
@@ -2515,7 +2515,7 @@ async fn handle_cloud_bridge_invite(
             cache.invalidate(&format!("{}None", cache_key_prefix)).await;
 
             let metrics_cache = METRICS_CACHE.get_or_init(|| HybridCache::new(None));
-            metrics_cache.invalidate("aggregated_metrics").await;
+            metrics_cache.invalidate(&format!("aggregated_metrics_{}", req.team_id)).await;
 
             let msg = state.hub.sanitize_hub_event(serde_json::json!({ "type": "growth.cloud_bridge_invite_created", "team_id": req.team_id, "inviter_id": req.inviter_id, "invitee_id": req.invitee_id }));
             state.hub.append_recent_event(msg);


### PR DESCRIPTION
This PR addresses an issue where the viral loop metrics on the dashboard do not update when an invite is generated or accepted. The bug was traced to the cache invalidation logic, which incorrectly used a hardcoded string `aggregated_metrics` instead of the required tenant-specific format `aggregated_metrics_{team_id}`.

The change corrects the cache invalidation across the three impacted handlers: `handle_cloud_bridge_invite`, `handle_create_team_invite`, and `handle_team_invite_accept` to correctly clear the tenant's cache so that subsequent requests for the metrics retrieve fresh data from the database.

---
*PR created automatically by Jules for task [6282231011079353786](https://jules.google.com/task/6282231011079353786) started by @ql-owo-lp*