### PR TITLE
🧹 Auditor: [Codebase optimization] Remove redundant duplicate if statements in sqlite_store

### DIFF
--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -77,9 +77,6 @@ impl UserRepository for SqliteUserRepository {
         if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
             return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
         }
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1"
         } else {
@@ -112,9 +109,6 @@ impl UserRepository for SqliteUserRepository {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
         if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
             return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
         }
@@ -153,9 +147,6 @@ impl UserRepository for SqliteUserRepository {
         if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
             return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
         }
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1"
         } else {
@@ -191,9 +182,6 @@ impl UserRepository for SqliteUserRepository {
         if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
             return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
         }
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1"
         } else {
@@ -226,9 +214,6 @@ impl UserRepository for SqliteUserRepository {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
         if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
             return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
         }
@@ -269,9 +254,6 @@ impl UserRepository for SqliteUserRepository {
         let roles_json = serde_json::to_string(&user.roles).unwrap_or_default();
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
         if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
             return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
         }
@@ -330,9 +312,6 @@ impl UserRepository for SqliteUserRepository {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-        if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
-            return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
-        }
         if is_multitenant && org_id.trim().eq_ignore_ascii_case("system") {
             return Err("tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
         }


### PR DESCRIPTION
**Summary**
This PR cleans up redundant duplicated `if is_multitenant && org_id.trim().eq_ignore_ascii_case("system")` lines across multiple methods in `src/server/auth/sqlite_store.rs`. 

**Impact & Scope**
* Cleaned up duplicated validations for system tenant bypassing to reduce noise and lint.
* Evaluated database and orchestrations functionality through local automated UI Playwright suites and `bazelisk test //...` which pass correctly. 

**Testing**
* Successfully compiled all testing environments.
* E2E Playwright `//src/e2e:playwright` passes cleanly.
* Unit testing `//src/server/auth/...` and `//...` completes properly.

---
*PR created automatically by Jules for task [12018742997988856513](https://jules.google.com/task/12018742997988856513) started by @ql-owo-lp*