### PR TITLE
fix: enqueue offline mutations and correct POS receipt for offline tap-to-pay

### DIFF
--- a/src/ui/tauri/src/ui/pos.html
+++ b/src/ui/tauri/src/ui/pos.html
@@ -646,21 +646,35 @@
 
           // In real flow, we'd confirm the intent and sync offline txs.
           // We simulate the offline sync for E2E validation:
-          const tenantId = localStorage.getItem('tenant_id') || 'default';
-          fetch('/api/v1/payments/terminal/sync_offline', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                  session_id: 'web_session',
-                  transactions: [{
-                      id: 'tx_' + Date.now(),
-                      client_id: 'web_client',
-                      amount_cents: currentAmountCents,
-                      currency: 'usd',
-                      payload: '{}'
-                  }]
-              })
-          }).catch(console.error);
+          if (!navigator.onLine) {
+              document.querySelector('.receipt-text').innerText = "Payment saved offline. Will sync when network is restored.";
+              enqueueOfflineMutation({
+                  type: 'tap_to_pay',
+                  id: 'tx_' + Date.now(),
+                  amount: currentAmountCents,
+                  currency: 'usd',
+                  product_id: 'quick_charge',
+                  quantity: 1,
+                  timestamp: new Date().toISOString()
+              });
+          } else {
+              document.querySelector('.receipt-text').innerText = "Payment Successful";
+              const tenantId = localStorage.getItem('tenant_id') || 'default';
+              fetch('/api/v1/payments/terminal/sync_offline', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                      session_id: 'web_session',
+                      transactions: [{
+                          id: 'tx_' + Date.now(),
+                          client_id: 'web_client',
+                          amount_cents: currentAmountCents,
+                          currency: 'usd',
+                          payload: '{}'
+                      }]
+                  })
+              }).catch(console.error);
+          }
       });
 
       function cancelCharge() {


### PR DESCRIPTION
* **Product-use evidence**: 
  - **Persona**: Fatima the Food Cart Operator.
  - **Attempted Flow**: Clock into the POS. Click 'Charge $50.00' and simulate a payment tap while offline.
  - **CUJ Gap Observed**: While the code had a mechanism for enqueuing offline mutations in `enqueueOfflineMutation`, it wasn't connected to the simulate tap functionality used in the web POS component. Furthermore, the receipt message hardcoded "Payment Successful" instead of informing the operator that the payment was saved offline for future syncing.
  - **User-experience reason for the fix**: Fatima needs immediate continuity of service when network reception drops. Failing to locally queue the transaction means the payment process stalls or drops silently, resulting in lost revenue or manual double-entry once the connection returns. Showing "Payment Successful" is inaccurate and provides false confidence; "Payment Saved Offline" clearly communicates the pending state so the operator knows to sync later.
  - **Post-fix UI flow**: The operator can click the charge button, simulate the tap offline, and will see the "Payment Saved Offline" notification, confident that their transaction is securely queued.

* **Changes**:
  - Updated `src/ui/tauri/src/ui/pos.html` to inspect `!navigator.onLine` in `simulateTapBtn` click listener.
  - Enqueues the appropriate offline `tap_to_pay` mutation when offline.
  - Updates the text in the receipt element to read "Payment Saved Offline" when the transaction is successfully queued.

Resolves #28895

---
*PR created automatically by Jules for task [18036731917597778210](https://jules.google.com/task/18036731917597778210) started by @ql-owo-lp*