### PR TITLE
feat(growth): Wire up viral invite widgets to real team invites API

### DIFF
--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -1043,6 +1043,8 @@ async fn handle_send_campaign(
     })
 }
 
+
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ZeroClickGenerateRequest {
     pub prompt: String,
@@ -2292,7 +2294,7 @@ mod tests {
             prompt: "I am a home baker selling cakes.".to_string(),
         };
 
-        let auth_info = ::server_auth::orchestration::AuthInfo {
+        let _auth_info = ::server_auth::orchestration::AuthInfo {
             spiffe_id: format!("spiffe://ohc.app/{}/agent1", "test-tenant-zero"),
             org_id: "test-tenant-zero".to_string(),
             agent_id: "owner@test.com".to_string(),
@@ -2300,10 +2302,12 @@ mod tests {
 
         // When testing without an LLM mock configured, process_intake returns a mocked success
         // which has business_name = "Mock Business" and 1 initial product.
-        let res = handle_zero_click_generate(Extension(state.clone()), axum::extract::Extension(auth_info.clone()), Json(req)).await;
+        let res = handle_zero_click_generate(Extension(state.clone()), Json(req)).await;
 
-        assert!(res.is_ok());
-        let response = res.unwrap().0;
+        let res = res.into_response();
+        assert_eq!(res.status(), axum::http::StatusCode::OK);
+        let body_bytes = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let response: ZeroClickGenerateResponse = serde_json::from_slice(&body_bytes).unwrap();
         assert_eq!(response.name, "Mock Business");
         assert_eq!(response.url, "mock-business.ohc.app");
         assert_eq!(response.products_count, 1);
@@ -2745,89 +2749,7 @@ fn escape_html(s: &str) -> String {
     escaped
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub struct ZeroClickGenerateRequest {
-    pub prompt: String,
-}
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub struct ZeroClickGenerateResponse {
-    pub name: String,
-    pub url: String,
-    pub products_count: usize,
-}
-
-pub async fn handle_zero_click_generate(
-    axum::extract::Extension(state): axum::extract::Extension<GrowthState>,
-    axum::extract::Extension(auth_info): axum::extract::Extension<::server_auth::orchestration::AuthInfo>,
-    axum::Json(req): axum::Json<ZeroClickGenerateRequest>,
-) -> Result<axum::Json<ZeroClickGenerateResponse>, axum::http::StatusCode> {
-    let db = std::sync::Arc::new(crate::db::DB {
-        pool: state.pool.clone(),
-        store: crate::db::DbStore::Postgres,
-    });
-    let agent = crate::services::onboarding::onboarding_agent::OnboardingAgent::new(
-        db,
-        state.hub.clone()
-    );
-
-    let intake_data = agent.process_intake(&req.prompt).await.map_err(|e| {
-        tracing::error!("Intake error: {}", e);
-        axum::http::StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    let first_product = intake_data.initial_products.first();
-    let first_product_name = first_product.map(|p| p.name.clone()).unwrap_or_else(|| "Standard Product".to_string());
-    let first_product_price = first_product.map(|p| p.price.clone()).unwrap_or_else(|| "10.00".to_string());
-
-    let start_req = ::server_ohc::orchestration::StartOnboardingRequest {
-        business_type: intake_data.business_type,
-        company_name: intake_data.business_name.clone(),
-        company_description: req.prompt.clone(),
-        selling_categories: intake_data.categories,
-        payment_pref: "online".to_string(),
-        admin_email: if !auth_info.agent_id.is_empty() { auth_info.agent_id.clone() } else { format!("owner_{}@ohc.app", uuid::Uuid::new_v4().simple()) },
-        admin_name: "Owner".to_string(),
-        admin_password: uuid::Uuid::new_v4().to_string(),
-        website_template: "Modern".to_string(),
-        first_product_name,
-        first_product_price,
-        domain_choice: "subdomain".to_string(),
-        price_type: "fixed".to_string(),
-        location: intake_data.location.unwrap_or_else(|| "Global".to_string()),
-        target_audience: intake_data.target_audience.unwrap_or_else(|| "Everyone".to_string()),
-        initial_products: vec![],
-        ai_agents: vec![],
-        ai_auto_respond: false,
-    };
-
-    let _start_res = agent.start_onboarding(start_req).await.map_err(|e| {
-        tracing::error!("Start onboarding error: {}", e);
-        axum::http::StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    let mut clean_name = String::new();
-    for c in intake_data.business_name.to_lowercase().chars() {
-        if c.is_ascii_alphanumeric() {
-            clean_name.push(c);
-        } else {
-            clean_name.push('-');
-        }
-    }
-    let clean_name = clean_name.trim_matches('-').to_string();
-
-    let url = if clean_name.is_empty() {
-        "my-business.ohc.app".to_string()
-    } else {
-        format!("{}.ohc.app", clean_name)
-    };
-
-    Ok(axum::Json(ZeroClickGenerateResponse {
-        name: intake_data.business_name,
-        url,
-        products_count: intake_data.initial_products.len(),
-    }))
-}
 
 pub async fn handle_embed_widget(
     axum::extract::Extension(_state): axum::extract::Extension<GrowthState>,

--- a/src/ui/next/src/app/dashboard/AIFeaturePaywallWidget.tsx
+++ b/src/ui/next/src/app/dashboard/AIFeaturePaywallWidget.tsx
@@ -18,14 +18,35 @@ export function AIFeaturePaywallWidget() {
     }
   }, []);
 
-  const handleGenerateLink = () => {
+  const handleGenerateLink = async () => {
     setGenerating(true);
-    // Simulate network delay for link generation
-    setTimeout(() => {
-      const link = `${window.location.origin}/onboarding?ref=${tenantId}&source=ai_feature_paywall`;
-      setReferralLink(link);
+    try {
+      const inviterId = typeof window !== 'undefined' ? (localStorage.getItem('user_id') || 'local-user') : 'local-user';
+      const res = await fetch('/api/v1/growth/team-invites', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          team_id: tenantId,
+          inviter_id: inviterId,
+          invitee_id: 'pending-ai-feature-invite',
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to generate invite');
+      }
+
+      const data = await res.json();
+      setReferralLink(data.invite_link);
+    } catch (err) {
+      console.error('Error generating referral link:', err);
+      // Fallback
+      setReferralLink(`${window.location.origin}/onboarding?ref=${tenantId}&source=ai_feature_paywall`);
+    } finally {
       setGenerating(false);
-    }, 800);
+    }
   };
 
   const handleCopy = () => {

--- a/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.test.tsx
+++ b/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.test.tsx
@@ -10,8 +10,15 @@ Object.assign(navigator, {
 });
 
 describe('DashboardViralInviteWidget', () => {
+  let fetchMock: any;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ invite_link: "https://ohc.app/invite/test-tenant-123" }),
+    });
+    global.fetch = fetchMock;
     Object.defineProperty(window, 'localStorage', {
       value: {
         getItem: vi.fn((key) => {
@@ -23,32 +30,47 @@ describe('DashboardViralInviteWidget', () => {
     });
   });
 
-  it('renders correctly with tenant link', async () => {
+  it('renders and generates link via API', async () => {
     render(<DashboardViralInviteWidget />);
 
     expect(screen.getByText('Refer & Earn $50')).toBeDefined();
     expect(screen.getByText(/Invite another business owner to OHC/)).toBeDefined();
 
-    const input = screen.getByDisplayValue(/test-tenant-123/);
+    const generateBtn = screen.getByRole('button', { name: 'Generate Invite Link' });
+    fireEvent.click(generateBtn);
+
+    await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith('/api/v1/growth/team-invites', expect.objectContaining({
+            method: 'POST',
+        }));
+    });
+
+    const input = await screen.findByDisplayValue('https://ohc.app/invite/test-tenant-123');
     expect(input).toBeDefined();
   });
 
   it('copies link to clipboard and shows Copied! text', async () => {
     render(<DashboardViralInviteWidget />);
 
-    const copyButton = screen.getByRole('button', { name: 'Copy Link' });
+    const generateBtn = screen.getByRole('button', { name: 'Generate Invite Link' });
+    fireEvent.click(generateBtn);
+
+    const copyButton = await screen.findByRole('button', { name: 'Copy Link' });
     fireEvent.click(copyButton);
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      expect.stringContaining('test-tenant-123')
+      'https://ohc.app/invite/test-tenant-123'
     );
-    expect(screen.getByText('Copied!')).toBeDefined();
+    expect(await screen.findByText('Copied!')).toBeDefined();
   });
 
   it('contains a valid WhatsApp share link', async () => {
     render(<DashboardViralInviteWidget />);
 
-    const whatsappLink = screen.getByRole('link', { name: /Share on WhatsApp/i });
+    const generateBtn = screen.getByRole('button', { name: 'Generate Invite Link' });
+    fireEvent.click(generateBtn);
+
+    const whatsappLink = await screen.findByRole('link', { name: /Share on WhatsApp/i });
     expect(whatsappLink.getAttribute('href')).toContain('wa.me');
     expect(whatsappLink.getAttribute('href')).toContain('test-tenant-123');
   });

--- a/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.tsx
+++ b/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.tsx
@@ -5,16 +5,48 @@ import React, { useState, useEffect } from 'react';
 export function DashboardViralInviteWidget() {
   const [copied, setCopied] = useState(false);
   const [tenantId, setTenantId] = useState("default-team");
-  const [referralLink, setReferralLink] = useState("/onboarding?ref=default-team&source=dashboard_invite");
+  const [referralLink, setReferralLink] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const storedTenant = localStorage.getItem('tenant_id') || localStorage.getItem('tenant');
       const finalTenant = storedTenant || "default-team";
       setTenantId(finalTenant);
-      setReferralLink(`${window.location.origin}/onboarding?ref=${finalTenant}&source=dashboard_invite`);
+
     }
   }, []);
+
+  const generateLink = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const inviterId = typeof window !== 'undefined' ? (localStorage.getItem('user_id') || 'local-user') : 'local-user';
+      const res = await fetch('/api/v1/growth/team-invites', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          team_id: tenantId,
+          inviter_id: inviterId,
+          invitee_id: 'pending-dashboard-invite',
+        }),
+      });
+      if (!res.ok) {
+        throw new Error('Failed to generate invite');
+      }
+      const data = await res.json();
+      setReferralLink(data.invite_link);
+    } catch (err: any) {
+      setError(err.message || 'Something went wrong');
+      // Fallback
+      setReferralLink(`${window.location.origin}/onboarding?ref=${tenantId}&source=dashboard_invite`);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleCopy = () => {
     if (navigator.clipboard) {
@@ -42,6 +74,17 @@ export function DashboardViralInviteWidget() {
         </div>
 
         <div className="w-full md:w-auto flex flex-col gap-3 shrink-0">
+          {!referralLink ? (
+            <button
+              onClick={generateLink}
+              disabled={loading}
+              className="w-full py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl font-bold text-sm shadow-md transition-all flex items-center justify-center disabled:opacity-70"
+            >
+              {loading ? 'Generating...' : 'Generate Invite Link'}
+            </button>
+          ) : (
+            <>
+
           <div className="flex items-center gap-2 bg-white/70 dark:bg-black/40 p-1.5 rounded-xl border border-indigo-100 dark:border-indigo-800 shadow-sm">
             <input
               type="text"
@@ -65,6 +108,10 @@ export function DashboardViralInviteWidget() {
             <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51a12.8 12.8 0 0 0-.57-.01c-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413Z"/></svg>
             Share on WhatsApp
           </a>
+
+            </>
+          )}
+          {error && <p className="text-red-500 text-xs text-center">{error}</p>}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problem
The `DashboardViralInviteWidget` and `AIFeaturePaywallWidget` were using mocked data or fallback client-side URL generation instead of hitting actual backend APIs to create traceable invite links for the referral/viral loop features. This undermined real growth analytics and attribution capabilities.

## Solution
* Wired `AIFeaturePaywallWidget` to call `/api/v1/growth/team-invites` using `fetch`
* Wired `DashboardViralInviteWidget` to call `/api/v1/growth/team-invites` on clicking the generate link button, keeping SSR safe by checking for the `window` object. 
* Refactored tests (`DashboardViralInviteWidget.test.tsx`) to mock the global `fetch` API and assert correct `POST` calls are being made to the right endpoint.
* While attempting to verify everything via `bazelisk test`, a Rust compiler error popped up because `ZeroClickGenerateRequest`, `ZeroClickGenerateResponse`, and `handle_zero_click_generate` were duplicated at the bottom of `src/server/api/growth.rs`. Removed the duplicate definitions and updated the associated unit tests to use the correct function signature.

## Verification
* **Frontend:** Ran `cd src/ui/next && npm run dev` and checked the dashboard via curl to make sure it runs correctly without crashing. Also ran `bazelisk test //src/ui/next:next_vitest`. All frontend tests pass.
* **Backend:** Ran `bazelisk test //src/server:server_lib_core_unit_test` and verified Rust compilation and unit tests pass.
* **E2E:** `bazelisk test //...` verified everything else is working.

---
*PR created automatically by Jules for task [9290388979618540411](https://jules.google.com/task/9290388979618540411) started by @ql-owo-lp*