### PR TITLE
⚙️ Consolidator: Fix test timeout and SQLite Vector Fallback Test

### DIFF
--- a/src/agents/builtin/memory_store.rs
+++ b/src/agents/builtin/memory_store.rs
@@ -3627,3 +3627,86 @@ mod override_tests_resolve {
         );
     }
 }
+
+
+#[cfg(test)]
+mod additional_tests_fallback {
+    use super::*;
+    use std::str::FromStr;
+
+    #[tokio::test]
+    async fn test_sqlite_fallback_conflict() {
+        let conn_opts = sqlx::sqlite::SqliteConnectOptions::from_str("sqlite::memory:").unwrap();
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .connect_with(conn_opts)
+            .await
+            .unwrap();
+
+        let _ = sqlx::query(
+            "CREATE TABLE IF NOT EXISTS consolidated_memory (
+                id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                agent_id TEXT,
+                content TEXT NOT NULL,
+                embedding TEXT,
+                source_type TEXT NOT NULL,
+                created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                last_referenced_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                reference_count INTEGER DEFAULT 0,
+                reliability_score INTEGER DEFAULT 50,
+                owner_override BOOLEAN DEFAULT FALSE,
+                metadata TEXT
+            );",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let repo = VectorRepository::new_sqlite(pool);
+
+        // Insert two very similar embeddings
+        let v1 = vec![1.0_f32; 10];
+        let mut v2 = vec![1.0_f32; 10];
+        v2[0] = 0.99; // Very similar, should be < 0.05 distance
+
+        let record_a = EmbeddingRecord {
+            id: "rec_fallback_a".to_string(),
+            tenant_id: "org_fallback".to_string(),
+            agent_id: "agent_1".to_string(),
+            content: "content A".to_string(),
+            embedding: v1,
+            source_type: "NOTES".to_string(),
+            created_at: chrono::Utc::now(),
+            last_referenced_at: chrono::Utc::now(),
+            reference_count: 0,
+            reliability_score: 50,
+            owner_override: false,
+            metadata: None,
+        };
+
+        let record_b = EmbeddingRecord {
+            id: "rec_fallback_b".to_string(),
+            tenant_id: "org_fallback".to_string(),
+            agent_id: "agent_1".to_string(),
+            content: "content B".to_string(),
+            embedding: v2,
+            source_type: "NOTES".to_string(),
+            created_at: chrono::Utc::now(),
+            last_referenced_at: chrono::Utc::now(),
+            reference_count: 0,
+            reliability_score: 50,
+            owner_override: false,
+            metadata: None,
+        };
+
+        repo.upsert(&record_a).await.unwrap();
+        repo.upsert(&record_b).await.unwrap();
+
+        let conflicts = repo.get_conflicting_pairs().await.unwrap();
+        assert_eq!(conflicts.len(), 1, "Should find exactly 1 conflicting pair");
+
+        let (a, b) = &conflicts[0];
+        assert_eq!(a.id, "rec_fallback_a");
+        assert_eq!(b.id, "rec_fallback_b");
+    }
+}

--- a/src/server/workers/memory.rs
+++ b/src/server/workers/memory.rs
@@ -19,7 +19,7 @@ impl MemoryConsolidationWorker {
         }
     }
 
-    pub fn start(&self) {
+    pub fn start(&self) -> tokio::task::JoinHandle<()> {
         let repository = self.repository.clone();
         let interval_duration = self.poll_interval;
         let prune_threshold_days = self.prune_threshold_days;
@@ -37,7 +37,7 @@ impl MemoryConsolidationWorker {
                     tracing::error!("Consolidation Worker: Failed to resolve memory conflicts: {}", e);
                 }
             }
-        });
+        })
     }
 }
 
@@ -56,11 +56,12 @@ mod tests {
         let repo = Arc::new(VectorRepository::new_sqlite(pool));
         let worker = MemoryConsolidationWorker::new(repo);
 
-        worker.start();
+        let handle = worker.start();
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         assert!(true, "Worker started successfully");
+        handle.abort();
     }
 
     #[tokio::test]
@@ -131,7 +132,7 @@ mod tests {
 
         let mut worker = MemoryConsolidationWorker::new(repo.clone());
         worker.poll_interval = std::time::Duration::from_millis(10); // Fast interval for testing
-        worker.start();
+        let handle = worker.start();
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
@@ -143,6 +144,7 @@ mod tests {
             .expect("Failed to query consolidated_memory count");
 
         assert_eq!(row.0, 0, "Stale record should be pruned by worker pipeline");
+        handle.abort();
     }
 
     #[tokio::test]
@@ -232,7 +234,7 @@ mod tests {
 
         let mut worker = MemoryConsolidationWorker::new(repo.clone());
         worker.poll_interval = std::time::Duration::from_millis(10);
-        worker.start();
+        let handle = worker.start();
 
         tokio::time::sleep(std::time::Duration::from_millis(150)).await;
 
@@ -249,6 +251,7 @@ mod tests {
         assert_eq!(id, "conflict_winner", "The winner must be preserved");
         // Loser has 1, winner has 2, logic increments winner by loser + 1 -> 2 + 1 + 1 = 4.
         assert_eq!(ref_count, 4, "The winner should inherit the loser's reference count");
+        handle.abort();
     }
 }
 // Integration complete.
@@ -270,11 +273,12 @@ mod additional_tests {
         let mut worker = MemoryConsolidationWorker::new(repo);
         worker.poll_interval = std::time::Duration::from_millis(10);
 
-        worker.start();
+        let handle = worker.start();
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         // The worker will fail queries internally but shouldn't panic
         assert!(true, "Worker didn't panic when schema is missing");
+        handle.abort();
     }
 
     #[tokio::test]
@@ -309,9 +313,10 @@ mod additional_tests {
         worker.poll_interval = std::time::Duration::from_millis(10);
         worker.prune_threshold_days = 90;
 
-        worker.start();
+        let handle = worker.start();
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         assert_eq!(worker.prune_threshold_days, 90, "Worker threshold properly configured and stable during rapid loop");
+        handle.abort();
     }
 }


### PR DESCRIPTION
This PR fixes a bug where bazel tests in `workers` and E2E suites timed out at 400 seconds because `MemoryConsolidationWorker` spawned unaborted infinite loop tasks in tests. It also adds a unit test for the SQLite vector conflict fallback to guarantee Standalone mode operates correctly according to the Maintainer objective.

---
*PR created automatically by Jules for task [8264448221738912565](https://jules.google.com/task/8264448221738912565) started by @ql-owo-lp*