### PR TITLE
fix(db): Add _sync_status column to pos_offline_transactions

### DIFF
--- a/src/server/db/migrations/131_pos_offline_transactions_sync_status.sql
+++ b/src/server/db/migrations/131_pos_offline_transactions_sync_status.sql
@@ -1,0 +1,2 @@
+-- Migration 131: Add _sync_status to pos_offline_transactions
+ALTER TABLE pos_offline_transactions ADD COLUMN IF NOT EXISTS _sync_status VARCHAR(50) DEFAULT 'pending';


### PR DESCRIPTION
Added missing _sync_status column to pos_offline_transactions to resolve the hybrid sync daemon failures.

---
*PR created automatically by Jules for task [10037094305894517242](https://jules.google.com/task/10037094305894517242) started by @ql-owo-lp*