### PR TITLE
💰 Miser: Update plan dashboard with correct macOS Glassmorphism classes and Upgrade button text

### DIFF
--- a/src/e2e/my_plan_dashboard.spec.ts
+++ b/src/e2e/my_plan_dashboard.spec.ts
@@ -10,7 +10,7 @@ test.describe('My Plan and Cost Dashboard Screens', () => {
     await expect(page.locator('h2', { hasText: 'Your Current Usage' })).toBeVisible();
 
     // Verify upgrade routing
-    const upgradeButton = page.locator('button', { hasText: 'View Upgrade Plans' });
+    const upgradeButton = page.locator('button', { hasText: 'Upgrade' });
     await expect(upgradeButton).toBeVisible();
     await upgradeButton.click();
     await expect(page.url()).toContain('/pricing.html');

--- a/src/ui/next/src/app/plan/page.tsx
+++ b/src/ui/next/src/app/plan/page.tsx
@@ -77,7 +77,7 @@ export default function MyPlanPage() {
       <main className="p-4 md:p-8 flex-1 max-w-4xl mx-auto w-full flex flex-col gap-6">
 
         {/* Status Snapshot */}
-        <section className="app-panel bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 rounded-2xl shadow-lg p-6 dark:bg-gray-900/70 dark:border-white/10">
+        <section className="app-card glassmorphism ohc-growth-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 rounded-2xl shadow-lg p-6 dark:bg-gray-900/70 dark:border-white/10">
             <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
                 <div>
                     <h2 className="text-2xl font-bold font-outfit text-gray-900 flex items-center gap-2">
@@ -95,7 +95,7 @@ export default function MyPlanPage() {
                 <button
                     onClick={() => router.push('/pricing')}
                     className="w-full sm:w-auto px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl font-medium transition-all shadow-sm text-center">
-                    View Upgrade Plans
+                    Upgrade
                 </button>
                 <button
                     onClick={() => router.push('/cost-dashboard')}
@@ -106,7 +106,7 @@ export default function MyPlanPage() {
         </section>
 
         {/* Current Usage Section */}
-        <section className="app-panel bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 rounded-2xl shadow-lg mt-4 dark:bg-gray-900/70 dark:border-white/10">
+        <section className="app-card glassmorphism ohc-growth-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 rounded-2xl shadow-lg mt-4 dark:bg-gray-900/70 dark:border-white/10">
           <div className="app-panel-header px-6 py-4 border-b border-white/40 bg-transparent">
              <h2 className="app-panel-title text-xl font-bold font-outfit text-gray-900">Your Current Usage</h2>
           </div>


### PR DESCRIPTION
Update the UI components on the My Plan screen to adhere to the requested visual designs (macOS translucent glass) and update the label of the upgrade button to "Upgrade". Modifies Playwright E2E tests to expect the updated changes. All Bazel tests for Playwright E2E pass.

---
*PR created automatically by Jules for task [10175432130912147738](https://jules.google.com/task/10175432130912147738) started by @ql-owo-lp*