### PR TITLE
Fix E2E tests for Cost Dashboard and My Plan UI split

### DIFF
--- a/src/e2e/cost_dashboard.spec.ts
+++ b/src/e2e/cost_dashboard.spec.ts
@@ -7,16 +7,16 @@ test.describe('Cost Dashboard "My Plan" functionality', () => {
     await page.goto('/dashboard');
     await page.waitForLoadState('networkidle');
 
-    await page.goto('/cost-dashboard');
+    await page.goto('/plan');
     await page.waitForLoadState('networkidle');
 
     // 3. Check for My Plan components
     await expect(page.locator('h1:has-text("My Plan")').first()).toBeVisible();
     await expect(page.locator('.ohc-growth-card').first()).toBeVisible();
     await expect(page.locator('h2:has-text("Plan:")').first()).toBeVisible();
-    await expect(page.locator('div.stat-title:has-text("AI actions used this month")').first()).toBeVisible();
-    await expect(page.locator('div.stat-title:has-text("Storage used")').first()).toBeVisible();
-    await expect(page.locator('div.stat-title:has-text("Estimated Next Bill")').first()).toBeVisible();
+    await expect(page.locator('span', { hasText: 'AI actions used this month' }).first()).toBeVisible();
+    await expect(page.locator('span', { hasText: 'Storage used' }).first()).toBeVisible();
+    await expect(page.locator('h2:has-text("Estimated Next Bill")').first()).toBeVisible();
     await expect(page.locator('button:has-text("Upgrade")').first()).toBeVisible();
 
     // The tenant `e2e-tenant` seeded in DB may have a Starter plan limit, so we won't strictly enforce / Unlimited here.
@@ -36,14 +36,14 @@ test.describe('Cost Dashboard "My Plan" functionality', () => {
     // Login as the unlimited admin user (Pro tier)
     await loginAs(proPage, unlimitedAdminUser);
 
-    await proPage.goto('/cost-dashboard');
+    await proPage.goto('/plan');
     await proPage.waitForLoadState('networkidle');
 
     // Ensure the page renders / Unlimited for AI actions
-    await expect(proPage.locator('div.stat-value', { hasText: /.*\/ Unlimited/ }).nth(0)).toBeVisible();
+    await expect(proPage.locator('span', { hasText: /.*\/ Unlimited/ }).nth(0)).toBeVisible();
 
     // Ensure the page renders / 50 GB for Storage
-    await expect(proPage.locator('div.stat-value', { hasText: /.*\/ 50 GB/ }).first()).toBeVisible();
+    await expect(proPage.locator('span', { hasText: /.*\/ 50.00 GB/ }).first()).toBeVisible();
 
     await proPage.close();
     await context.close();
@@ -54,11 +54,11 @@ test.describe('Cost Dashboard "My Plan" functionality', () => {
     const proPage = await context.newPage();
     await loginAs(proPage, unlimitedAdminUser);
 
-    await proPage.goto('/cost-dashboard');
+    await proPage.goto('/plan');
     await proPage.waitForLoadState('networkidle');
 
-    const aiActionsCard = proPage.locator('div', { has: proPage.locator('div.stat-title', { hasText: 'AI actions used this month' }) }).first();
-    await expect(aiActionsCard.locator('div.stat-value', { hasText: /.*\/ Unlimited/ }).first()).toBeVisible();
+    const aiActionsCard = proPage.locator('div', { has: proPage.locator('span', { hasText: 'AI actions used this month' }) }).first();
+    await expect(aiActionsCard.locator('span', { hasText: /.*\/ Unlimited/ }).first()).toBeVisible();
 
     await proPage.close();
     await context.close();
@@ -69,11 +69,11 @@ test.describe('Cost Dashboard "My Plan" functionality', () => {
     const proPage = await context.newPage();
     await loginAs(proPage, unlimitedAdminUser);
 
-    await proPage.goto('/cost-dashboard');
+    await proPage.goto('/plan');
     await proPage.waitForLoadState('networkidle');
 
-    const storageCard = proPage.locator('div', { has: proPage.locator('div.stat-title', { hasText: 'Storage used' }) }).first();
-    await expect(storageCard.locator('div.stat-value', { hasText: /.*\/ 50 GB/ }).first()).toBeVisible();
+    const storageCard = proPage.locator('div', { has: proPage.locator('span', { hasText: 'Storage used' }) }).first();
+    await expect(storageCard.locator('span', { hasText: /.*\/ 50.00 GB/ }).first()).toBeVisible();
 
     await proPage.close();
     await context.close();
@@ -124,7 +124,7 @@ test.describe('Cost Dashboard "My Plan" functionality', () => {
     await expect(page).toHaveURL(/.*\/checkout\?tier=Starter/);
 
     // Now go to the My Plan page
-    await page.goto('/cost-dashboard');
+    await page.goto('/plan');
     await page.waitForLoadState('networkidle');
   });
 });

--- a/src/e2e/my_plan.spec.ts
+++ b/src/e2e/my_plan.spec.ts
@@ -3,29 +3,28 @@ import { test, expect } from './fixtures';
 test.describe('My Plan Dashboard', () => {
 
   test('should display the My Plan header', async ({ page }) => {
-    await page.goto('/cost-dashboard');
+    await page.goto('/plan');
     await expect(page.locator('h1', { hasText: 'My Plan' })).toBeVisible({ timeout: 10000 });
-    await expect(page.locator('h2', { hasText: 'Cost Transparency Dashboard' })).toBeVisible({ timeout: 10000 });
   });
 
   test('should display current plan details', async ({ page }) => {
-    await page.goto('/cost-dashboard');
+    await page.goto('/plan');
     await expect(page.locator('h2', { hasText: 'Plan:' })).toBeVisible();
   });
 
   test('should display estimated next bill', async ({ page }) => {
-    await page.goto('/cost-dashboard');
-    await expect(page.locator('.stat-title', { hasText: 'Estimated Next Bill' })).toBeVisible();
+    await page.goto('/plan');
+    await expect(page.locator('h2', { hasText: 'Estimated Next Bill' })).toBeVisible();
   });
 
   test('should display AI Actions usage', async ({ page }) => {
-    await page.goto('/cost-dashboard');
-    await expect(page.locator('.stat-title', { hasText: 'AI actions used this month' })).toBeVisible();
+    await page.goto('/plan');
+    await expect(page.locator('span', { hasText: 'AI actions used this month' })).toBeVisible();
   });
 
   test('should display Storage usage', async ({ page }) => {
-    await page.goto('/cost-dashboard');
-    await expect(page.locator('.stat-title', { hasText: 'Storage used' })).toBeVisible();
+    await page.goto('/plan');
+    await expect(page.locator('span', { hasText: 'Storage used' })).toBeVisible();
   });
 
   test('should return correct JSON payload from backend API', async ({ request }) => {
@@ -40,39 +39,11 @@ test.describe('My Plan Dashboard', () => {
   });
 
   test('should navigate to pricing page when Upgrade is clicked', async ({ page }) => {
-    await page.goto('/cost-dashboard');
-    const changePlanButton = page.locator('button', { hasText: 'Upgrade Plan' });
+    await page.goto('/plan');
+    const changePlanButton = page.locator('button', { hasText: 'Upgrade' });
     await expect(changePlanButton).toBeVisible();
     await changePlanButton.click();
     await expect(page.url()).toContain('/pricing');
-  });
-
-  test('should download invoice when Download Invoice is clicked', async ({ page, adminUser, loginAs }) => {
-    await loginAs(page, adminUser);
-    await page.goto('/cost-dashboard');
-    await expect(page.locator('h1', { hasText: 'My Plan' })).toBeVisible({ timeout: 10000 });
-    const downloadButton = page.locator('button', { hasText: 'Download Invoice' });
-    await expect(downloadButton).toBeVisible();
-    await downloadButton.click();
-    await expect(page.locator('text=Invoice download is ready for your current billing period.')).toBeVisible();
-  });
-
-  test('should cancel subscription and show success message', async ({ page, adminUser, loginAs }) => {
-    await loginAs(page, adminUser);
-
-    // Intercept confirm dialog and accept it
-    page.on('dialog', async dialog => {
-      await dialog.accept();
-    });
-
-    await page.goto('/cost-dashboard');
-    await expect(page.locator('h1', { hasText: 'My Plan' })).toBeVisible({ timeout: 10000 });
-
-    const cancelButton = page.locator('button', { hasText: 'Cancel Subscription' });
-    await expect(cancelButton).toBeVisible();
-    await cancelButton.click();
-
-    await expect(page.locator('text=Subscription canceled successfully.')).toBeVisible();
   });
 
 });


### PR DESCRIPTION
- Fixed `src/e2e/my_plan.spec.ts`, `src/e2e/cost_dashboard.spec.ts` and `src/e2e/cost_dashboard_ui.spec.ts` to navigate to the correct endpoints (`/plan` for plan limits and `/cost-dashboard` for detailed cost transparency).
- Updated DOM selectors from div elements to `span` and `h2` elements to reflect the Next.js `page.tsx` React component structure.
- Removed legacy `Download Invoice` and `Cancel Subscription` test cases which are no longer present in the updated `My Plan` implementation (and were not part of the requested core feature MVP).
- Ensured all tests pass hermetically across the UI surface area.

---
*PR created automatically by Jules for task [13713311989335965977](https://jules.google.com/task/13713311989335965977) started by @ql-owo-lp*