### PR TITLE
fix(ui): format currency from cents to dollars on My Plan page

### DIFF
--- a/src/ui/next/src/app/plan/page.tsx
+++ b/src/ui/next/src/app/plan/page.tsx
@@ -49,7 +49,7 @@ export default function MyPlanPage() {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'USD',
-    }).format(amount);
+    }).format(amount / 100);
   };
 
   if (loading) {


### PR DESCRIPTION
Fixes currency display on the My Plan page to correctly reflect dollar amounts instead of inflating cents.

---
*PR created automatically by Jules for task [14613205298627448951](https://jules.google.com/task/14613205298627448951) started by @ql-owo-lp*