### PR TITLE
feat(ui): OHC Premium Translucent Glass Design Layout

### DIFF
--- a/src/e2e/fixtures.ts
+++ b/src/e2e/fixtures.ts
@@ -25,7 +25,7 @@ async function loginAs(page: Page, user: E2EUser) {
   // The actual tenant_id comes from a header or cookie in a real deployment.
   // In the real system, it's determined by the login session. But in our e2e fixture,
   // we can use Playwright to set the context or navigate.
-  await page.goto('/dashboard.html');
+  await page.goto('/dashboard');
 }
 
 function rejectNetworkStubbing(context: BrowserContext, page?: Page) {

--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -194,10 +194,10 @@ body {
 }
 
 .app-card {
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.65);
   -webkit-backdrop-filter: blur(30px) saturate(210%);
   backdrop-filter: blur(30px) saturate(210%);
-  border: 1px solid rgba(216, 222, 232, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 16px;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
 }
@@ -213,10 +213,10 @@ body {
 }
 
 .app-panel {
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.65);
   -webkit-backdrop-filter: blur(30px) saturate(210%);
   backdrop-filter: blur(30px) saturate(210%);
-  border: 1px solid rgba(216, 222, 232, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 16px;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
   overflow: hidden;
@@ -581,10 +581,10 @@ body {
 
 .glassmorphism {
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.65);
   -webkit-backdrop-filter: blur(30px) saturate(210%);
   backdrop-filter: blur(30px) saturate(210%);
-  border: 1px solid rgba(216, 222, 232, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.4);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -598,10 +598,10 @@ body {
 }
 
 .glass-card {
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.65);
   -webkit-backdrop-filter: blur(30px) saturate(210%);
   backdrop-filter: blur(30px) saturate(210%);
-  border: 1px solid rgba(216, 222, 232, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 16px;
 }
 
@@ -659,19 +659,19 @@ input[type="url"],
 input[type="search"],
 textarea,
 select {
-  border-radius: 16px;
+  border-radius: 8px;
 }
 
 button {
-  border-radius: 16px;
+  border-radius: 8px;
 }
 
 .app-button {
-  border-radius: 16px;
+  border-radius: 8px;
 }
 
 .charge-btn {
-  border-radius: 16px;
+  border-radius: 8px;
 }
 
 .glass-panel {


### PR DESCRIPTION
Updates global css for glassmorphism and cards to match OHC translucent glass layout standards. Fixes Playwright test URLs (dashboard.html -> dashboard). Updates inputs and buttons to use 8px border-radius while keeping containers at 16px.

---
*PR created automatically by Jules for task [15146691323239886718](https://jules.google.com/task/15146691323239886718) started by @ql-owo-lp*