### PR TITLE
💰 Miser: Dynamic Model Prompt Caching Cost Calculation

### DIFF
--- a/src/server/minimax.rs
+++ b/src/server/minimax.rs
@@ -126,7 +126,7 @@ impl MinimaxClient {
         };
 
         // 1. Check Cache
-        if let (Some(cached), _cost_cents) = self.cache.get_with_cost_cents(&optimized_prompt) {
+        if let (Some(cached), _cost_cents) = self.cache.get_with_cost_cents(&optimized_prompt, "minimax-text-01") {
             tracing::info!("Prompt cache hit (saved ~{} tokens)", cached.token_count);
             return Ok(cached.text);
         }
@@ -243,7 +243,7 @@ impl MinimaxClient {
         let (tx, rx) = tokio::sync::mpsc::channel(100);
 
         // 1. Check Cache
-        if let (Some(cached), _cost_cents) = self.cache.get_with_cost_cents(&optimized_prompt) {
+        if let (Some(cached), _cost_cents) = self.cache.get_with_cost_cents(&optimized_prompt, "minimax-text-01") {
             tracing::info!("Prompt cache hit in stream (saved ~{} tokens)", cached.token_count);
             let cached_text = cached.text.clone();
             tokio::spawn(async move {
@@ -443,7 +443,7 @@ impl LocalLLMClient {
             PromptCache::truncate_context(prompt, 2000)
         };
 
-        if let (Some(cached), _cost_cents) = self.cache.get_with_cost_cents(&optimized_prompt) {
+        if let (Some(cached), _cost_cents) = self.cache.get_with_cost_cents(&optimized_prompt, &self.model) {
             tracing::info!("Prompt cache hit (saved ~{} tokens)", cached.token_count);
             return Ok(cached.text);
         }

--- a/src/server/pricing/prompt_caching.rs
+++ b/src/server/pricing/prompt_caching.rs
@@ -46,18 +46,11 @@ impl PromptCache {
         None
     }
 
-    pub fn get_with_cost_cents(&self, prompt: &str) -> (Option<CachedResponse>, i64) {
+    pub fn get_with_cost_cents(&self, prompt: &str, model: &str) -> (Option<CachedResponse>, i64) {
         tracing::info!("💰 Miser telemetry: Prompt cache lookup");
         let res = self.get(prompt);
         let cost = if let Some(ref r) = res {
             tracing::info!("💰 Miser cost optimization: Prompt cache hit saved {} tokens", r.token_count);
-
-            // Fast-path: Avoid taking OS environment locks on every cache hit
-            static MODEL: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-
-            let model = MODEL.get_or_init(|| {
-                std::env::var("OHC_LLM_MODEL").unwrap_or_else(|_| "gpt-4o".to_string())
-            });
 
             let pricing = super::calculator::get_pricing(model);
             let cost_dollars = (r.token_count as f64 / 1_000_000.0) * pricing.cached_cost;
@@ -204,7 +197,7 @@ mod tests {
         let cache = PromptCache::new(Duration::from_secs(10));
         cache.set("What is the capital of France?", "Paris", 1_000_000);
 
-        let (response, cost) = cache.get_with_cost_cents("What is the capital of France?");
+        let (response, cost) = cache.get_with_cost_cents("What is the capital of France?", "gpt-4o");
         assert!(response.is_some());
         assert_eq!(response.unwrap().text, "Paris");
         // 1,000,000 tokens * 2.50 / 1M = 2.5 dollars = 250 cents
@@ -216,7 +209,7 @@ mod tests {
         let cache = PromptCache::new(Duration::from_secs(10));
         let response = cache.get("What is the capital of France?");
         assert!(response.is_none());
-        let (response_with_cost, cost) = cache.get_with_cost_cents("What is the capital of France?");
+        let (response_with_cost, cost) = cache.get_with_cost_cents("What is the capital of France?", "gpt-4o");
         assert!(response_with_cost.is_none());
         assert_eq!(cost, 0);
     }


### PR DESCRIPTION
Fix prompt caching cost calculation to support dynamic models

The PromptCache::get_with_cost_cents function was previously using a
global static OnceLock to cache the LLM model name. This caused issues
because the model name used for cost calculation would be locked to the
first model initialized, rather than the actual model used for the
cached prompt, breaking token efficiency measurements and billing logic
when multiple models were active (e.g. minimax and local models).

This change updates the function signature to accept the `model` as an
explicit argument and updates all callers in minimax.rs and local
providers to pass the correct context. All tests pass successfully.

---
*PR created automatically by Jules for task [5825495793786786700](https://jules.google.com/task/5825495793786786700) started by @ql-owo-lp*