### PR TITLE
fix(ui): responsive setup wizard without horizontal scroll and stable resume state

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -13,6 +13,7 @@
         align-items: center;
         justify-content: center;
         height: 100vh;
+        overflow-x: hidden;
       }
       .container {
         background: rgba(255, 255, 255, 0.65);
@@ -740,6 +741,7 @@
       }
 
             @media (max-width: 375px) {
+        .container { box-sizing: border-box; overflow-x: hidden; padding: 20px; }
         .stepper {
           gap: 4px;
         }
@@ -1363,7 +1365,7 @@
       if (state.step === undefined || state.step === 0) {
          goToStep('step-initial');
       } else {
-         const steps = ['step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template'];
+         const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template', 'step-instant', 'step-chat'];
          if (state.step < steps.length) {
             goToStep(steps[state.step]);
          }
@@ -1439,7 +1441,7 @@
           }
 
           if (state.step !== undefined && state.step > 0) {
-              const steps = ['step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template'];
+              const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template', 'step-instant', 'step-chat'];
               if (state.step < steps.length) {
                   goToStep(steps[state.step]);
               }
@@ -1470,15 +1472,13 @@
           let stepNumber = 0;
           const activeStep = document.querySelector('.step.active');
           if (activeStep) {
-              if (activeStep.id === 'step-context') stepNumber = 0;
-              if (activeStep.id === 'step-categories') stepNumber = 1;
-              if (activeStep.id === 'step-name') stepNumber = 2;
-              if (activeStep.id === 'step-assistant') stepNumber = 3;
-              if (activeStep.id === 'step-admin') stepNumber = 4;
-              if (activeStep.id === 'step-offer') stepNumber = 5;
-              if (activeStep.id === 'step-template') stepNumber = 6;
+              stepNumber = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template', 'step-instant', 'step-chat'].indexOf(activeStep.id);
+              if (stepNumber === -1) stepNumber = 0;
           }
           state.step = stepNumber;
+
+          // Always set localStorage directly
+          localStorage.setItem('onboardingState', JSON.stringify(state));
 
           if (window.__TAURI__ && window.__TAURI__.core) {
               window.__TAURI__.core.invoke("save_onboarding_state", { state }).catch(console.error);


### PR DESCRIPTION
Fix the OHC Setup wizard responsiveness on 375px screens by eliminating horizontal scroll and ensuring state is correctly serialized to `localStorage` when users navigate between wizard steps.

---
*PR created automatically by Jules for task [11042113572314787345](https://jules.google.com/task/11042113572314787345) started by @ql-owo-lp*