### PR TITLE
🧹 Cleaner: Remove `console.log` statements from SyncManager.ts

### DIFF
--- a/src/ui/next/src/lib/sync/SyncManager.ts
+++ b/src/ui/next/src/lib/sync/SyncManager.ts
@@ -22,13 +22,11 @@ export class SyncManager {
 
     const ws = new WebSocket(wsUrl);
     ws.onmessage = (event) => {
-      console.log('Received real-time sync event:', event.data);
       if (typeof window !== 'undefined') {
         window.dispatchEvent(new Event('ohc_queue_updated'));
       }
     };
     ws.onclose = () => {
-      console.log('Sync WebSocket closed, reconnecting in 5s...');
       setTimeout(() => this.connectWebSocket(), 5000);
     };
     ws.onerror = (err) => {


### PR DESCRIPTION
Removed `console.log` statements in `src/ui/next/src/lib/sync/SyncManager.ts` to adhere to multi-tenant safety standards preventing potential data leaks.

---
*PR created automatically by Jules for task [5246396949639070065](https://jules.google.com/task/5246396949639070065) started by @ql-owo-lp*