### PR TITLE
Optimize UI: Use local swagger-ui and fix checkout tests act() warnings

### DIFF
--- a/src/ui/next/src/app/api-docs/page.tsx
+++ b/src/ui/next/src/app/api-docs/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import SwaggerUI from "swagger-ui-react";
+import "swagger-ui-react/swagger-ui.css";
 
 import { WithTooltip } from "../../components/TooltipRegistry";
 

--- a/src/ui/next/src/app/checkout/page.test.tsx
+++ b/src/ui/next/src/app/checkout/page.test.tsx
@@ -62,7 +62,11 @@ beforeEach(() => {
 
     render(<CheckoutPage />);
 
-    expect(screen.getByText('Plan Upgrade')).toBeDefined();
+    // Wait for the Suspense inner content to load
+    await waitFor(() => {
+      expect(screen.getByText('Plan Upgrade')).toBeDefined();
+    });
+
     expect(screen.getByText('OHC Starter Plan')).toBeDefined();
 
     const payButton = screen.getByText('Upgrade');
@@ -97,7 +101,10 @@ beforeEach(() => {
 
     render(<CheckoutPage />);
 
-    expect(screen.getByText('Secure Checkout')).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByText('Secure Checkout')).toBeDefined();
+    });
+
     expect(screen.getByText('Service Deposit')).toBeDefined();
     expect(screen.getByText('Subscribe & Save 10%')).toBeDefined();
     expect(screen.getAllByText('$45.00')[0]).toBeDefined();
@@ -124,6 +131,10 @@ beforeEach(() => {
 
     render(<CheckoutPage />);
 
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Enter address for delivery quote')).toBeDefined();
+    });
+
     const addressInput = screen.getByPlaceholderText('Enter address for delivery quote');
     fireEvent.change(addressInput, { target: { value: '123 Main St' } });
 
@@ -140,9 +151,23 @@ beforeEach(() => {
     });
   });
 
-  it('renders the PoweredByOHC component', () => {
+  it('renders the PoweredByOHC component', async () => {
+    // Mock the fetch call for the loyalty points since the component uses it on mount
+    global.fetch = vi.fn().mockImplementation((url) => {
+      if (url.includes('/api/v1/growth/loyalty')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ points_balance: 50 }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
     render(<CheckoutPage />);
-    const components = screen.getAllByTestId('powered-by-ohc');
-    expect(components.length).toBeGreaterThan(0);
+
+    await waitFor(() => {
+      const components = screen.getAllByTestId('powered-by-ohc');
+      expect(components.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/src/ui/next/src/app/layout.tsx
+++ b/src/ui/next/src/app/layout.tsx
@@ -24,8 +24,6 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
-        <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
       </head>
       <body>
         <RateLimitWarningProvider>


### PR DESCRIPTION
Optimize UI: Use local swagger-ui and fix checkout tests act() warnings

- Remove the external unpkg CDN dependencies for Swagger UI in layout.tsx.
- Import the Swagger UI CSS locally within api-docs/page.tsx.
- Fix act() warnings in checkout page tests by wrapping rendering in waitFor.

---
*PR created automatically by Jules for task [3660531755747341957](https://jules.google.com/task/3660531755747341957) started by @ql-owo-lp*