### PR TITLE
🔨 Forge: Implement Missing Agent Feed Action Approval Flow (Unified Inbox Action Cards)

### DIFF
--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -70,6 +70,8 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
   const [isOffline, setIsOffline] = useState(false);
   const [offlineActionsCount, setOfflineActionsCount] = useState(0);
   const [queuedActionIds, setQueuedActionIds] = useState<Set<string>>(new Set());
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editContent, setEditContent] = useState<string>("");
 
   const tenantId = () => {
     if (typeof window === "undefined") return "default";
@@ -373,7 +375,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
     return "warning";
   };
 
-  const submitDecision = async (id: string, approved: boolean) => {
+  const submitDecision = async (id: string, approved: boolean, modified_content?: string) => {
     const tenant = tenantId();
     const res = await fetch(`/api/agent-feed/${id}`, {
       method: "PUT",
@@ -382,7 +384,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
         "x-tenant-id": tenant,
         "x-user-id": "default",
       },
-      body: JSON.stringify({ state: approved ? "APPROVED" : "DISMISSED" }),
+      body: JSON.stringify({ state: approved ? "APPROVED" : "DISMISSED", modified_content }),
     });
 
     if (!res.ok) {
@@ -390,13 +392,13 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
     }
   };
 
-  const handleDecision = async (id: string, approved: boolean) => {
+  const handleDecision = async (id: string, approved: boolean, modified_content?: string) => {
     if (isOffline) {
       // Enqueue offline action
       await enqueueAction({
         id: crypto.randomUUID(),
         type: 'approve_agent_feed',
-        payload: { id, approved },
+        payload: { id, approved, modified_content },
         timestamp: Date.now()
       });
       setOfflineActionsCount(prev => prev + 1);
@@ -408,7 +410,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
     setItems(prev => prev.filter(app => app.id !== id));
 
     try {
-      await submitDecision(id, approved);
+      await submitDecision(id, approved, modified_content);
     } catch (err: any) {
       // Revert optimistic update gracefully by refetching
       const tenant = tenantId();
@@ -964,24 +966,67 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
                       </button>
                     </div>
                   ) : (approval.proposed_action || approval.context_payload)?.feature_type === 'ambassador_reply' ? (
-                    <div className="flex flex-col sm:flex-row gap-3 w-full">
-                      <button
-                        onClick={() => handleDecision(approval.id, true)}
-                        className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all duration-200 shadow-md flex items-center justify-center"
-                        aria-label="Approve & Send Draft"
-                        data-testid="approve-ambassador-reply"
-                      >
-                        ✨ 1-Tap Approve
-                      </button>
-                      <button
-                        onClick={() => handleDecision(approval.id, false)}
-                        className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
-                        aria-label="Dismiss Draft"
-                        data-testid="dismiss-ambassador-reply"
-                      >
-                        Dismiss
-                      </button>
-                    </div>
+                    editingId === approval.id ? (
+                      <div className="flex flex-col gap-3 w-full">
+                        <textarea
+                          className="w-full p-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-[#1D1D1F] dark:text-[#F5F5F7] text-sm focus:ring-2 focus:ring-[#0066FF] outline-none transition-all resize-none"
+                          rows={4}
+                          value={editContent}
+                          onChange={(e) => setEditContent(e.target.value)}
+                          data-testid="edit-ambassador-reply-textarea"
+                          autoFocus
+                        />
+                        <div className="flex gap-3">
+                          <button
+                            onClick={() => {
+                              handleDecision(approval.id, true, editContent);
+                              setEditingId(null);
+                            }}
+                            className="flex-1 min-h-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all shadow-md flex items-center justify-center"
+                            data-testid="save-send-ambassador-reply"
+                          >
+                            Save & Send
+                          </button>
+                          <button
+                            onClick={() => setEditingId(null)}
+                            className="flex-1 min-h-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all flex items-center justify-center"
+                            data-testid="cancel-edit-ambassador-reply"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex flex-col sm:flex-row gap-3 w-full">
+                        <button
+                          onClick={() => handleDecision(approval.id, true)}
+                          className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all duration-200 shadow-md flex items-center justify-center"
+                          aria-label="Approve & Send Draft"
+                          data-testid="approve-ambassador-reply"
+                        >
+                          ✨ 1-Tap Approve
+                        </button>
+                        <button
+                          onClick={() => {
+                            setEditingId(approval.id);
+                            setEditContent((approval.proposed_action || approval.context_payload)?.generated_response || "");
+                          }}
+                          className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
+                          aria-label="Edit Draft"
+                          data-testid="edit-ambassador-reply"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={() => handleDecision(approval.id, false)}
+                          className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
+                          aria-label="Dismiss Draft"
+                          data-testid="dismiss-ambassador-reply"
+                        >
+                          Dismiss
+                        </button>
+                      </div>
+                    )
                   ) : (approval.proposed_action || approval.context_payload)?.feature_type === "quote_draft" ? (
                     <div className="flex flex-col sm:flex-row gap-3 w-full">
                       <button
@@ -1087,6 +1132,37 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
                       </div>
                     </>
                   ) : (
+                    editingId === approval.id ? (
+                      <div className="flex flex-col gap-3 w-full">
+                        <textarea
+                          className="w-full p-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-[#1D1D1F] dark:text-[#F5F5F7] text-sm focus:ring-2 focus:ring-[#0066FF] outline-none transition-all resize-none"
+                          rows={4}
+                          value={editContent}
+                          onChange={(e) => setEditContent(e.target.value)}
+                          data-testid="edit-proposal-textarea"
+                          autoFocus
+                        />
+                        <div className="flex gap-3">
+                          <button
+                            onClick={() => {
+                              handleDecision(approval.id, true, editContent);
+                              setEditingId(null);
+                            }}
+                            className="flex-1 min-h-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all shadow-md flex items-center justify-center"
+                            data-testid="save-proposal"
+                          >
+                            Save & Approve
+                          </button>
+                          <button
+                            onClick={() => setEditingId(null)}
+                            className="flex-1 min-h-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all flex items-center justify-center"
+                            data-testid="cancel-edit-proposal"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
                     <>
                       <button
                         onClick={() => handleDecision(approval.id, true)}
@@ -1098,7 +1174,14 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
                       </button>
                       <div className="flex flex-col sm:flex-row gap-3 w-full">
                         <button
-                          onClick={() => {}}
+                          onClick={() => {
+                            setEditingId(approval.id);
+                            const textToEdit =
+                              (approval.proposed_action || approval.context_payload)?.generated_response ||
+                              (approval.proposed_action || approval.context_payload)?.draft_reply ||
+                              (approval.context_payload?.description || approval.proposed_action?.message || approval.proposed_action?.action_type || approval.event_source);
+                            setEditContent(textToEdit || "");
+                          }}
                           className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
                           aria-label="Edit proposal"
                           data-testid="edit-proposal"
@@ -1115,6 +1198,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
                         </button>
                       </div>
                     </>
+                    )
                   )}
                 </div>
               </div>

--- a/src/ui/next/src/e2e/unified_agent_feed_interaction.spec.ts
+++ b/src/ui/next/src/e2e/unified_agent_feed_interaction.spec.ts
@@ -126,4 +126,70 @@ test.describe('Unified Agent Feed Interactive Flow', () => {
     await expect(feedContainer).toBeVisible({ timeout: 15000 });
   });
 
+
+  test('should handle inline editing of a proposal', async ({ page }) => {
+    test.setTimeout(180000);
+
+    await page.goto('/dashboard');
+    await expect(page.locator('h1', { hasText: 'Dashboard' }).first()).toBeVisible({ timeout: 25000 });
+
+    const approveBtn = page.getByTestId('approve-proposal').first();
+    const editBtn = page.getByTestId('edit-proposal').first();
+
+    if (await editBtn.isVisible({ timeout: 10000 }).catch(() => false)) {
+      // Click edit
+      await editBtn.click();
+
+      // Verify textarea appears
+      const textarea = page.getByTestId('edit-proposal-textarea');
+      await expect(textarea).toBeVisible();
+
+      // Modify the text
+      await textarea.fill('This is my manually edited draft text');
+
+      // Click cancel first
+      const cancelBtn = page.getByTestId('cancel-edit-proposal');
+      await cancelBtn.click();
+      await expect(textarea).not.toBeVisible();
+
+      // Re-edit and save
+      await editBtn.click();
+      await textarea.fill('Second edited text');
+
+      const saveBtn = page.getByTestId('save-proposal');
+      await saveBtn.click();
+
+      // It should optimistically disappear
+      await expect(textarea).not.toBeVisible({ timeout: 2000 });
+      await expect(editBtn).not.toBeVisible({ timeout: 2000 });
+    }
+  });
+
+  test('should handle inline editing of an ambassador reply', async ({ page }) => {
+    test.setTimeout(180000);
+
+    await page.goto('/dashboard');
+    await expect(page.locator('h1', { hasText: 'Dashboard' }).first()).toBeVisible({ timeout: 25000 });
+
+    const editBtn = page.getByTestId('edit-ambassador-reply').first();
+
+    if (await editBtn.isVisible({ timeout: 10000 }).catch(() => false)) {
+      // Click edit
+      await editBtn.click();
+
+      // Verify textarea appears
+      const textarea = page.getByTestId('edit-ambassador-reply-textarea');
+      await expect(textarea).toBeVisible();
+
+      // Modify the text
+      await textarea.fill('Edited ambassador reply');
+
+      const saveBtn = page.getByTestId('save-send-ambassador-reply');
+      await saveBtn.click();
+
+      // It should optimistically disappear
+      await expect(textarea).not.toBeVisible({ timeout: 2000 });
+      await expect(editBtn).not.toBeVisible({ timeout: 2000 });
+    }
+  });
 });


### PR DESCRIPTION
feat: Implement Missing Agent Feed Action Approval Flow (Unified Inbox Action Cards)

- Resolves #28590
- Adds state to `UnifiedAgentFeed` to handle inline edits
- Replaces the generic buttons with Edit buttons for Ambassador replies and Proposals
- Adds inline `textarea` that takes up the space
- Sends `modified_content` via the `PUT` API endpoint to the backend
- Updates `unified_agent_feed_interaction.spec.ts` with Playwright e2e tests
- Verified all unit and Playwright tests pass

---
*PR created automatically by Jules for task [10216600448786654953](https://jules.google.com/task/10216600448786654953) started by @wbbsuper*