### PR TITLE
fix: Return to step 3 on onboarding start failure

### DIFF
--- a/src/ui/next/src/app/onboarding/page.test.tsx
+++ b/src/ui/next/src/app/onboarding/page.test.tsx
@@ -341,7 +341,7 @@ describe('OnboardingWizard', () => {
 
     // Set initial state to Step 3 to test start API directly
     act(() => {
-      useOnboardingStore.setState({ step: 3 });
+      useOnboardingStore.setState({ step: 3, adminName: "Test Admin", adminEmail: "test@example.com", adminPassword: "Password123" });
     });
 
     // Mock start failure

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -564,7 +564,7 @@ export default function OnboardingWizard() {
       } catch (err: any) {
         console.error(err);
         setError(err.message || 'Failed to start onboarding');
-        setStep(-1); syncStateToBackend({ step: -1 });
+        setStep(3); syncStateToBackend({ step: 3 });
         setIsLoading(false);
         return;
       }
@@ -644,7 +644,7 @@ export default function OnboardingWizard() {
     } catch (err: any) {
       console.error(err);
       setError(err.message || 'Failed to start onboarding');
-      setStep(3); syncStateToBackend({ step: 3 }); // Go back to last input screen on error
+      setStep(3); syncStateToBackend({ step: 3 });
     } finally {
       setIsLoading(false);
     }
@@ -1366,7 +1366,7 @@ export default function OnboardingWizard() {
 
               <div className="mt-auto pt-6">
                 <button
-                  onClick={handleStartOnboarding}
+                  onClick={() => handleStartOnboarding()}
                   disabled={isLoading}
                   className="w-full bg-[#0066FF] text-white min-h-[44px] min-w-[44px] p-4 rounded-[8px] font-bold shadow-[0_4px_14px_0_rgba(0,102,255,0.39)] hover:bg-[#0052cc] active:scale-[0.98] transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] disabled:opacity-50 disabled:cursor-not-allowed"
                 >


### PR DESCRIPTION
Fixes the issue where an API failure during onboarding would set the UI step to -1. The correct behavior is to revert to step 3. Also fixes the associated unit test by correctly seeding the store with the required admin details.

---
*PR created automatically by Jules for task [17272571432019587176](https://jules.google.com/task/17272571432019587176) started by @ql-owo-lp*