### PR TITLE
fix(onboarding): pass AI-generated initial_products on manual launch

### DIFF
--- a/src/ui/next/src/app/onboarding/page.test.tsx
+++ b/src/ui/next/src/app/onboarding/page.test.tsx
@@ -812,4 +812,39 @@ describe('OnboardingWizard', () => {
     expect(screen.getByText('10-Minute Setup Wizard')).toBeInTheDocument();
     expect(useOnboardingStore.getState().step).toBe(0);
   });
+
+  it('Step 3: Passes initial_products from localStorage to /api/onboarding/start', async () => {
+    const user = userEvent.setup({ delay: null });
+
+    localStorage.setItem('onboarding_initial_products', JSON.stringify([
+      { name: 'Custom AI Product', price: '99' }
+    ]));
+
+    act(() => {
+      useOnboardingStore.setState({ step: 3, adminName: "Test Admin", adminEmail: "test@example.com", adminPassword: "Password123" });
+    });
+
+    let startRequestPayload: any = null;
+    (global.fetch as any).mockImplementation((url: string, options: any) => {
+      if (url === '/api/onboarding/start') {
+        startRequestPayload = JSON.parse(options.body);
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ organization_id: 'org_123', status: 'started' })
+        });
+      }
+      if (url === '/api/onboarding/launch') { return Promise.resolve({ ok: true, json: async () => ({}) }); }
+      if (url === '/api/onboarding/state') { return Promise.resolve({ ok: true, json: async () => ({}) }); }
+      if (url === '/api/onboarding/draft') { return Promise.resolve({ ok: true, json: async () => ({}) }); }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(<TooltipProvider><OnboardingWizard /></TooltipProvider>);
+
+    const launchButton = await screen.findByRole('button', { name: /Launch Store/i });
+    await user.click(launchButton);
+
+    expect(startRequestPayload).toBeDefined();
+    expect(startRequestPayload.initial_products).toEqual([{ name: 'Custom AI Product', price: '99' }]);
+  });
 });

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -620,7 +620,8 @@ export default function OnboardingWizard() {
           location: location || '',
           target_audience: targetAudience || '',
           ai_agents: aiAgents,
-          ai_auto_respond: aiAutoRespond
+          ai_auto_respond: aiAutoRespond,
+          initial_products: JSON.parse(localStorage.getItem('onboarding_initial_products') || '[]')
         })
       });
 


### PR DESCRIPTION
During the onboarding process, when the AI generates the initial products in the chat, these are shown back to the user but they weren't being correctly forwarded to the backend when the user clicked the "Launch Store" button. As a result, the backend was ignoring the AI's tailored variants and descriptions, substituting them with generic fallbacks instead.

This fix reads the saved `onboarding_initial_products` from localStorage on manual launch and includes them in the start payload, preserving the personalized experience.

Fixes an issue where `handleStartOnboarding` was missing the `initial_products` payload unless called by a direct bypass. Also includes a React testing-library test to verify this behaviour.

---
*PR created automatically by Jules for task [8430869648236236151](https://jules.google.com/task/8430869648236236151) started by @ql-owo-lp*