### PR TITLE
feat(offline): Add failed_count logic to offline sync handler

### DIFF
--- a/src/server/api/offline_sync.rs
+++ b/src/server/api/offline_sync.rs
@@ -23,6 +23,7 @@ pub struct OfflineSyncRequest {
 #[derive(Serialize)]
 pub struct OfflineSyncResponse {
     pub success: bool,
+    pub failed_count: i32,
 }
 
 pub async fn offline_sync_handler(
@@ -38,14 +39,14 @@ pub async fn offline_sync_handler(
     if tenant_id.is_empty() {
         return (
             StatusCode::UNAUTHORIZED,
-            Json(OfflineSyncResponse { success: false }),
+            Json(OfflineSyncResponse { success: false, failed_count: 0 }),
         ).into_response();
     }
 
     let cache = crate::builder::edge::get_edge_cache();
     cache.invalidate_by_tag(&format!("tenant-id:{}", tenant_id)).await;
 
-    let mut futures: Vec<std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>> = Vec::new();
+    let mut futures: Vec<std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send>>> = Vec::new();
     for mutation in &payload.mutations {
         let mutation = mutation.clone();
         let cache_clone = cache.clone();
@@ -69,7 +70,8 @@ pub async fn offline_sync_handler(
                 .execute(&mut *db_tx)
                 .await;
                 db_tx.commit().await.unwrap();
-            }) as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>);
+                Ok(())
+            }) as std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send>>);
             continue;
         }
 
@@ -187,22 +189,27 @@ pub async fn offline_sync_handler(
                         }).to_string().into_bytes(),
                     };
                     let _ = mesh_clone.publish("mesh:inventory:updated", event).await;
+                    Ok(())
                 }
                 Ok(None) => {
                     tracing::warn!("Product {} not found or unauthorized for tenant {}", mutation.product_id, tenant_id_clone);
+                    Err("Product not found or unauthorized".to_string())
                 }
                 Err(e) => {
                     ::server_telemetry::record_error_signal("Failed to deduct inventory for product ");
                     tracing::error!("Failed to deduct inventory for product {}: {}", mutation.product_id, e);
+                    Err("Database error".to_string())
                 }
             }
-        }) as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>);
+        }) as std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send>>);
     }
-    futures::future::join_all(futures).await;
+    let results = futures::future::join_all(futures).await;
+
+    let failed_count = results.into_iter().filter(|r| r.is_err()).count() as i32;
 
     (
         StatusCode::OK,
-        Json(OfflineSyncResponse { success: true }),
+        Json(OfflineSyncResponse { success: true, failed_count }),
     ).into_response()
 }
 
@@ -279,7 +286,30 @@ mod tests {
             ],
         };
 
-        let response2 = offline_sync_handler(state, headers, Json(req_over)).await.into_response();
+        let response2 = offline_sync_handler(state.clone(), headers.clone(), Json(req_over)).await.into_response();
         assert_eq!(response2.status(), StatusCode::OK);
+
+        // Test with a non-existent product which should fail
+        let req_fail = OfflineSyncRequest {
+            mutations: vec![
+                OfflineMutation {
+                    transaction_id: "tx3".to_string(),
+                    product_id: "prod-offline-nonexistent".to_string(),
+                    quantity_deducted: 1,
+                    amount: Some(1000),
+                    payment_method: None,
+                    payment_intent_id: None,
+                    currency: Some("USD".to_string()), mutation_type: None, payload: None,
+                },
+            ],
+        };
+
+        let response_fail = offline_sync_handler(state, headers, Json(req_fail)).await.into_response();
+        assert_eq!(response_fail.status(), StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(response_fail.into_body(), usize::MAX).await.unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(body_json["success"], true);
+        assert_eq!(body_json["failed_count"], 1);
     }
 }


### PR DESCRIPTION
Added `failed_count` field to `OfflineSyncResponse` in `src/server/api/offline_sync.rs`.
Modified the futures in `offline_sync_handler` to return `Result<(), String>` rather than `()`, allowing us to track which mutations succeed and which ones fail.
Calculated `failed_count` based on the number of returned errors and included it in the HTTP response.
Added a unit test `test_offline_sync_success_and_negative_guard` ensuring it properly computes `failed_count` when mutations fail (e.g. product not found).

Resolves #28467

---
*PR created automatically by Jules for task [16094993862447508971](https://jules.google.com/task/16094993862447508971) started by @ql-owo-lp*