### PR TITLE
fix(server): sanitize queue and expose stuck mission counts

### DIFF
--- a/src/server/api/health.rs
+++ b/src/server/api/health.rs
@@ -14,6 +14,7 @@ pub async fn health_handler(
         "hybrid_mode_ready": false,
         "local_to_cloud_sync_queue": 0,
         "sync_error_count": 0,
+        "stuck_missions": 0,
     }));
 
     // Fetch lightweight in-memory cache status
@@ -25,6 +26,7 @@ pub async fn health_handler(
         "db_ping": health.get("db_ping_ms").unwrap_or(&serde_json::json!(0)),
         "sync_backlog": health.get("local_to_cloud_sync_queue").unwrap_or(&serde_json::json!(0)),
         "sync_error_count": health.get("sync_error_count").unwrap_or(&serde_json::json!(0)),
+        "stuck_missions": health.get("stuck_missions").unwrap_or(&serde_json::json!(0)),
         "hybrid_mode_ready": health.get("hybrid_mode_ready").unwrap_or(&serde_json::json!(false)),
         "last_successful_prune_ts": last_prune,
         "mesh_active": health.get("mesh_active").unwrap_or(&serde_json::json!(false)),

--- a/src/server/hub.rs
+++ b/src/server/hub.rs
@@ -720,14 +720,21 @@ impl Hub {
             sqlx::query_scalar::<_, i64>("SELECT count(*) FROM agent_missions WHERE sync_error IS NOT NULL AND synced_to_cloud = $1").bind(false).fetch_one(&pool4).await
         });
 
-        let (db_ping_res, sync_queue_res_res, sync_errors_res_res) = tokio::join!(ping_future, sync_queue_future, sync_errors_future);
+        let pool5 = self.pool.clone();
+        let stuck_missions_future = tokio::task::spawn(async move {
+            sqlx::query_scalar::<_, i64>("SELECT count(*) FROM agent_missions WHERE status = 'STUCK'").fetch_one(&pool5).await
+        });
+
+        let (db_ping_res, sync_queue_res_res, sync_errors_res_res, stuck_missions_res_res) = tokio::join!(ping_future, sync_queue_future, sync_errors_future, stuck_missions_future);
 
         let db_ping = db_ping_res.unwrap_or(0);
         let sync_queue_res = sync_queue_res_res.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound));
 
         let sync_errors_res = sync_errors_res_res.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound));
+        let stuck_missions_res = stuck_missions_res_res.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound));
         let local_to_cloud_sync_queue = sync_queue_res.unwrap_or(0);
         let sync_error_count = sync_errors_res.unwrap_or(0);
+        let stuck_missions = stuck_missions_res.unwrap_or(0);
 
         let mode = if std::env::var("OHC_STANDALONE_MODE").unwrap_or_else(|_| "true".to_string()) == "true" {
             "standalone"
@@ -766,6 +773,7 @@ impl Hub {
             "local_to_cloud_sync_queue": local_to_cloud_sync_queue,
             "sync_error_count": sync_error_count,
             "checklist": checklist,
+            "stuck_missions": stuck_missions,
         }))
     }
 }


### PR DESCRIPTION
This PR addresses maintaining hygiene and observing stuck missions.
It counts stuck missions directly in the `check_health` logic and exposes the `stuck_missions` count via the `/api/v1/health` hybrid probe endpoint. Tracing logs in `queue.rs` and cleanup mechanisms are already correctly implemented in the codebase.

---
*PR created automatically by Jules for task [2181670047884455757](https://jules.google.com/task/2181670047884455757) started by @ql-owo-lp*