### PR TITLE
fix(chaos): enforce 60-second database operation timeout

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -570,7 +570,14 @@ impl DB {
         #[cfg(test)]
         let mut backoff = std::time::Duration::from_millis(1);
 
+        // Enforce the 60-second ML-Resilience rule for database operations
+        let start_time = std::time::Instant::now();
+        let timeout_duration = std::time::Duration::from_secs(60);
+
         loop {
+            if start_time.elapsed() > timeout_duration {
+                return Err(E::from(format!("Database operation '{}' timed out after 60 seconds", operation)));
+            }
             match f().await {
                 Ok(val) => return Ok(val),
                 Err(err) => {


### PR DESCRIPTION
Enforces a 60-second timeout constraint on database operations inside the `execute_with_retry` function. This satisfies the ML-Resilience rule: "AI agent jobs must have a 60-second timeout with automatic retry", and ensures the entire application correctly fail-safes during slow network conditions instead of infinitely looping. All chaos stress tests are now completely passing.

---
*PR created automatically by Jules for task [18032167176196446514](https://jules.google.com/task/18032167176196446514) started by @ql-owo-lp*