### PR TITLE
style: apply premium macOS translucent glass tokens to Help Center documentation components

### DIFF
--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -50,7 +50,7 @@ export default function HelpCenterPage() {
             placeholder="Search for help articles and videos..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full p-4 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-[0_8px_32px_rgba(0,0,0,0.05)] text-gray-900 bg-white/60 dark:bg-black/40 backdrop-blur-2xl saturate-[210%] border border-white/50 dark:border-white/10 hover:bg-white/75 min-h-[44px] text-base placeholder:text-gray-500 transition-all rounded-xl"
+            className="w-full p-4 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-[0_8px_32px_rgba(0,0,0,0.05)] text-gray-900 bg-white/60 dark:bg-black/40 backdrop-blur-[30px] saturate-[210%] border border-white/80 dark:border-white/20 hover:bg-white/80 min-h-[50px] text-base placeholder:text-gray-500 transition-all rounded-2xl"
           />
         </div>
 

--- a/src/ui/next/src/components/VideoTutorialList.tsx
+++ b/src/ui/next/src/components/VideoTutorialList.tsx
@@ -58,7 +58,7 @@ export function VideoTutorialList({
       <h2 className="text-2xl font-extrabold font-outfit text-gray-900 mb-6 text-center sm:text-left">Video Tutorials</h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {videos.map(video => (
-          <div key={video.id} onClick={() => setActiveVideo(video)} className="backdrop-blur-xl bg-white/60 dark:bg-black/40 saturate-[210%] rounded-2xl shadow-[0_4px_16px_rgba(0,0,0,0.04)] border border-white/50 dark:border-white/10 overflow-hidden group hover:shadow-md transition-all cursor-pointer flex flex-col">
+          <div key={video.id} onClick={() => setActiveVideo(video)} className="backdrop-blur-[30px] bg-white/80 dark:bg-black/40 saturate-[250%] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.08)] border border-white/80 dark:border-white/20 overflow-hidden group hover:shadow-lg transition-all cursor-pointer flex flex-col hover:-translate-y-1">
             {/* Mock video player area (portrait optimized 9:16 approx for mobile shorts feel, or standard 16:9) */}
             <div className="w-full aspect-[9/16] sm:aspect-video bg-gray-900 relative flex items-center justify-center">
               {/* Play button overlay */}

--- a/src/ui/next/src/components/help.tsx
+++ b/src/ui/next/src/components/help.tsx
@@ -313,8 +313,8 @@ export function HelpWidget() {
                   {chatMessages.map((msg) => {
                     const className = `p-3 rounded-2xl text-sm w-4/5 ${
                       msg.role === "bot"
-                        ? "bg-blue-50 text-blue-900 rounded-tl-none"
-                        : "bg-gray-100 text-gray-800 rounded-tr-none ml-auto"
+                        ? "backdrop-blur-2xl bg-white/80 border border-white/60 shadow-sm text-blue-900 rounded-tl-none"
+                        : "backdrop-blur-2xl bg-white/40 border border-white/40 shadow-sm text-gray-800 rounded-tr-none ml-auto"
                     }`;
                     return msg.role === "bot" ? (
                       <div key={msg.id} className={className}>


### PR DESCRIPTION
* Edited `src/ui/next/src/components/help.tsx` to ensure `HelpWidget` chat and center bubbles use true translucent glass styling.
* Edited `src/ui/next/src/app/help/page.tsx` to refine the search bar with `backdrop-blur-[30px]`, `saturate-[210%]`, and glassmorphism.
* Edited `src/ui/next/src/components/VideoTutorialList.tsx` to improve the video cards with better `saturate-[250%]` and `backdrop-blur-[30px]`.
* Verified that tests including E2E pass with these changes.

---
*PR created automatically by Jules for task [7136257308994293344](https://jules.google.com/task/7136257308994293344) started by @ql-owo-lp*