### PR TITLE
🔗 Link: Fix The Ambassador agent missing inbox_message_id

### DIFF
--- a/src/server/api/inbox/webhook.rs
+++ b/src/server/api/inbox/webhook.rs
@@ -94,6 +94,7 @@ pub async fn handle_omnichannel_webhook(
 
     let payload_json = serde_json::json!({
         "message_id": id,
+        "inbox_message_id": id,
         "source": payload.source,
         "content": payload.message,
         "sender_id": payload.sender_id

--- a/src/server/api/omni_inbox_webhook.rs
+++ b/src/server/api/omni_inbox_webhook.rs
@@ -95,6 +95,7 @@ pub async fn omni_inbox_post_handler(
     let job_id = Uuid::new_v4().to_string();
     let mut payload_json = serde_json::json!({
         "message_id": inbox_id,
+        "inbox_message_id": inbox_id,
         "source": source,
         "content": message,
         "sender_id": sender_id


### PR DESCRIPTION
This PR ensures `inbox_message_id` is supplied in the `tenant.omnichannel.message.received` payload so the Ambassador agent correctly saves its draft responses to the database.

---
*PR created automatically by Jules for task [1469085471863853762](https://jules.google.com/task/1469085471863853762) started by @ql-owo-lp*

Resolves #28751