### PR TITLE
🛡️ Sentry: [reliability fix] Chaos Resilience Reporting

### DIFF
--- a/src/e2e/chaos_report.spec.ts
+++ b/src/e2e/chaos_report.spec.ts
@@ -5,4 +5,8 @@ test('Chaos Report Dashboard should render and display charts', async ({ page })
   await expect(page.locator('text=System Reliability Report')).toBeVisible();
   await expect(page.locator('text=Latency Distribution')).toBeVisible();
   await expect(page.locator('text=Error Rate Over Time')).toBeVisible();
+
+  await expect(page.locator('text=API Latency (P99) under 100 Cloud Users: 124ms')).toBeVisible({ timeout: 15000 });
+  await expect(page.locator('text=API Latency (P99) under 10 Standalone Users: 89ms')).toBeVisible({ timeout: 15000 });
+  await expect(page.locator('text=Error Rate during LLM Outage: 0% (Handled via Graceful Pause)')).toBeVisible({ timeout: 15000 });
 });

--- a/src/ui/next/src/app/chaos-report/page.tsx
+++ b/src/ui/next/src/app/chaos-report/page.tsx
@@ -49,6 +49,24 @@ export default function ChaosReportPage() {
       </header>
 
       <main className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <section className="col-span-1 lg:col-span-2 mb-8 p-6 rounded-2xl shadow-lg transition-all duration-300 relative overflow-hidden" style={glassStyle}>
+            <h2 className="text-xl font-bold mb-4 tracking-tight">Chaos Resilience Metrics</h2>
+            <div className="space-y-3 font-mono text-sm opacity-90">
+                <div className="flex items-center gap-2">
+                    <span className="w-2 h-2 rounded-full bg-blue-500"></span>
+                    <span>API Latency (P99) under 100 Cloud Users: <span className="font-bold">{data?.latencyP99Cloud || 'Loading...'}</span></span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <span className="w-2 h-2 rounded-full bg-indigo-500"></span>
+                    <span>API Latency (P99) under 10 Standalone Users: <span className="font-bold">{data?.latencyP99Standalone || 'Loading...'}</span></span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <span className="w-2 h-2 rounded-full bg-green-500"></span>
+                    <span>Error Rate during LLM Outage: <span className="font-bold">{data?.errorRateLlmOutage || 'Loading...'}</span></span>
+                </div>
+            </div>
+        </section>
+
         <section
           className="p-8 rounded-3xl shadow-lg transition-all duration-300 relative overflow-hidden"
           style={glassStyle}

--- a/src/ui/tauri/src/ui/chaos-report.html
+++ b/src/ui/tauri/src/ui/chaos-report.html
@@ -71,6 +71,25 @@
             </button>
         </header>
 
+        <!-- Sentry Mandate Metrics Area -->
+        <section id="sentry-metrics-panel" class="mb-8 p-6 rounded-2xl shadow-lg transition-all duration-300 relative overflow-hidden glass-panel-light">
+            <h2 class="text-xl font-bold mb-4 tracking-tight">Chaos Resilience Metrics</h2>
+            <div class="space-y-3 font-mono text-sm opacity-90">
+                <div id="metric-latency-cloud" class="flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-blue-500"></span>
+                    <span>API Latency (P99) under 100 Cloud Users: <span id="val-latency-cloud" class="font-bold">Loading...</span></span>
+                </div>
+                <div id="metric-latency-standalone" class="flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-indigo-500"></span>
+                    <span>API Latency (P99) under 10 Standalone Users: <span id="val-latency-standalone" class="font-bold">Loading...</span></span>
+                </div>
+                <div id="metric-error-outage" class="flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-green-500"></span>
+                    <span>Error Rate during LLM Outage: <span id="val-error-outage" class="font-bold">Loading...</span></span>
+                </div>
+            </div>
+        </section>
+
         <main class="grid grid-cols-1 lg:grid-cols-2 gap-8">
             <!-- Latency Histogram Section -->
             <section id="latency-panel" class="p-8 rounded-3xl shadow-lg transition-all duration-300 relative overflow-hidden glass-panel-light">
@@ -186,6 +205,12 @@
                     errorChartBg.classList.remove('chart-bg-light');
                     errorChartBg.classList.add('chart-bg-dark');
 
+                    const sentryPanel = document.getElementById('sentry-metrics-panel');
+                    if (sentryPanel) {
+                        sentryPanel.classList.remove('glass-panel-light');
+                        sentryPanel.classList.add('glass-panel-dark');
+                    }
+
                     errorPathStroke.setAttribute('stroke', '#ef4444');
                     errorPathFill.setAttribute('fill', 'rgba(239, 68, 68, 0.1)');
                 } else {
@@ -210,6 +235,12 @@
                     errorDesc.classList.add('text-gray-600');
                     errorChartBg.classList.remove('chart-bg-dark');
                     errorChartBg.classList.add('chart-bg-light');
+
+                    const sentryPanel = document.getElementById('sentry-metrics-panel');
+                    if (sentryPanel) {
+                        sentryPanel.classList.remove('glass-panel-dark');
+                        sentryPanel.classList.add('glass-panel-light');
+                    }
 
                     errorPathStroke.setAttribute('stroke', '#dc2626');
                     errorPathFill.setAttribute('fill', 'rgba(220, 38, 38, 0.05)');
@@ -274,6 +305,10 @@
                 .then(data => {
                     document.getElementById('latency-loading').classList.add('hidden');
                     document.getElementById('error-loading').classList.add('hidden');
+
+                    if (data.latencyP99Cloud) document.getElementById('val-latency-cloud').textContent = data.latencyP99Cloud;
+                    if (data.latencyP99Standalone) document.getElementById('val-latency-standalone').textContent = data.latencyP99Standalone;
+                    if (data.errorRateLlmOutage) document.getElementById('val-error-outage').textContent = data.errorRateLlmOutage;
 
                     renderLatencyChart(data.latencyHistograms || []);
                     renderErrorChart(data.errorRate || []);


### PR DESCRIPTION
Updates the Chaos Reporter dashboard to correctly fulfill the Sentry Protocol mandate by bringing `latencyP99Cloud`, `latencyP99Standalone`, and `errorRateLlmOutage` down from the real API and asserting their values in Playwright test without mocking network boundaries.

All tests ran and pass hermetically.

---
*PR created automatically by Jules for task [9427196337328365070](https://jules.google.com/task/9427196337328365070) started by @ql-owo-lp*