### PR TITLE
docs: replace hardcoded changelog with dynamic parsing

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ exports_files([
     "playwright.config.ts",
     "package.json",
     "package-lock.json",
+    "CHANGELOG.md",
 ])
 
 config_setting(

--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -334,6 +334,7 @@ rust_library(
     compile_data = [
         "//src/ui/tauri/src/ui:all_files",
         "//src/ui/next/public/api/ui:all_files",
+        "//:CHANGELOG.md",
     ],
     data = ["//src/server/migrations"],
     edition = "2024",

--- a/src/server/api/BUILD.bazel
+++ b/src/server/api/BUILD.bazel
@@ -94,6 +94,9 @@ rust_library(
         "//src/server/api/booking:mod.rs",
         "//src/server/api/booking:request.rs",
     ],
+    compile_data = [
+        "//:CHANGELOG.md",
+    ],
     crate_root = "bazel_lib.rs",
     edition = "2024",
     rustc_flags = ["--cfg=ohc_bazel_package"],

--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -278,30 +278,37 @@ pub struct ChangelogSection {
 }
 
 pub fn get_changelog_data() -> Vec<ChangelogSection> {
-    vec![
-        ChangelogSection {
-            version: "Version 1.1 (Latest)".to_string(),
-            screenshot_url: None,
-            content_lines: vec![
-                "### 🌟 New Features".to_string(),
-                "- **Help Center:** Fully searchable help center with video tutorials and articles.".to_string(),
-                "- **Contextual Tooltips:** Added plain language tooltips across the app to guide you.".to_string(),
-            ]
-        },
-        ChangelogSection {
-            version: "Version 1.0".to_string(),
-            screenshot_url: Some("/dashboard_with_charts.png".to_string()),
-            content_lines: vec![
-                "### 🌟 New Features".to_string(),
-                "- **Interactive AI Store Builder:** You can now generate a complete storefront from just a short description of your business. AI will handle the layout and copy for you.".to_string(),
-                "- **Smart Tooltips:** We added helpful text bubbles to all major buttons to help you learn the system faster.".to_string(),
-                "- **Help Center Upgrade:** Find answers instantly with our new searchable Help Center.".to_string(),
-                "### 🛠️ Improvements".to_string(),
-                "- Faster loading times for product images.".to_string(),
-                "- Simplified checkout process for your customers.".to_string(),
-            ]
+    let mut sections = Vec::new();
+    let content = std::include_str!("../../../CHANGELOG.md");
+
+    let mut current_version = String::new();
+    let mut current_lines = Vec::new();
+
+    for line in content.lines() {
+        if line.starts_with("## ") {
+            if !current_version.is_empty() {
+                sections.push(ChangelogSection {
+                    version: current_version.clone(),
+                    screenshot_url: None,
+                    content_lines: current_lines.clone(),
+                });
+            }
+            current_version = line.trim_start_matches("## ").trim().to_string();
+            current_lines = Vec::new();
+        } else if !current_version.is_empty() && !line.trim().is_empty() {
+            current_lines.push(line.to_string());
         }
-    ]
+    }
+
+    if !current_version.is_empty() {
+        sections.push(ChangelogSection {
+            version: current_version,
+            screenshot_url: None,
+            content_lines: current_lines,
+        });
+    }
+
+    sections
 }
 
 pub async fn get_changelog() -> Json<Vec<ChangelogSection>> {


### PR DESCRIPTION
This PR implements dynamic changelog parsing for the Help Center. 
Instead of rendering hardcoded values, the API now reads `CHANGELOG.md` directly. 

Changes:
- Added `CHANGELOG.md` to `compile_data` in Bazel BUILD files so it is accessible at compile time.
- Updated `src/server/api/docs.rs` to parse the `CHANGELOG.md` using `std::include_str!`. It splits headers on `## ` lines and extracts content appropriately. 

Tested:
- `bazelisk test //src/server/api:server_api_unit_test` passes.
- `bazelisk test //src/ui/next:next_vitest` passes.
- `bazelisk test //src/e2e:playwright_spec_coverage` passes.

---
*PR created automatically by Jules for task [15185799639068124281](https://jules.google.com/task/15185799639068124281) started by @ql-owo-lp*