### PR TITLE
Fix outdated selector in cost-dashboard test

### DIFF
--- a/src/e2e/test_ui.spec.ts
+++ b/src/e2e/test_ui.spec.ts
@@ -6,5 +6,5 @@ test('Cost Soft Limit friendly prompt shows', async ({ page, loginAs, unlimitedA
   await page.waitForLoadState('networkidle');
   // We cannot easily assert the limit reached text without a specific tenant setup in DB.
   // But we must at least assert that the plan page loads fully for the E2E.
-  await expect(page.locator('div.stat-title:has-text("AI actions used this month")').first()).toBeVisible();
+  await expect(page.locator('h3:has-text("AI actions used")').first()).toBeVisible();
 });


### PR DESCRIPTION
Fixes a test assertion locator for `test_ui.spec.ts` to match the exact updated text "AI actions used" within `h3` tags rendered by `cost-dashboard/page.tsx`. Verified and tested successfully.

---
*PR created automatically by Jules for task [2699563910323121604](https://jules.google.com/task/2699563910323121604) started by @ql-owo-lp*