### PR TITLE
fix(ui): resolve javascript syntax error in setup.html walkthrough

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2650,7 +2650,7 @@ function initWalkthrough() {
             `;
 
             document.getElementById('wt-close').onclick = closeWalkthrough;
-            if (document.getElementById('wt-prev')) document.getElementById('wt-prev').onclick = () => { currentStep--; renderStep();
+            if (document.getElementById('wt-prev')) document.getElementById('wt-prev').onclick = () => { currentStep--; renderStep(); };
             document.getElementById('wt-next').onclick = () => {
                 if (currentStep === steps.length - 1) {
                     closeWalkthrough();
@@ -3191,7 +3191,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 `;
 
                 document.getElementById('wt-close').onclick = closeWalkthrough;
-                if (document.getElementById('wt-prev')) document.getElementById('wt-prev').onclick = () => { currentStep--; renderStep();
+                if (document.getElementById('wt-prev')) document.getElementById('wt-prev').onclick = () => { currentStep--; renderStep(); };
                 document.getElementById('wt-next').onclick = () => {
                     if (currentStep === steps.length - 1) {
                         closeWalkthrough();


### PR DESCRIPTION
This PR fixes a critical JavaScript syntax error in the onboarding setup UI (`src/ui/tauri/src/ui/setup.html`).

**Problem:**
The inline arrow function assigned to the `onclick` handler of the "Previous" walkthrough button (`wt-prev`) was missing a closing brace and semicolon. This caused a parsing error, breaking the execution of the entire script and preventing the walkthrough from functioning.

**Solution:**
Added the missing ` };` to the `onclick` assignments in both locations where the walkthrough is instantiated.

**User Experience Evidence:**
- **Persona:** Small business owner setting up their OHC instance for the first time.
- **Observed Gap:** The interactive walkthrough ("tours") failed to initialize or navigate correctly due to the script execution halting on a syntax error.
- **Fix:** Correcting the syntax allows the script to parse and execute, making the onboarding walkthrough functional again.

---
*PR created automatically by Jules for task [2427129361843258376](https://jules.google.com/task/2427129361843258376) started by @ql-owo-lp*