### PR TITLE
Fix onboarding keyboard friction

### DIFF
--- a/src/e2e/onboarding_keyboard_friction.spec.ts
+++ b/src/e2e/onboarding_keyboard_friction.spec.ts
@@ -135,4 +135,44 @@ test.describe('Onboarding Keyboard Friction Mitigation', () => {
     expect(val).toBe('Test bio\n');
   });
 
+  test('Enter key submits chat message in Conversational Setup', async ({ page }) => {
+    const workspaceRoot = process.env.TEST_WORKSPACE
+        ? path.join(process.env.TEST_SRCDIR || process.cwd(), process.env.TEST_WORKSPACE)
+        : process.cwd();
+
+    const tauriUiDir = path.join(workspaceRoot, 'src/ui/tauri/src/ui');
+
+    await page.route('http://mock/setup.html', async route => {
+        const content = fs.readFileSync(path.join(tauriUiDir, 'setup.html'), 'utf-8');
+        await route.fulfill({ contentType: 'text/html', body: content });
+    });
+
+    let chatRequestSent = false;
+    await page.route('**/api/onboarding/chat', async route => {
+        chatRequestSent = true;
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                reply: 'Hello there!',
+                is_complete: false
+            })
+        });
+    });
+
+    await page.goto('http://mock/setup.html');
+
+    // Go to chat setup
+    await page.getByRole('button', { name: 'Conversational Setup' }).click();
+    await expect(page.locator('#step-chat')).toHaveClass(/active/);
+
+    // Press Enter to submit chat
+    await page.locator('#chat-input').fill('Test chat message');
+    await page.locator('#chat-input').press('Enter');
+
+    // It should add a message bubble to the view and send the API request
+    await expect(page.locator('#chat-messages').getByText('Test chat message')).toBeVisible();
+    expect(chatRequestSent).toBe(true);
+  });
+
 });

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1918,7 +1918,6 @@
       }
 
       if (chatSendBtn) { chatSendBtn.addEventListener('click', sendChatMessage); }
-      if (chatInputEl) { chatInputEl.addEventListener('keydown', (e) => { if (e.key === 'Enter') sendChatMessage(); }); }
 
       if (generateStorefrontBtn) {
           generateStorefrontBtn.addEventListener('click', async () => {
@@ -2220,6 +2219,8 @@ document.addEventListener('DOMContentLoaded', () => {
               if (activeStep) {
                   // Don't auto-advance in chat if we are focused on chat input
                   if (activeStep.id === 'step-chat' && (e.target.id === 'chat-input' || e.target.id === 'chat-image-url')) {
+                      e.preventDefault();
+                      sendChatMessage();
                       return;
                   }
                   e.preventDefault();


### PR DESCRIPTION
The onboarding assistant chat was suffering from keyboard friction where typing a message in the Conversational Setup wizard would not successfully be submitted if the user hit `Enter`. This has been resolved by modifying the global keydown listener to trigger `sendChatMessage()` when hitting Enter on the `chat-input` or `chat-image-url` inputs.

Included a Playwright E2E test verifying this fix in `src/e2e/onboarding_keyboard_friction.spec.ts`.

---
*PR created automatically by Jules for task [8507843609694748694](https://jules.google.com/task/8507843609694748694) started by @ql-owo-lp*