### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Apply RLS to Documentation Schema

### DIFF
--- a/src/server/db/migrations/131_documentation_schema_rls.sql
+++ b/src/server/db/migrations/131_documentation_schema_rls.sql
@@ -1,0 +1,52 @@
+-- +goose Up
+DO $$
+BEGIN
+    -- help_articles
+    IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'help_articles') THEN
+        ALTER TABLE help_articles ENABLE ROW LEVEL SECURITY;
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_policies WHERE schemaname = current_schema() AND tablename = 'help_articles' AND policyname = 'tenant_isolation_help_articles'
+        ) THEN
+            CREATE POLICY tenant_isolation_help_articles ON help_articles USING (tenant_id::text = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+        END IF;
+    END IF;
+
+    -- video_tutorials
+    IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'video_tutorials') THEN
+        ALTER TABLE video_tutorials ENABLE ROW LEVEL SECURITY;
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_policies WHERE schemaname = current_schema() AND tablename = 'video_tutorials' AND policyname = 'tenant_isolation_video_tutorials'
+        ) THEN
+            CREATE POLICY tenant_isolation_video_tutorials ON video_tutorials USING (tenant_id::text = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+        END IF;
+    END IF;
+
+    -- tooltips
+    IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'tooltips') THEN
+        ALTER TABLE tooltips ENABLE ROW LEVEL SECURITY;
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_policies WHERE schemaname = current_schema() AND tablename = 'tooltips' AND policyname = 'tenant_isolation_tooltips'
+        ) THEN
+            CREATE POLICY tenant_isolation_tooltips ON tooltips USING (tenant_id::text = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+        END IF;
+    END IF;
+
+    -- walkthrough_steps
+    IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'walkthrough_steps') THEN
+        ALTER TABLE walkthrough_steps ENABLE ROW LEVEL SECURITY;
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_policies WHERE schemaname = current_schema() AND tablename = 'walkthrough_steps' AND policyname = 'tenant_isolation_walkthrough_steps'
+        ) THEN
+            CREATE POLICY tenant_isolation_walkthrough_steps ON walkthrough_steps USING (tenant_id::text = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+        END IF;
+    END IF;
+END $$;
+
+-- +goose Down
+DO $$
+BEGIN
+    DROP POLICY IF EXISTS tenant_isolation_help_articles ON help_articles;
+    DROP POLICY IF EXISTS tenant_isolation_video_tutorials ON video_tutorials;
+    DROP POLICY IF EXISTS tenant_isolation_tooltips ON tooltips;
+    DROP POLICY IF EXISTS tenant_isolation_walkthrough_steps ON walkthrough_steps;
+END $$;


### PR DESCRIPTION
**Summary**
This PR addresses a critical multi-tenant isolation vulnerability by enforcing Row Level Security (RLS) on newly added documentation-related tables (`help_articles`, `video_tutorials`, `tooltips`, `walkthrough_steps`). These tables were previously introduced in Cloud Mode without enforcing the `tenant_id` boundary context, risking data leakage between tenants.

**Impact & Severity**
*   **Severity:** High (Tenant data exposure risk if these tables start actively writing data).
*   **Impact:** A compromised tenant could potentially query or manipulate documentation data, tooltips, or configuration belonging to another tenant via API calls if the underlying database doesn't enforce strict tenant bounding natively. 

**Fix details**
Added `src/server/db/migrations/131_documentation_schema_rls.sql` using a PL/pgSQL `DO` block to gracefully check table existence before applying the `ENABLE ROW LEVEL SECURITY` configuration and attaching `CREATE POLICY` to bind isolation exactly to the `app.current_tenant` context missing-ok (`true`) setting.

**Testing**
*   Ran full unit and E2E test suites (`bazelisk test //...` and `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"`). All tests pass. 
*   Analyzed code dependencies and found that current docs usage relies on hardcoded vector constants instead of the database layer, meaning no active leaks could have occurred yet. The database is now secure before future development connects to it.

---
*PR created automatically by Jules for task [12621184509669057193](https://jules.google.com/task/12621184509669057193) started by @wbbsuper*