### PR TITLE
Fix Tauri onboarding test and setup.html javascript syntax errors

### DIFF
--- a/src/e2e/tauri_onboarding.spec.ts
+++ b/src/e2e/tauri_onboarding.spec.ts
@@ -269,7 +269,7 @@ test.describe('Tauri Onboarding Wizard Flow', () => {
     await expect(container).toBeVisible();
     await expect(container).toHaveClass(/glassmorphism/);
 
-    const option = page.locator('.radio-option').first();
+    const option = page.locator('.context-card').first();
     const optionBox = await option.boundingBox();
     const catInput = page.getByPlaceholder("e.g. Graphic Design");
 

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1181,7 +1181,7 @@
         .then(res => res.json())
         .then(apiState => {
             if (apiState && Object.keys(apiState).length > 0) {
-                state = { ...state, ...(apiState)
+                state = { ...state, ...(apiState) };
                 localStorage.setItem('onboardingState', JSON.stringify(state)); // Sync cross-device state down to local
                 populateForm();
             }
@@ -1471,6 +1471,7 @@
           'Storefront': ['Bakery', 'Cafe', 'Restaurant', 'Retail', 'Salon', 'Spa', 'Gym', 'Boutique', 'Other'],
           'Online Creator': ['Tutoring', 'Consulting', 'Digital Art', 'Software', 'Writing', 'Video Creation', 'Music', 'Other'],
           'Agency': ['Marketing', 'Design', 'Development', 'Consulting', 'Advertising', 'PR', 'Other']
+      };
 
 
       function populateCategories() {
@@ -1633,6 +1634,7 @@
                       location: intakeData.location || "Local",
                       targetAudience: intakeData.target_audience || "General",
                       initialProducts: intakeData.initial_products || []
+                  };
 
 
                   if (window.__TAURI__ && window.__TAURI__.core) {
@@ -1748,6 +1750,7 @@
                       location: intakeData.location || "Local",
                       targetAudience: intakeData.target_audience || "General",
                       initialProducts: intakeData.initial_products || []
+                  };
 
 
                   if (window.__TAURI__ && window.__TAURI__.core) {
@@ -1896,6 +1899,7 @@
                    price_type: "fixed",
                    location: "Local",
                    target_audience: "General"
+               };
 
 
 


### PR DESCRIPTION
I found multiple syntax errors in `setup.html` which caused Javascript functions like `goToStep` to be undefined. The tests failed trying to navigate through the wizard because of this. I have fixed these Javascript syntax errors and updated the test locator in `tauri_onboarding.spec.ts` for the 44px test. All `tauri_onboarding` tests now pass.

---
*PR created automatically by Jules for task [11449146631988647754](https://jules.google.com/task/11449146631988647754) started by @wbbsuper*