### PR TITLE
✍️ Scribe: Fix interactive walkthrough "Back" button behavior

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2650,7 +2650,7 @@ function initWalkthrough() {
             `;
 
             document.getElementById('wt-close').onclick = closeWalkthrough;
-            if (document.getElementById('wt-prev')) document.getElementById('wt-prev').onclick = () => { currentStep--; renderStep();
+            if (document.getElementById('wt-prev')) document.getElementById('wt-prev').onclick = () => { currentStep--; renderStep(); };
             document.getElementById('wt-next').onclick = () => {
                 if (currentStep === steps.length - 1) {
                     closeWalkthrough();
@@ -3191,7 +3191,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 `;
 
                 document.getElementById('wt-close').onclick = closeWalkthrough;
-                if (document.getElementById('wt-prev')) document.getElementById('wt-prev').onclick = () => { currentStep--; renderStep();
+                if (document.getElementById('wt-prev')) document.getElementById('wt-prev').onclick = () => { currentStep--; renderStep(); };
                 document.getElementById('wt-next').onclick = () => {
                     if (currentStep === steps.length - 1) {
                         closeWalkthrough();


### PR DESCRIPTION
This PR fixes an issue where the "Back" button inside interactive walkthroughs was broken due to an unclosed inline JavaScript arrow function across multiple HTML files (`if (document.getElementById('wt-prev')) document.getElementById('wt-prev').onclick = () => { currentStep--; renderStep();`). 

A bash script using `sed` was utilized to properly close the `onclick` handler across all affected HTML files. Verified that `bazel test //...` and the E2E tests `bazel test //src/e2e:playwright` succeed locally with no regressions.

---
*PR created automatically by Jules for task [8856942036321414387](https://jules.google.com/task/8856942036321414387) started by @ql-owo-lp*