### PR TITLE
Fix Tooltip Registry Route

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6108,6 +6108,9 @@ async fn create_ui_bom_item_handler(
         .route("/api/ui/api-docs.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/api-docs.html"))
         }))
+        .route("/api/ui/tooltip-registry.html", axum::routing::get(|| async {
+            axum::response::Html(include_str!("../ui/tauri/src/ui/tooltip-registry.html"))
+        }))
         .route("/api/ui/changelog.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/next/public/api/ui/changelog.html"))
         }))

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -2746,7 +2746,7 @@ document.addEventListener('DOMContentLoaded', () => {
             </ul>
             <div style="margin-top: auto; padding-top: 16px; border-top: 1px solid rgba(226, 232, 240, 0.5);">
                 <a href="/api-docs.html" style="color: #64748b; font-size: 13px; text-decoration: none; display: block; margin-bottom: 8px;">API Reference for advanced users</a>
-                <a href="/tooltip-registry.html" style="color: #64748b; font-size: 13px; text-decoration: none; display: block;">Tooltip Registry</a>
+                <a href="/api/ui/tooltip-registry.html" style="color: #64748b; font-size: 13px; text-decoration: none; display: block;">Tooltip Registry</a>
             </div>
         </div>
 


### PR DESCRIPTION
Fixes missing `tooltip-registry.html` routing that caused e2e test failures.

---
*PR created automatically by Jules for task [7633611329310439742](https://jules.google.com/task/7633611329310439742) started by @ql-owo-lp*