### PR TITLE
💰 Miser: Add missing auth headers and proxy routes for billing

### DIFF
--- a/src/ui/next/src/app/api/billing/cancel-subscription/route.ts
+++ b/src/ui/next/src/app/api/billing/cancel-subscription/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const backendUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+    const headers: Record<string, string> = {};
+
+    const authHeader = req.headers.get('Authorization');
+    if (authHeader) {
+      headers['Authorization'] = authHeader;
+    }
+
+    const res = await fetch(`${backendUrl}/api/billing/cancel-subscription`, {
+      method: 'POST',
+      headers,
+    });
+
+    if (!res.ok) {
+        console.error('Failed to cancel subscription on backend', res.status);
+        return NextResponse.json({ error: 'Failed to cancel subscription' }, { status: res.status });
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    if (process.env.NODE_ENV !== "test") console.warn('Warn proxying to backend:', error);
+    return NextResponse.json(
+      { message: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/ui/next/src/app/api/billing/download-invoice/route.ts
+++ b/src/ui/next/src/app/api/billing/download-invoice/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const backendUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+    const headers: Record<string, string> = {};
+
+    const authHeader = req.headers.get('Authorization');
+    if (authHeader) {
+      headers['Authorization'] = authHeader;
+    }
+
+    const res = await fetch(`${backendUrl}/api/billing/download-invoice`, {
+      method: 'POST',
+      headers,
+    });
+
+    if (!res.ok) {
+        console.error('Failed to download invoice on backend', res.status);
+        return NextResponse.json({ error: 'Failed to download invoice' }, { status: res.status });
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    if (process.env.NODE_ENV !== "test") console.warn('Warn proxying to backend:', error);
+    return NextResponse.json(
+      { message: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/ui/next/src/app/plan/page.tsx
+++ b/src/ui/next/src/app/plan/page.tsx
@@ -21,7 +21,10 @@ export default function MyPlanPage() {
   useEffect(() => {
     const fetchPlanData = async () => {
       try {
-        const response = await fetch('/api/billing/my-plan');
+        const token = localStorage.getItem('token');
+        const response = await fetch('/api/billing/my-plan', {
+          headers: token ? { 'Authorization': `Bearer ${token}` } : {}
+        });
         if (response.ok) {
           const json = await response.json();
           setData(json);

--- a/src/ui/next/src/app/pricing/page.tsx
+++ b/src/ui/next/src/app/pricing/page.tsx
@@ -11,10 +11,12 @@ export default function PricingPage() {
 
   const handleUpgrade = async (tier: string) => {
     try {
+      const token = localStorage.getItem('token');
       const response = await fetch('/api/billing/create-checkout-session', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          ...(token ? { 'Authorization': `Bearer ${token}` } : {})
         },
         body: JSON.stringify({ tier }),
       });

--- a/src/ui/next/src/e2e/cost-dashboard.spec.ts
+++ b/src/ui/next/src/e2e/cost-dashboard.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '@playwright/test';
 
 test.describe('Cost Dashboard Loop', () => {
   test('Cost dashboard loads and displays data', async ({ page }) => {

--- a/src/ui/next/src/e2e/dashboard_ux.spec.ts
+++ b/src/ui/next/src/e2e/dashboard_ux.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { currentAppSmoke } from '../../../../e2e/current_app_smoke';
+import { test as base } from '../../../../e2e/fixtures';
 
 test.describe('Dashboard UX', () => {
   test('should display Growth & Virality section with Share Cards link', async ({ page }) => {

--- a/src/ui/next/src/e2e/hyperlocal-lead-gen.spec.ts
+++ b/src/ui/next/src/e2e/hyperlocal-lead-gen.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { adminPage } from './fixtures';
-
+import { adminPage } from '../../../../e2e/fixtures';
 
 test.describe('Hyperlocal Lead Gen CUJ', () => {
   test('Carlos the Handyman sets up a weekly lead gen campaign', async ({ page }) => {


### PR DESCRIPTION
- Added missing `Authorization` header logic using `localStorage.getItem('token')` to the `/pricing` and `/plan` frontend pages.
- Created proxy routes for `cancel-subscription` and `download-invoice` in Next.js to forward these requests correctly to the backend API.
- Fixed missing or incorrect imports for `@playwright/test` across several E2E specs that were breaking the build.
- Validated all tests passing locally with `bazelisk test //...` and `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"`.

---
*PR created automatically by Jules for task [6341126338203378868](https://jules.google.com/task/6341126338203378868) started by @ql-owo-lp*