### PR TITLE
🚀 Nova: [Project Showcase Generator growth loop]

### DIFF
--- a/src/ui/next/next-env.d.ts
+++ b/src/ui/next/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/ui/next/src/app/project-showcase/page.test.tsx
+++ b/src/ui/next/src/app/project-showcase/page.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ProjectShowcasePage from './page';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock('../components/PoweredByOHC', () => ({
+  PoweredByOHC: () => <div data-testid="powered-by-ohc">⚡ Powered by OHC</div>,
+}));
+
+describe('ProjectShowcasePage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders Powered by OHC branding in preview by default', () => {
+    render(<ProjectShowcasePage />);
+
+    const brandingElements = screen.getAllByTestId('powered-by-ohc');
+    expect(brandingElements.length).toBeGreaterThan(0);
+    expect(brandingElements[0]).toBeInTheDocument();
+  });
+
+  it('shows paywall when free user tries to remove branding', () => {
+    localStorage.setItem('has_pro', 'false');
+    render(<ProjectShowcasePage />);
+
+    const toggle = screen.getByRole('checkbox');
+    fireEvent.click(toggle);
+
+    expect(screen.getByText('Upgrade to Pro')).toBeInTheDocument();
+
+    const brandingElements = screen.getAllByTestId('powered-by-ohc');
+    expect(brandingElements[0]).toBeInTheDocument();
+  });
+
+  it('allows pro users to remove branding', () => {
+    localStorage.setItem('has_pro', 'true');
+    render(<ProjectShowcasePage />);
+
+    // Checkbox should be checked by default for pro users (per useEffect)
+    const toggle = screen.getByRole('checkbox');
+    expect(toggle).toBeChecked();
+
+    // PoweredBy should not be rendered
+    expect(screen.queryByTestId('powered-by-ohc')).toBeNull();
+  });
+});

--- a/src/ui/next/src/app/project-showcase/page.tsx
+++ b/src/ui/next/src/app/project-showcase/page.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { PoweredByOHC } from '../components/PoweredByOHC';
+
+export default function ProjectShowcasePage() {
+  const router = useRouter();
+  const [projectName, setProjectName] = useState('');
+  const [customerName, setCustomerName] = useState('');
+  const [description, setDescription] = useState('');
+  const [beforeImage, setBeforeImage] = useState('');
+  const [afterImage, setAfterImage] = useState('');
+  const [ctaLink, setCtaLink] = useState('');
+
+  const [removeBranding, setRemoveBranding] = useState(false);
+  const [hasPro, setHasPro] = useState(false);
+  const [showPaywall, setShowPaywall] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const [tenant, setTenant] = useState('demo');
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const isPro = localStorage.getItem('has_pro') === 'true';
+      setHasPro(isPro);
+      if (isPro) setRemoveBranding(true);
+      setTenant(localStorage.getItem('tenant') || 'demo');
+    }
+  }, []);
+
+  const handleBrandingToggle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!hasPro && e.target.checked) {
+      setShowPaywall(true);
+      e.preventDefault();
+      return;
+    }
+    setRemoveBranding(e.target.checked);
+  };
+
+  const getShareLink = () => {
+    const data = {
+      p: projectName,
+      c: customerName,
+      d: description,
+      b: beforeImage,
+      a: afterImage,
+      l: ctaLink,
+      r: removeBranding ? '1' : '0',
+      t: tenant
+    };
+
+    // Convert to query string
+    const query = new URLSearchParams();
+    Object.entries(data).forEach(([key, value]) => {
+      if (value) query.append(key, value);
+    });
+
+    return `${window.location.origin}/showcase?${query.toString()}`;
+  };
+
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(getShareLink());
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen bg-[#F5F5F7] text-[#1D1D1F] font-inter">
+      {/* Header */}
+      <header className="px-4 py-4 md:px-6 flex items-center justify-between sticky top-0 z-40 bg-[#F5F5F7]/80 backdrop-blur-xl border-b border-[#E5E5EA]">
+        <h1 className="text-xl md:text-2xl font-bold tracking-tight">Project Showcase</h1>
+        <button
+          onClick={() => router.push('/dashboard')}
+          className="px-4 py-2 bg-white rounded-full text-sm font-semibold shadow-sm border border-[#E5E5EA] hover:bg-gray-50 transition-colors"
+        >
+          Close
+        </button>
+      </header>
+
+      <main className="flex-1 p-4 md:p-6 w-full max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8">
+
+        {/* Editor Section */}
+        <section className="flex flex-col gap-6">
+          <div className="bg-white rounded-3xl p-6 shadow-sm border border-[#E5E5EA]">
+            <h2 className="text-lg font-semibold mb-4">Project Details</h2>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-[#86868B] mb-1">Project Name *</label>
+                <input
+                  type="text"
+                  className="w-full px-4 py-3 rounded-xl bg-[#F5F5F7] border border-transparent focus:border-[#0066CC] focus:bg-white focus:outline-none transition-colors"
+                  placeholder="e.g. Modern Kitchen Remodel"
+                  value={projectName}
+                  onChange={(e) => setProjectName(e.target.value)}
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-[#86868B] mb-1">Customer Name (Optional)</label>
+                <input
+                  type="text"
+                  className="w-full px-4 py-3 rounded-xl bg-[#F5F5F7] border border-transparent focus:border-[#0066CC] focus:bg-white focus:outline-none transition-colors"
+                  placeholder="e.g. The Smith Family"
+                  value={customerName}
+                  onChange={(e) => setCustomerName(e.target.value)}
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-[#86868B] mb-1">Description *</label>
+                <textarea
+                  className="w-full px-4 py-3 rounded-xl bg-[#F5F5F7] border border-transparent focus:border-[#0066CC] focus:bg-white focus:outline-none transition-colors min-h-[100px] resize-y"
+                  placeholder="Describe the work done, the challenges, and the outcome..."
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-[#86868B] mb-1">Before Image URL</label>
+                  <input
+                    type="url"
+                    className="w-full px-4 py-3 rounded-xl bg-[#F5F5F7] border border-transparent focus:border-[#0066CC] focus:bg-white focus:outline-none transition-colors"
+                    placeholder="https://example.com/before.jpg"
+                    value={beforeImage}
+                    onChange={(e) => setBeforeImage(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-[#86868B] mb-1">After Image URL</label>
+                  <input
+                    type="url"
+                    className="w-full px-4 py-3 rounded-xl bg-[#F5F5F7] border border-transparent focus:border-[#0066CC] focus:bg-white focus:outline-none transition-colors"
+                    placeholder="https://example.com/after.jpg"
+                    value={afterImage}
+                    onChange={(e) => setAfterImage(e.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-[#86868B] mb-1">"Book Me" Link URL</label>
+                <input
+                  type="url"
+                  className="w-full px-4 py-3 rounded-xl bg-[#F5F5F7] border border-transparent focus:border-[#0066CC] focus:bg-white focus:outline-none transition-colors"
+                  placeholder="https://mybusiness.com/book"
+                  value={ctaLink}
+                  onChange={(e) => setCtaLink(e.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-3xl p-6 shadow-sm border border-[#E5E5EA]">
+            <h2 className="text-lg font-semibold mb-4">Sharing Options</h2>
+
+            <div className="flex items-center justify-between p-4 bg-[#F5F5F7] rounded-xl mb-4">
+              <div>
+                <p className="font-medium text-sm">Remove "Powered by OHC" Badge</p>
+                <p className="text-xs text-[#86868B] mt-1">Make the showcase 100% white-labeled</p>
+              </div>
+              <label className="relative inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="sr-only peer"
+                  checked={removeBranding}
+                  onChange={handleBrandingToggle}
+                />
+                <div className="w-11 h-6 bg-[#D1D1D6] peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-[#E5E5EA] after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#34C759]"></div>
+              </label>
+            </div>
+
+            <button
+              onClick={handleCopyLink}
+              className="w-full py-3 px-4 bg-[#0066CC] text-white rounded-xl font-semibold hover:bg-[#0055B3] transition-colors flex items-center justify-center gap-2"
+            >
+              {copied ? '✓ Link Copied!' : 'Copy Share Link'}
+            </button>
+          </div>
+        </section>
+
+        {/* Preview Section */}
+        <section className="flex flex-col h-full min-h-[600px] lg:min-h-0 bg-white rounded-3xl overflow-hidden shadow-xl border border-[#E5E5EA]">
+          <div className="bg-[#F5F5F7] px-4 py-3 border-b border-[#E5E5EA] flex items-center gap-2">
+            <div className="flex gap-1.5">
+              <div className="w-3 h-3 rounded-full bg-[#FF3B30]"></div>
+              <div className="w-3 h-3 rounded-full bg-[#FFCC00]"></div>
+              <div className="w-3 h-3 rounded-full bg-[#34C759]"></div>
+            </div>
+            <div className="ml-4 text-xs text-[#86868B] font-medium tracking-wide">LIVE PREVIEW</div>
+          </div>
+
+          <div className="flex-1 overflow-y-auto bg-[#F5F5F7] p-4 md:p-8">
+            <div className="max-w-2xl mx-auto bg-white rounded-2xl shadow-sm overflow-hidden border border-[#E5E5EA] flex flex-col">
+
+              {/* Showcase Content */}
+              <div className="p-6 md:p-8 flex-1">
+                {projectName ? (
+                  <h1 className="text-3xl font-bold tracking-tight mb-2">{projectName}</h1>
+                ) : (
+                  <h1 className="text-3xl font-bold tracking-tight text-[#D1D1D6] mb-2">Project Name</h1>
+                )}
+
+                {customerName && (
+                  <p className="text-sm text-[#86868B] font-medium uppercase tracking-wider mb-6">For {customerName}</p>
+                )}
+
+                {(!customerName && projectName) && (
+                  <div className="mb-6"></div>
+                )}
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+                  <div className="space-y-2">
+                    <div className="text-xs font-semibold text-[#86868B] tracking-widest uppercase">Before</div>
+                    <div className="aspect-[4/3] bg-[#F5F5F7] rounded-xl overflow-hidden flex items-center justify-center border border-[#E5E5EA]">
+                      {beforeImage ? (
+                        <img src={beforeImage} alt="Before" className="w-full h-full object-cover" />
+                      ) : (
+                        <span className="text-[#86868B] text-sm">No image</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <div className="text-xs font-semibold text-[#86868B] tracking-widest uppercase">After</div>
+                    <div className="aspect-[4/3] bg-[#F5F5F7] rounded-xl overflow-hidden flex items-center justify-center border border-[#E5E5EA]">
+                      {afterImage ? (
+                        <img src={afterImage} alt="After" className="w-full h-full object-cover" />
+                      ) : (
+                        <span className="text-[#86868B] text-sm">No image</span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="prose prose-sm max-w-none text-[#1D1D1F] mb-8">
+                  {description ? (
+                    <p className="whitespace-pre-wrap">{description}</p>
+                  ) : (
+                    <p className="text-[#D1D1D6]">Project description will appear here...</p>
+                  )}
+                </div>
+
+                {ctaLink && (
+                  <div className="mt-8 pt-8 border-t border-[#E5E5EA]">
+                    <a
+                      href={ctaLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block w-full py-4 px-6 bg-[#1D1D1F] text-white text-center rounded-xl font-semibold hover:bg-black transition-colors"
+                    >
+                      Book a Similar Project
+                    </a>
+                  </div>
+                )}
+              </div>
+
+              {/* Powered By OHC Loop */}
+              {!removeBranding && (
+                <div className="bg-[#F5F5F7] py-6 flex justify-center border-t border-[#E5E5EA]">
+                  <PoweredByOHC tenantId={tenant} />
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+      </main>
+
+      {/* Paywall Modal */}
+      {showPaywall && (
+        <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+          <div className="bg-white rounded-3xl p-8 max-w-md w-full shadow-2xl relative animate-in fade-in zoom-in-95 duration-200">
+            <button
+              onClick={() => setShowPaywall(false)}
+              className="absolute top-4 right-4 p-2 text-[#86868B] hover:text-[#1D1D1F] transition-colors"
+            >
+              ✕
+            </button>
+            <div className="w-16 h-16 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-2xl flex items-center justify-center text-white text-2xl mb-6 shadow-lg">
+              ✨
+            </div>
+            <h2 className="text-2xl font-bold mb-2">Upgrade to Pro</h2>
+            <p className="text-[#86868B] mb-8">
+              Make the Project Showcase 100% white-labeled. Upgrade to Pro to remove the "Powered by OHC" watermark.
+            </p>
+            <div className="space-y-3">
+              <button
+                onClick={() => router.push('/pricing')}
+                className="w-full py-3 bg-[#0066CC] text-white rounded-xl font-semibold hover:bg-[#0055B3] transition-colors shadow-md"
+              >
+                View Plans
+              </button>
+              <button
+                onClick={() => setShowPaywall(false)}
+                className="w-full py-3 bg-[#F5F5F7] text-[#1D1D1F] rounded-xl font-semibold hover:bg-[#E5E5EA] transition-colors"
+              >
+                Maybe Later
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <style dangerouslySetInnerHTML={{__html: `
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+        .font-inter { font-family: 'Inter', sans-serif; }
+      `}} />
+    </div>
+  );
+}

--- a/src/ui/next/src/app/showcase/page.tsx
+++ b/src/ui/next/src/app/showcase/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { PoweredByOHC } from '../components/PoweredByOHC';
+import { useSearchParams } from 'next/navigation';
+
+export default function PublicShowcasePage() {
+  const searchParams = useSearchParams();
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  if (!isClient) return null;
+
+  const projectName = searchParams.get('p') || 'Project Showcase';
+  const customerName = searchParams.get('c') || '';
+  const description = searchParams.get('d') || '';
+  const beforeImage = searchParams.get('b') || '';
+  const afterImage = searchParams.get('a') || '';
+  const ctaLink = searchParams.get('l') || '';
+  const removeBranding = searchParams.get('r') === '1';
+  const tenant = searchParams.get('t') || 'ohc';
+
+  return (
+    <div className="flex flex-col min-h-screen bg-[#F5F5F7] text-[#1D1D1F] font-inter">
+      <main className="flex-1 overflow-y-auto p-4 md:p-8 flex items-center justify-center">
+        <div className="max-w-3xl w-full mx-auto bg-white rounded-3xl shadow-2xl overflow-hidden border border-[#E5E5EA] flex flex-col min-h-[60vh]">
+
+          {/* Showcase Content */}
+          <div className="p-8 md:p-12 flex-1">
+            <h1 className="text-3xl md:text-5xl font-bold tracking-tight mb-4">{projectName}</h1>
+
+            {customerName && (
+              <p className="text-sm md:text-base text-[#86868B] font-medium uppercase tracking-wider mb-8">For {customerName}</p>
+            )}
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+              {beforeImage && (
+                <div className="space-y-3">
+                  <div className="text-sm font-semibold text-[#86868B] tracking-widest uppercase">Before</div>
+                  <div className="aspect-[4/3] bg-[#F5F5F7] rounded-2xl overflow-hidden flex items-center justify-center border border-[#E5E5EA] shadow-inner">
+                    <img src={beforeImage} alt="Before" className="w-full h-full object-cover hover:scale-105 transition-transform duration-500" />
+                  </div>
+                </div>
+              )}
+              {afterImage && (
+                <div className="space-y-3">
+                  <div className="text-sm font-semibold text-[#86868B] tracking-widest uppercase">After</div>
+                  <div className="aspect-[4/3] bg-[#F5F5F7] rounded-2xl overflow-hidden flex items-center justify-center border border-[#E5E5EA] shadow-inner">
+                    <img src={afterImage} alt="After" className="w-full h-full object-cover hover:scale-105 transition-transform duration-500" />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {description && (
+              <div className="prose prose-lg max-w-none text-[#1D1D1F] mb-12">
+                <p className="whitespace-pre-wrap leading-relaxed">{description}</p>
+              </div>
+            )}
+
+            {ctaLink && (
+              <div className="mt-10 pt-10 border-t border-[#E5E5EA] flex justify-center">
+                <a
+                  href={ctaLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block w-full md:w-auto min-w-[280px] py-4 px-8 bg-[#1D1D1F] text-white text-center rounded-2xl font-bold text-lg hover:bg-black hover:scale-[1.02] transition-all shadow-lg hover:shadow-xl"
+                >
+                  Book a Similar Project
+                </a>
+              </div>
+            )}
+          </div>
+
+          {/* Powered By OHC Loop */}
+          {!removeBranding && (
+            <div className="bg-[#F5F5F7] py-8 flex justify-center border-t border-[#E5E5EA]">
+              <PoweredByOHC tenantId={tenant} />
+            </div>
+          )}
+        </div>
+      </main>
+
+      <style dangerouslySetInnerHTML={{__html: `
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+        .font-inter { font-family: 'Inter', sans-serif; }
+      `}} />
+    </div>
+  );
+}

--- a/src/ui/next/src/e2e/project-showcase.spec.ts
+++ b/src/ui/next/src/e2e/project-showcase.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Project Showcase Generator (Growth Loop)', () => {
+    test.beforeEach(async ({ page }) => {
+        // Clear local storage and set tenant so we get a consistent PoweredByOHC link
+        await page.goto('/dashboard');
+        await page.evaluate(() => {
+            window.localStorage.clear();
+            window.localStorage.setItem('has_onboarded', 'true');
+            window.localStorage.setItem('tenant', 'demo-tenant');
+        });
+    });
+
+    test('renders form, updates preview, and displays "Powered by OHC"', async ({ page }) => {
+        // Go to the Project Showcase generator page
+        await page.goto('/project-showcase');
+
+        // Fill out the project details
+        await page.fill('input[placeholder="e.g. Modern Kitchen Remodel"]', 'A Beautiful New Kitchen');
+        await page.fill('input[placeholder="e.g. The Smith Family"]', 'The Smiths');
+        await page.fill('textarea[placeholder="Describe the work done, the challenges, and the outcome..."]', 'Replaced all the cabinets and installed new granite countertops.');
+
+        // Ensure preview updates
+        await expect(page.locator('h1', { hasText: 'A Beautiful New Kitchen' }).first()).toBeVisible();
+        await expect(page.locator('p', { hasText: 'For The Smiths' }).first()).toBeVisible();
+
+        // 1. Verify "Powered by OHC" watermark is visible in the preview area
+        const watermark = page.locator('a', { hasText: '⚡ Powered by OHC' });
+        await expect(watermark).toBeVisible();
+
+        // The link should direct back to OHC with the tenant as a reference source
+        await expect(watermark).toHaveAttribute('href', /.*\/onboarding\?ref=demo-tenant.*/);
+
+        // 2. Click the "Remove Branding" toggle (simulating free user)
+        const toggle = page.locator('input[type="checkbox"]');
+        await toggle.click({ force: true }); // force click on hidden input
+
+        // 3. Verify that the Pro Paywall modal appears instead of removing the branding
+        const paywallModal = page.locator('div:has-text("Upgrade to Pro")').last();
+        await expect(paywallModal).toBeVisible();
+        await expect(page.locator('h2', { hasText: 'Upgrade to Pro' })).toBeVisible();
+
+        // Close the modal
+        await page.locator('button', { hasText: 'Maybe Later' }).click();
+        await expect(page.locator('h2', { hasText: 'Upgrade to Pro' })).not.toBeVisible();
+
+        // 4. Test sharing link creation functionality
+        const copyButton = page.locator('button', { hasText: 'Copy Share Link' });
+        await copyButton.click();
+
+        // Should show copied status
+        await expect(page.locator('button', { hasText: '✓ Link Copied!' })).toBeVisible();
+
+        // 5. Verify the actual generated page end-to-end
+        const params = new URLSearchParams({
+            p: 'A Beautiful New Kitchen',
+            c: 'The Smiths',
+            d: 'Replaced all the cabinets and installed new granite countertops.',
+            r: '0',
+            t: 'demo-tenant'
+        });
+
+        await page.goto(`/showcase?${params.toString()}`);
+        await expect(page.locator('h1', { hasText: 'A Beautiful New Kitchen' })).toBeVisible();
+        await expect(page.locator('p', { hasText: 'For The Smiths' })).toBeVisible();
+        await expect(page.locator('p', { hasText: 'Replaced all the cabinets and installed new granite countertops.' })).toBeVisible();
+
+        // The public showcase should also have the powered by watermark
+        const publicWatermark = page.locator('a', { hasText: '⚡ Powered by OHC' });
+        await expect(publicWatermark).toBeVisible();
+    });
+
+    test('allows pro users to toggle branding off', async ({ page }) => {
+        // Simulate a Pro user
+        await page.goto('/dashboard');
+        await page.evaluate(() => {
+            window.localStorage.setItem('has_pro', 'true');
+        });
+
+        // Go to the Project Showcase generator page
+        await page.goto('/project-showcase');
+
+        // Verify watermark is hidden by default for pro users (our component logic sets it to true if pro)
+        await expect(page.locator('a', { hasText: '⚡ Powered by OHC' })).not.toBeVisible();
+
+        // Verify the checkbox is checked
+        const toggle = page.locator('input[type="checkbox"]');
+        await expect(toggle).toBeChecked();
+
+        // Toggle branding back on
+        await toggle.click({ force: true });
+
+        // Watermark should reappear
+        const watermark = page.locator('a', { hasText: '⚡ Powered by OHC' });
+        await expect(watermark).toBeVisible();
+        await expect(toggle).not.toBeChecked();
+    });
+});

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
### Product-use evidence
- **Persona:** Carlos (Field Service Owner) or Nora (Agency Principal).
- **Observed CUJ Gap:** There was no feature for a small business owner to generate a before/after project showcase digital card to share with prospective customers. 
- **Owner Rationale:** An owner needs a fast, simple way to share visual proof of past work (before and after) and give viewers an easy "Book Me" link. They also need this without building a heavy website.
- **The Loop:** When the owner shares the showcase link, the showcase page contains a "Powered by OHC" footer. New viewers (potential owners themselves) can click the footer and be onboarded to OHC.
- **Post-Fix Verification:** A user can fill out the form, preview the project showcase card with the "Powered by OHC" watermark, copy the share link, and share it. The shared link directs to the `/showcase` page showing the before/after images and the CTA to book them. Pro users can remove the watermark.
- **Testing:** Implemented e2e coverage in Playwright verifying all steps. All tests pass `bazel test //...` and `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"`.
- **Superpowers loaded:** "Think Contextually", "Test Driven Development".

### Improvements 
- Added a full `Project Showcase` generator view at `/project-showcase`.
- Added the public showcase view at `/showcase`.
- Added dynamic branding loop with tenant injection.
- Added paywall component for Pro features.

---
*PR created automatically by Jules for task [14756930845917399931](https://jules.google.com/task/14756930845917399931) started by @ql-owo-lp*