### PR TITLE
🎥 Lens Audit: fix(ui): update design tokens to use macOS-style 8px rounded corners and Apple Blue (#0071E3) for primary buttons

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -94,7 +94,7 @@ body {
   align-items: center;
   gap: 10px;
   padding: 0 10px;
-  border-radius: 6px;
+  border-radius: 8px;
   color: #b9c2d0;
   font-size: 13px;
   font-weight: 600;
@@ -114,7 +114,7 @@ body {
 .app-nav-marker {
   width: 20px;
   height: 20px;
-  border-radius: 5px;
+  border-radius: 8px;
   display: grid;
   place-items: center;
   background: rgba(255, 255, 255, 0.08);
@@ -334,7 +334,7 @@ body {
   justify-content: center;
   gap: 7px;
   padding: 0 12px;
-  border-radius: 6px;
+  border-radius: 8px;
   border: 1px solid #cbd5e1;
   background: #fff;
   color: #263244;
@@ -344,8 +344,8 @@ body {
 }
 
 .app-button.primary {
-  border-color: #1f78e5;
-  background: #1f78e5;
+  border-color: #0071E3;
+  background: #0071E3;
   color: #fff;
 }
 
@@ -354,7 +354,7 @@ body {
 }
 
 .app-button.primary:hover {
-  background: #1768ca;
+  background: #005bb5;
 }
 
 .app-table-wrap {

--- a/src/ui/next/src/e2e/design_tokens.spec.ts
+++ b/src/ui/next/src/e2e/design_tokens.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('OHC Design Token Compliance', () => {
+  test('buttons have 8px border-radius', async ({ page }) => {
+    await page.goto('/dashboard');
+    // Wait for the page to load
+    await page.waitForSelector('.app-button', { timeout: 10000 });
+
+    // Evaluate the computed style of the first button
+    const borderRadius = await page.$eval('.app-button', (el) => {
+      return window.getComputedStyle(el).borderRadius;
+    });
+
+    expect(borderRadius).toBe('8px');
+  });
+
+  test('primary buttons use Apple Blue accent', async ({ page }) => {
+    await page.goto('/dashboard');
+    // Wait for the page to load
+    await page.waitForSelector('.app-button.primary', { timeout: 10000 });
+
+    // Evaluate the computed style of the primary button
+    const bgColor = await page.$eval('.app-button.primary', (el) => {
+      return window.getComputedStyle(el).backgroundColor;
+    });
+
+    // #0071E3 is rgb(0, 113, 227)
+    expect(bgColor).toBe('rgb(0, 113, 227)');
+  });
+});


### PR DESCRIPTION
I have completed the task by:

1. Modifying the `globals.css` file to match the design tokens described in the audit baseline instructions. I've updated the `border-radius` to `8px` for `.app-button`, `.app-nav-link`, and `.app-nav-marker`.
2. I updated the primary button color to `#0071E3`.
3. Added a new e2e playwright test inside `src/ui/next/src/e2e/design_tokens.spec.ts` that specifically validates these design tokens are applied properly to the main dashboard container.
4. I ran the full test suite via `bazelisk test //...` and the specific e2e via `bazelisk test //src/e2e:playwright_shard_1_of_1` to ensure all tests passed.

---
*PR created automatically by Jules for task [606086317417225194](https://jules.google.com/task/606086317417225194) started by @ql-owo-lp*