### PR TITLE
fix(inventory): properly deduct available quantity on offline pos sync

### DIFF
--- a/src/server/api/offline_sync.rs
+++ b/src/server/api/offline_sync.rs
@@ -97,10 +97,11 @@ pub async fn offline_sync_handler(
 
                     let new_stock = std::cmp::max(0, stock - mutation.quantity_deducted);
 
-                    let _ = sqlx::query("UPDATE products SET inventory_count = $1 WHERE id = $2 AND tenant_id = $3")
+                    let _ = sqlx::query("UPDATE products SET inventory_count = $1, available_quantity = GREATEST(0, available_quantity - $4) WHERE id = $2 AND tenant_id = $3")
                         .bind(new_stock)
                         .bind(&mutation.product_id)
                         .bind(&tenant_id_clone)
+                        .bind(mutation.quantity_deducted)
                         .execute(&mut *db_tx)
                         .await;
 


### PR DESCRIPTION
# Product-use evidence

- **Persona**: Priya (boutique owner)
- **CUJ**: Priya uses the OHC mobile app (POS mode) while an online customer browses her storefront.
- **Observed Gap**: The `offline_sync` handler was incorrectly deducting from `inventory_count` but skipping deduction from `available_quantity`. As a result, the `available_quantity` count would not be synchronized correctly if an offline sync process happened, which could lead to an online checkout attempting to grab an item that has already been purchased in a terminal POS offline queue.
- **Why it matters**: Double-bookings can occur if a physical POS transaction and an online checkout compete for the same stock without proper cross-field quantity deduction.
- **Fix**: Replaced the direct update to `inventory_count` in `offline_sync.rs` with an update that also properly updates `available_quantity` via `available_quantity = GREATEST(0, available_quantity - $4)` allowing it to reflect the offline sync deductions.

The rest of the features required by the issue such as the Redlock implementation within `terminal_api.rs:528` (`reserve_inventory`) & `inventory/service.rs:102` (`reserve_inventory` function executing Redlock `SET ... NX EX`), Pos Terminal Session schema updates (`038_pos_offline_sync_reconciliation.sql`) and Operations Agent `LowStockAlert` routing capabilities (`inventory/service.rs` around line 333 / `operations_agent.rs` line 54 natively) were already perfectly implemented. The issue was purely the synchronization deduction bug preventing full stability of the feature under high contention scenarios. All tests including the full E2E Playwright test suite pass successfully on this commit.

Resolves #28638

---
*PR created automatically by Jules for task [2864994409734351947](https://jules.google.com/task/2864994409734351947) started by @ql-owo-lp*