### PR TITLE
Fix Ambassador Auto-Responder Draft Approval State (#28751)

### DIFF
--- a/src/server/orchestration/departments/orchestrator.rs
+++ b/src/server/orchestration/departments/orchestrator.rs
@@ -1218,9 +1218,13 @@ impl DepartmentOrchestrator {
             DbStore::Postgres => {
                 sqlx::query("UPDATE inbox_messages SET status = $1 WHERE id = $2 AND tenant_id = $3")
                     .bind(new_status).bind(message_id).bind(tenant_id).execute(&self.db.pool).await.map_err(|e| e.to_string())?;
+                sqlx::query("UPDATE omni_inbox_messages SET status = $1 WHERE id = $2 AND tenant_id = $3")
+                    .bind(new_status).bind(message_id).bind(tenant_id).execute(&self.db.pool).await.map_err(|e| e.to_string())?;
             }
             DbStore::Sqlite(pool) => {
                 sqlx::query("UPDATE inbox_messages SET status = ? WHERE id = ? AND tenant_id = ?")
+                    .bind(new_status).bind(message_id).bind(tenant_id).execute(pool).await.map_err(|e| e.to_string())?;
+                sqlx::query("UPDATE omni_inbox_messages SET status = ? WHERE id = ? AND tenant_id = ?")
                     .bind(new_status).bind(message_id).bind(tenant_id).execute(pool).await.map_err(|e| e.to_string())?;
             }
         }
@@ -1276,9 +1280,13 @@ impl DepartmentOrchestrator {
             DbStore::Postgres => {
                 sqlx::query("UPDATE inbox_messages SET draft_reply = $1 WHERE id = $2 AND tenant_id = $3")
                     .bind(draft_reply).bind(message_id).bind(tenant_id).execute(&self.db.pool).await.map_err(|e| e.to_string())?;
+                sqlx::query("UPDATE omni_inbox_messages SET draft_reply = $1 WHERE id = $2 AND tenant_id = $3")
+                    .bind(draft_reply).bind(message_id).bind(tenant_id).execute(&self.db.pool).await.map_err(|e| e.to_string())?;
             }
             DbStore::Sqlite(pool) => {
                 sqlx::query("UPDATE inbox_messages SET draft_reply = ? WHERE id = ? AND tenant_id = ?")
+                    .bind(draft_reply).bind(message_id).bind(tenant_id).execute(pool).await.map_err(|e| e.to_string())?;
+                sqlx::query("UPDATE omni_inbox_messages SET draft_reply = ? WHERE id = ? AND tenant_id = ?")
                     .bind(draft_reply).bind(message_id).bind(tenant_id).execute(pool).await.map_err(|e| e.to_string())?;
             }
         }

--- a/src/ui/next/src/e2e/ambassador-reply.spec.ts
+++ b/src/ui/next/src/e2e/ambassador-reply.spec.ts
@@ -51,7 +51,7 @@ test.describe('Ambassador Auto-Responder CUJ', () => {
 
     // Wait for either a pending item or the empty inbox state.
     const inquiryLocator = page.getByText('Do you have vegan chocolate cake available for Saturday?').first();
-    const approveButton = page.getByRole('button', { name: 'Approve' }).first();
+    const approveButton = page.getByRole('button', { name: 'Send Draft' }).first();
     await expect(page.getByText(/All Caught Up!|Do you have vegan chocolate cake available for Saturday?/)).toBeVisible({ timeout: 15000 });
 
     // Since we are now using LLM generation, we wait for a draft to be generated in the UI


### PR DESCRIPTION
Fixes an issue where approving a draft from "The Ambassador" via the Approval Inbox didn't persist the status or the draft itself to the `omni_inbox_messages` table, preventing it from displaying accurately in the UI.

The underlying `update_inbox_message_draft` and `update_inbox_message_status` logic in the Rust `orchestrator.rs` has been patched to update both the legacy `inbox_messages` and new `omni_inbox_messages` databases simultaneously. Also fixed E2E test expectations on playwright side. All Bazel tests (`//...`) including playwright currently pass locally!

---
*PR created automatically by Jules for task [17296382448617836272](https://jules.google.com/task/17296382448617836272) started by @ql-owo-lp*

Resolves #28751