### PR TITLE
fix: Use codeload.github.com for xds fetch

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -148,7 +148,7 @@ def go_repositories():
         importpath = "github.com/cncf/xds/go",
         sum = "h1:Rjjh4E6iCUSW3n8E14lM6j1D0aRzDtdGk1iZ/g78A58=",
         version = "v0.0.0-20230607035331-e9ce68804cb4",
-        urls = ["https://github.com/cncf/xds/archive/e9ce68804cb4.tar.gz"],
+        urls = ["https://codeload.github.com/cncf/xds/tar.gz/e9ce68804cb4"],
     )
     go_repository(
         name = "com_github_coder_websocket",


### PR DESCRIPTION
Update `repositories.bzl` to point the `com_github_cncf_xds_go` repository
URL to `https://codeload.github.com/cncf/xds/tar.gz/e9ce68804cb4` instead
of the broken GitHub archive link. This bypasses the GitHub redirect and
directly fetches the tarball, solving the Bazel timeout and network fetch
failures preventing the workspace from building properly.

---
*PR created automatically by Jules for task [13639092258807373050](https://jules.google.com/task/13639092258807373050) started by @ql-owo-lp*