### PR TITLE
feat(billing): Fix get_tenant_cached_tokens in Tracker

### DIFF
--- a/src/server/billing.rs
+++ b/src/server/billing.rs
@@ -222,6 +222,14 @@ impl Tracker {
         }
     }
 
+    pub fn get_tenant_cached_tokens(&self, tenant_id: &str) -> i64 {
+        if let Some(ref auditor) = self.auditor {
+            auditor.get_tenant_cached_tokens(tenant_id)
+        } else {
+            0
+        }
+    }
+
     pub fn get_tenant_cost_cents(&self, tenant_id: &str) -> i64 {
         if let Some(ref auditor) = self.auditor {
             auditor.get_tenant_cost_cents(tenant_id)
@@ -259,13 +267,19 @@ impl Tracker {
         } else {
             0
         };
-        TokenSummary { total_tokens }
+        let total_cached_tokens = if let Some(auditor) = &self.auditor {
+            auditor.get_total_cached_tokens()
+        } else {
+            0
+        };
+        TokenSummary { total_tokens, total_cached_tokens }
     }
 }
 
 #[derive(Default)]
 pub struct TokenSummary {
     pub total_tokens: i64,
+    pub total_cached_tokens: i64,
 }
 
 impl Default for Tracker {

--- a/src/server/services/billing/auditor.rs
+++ b/src/server/services/billing/auditor.rs
@@ -266,6 +266,11 @@ impl CostAuditor {
         agent_tokens.values().sum()
     }
 
+    pub fn get_total_cached_tokens(&self) -> i64 {
+        let tenant_cached_tokens = self.tenant_cached_tokens.lock().unwrap();
+        tenant_cached_tokens.values().sum()
+    }
+
     pub fn get_tenant_tokens(&self, tenant_id: &str) -> i64 {
         let tenant_tokens = self.tenant_tokens.lock().unwrap();
         *tenant_tokens.get(tenant_id).unwrap_or(&0)


### PR DESCRIPTION
Fixed the cost transparency metrics in the OHC assistant logic by correctly wiring `get_tenant_cached_tokens` and `get_total_cached_tokens` from `CostAuditor` to `Tracker`. This enables accurate tracking of token efficiency and cache utilization. All unit and E2E tests have passed.

---
*PR created automatically by Jules for task [1214493214699009700](https://jules.google.com/task/1214493214699009700) started by @ql-owo-lp*