### PR TITLE
test(wizard): fix cross device e2e spec state and copy assertions

### DIFF
--- a/src/e2e/wizard_cross_device.spec.ts
+++ b/src/e2e/wizard_cross_device.spec.ts
@@ -6,23 +6,24 @@ test.describe('Wizard Cross Device E2E', () => {
     await page.addInitScript((tenantId) => {
       localStorage.setItem('tenant_id', tenantId);
       localStorage.setItem('user_id', tenantId);
-      localStorage.removeItem('website-builder-storage');
+      localStorage.removeItem('onboarding-storage-v3');
     }, 'storefront');
     await page.goto('/onboarding');
     await page.waitForLoadState('networkidle');
 
     // 2. Click Start My Business to advance to step 1
+    // The first screen is "10-Minute Setup Wizard", clicking "Start My Business" moves to step 1
     await page.getByRole('button', { name: /Start My Business/ }).click();
-    await expect(page.getByRole('heading', { name: 'What kind of business are you building?' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: "What's the name of your business?" })).toBeVisible();
 
     // 3. Move to step 2 and enter business name
-    await page.getByRole('button', { name: /Online Store/ }).click();
-    await expect(page.getByRole('heading', { name: 'Give your business a name' })).toBeVisible();
-    await page.getByPlaceholder('What is your business called?').fill('Cross Device Wizard');
+    // It's already at the "What's the name of your business?" step. We fill the input.
+    // The placeholder is "e.g. Maya's Custom Cakes"
+    await page.getByPlaceholder("e.g. Maya's Custom Cakes").fill('Cross Device Wizard');
 
     // Wait until local storage is updated with the business name
     await expect.poll(async () => {
-      const stateStr = await page.evaluate(() => localStorage.getItem('website-builder-storage'));
+      const stateStr = await page.evaluate(() => localStorage.getItem('onboarding-storage-v3'));
       if (!stateStr) return '';
       try {
         const state = JSON.parse(stateStr);
@@ -35,6 +36,11 @@ test.describe('Wizard Cross Device E2E', () => {
       timeout: 5000,
     }).toBe('Cross Device Wizard');
 
+    // Also trigger save to backend
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page.getByRole('heading', { name: "What do you sell?" })).toBeVisible();
+    await page.waitForTimeout(1000);
+
     // 4. Simulate a cross-device session with a new browser context
     const newContext = await browser.newContext();
     const newPage = await newContext.newPage();
@@ -42,21 +48,24 @@ test.describe('Wizard Cross Device E2E', () => {
     // Inject the exact same local storage state to the new context to test restoration
     // We navigate to dashboard first to have the right origin
     await newPage.goto('/dashboard');
-    const wizardState = await page.evaluate(() => localStorage.getItem('website-builder-storage'));
+    const wizardState = await page.evaluate(() => localStorage.getItem('onboarding-storage-v3'));
 
     await newPage.evaluate((state) => {
         if(state) {
-            localStorage.setItem('website-builder-storage', state);
+            localStorage.setItem('onboarding-storage-v3', state);
         }
         localStorage.setItem('tenant_id', 'storefront');
         localStorage.setItem('user_id', 'storefront');
     }, wizardState);
 
     await newPage.goto('/onboarding');
+    await newPage.waitForLoadState('networkidle');
 
     // 5. Verify the business name and step was properly restored
-    await expect(newPage.getByRole('heading', { name: 'Give your business a name' })).toBeVisible();
-    await expect(newPage.getByPlaceholder('What is your business called?')).toHaveValue('Cross Device Wizard', { timeout: 10000 });
+    await expect(newPage.getByRole('heading', { name: 'What do you sell?' })).toBeVisible({ timeout: 10000 });
+    await newPage.locator('button:has-text("Back")').first().click();
+    await expect(newPage.getByRole('heading', { name: "What's the name of your business?" })).toBeVisible();
+    await expect(newPage.getByPlaceholder("e.g. Maya's Custom Cakes")).toHaveValue('Cross Device Wizard', { timeout: 10000 });
 
     await newContext.close();
   });


### PR DESCRIPTION
The `wizard_cross_device.spec.ts` E2E test was incorrectly failing due to:
1. Attempting to hydrate the Next.js onboarding state using an outdated localStorage key (`website-builder-storage`) instead of the correct Zustand key (`onboarding-storage-v3`).
2. Looking for outdated headers/copy (e.g. "What kind of business are you building?") rather than the current updated UI text ("What's the name of your business?").

This fix aligns the Playwright spec with the actual Next.js application state requirements.

---
*PR created automatically by Jules for task [16115380566234081893](https://jules.google.com/task/16115380566234081893) started by @ql-owo-lp*