### PR TITLE
fix(db): ensure search_workspace queries purchase_orders in Postgres

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -503,7 +503,7 @@ impl DB {
                 }
 
                 // Search Orders
-                let order_rows = sqlx::query("SELECT id, status, CAST(total_amount AS DOUBLE PRECISION) as total_amount FROM orders WHERE tenant_id = $1 AND (id ILIKE $2 OR status ILIKE $2) ORDER BY id ASC LIMIT 10")
+                let order_rows = sqlx::query("SELECT id, status, CAST(total_cost AS DOUBLE PRECISION) as total_cost FROM purchase_orders WHERE tenant_id = $1 AND (id ILIKE $2 OR status ILIKE $2) ORDER BY id ASC LIMIT 10")
                     .bind(tenant_id)
                     .bind(&query_lower)
                     .fetch_all(&self.pool)
@@ -514,7 +514,7 @@ impl DB {
                     use sqlx::Row;
                     let id: String = row.get("id");
                     let status: String = row.try_get("status").unwrap_or_default();
-                    let amount: Option<f64> = row.try_get("total_amount").unwrap_or_default();
+                    let amount: Option<f64> = row.try_get("total_cost").unwrap_or_default();
                     let amount: f64 = amount.unwrap_or(0.0);
                     results.push(SearchResult {
                         id: id.clone(),


### PR DESCRIPTION
Fixed a database parity failure in `search_workspace` for the Postgres store.
Previously, the Postgres backend was incorrectly querying the `orders` table and `total_amount` column.
This has been updated to query the `purchase_orders` table and `total_cost` column,
bringing it into parity with the SQLite implementation and resolving the unit test failure.

---
*PR created automatically by Jules for task [779091458119743496](https://jules.google.com/task/779091458119743496) started by @ql-owo-lp*