### PR TITLE
test(e2e): fix failing onboarding tests by updating placeholder locators

### DIFF
--- a/src/e2e/onboarding.spec.ts
+++ b/src/e2e/onboarding.spec.ts
@@ -195,7 +195,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
 
     await expect(page.getByRole('heading', { name: "Tell us about your business" })).toBeVisible();
 
-    const bioInput = page.getByPlaceholder("Tell us about your business that sells custom vegan cakes...");
+    const bioInput = page.getByPlaceholder("e.g. I run a local bakery that sells custom vegan cakes...");
     await expect(bioInput).toBeVisible();
     await expect(bioInput).toHaveClass(/glassmorphism/);
 
@@ -220,7 +220,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     const instantBuildButton = page.locator('button', { hasText: 'Instant Build' });
     await instantBuildButton.click();
 
-    const bioInput = page.getByPlaceholder("Tell us about your business that sells custom vegan cakes...");
+    const bioInput = page.getByPlaceholder("e.g. I run a local bakery that sells custom vegan cakes...");
     await bioInput.fill("Test business description.");
 
     const imageUrlInput = page.locator('#instant-image-url');
@@ -240,7 +240,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     const instantBuildButton = page.locator('button', { hasText: 'Instant Build' });
     await instantBuildButton.click();
 
-    const bioInput = page.getByPlaceholder("Tell us about your business that sells custom vegan cakes...");
+    const bioInput = page.getByPlaceholder("e.g. I run a local bakery that sells custom vegan cakes...");
     await bioInput.fill("Test business description without image.");
 
     const imageUrlInput = page.locator('#instant-image-url');
@@ -266,7 +266,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
 
     await expect(page.getByRole('heading', { name: "Tell us about your business" })).toBeVisible();
 
-    const bioInput = page.getByPlaceholder("Tell us about your business that sells custom vegan cakes...");
+    const bioInput = page.getByPlaceholder("e.g. I run a local bakery that sells custom vegan cakes...");
     await bioInput.fill("Will fail network request");
 
     await page.route('**/api/onboarding/**', route => route.abort('failed'));
@@ -313,7 +313,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     const instantBuildButton = page.locator('button', { hasText: 'Instant Build' });
     await instantBuildButton.click();
 
-    const bioInput = page.getByPlaceholder("Tell us about your business that sells custom vegan cakes...");
+    const bioInput = page.getByPlaceholder("e.g. I run a local bakery that sells custom vegan cakes...");
     // Only provide a generic description
     await bioInput.fill("I sell things online.");
 
@@ -332,7 +332,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     const instantBuildButton = page.locator('button', { hasText: 'Instant Build' });
     await instantBuildButton.click();
 
-    const bioInput = page.getByPlaceholder("Tell us about your business that sells custom vegan cakes...");
+    const bioInput = page.getByPlaceholder("e.g. I run a local bakery that sells custom vegan cakes...");
     const box = await bioInput.boundingBox();
     expect(Math.round(box?.height || 0)).toBeGreaterThanOrEqual(44);
     expect(box?.width).toBeLessThanOrEqual(375);


### PR DESCRIPTION
This PR fixes an issue where the `src/e2e/onboarding.spec.ts` test was failing because it expected the `bioInput` placeholder to be "Tell us about your business that sells custom vegan cakes...", but the actual text rendered by the UI component in `src/ui/next/src/app/onboarding/page.tsx` was "e.g. I run a local bakery that sells custom vegan cakes...".

I've updated the test to use the correct placeholder text, aligning it with the existing implementation. `bazelisk test //...` passes successfully.

---
*PR created automatically by Jules for task [11884417641467382476](https://jules.google.com/task/11884417641467382476) started by @ql-owo-lp*