### PR TITLE
fix(onboarding): Revert Open Dashboard back to Open Assistant

### DIFF
--- a/src/ui/next/src/app/onboarding/page.test.tsx
+++ b/src/ui/next/src/app/onboarding/page.test.tsx
@@ -540,7 +540,7 @@ describe('OnboardingWizard', () => {
     await waitFor(() => {
       expect(screen.getByText("You're Live!")).toBeInTheDocument();
       expect(screen.getByText("Your business has been successfully launched.")).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: /Open Dashboard/i })).toHaveAttribute('href', '/dashboard');
+      expect(screen.getByRole('link', { name: /Open Assistant/i })).toHaveAttribute('href', '/assistant');
       expect(screen.getByRole('link', { name: /Preview Storefront/i })).toBeInTheDocument();
     });
   });

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -1421,10 +1421,10 @@ export default function OnboardingWizard() {
                 </div>
 
                 <a
-                  href="/dashboard"
+                  href="/assistant"
                   className="flex w-full items-center justify-center glassmorphism text-[#1D1D1F] dark:text-[#F5F5F7] p-4 rounded-[8px] font-bold shadow-md hover:border-gray-400 dark:hover:border-gray-500 active:scale-[0.98] transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)]"
                 >
-                  <IconLabel icon="sparkles">Open Dashboard</IconLabel>
+                  <IconLabel icon="sparkles">Open Assistant</IconLabel>
                 </a>
                 <a
                   href="/builder"


### PR DESCRIPTION
This PR addresses a product alignment issue where the success page of the onboarding wizard linked to the "Dashboard" rather than the "Assistant", which is meant to be the central command center for operators. The change reverts the "Open Dashboard" button label and href back to "Open Assistant" and `/assistant`, and updates tests accordingly to align with the core assistant-first product vision.

---
*PR created automatically by Jules for task [2938918071692086740](https://jules.google.com/task/2938918071692086740) started by @ql-owo-lp*