### PR TITLE
fix: Use relative paths for growth viral links

### DIFF
--- a/src/e2e/viral_growth_features.spec.ts
+++ b/src/e2e/viral_growth_features.spec.ts
@@ -6,10 +6,10 @@ test.describe('Viral Growth Features', () => {
 
   test('Viral Badge Visibility and Link on Quote Page', async ({ page }) => {
     // Set tenant in localStorage
-    await page.goto(BASE_URL + '/dashboard.html');
+    await page.goto(BASE_URL + '/dashboard');
     await page.evaluate(() => localStorage.setItem('tenant_id', 'maya-cakes'));
 
-    await page.goto(BASE_URL + '/quote.html?id=123&tenant=maya-cakes');
+    await page.goto(BASE_URL + '/quote?id=123&tenant=maya-cakes');
 
     const badge = page.locator('#viral-badge');
     await expect(badge).toBeVisible();
@@ -23,11 +23,15 @@ test.describe('Viral Growth Features', () => {
   });
 
   test('Referral Card on Success Page (Deposit Flow)', async ({ page }) => {
-    await page.goto(BASE_URL + '/dashboard.html');
+    // Navigate and set storage
+    await page.goto(BASE_URL + '/dashboard');
     await page.evaluate(() => localStorage.setItem('tenant_id', 'carlos-repairs'));
 
     // Simulate successful deposit
-    await page.goto(BASE_URL + '/success.html?type=booking_deposit&tenant=carlos-repairs');
+    await page.goto(BASE_URL + '/success?type=booking_deposit&tenant=carlos-repairs');
+
+    // Make sure we wait for it to display via JS logic
+    await page.waitForSelector('#referral-success-card', { state: 'visible', timeout: 5000 });
 
     const referralCard = page.locator('#referral-success-card');
     await expect(referralCard).toBeVisible();
@@ -40,13 +44,13 @@ test.describe('Viral Growth Features', () => {
   });
 
   test('Success Page does NOT show Referral Card for non-deposit types', async ({ page }) => {
-    await page.goto(BASE_URL + '/success.html?type=general');
+    await page.goto(BASE_URL + '/success?type=general');
     const referralCard = page.locator('#referral-success-card');
     await expect(referralCard).not.toBeVisible();
   });
 
   test('Dashboard Footer Viral Link', async ({ page }) => {
-    await page.goto(BASE_URL + '/dashboard.html');
+    await page.goto(BASE_URL + '/dashboard');
     await page.evaluate(() => localStorage.setItem('tenant_id', 'nora-agency'));
     // Reload to apply script
     await page.reload();
@@ -62,7 +66,7 @@ test.describe('Viral Growth Features', () => {
 
   test('Mobile Responsiveness: Viral Badge Touch Target', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
-    await page.goto(BASE_URL + '/quote.html?id=123');
+    await page.goto(BASE_URL + '/quote?id=123');
 
     const badge = page.locator('#viral-badge');
     await expect(badge).toBeVisible();

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -840,7 +840,7 @@
     </div>
 
     <footer style="margin-top: 40px; text-align: center; padding: 24px; font-size: 14px; font-weight: 600; background: rgba(255, 255, 255, 0.4); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border-top: 1px solid rgba(255, 255, 255, 0.4); border-radius: 24px 24px 0 0; width: 100%; box-sizing: border-box;">
-      <a href="index.html" id="dashboard-footer-viral-link" style="color: #0066FF; text-decoration: none; display: flex; align-items: center; justify-content: center; gap: 8px;">
+      <a href="/onboarding" id="dashboard-footer-viral-link" style="color: #0066FF; text-decoration: none; display: flex; align-items: center; justify-content: center; gap: 8px;">
         <span style="background: #0066FF; color: white; padding: 4px 8px; border-radius: 8px; font-size: 10px; font-weight: 800;">OHC</span>
         Powered by OneHumanCorp
       </a>
@@ -1069,7 +1069,7 @@
         const tenantIdForFooter = localStorage.getItem("tenant_id") || localStorage.getItem("tenant") || "default-team";
         const footerLink = document.getElementById("dashboard-footer-viral-link");
         if (footerLink) {
-          footerLink.href = `index.html?ref=${encodeURIComponent(tenantIdForFooter)}&source=footer_widget`;
+          footerLink.href = `/onboarding?ref=${encodeURIComponent(tenantIdForFooter)}&source=footer_widget`;
         }
         const tenant = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team';
         try {

--- a/src/ui/tauri/src/ui/quote.html
+++ b/src/ui/tauri/src/ui/quote.html
@@ -631,7 +631,7 @@
         const tenantId = urlParams.get('tenant') || 'e2e-tenant';
 
         viralBadge.style.display = 'block';
-        viralLink.href = `https://ohc.app/onboarding?ref=${encodeURIComponent(tenantId)}&source=quote_viewer`;
+        viralLink.href = `/onboarding?ref=${encodeURIComponent(tenantId)}&source=quote_viewer`;
 
         const handlePayment = async () => {
           btnPayCard.innerText = 'Processing...';

--- a/src/ui/tauri/src/ui/success.html
+++ b/src/ui/tauri/src/ui/success.html
@@ -112,7 +112,7 @@
             const refCard = document.getElementById('referral-success-card');
             const refLink = document.getElementById('referral-success-link');
             refCard.style.display = 'block';
-            refLink.href = `https://ohc.app/onboarding?ref=${encodeURIComponent(tenantId)}&source=success_page`;
+            refLink.href = `/onboarding?ref=${encodeURIComponent(tenantId)}&source=success_page`;
             return;
         }
 


### PR DESCRIPTION
Fixes hardcoded https://ohc.app domains and index.html refs in dashboard.html, success.html, and quote.html to use relative pathing. Fixes the e2e test by updating to expect relative paths and adding a wait for the dynamic success card.

---
*PR created automatically by Jules for task [15220898057007236632](https://jules.google.com/task/15220898057007236632) started by @ql-owo-lp*