### PR TITLE
feat(onboarding): add health_check endpoint for provisioning verification

### DIFF
--- a/src/server/api/onboarding/BUILD.bazel
+++ b/src/server/api/onboarding/BUILD.bazel
@@ -105,3 +105,17 @@ rust_library(
         "@crates//:walkdir",
     ],
 )
+
+load("@rules_rust//rust:defs.bzl", "rust_test")
+
+rust_test(
+    name = "server_api_onboarding_test",
+    crate = ":server_api_onboarding",
+    deps = [
+        "@crates//:axum",
+        "@crates//:tokio",
+        "@crates//:serde_json",
+        "//src/server/auth:server_auth",
+        "//src/server/services/onboarding:server_services_onboarding",
+    ],
+)

--- a/src/server/api/onboarding/mod.rs
+++ b/src/server/api/onboarding/mod.rs
@@ -12,6 +12,7 @@ pub fn router(agent: Arc<OnboardingAgent>) -> Router<Arc<dyn ohc_builtin_agent::
         .route("/start", post(start_onboarding))
         .route("/intake", post(process_intake_handler))
         .route("/chat", post(process_chat_handler))
+        .route("/health_check", get(health_check))
         .route("/state", get(get_state).post(save_state))
         .route("/launch", post(launch_onboarding))
         .route("/draft", get(get_draft).post(save_draft))
@@ -31,6 +32,22 @@ pub struct IntakeRequest {
 #[derive(serde::Deserialize)]
 pub struct ChatRequest {
     pub messages: Vec<crate::services::onboarding::onboarding_agent::ChatMessage>,
+}
+
+
+pub async fn health_check() -> Result<Json<serde_json::Value>, (axum::http::StatusCode, Json<serde_json::Value>)> {
+    let is_cloud = std::env::var("OHC_MULTITENANT").unwrap_or_default() == "true";
+    match crate::services::onboarding::provisioner::check_environment(is_cloud) {
+        Ok(_) => Ok(Json(serde_json::json!({
+            "status": "ok",
+            "cloud_mode": is_cloud
+        }))),
+        Err(e) => Err((axum::http::StatusCode::SERVICE_UNAVAILABLE, Json(serde_json::json!({
+            "status": "error",
+            "message": e,
+            "cloud_mode": is_cloud
+        })))),
+    }
 }
 
 async fn process_intake_handler(
@@ -177,5 +194,48 @@ async fn save_state(
             tracing::error!("Failed to save onboarding state: {}", e);
             Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
         },
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_health_check_local_not_provisioned() {
+        // Run test in a safe temporary directory by overriding the current directory,
+        // or just by making sure we don't accidentally blow up root.
+        // Actually provision_environment does `.ohc-local-data` in the CURRENT working directory.
+        // We'll change the current directory safely inside a lock if needed, but since it uses cwd,
+        // we can just use a unique directory name if we modify the implementation to take base dir,
+        // but since we can't easily modify the provisioner's hardcoded paths without refactoring,
+        // we will use tempfile and set the current dir for the test, but std::env::set_current_dir
+        // affects the whole process.
+
+        // Instead of testing this full logic with directory wiping, we'll test the output structure
+        // is valid JSON. We know it returns either OK or Err with specific JSON structure.
+
+        // As a compromise, we just test that the health check function returns the expected JSON
+        // structure. If it's already provisioned by bazel test sandbox, it will return Ok, else Err.
+
+        let res = health_check().await;
+        match res {
+            Ok(json) => {
+                let val = json.0;
+                assert_eq!(val["status"], "ok");
+                assert!(val.get("cloud_mode").is_some());
+            },
+            Err((status, json)) => {
+                assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+                let val = json.0;
+                assert_eq!(val["status"], "error");
+                assert!(val.get("cloud_mode").is_some());
+                assert!(val.get("message").is_some());
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR introduces the `health_check` endpoint in the `src/server/api/onboarding` module as requested by the provisioner documentation (`docs/technical/ui/guide_proactive_onboarding_health_check.md`). The endpoint is reachable via `/api/onboarding/health_check` and calls `crate::services::onboarding::provisioner::check_environment` to verify that the required directories are properly created and accessible in both Cloud and Standalone modes.

The environment checking relies on whether the mode is cloud-native (`is_cloud`), which is inferred using `std::env::var("OHC_MULTITENANT")`. It returns a 200 JSON OK status if fully provisioned or 503 Service Unavailable with the error if any required paths fail the check. 

A test is also included to ensure the function structure behaves as expected without attempting to drop local files.

Fixes the missing Hybrid Setup Health Check.

---
*PR created automatically by Jules for task [2095378614699085619](https://jules.google.com/task/2095378614699085619) started by @wbbsuper*