### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Resolve Auth Tenant Leak in Token GC

### DIFF
--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -430,8 +430,13 @@ impl UserRepository for PgUserRepository {
 
     async fn revoke_token(&self, jti: String, exp: DateTime<Utc>, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
+        let is_multitenant = is_multitenant_mode();
+        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
-        set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
+        if !should_bypass {
+            set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
+        }
 
         sqlx::query(
             r#"
@@ -447,10 +452,17 @@ impl UserRepository for PgUserRepository {
         .map_err(|e| e.to_string())?;
 
         // GC expired entries
-        let _ = sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < CURRENT_TIMESTAMP AND tenant_id = $1")
-            .bind(org_id)
-            .execute(&mut *tx)
-            .await;
+        let query = if should_bypass {
+            "DELETE FROM revoked_tokens WHERE expires_at < CURRENT_TIMESTAMP"
+        } else {
+            "DELETE FROM revoked_tokens WHERE expires_at < CURRENT_TIMESTAMP AND tenant_id = $1"
+        };
+
+        let _ = if should_bypass {
+            sqlx::query(query).execute(&mut *tx).await
+        } else {
+            sqlx::query(query).bind(org_id).execute(&mut *tx).await
+        };
 
         tx.commit().await.map_err(|e| e.to_string())?;
 

--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -282,7 +282,6 @@ impl UserRepository for SqliteUserRepository {
                 .bind(user.active)
                 .bind(&user.oidc_subject)
                 .bind(user.updated_at)
-                .bind(org_id)
                 .fetch_optional(&self.pool)
                 .await
                 .map_err(|e| e.to_string())?
@@ -334,6 +333,9 @@ impl UserRepository for SqliteUserRepository {
 
     async fn revoke_token(&self, jti: String, exp: DateTime<Utc>, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
+        let is_multitenant = is_multitenant_mode();
+        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+
         sqlx::query(
             r#"
             INSERT INTO revoked_tokens (jti, expires_at, tenant_id) VALUES ($1, $2, $3)
@@ -348,10 +350,17 @@ impl UserRepository for SqliteUserRepository {
         .map_err(|e: sqlx::Error| e.to_string())?;
 
         // GC expired entries
-        let _ = sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < CURRENT_TIMESTAMP AND tenant_id = $1")
-            .bind(org_id)
-            .execute(&self.pool)
-            .await;
+        let query = if should_bypass {
+            "DELETE FROM revoked_tokens WHERE expires_at < CURRENT_TIMESTAMP"
+        } else {
+            "DELETE FROM revoked_tokens WHERE expires_at < CURRENT_TIMESTAMP AND tenant_id = $1"
+        };
+
+        let _ = if should_bypass {
+            sqlx::query(query).execute(&self.pool).await
+        } else {
+            sqlx::query(query).bind(org_id).execute(&self.pool).await
+        };
 
         Ok(())
     }


### PR DESCRIPTION
# Sentinel: Fix Hybrid Auth Tenant Isolation GC Leak

**Vulnerability:** In Standalone mode (system org bypass mode), garbage collection in `revoke_token` would strictly match the `tenant_id = $1` which effectively left global offline garbage behind. If run in bypass mode, the bound parameters in `update_user` for SQLite passed 9 parameters to an 8-parameter query string.

**Fix Details:**
- Modified `sqlite_store.rs` and `postgres_store.rs` to correctly conditionally format the SQL queries for `revoke_token` garbage collection. When `should_bypass` is true, the `AND tenant_id = $1` constraint and its associated `org_id` variable bind are skipped so the `CURRENT_TIMESTAMP` cleanup runs efficiently system-wide.
- Cleaned up a parameter count bug in `sqlite_store.rs` `update_user` to align with Postgres parity.

**Testing:**
Ran `cargo test --package server_auth --lib` to ensure regressions are captured effectively.

---
*PR created automatically by Jules for task [14751502684427828268](https://jules.google.com/task/14751502684427828268) started by @wbbsuper*