### PR TITLE
🚀 Nova: Implement WhatsApp Link Generator Referral Growth Loop

### DIFF
--- a/src/ui/next/src/app/whatsapp-link-generator/page.tsx
+++ b/src/ui/next/src/app/whatsapp-link-generator/page.tsx
@@ -12,8 +12,16 @@ export default function WhatsAppLinkGeneratorPage() {
   const [showPaywall, setShowPaywall] = useState(false);
   const [copied, setCopied] = useState(false);
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [tenant, setTenant] = useState("default");
 
-  const brandingText = "⚡ Powered by OHC";
+  useEffect(() => {
+    if (typeof localStorage !== "undefined") {
+      const storedTenant = localStorage.getItem("tenant");
+      if (storedTenant) setTenant(storedTenant);
+    }
+  }, []);
+
+  const brandingText = `⚡ Powered by OHC`;
 
   const finalMessage = React.useMemo(() => {
     let finalStr = message.trim();
@@ -29,7 +37,7 @@ export default function WhatsAppLinkGeneratorPage() {
 
   const cleanPhoneNumber = phoneNumber.replace(/\D/g, '');
   const generatedLink = cleanPhoneNumber
-    ? `https://wa.me/${cleanPhoneNumber}?text=${encodeURIComponent(finalMessage)}`
+    ? `https://wa.me/${cleanPhoneNumber}?text=${encodeURIComponent(finalMessage)}\n\nhttps://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref=${tenant}`
     : '';
 
   const handleCopy = async () => {
@@ -295,7 +303,7 @@ export default function WhatsAppLinkGeneratorPage() {
 
       {/* Persistent Footer Growth Loop */}
       <footer className="mt-12 py-8 border-t border-gray-200 text-center">
-          <a href="/onboarding" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-sm font-semibold text-gray-500 hover:text-indigo-600 transition-colors">
+          <a href={`/api/v1/growth/referrals/click?target=/onboarding&ref=${tenant}`}  target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-sm font-semibold text-gray-500 hover:text-indigo-600 transition-colors">
               <span className="text-base">⚡</span> Powered by OHC
           </a>
       </footer>

--- a/src/ui/next/src/e2e/whatsapp-link-generator.spec.ts
+++ b/src/ui/next/src/e2e/whatsapp-link-generator.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('WhatsApp Link Generator Growth Loop', () => {
+    test('renders the builder and viral branding loop correctly', async ({ page }) => {
+        // Mock localStorage to simulate a logged-in tenant
+        await page.addInitScript(() => {
+            window.localStorage.setItem('tenant', 'test-tenant-123');
+        });
+
+        await page.goto('/whatsapp-link-generator');
+
+        // Verify the Builder UI loads
+        await expect(page.locator('h1', { hasText: 'WhatsApp Link Generator' })).toBeVisible();
+
+        // Check the "Powered by OHC" footer loop branding
+        const footerLink = page.locator('a', { hasText: '⚡ Powered by OHC' });
+        await expect(footerLink).toBeVisible();
+
+        // Verify it includes the dynamic tenant mapping
+        await expect(footerLink).toHaveAttribute('href', /\/api\/v1\/growth\/referrals\/click\?target=\/onboarding&ref=test-tenant-123/);
+
+        // Generate the URL and verify the generated string
+        const phoneInput = page.locator('input[placeholder="e.g. 1234567890"]');
+        await phoneInput.fill('1234567890');
+        await page.click('button:has-text("Get Link")');
+        await expect(page.locator('textarea')).toHaveValue(/https:\/\/wa\.me\/1234567890\?text=.*?https:\/\/ohc\.app\/api\/v1\/growth\/referrals\/click\?target=\/onboarding&ref=test-tenant-123/);
+    });
+});


### PR DESCRIPTION
🚀 Nova: WhatsApp Link Generator Referral Loop

This PR resolves the missing referral tracking loop in the WhatsApp Link Generator. By appending the current user's `tenant` directly to the "Powered by OHC" acquisition loop on the interface AND the generated output link, successful users who share this generator are now attributed for subsequent onboarding signups.

* Dynamically populates the `ref=${tenant}` query parameter in the `whatsapp-link-generator`.
* Automatically includes the referral parameter in the output WhatsApp message.
* Created a corresponding E2E testing file `whatsapp-link-generator.spec.ts` under Playwright to prevent regressions in this CUJ.

---
*PR created automatically by Jules for task [14468925232197185681](https://jules.google.com/task/14468925232197185681) started by @ql-owo-lp*