### PR TITLE
chore: fix typescript and rust compilation errors blocking CI tests

### DIFF
--- a/src/agents/builtin/tools/magentic.rs
+++ b/src/agents/builtin/tools/magentic.rs
@@ -1,6 +1,5 @@
 use ohc_builtin_agent_core::types::ToolError;
 use serde_json::{json, Value};
-use serde::Deserialize;
 use std::sync::Arc;
 use super::task::Task;
 use chrono::Utc;

--- a/src/agents/builtin/tools/skill.rs
+++ b/src/agents/builtin/tools/skill.rs
@@ -1,10 +1,8 @@
 use ohc_builtin_agent_core::types::ToolError;
 use serde_json::{json, Value};
-use serde::Deserialize;
 use std::sync::Arc;
 
 use super::{Tool, ToolExecutor};
-use super::pydantic::{PydanticAdapter, PydanticToolExecutor};
 
 #[derive(Clone, Debug)]
 pub struct LoadedSkill {

--- a/src/server/api/sync.rs
+++ b/src/server/api/sync.rs
@@ -88,7 +88,6 @@ mod tests {
     use std::net::SocketAddr;
     use tokio::net::TcpListener;
     use tokio_tungstenite::connect_async;
-    use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
 
     #[tokio::test]
     async fn test_ws_sync_handler() {

--- a/src/ui/next/e2e/terminal_pos.spec.ts
+++ b/src/ui/next/e2e/terminal_pos.spec.ts
@@ -1,9 +1,7 @@
-import { test, expect } from '@playwright/test';
-import { setupE2E, getSeededUser } from '../../../e2e/fixtures';
+import { expect } from '@playwright/test';
+import { test } from '../../../e2e/fixtures';
 
 test.describe('Terminal POS - Mobile First & Inventory Sync', () => {
-  setupE2E();
-
   test.beforeEach(async ({ page }) => {
     // Navigate to POS terminal path
     await page.goto('/pos/terminal');

--- a/src/ui/next/src/components/NetworkStatusIndicator.tsx
+++ b/src/ui/next/src/components/NetworkStatusIndicator.tsx
@@ -1,9 +1,6 @@
 "use client";
 import { WithTooltip } from "./TooltipRegistry";
 
-
-import { WithTooltip } from "./TooltipRegistry";
-
 import React, { useState, useEffect } from 'react';
 import { SyncManager } from '../lib/sync/SyncManager';
 

--- a/src/ui/next/src/components/RateLimitWarning.tsx
+++ b/src/ui/next/src/components/RateLimitWarning.tsx
@@ -1,9 +1,6 @@
 "use client";
 import { WithTooltip } from "./TooltipRegistry";
 
-
-import { WithTooltip } from "./TooltipRegistry";
-
 import React, { createContext, useContext, useState, useEffect, ReactNode, useCallback } from 'react';
 
 interface RateLimitWarningContextType {

--- a/src/ui/next/src/components/VoiceAssistant.tsx
+++ b/src/ui/next/src/components/VoiceAssistant.tsx
@@ -1,9 +1,6 @@
 "use client";
 import { WithTooltip } from "./TooltipRegistry";
 
-
-import { WithTooltip } from "./TooltipRegistry";
-
 import React, { useState, useRef, useEffect, useCallback } from "react";
 
 export function VoiceAssistant() {

--- a/src/ui/next/src/e2e/assistant.spec.ts
+++ b/src/ui/next/src/e2e/assistant.spec.ts
@@ -1,9 +1,8 @@
-import { test, expect } from '@playwright/test';
-
+import { expect } from '@playwright/test';
+import { test } from '../../../../e2e/fixtures';
 
 test.describe('Assistant Page', () => {
   test('navigates to assistant and verifies authentic state', async ({ page }) => {
-    await adminPage({ page }, async ({ page }) => {
       await page.goto('/assistant');
 
       // Verify the page shell and layout
@@ -27,6 +26,5 @@ test.describe('Assistant Page', () => {
       // Check a panel (e.g., Remote Control)
       await page.getByRole('button', { name: 'Remote Control' }).click();
       await expect(page.getByRole('heading', { name: 'Remote Control' })).toBeVisible();
-    });
   });
 });


### PR DESCRIPTION
I have successfully fixed the broken state of the project tests by addressing the root compilation errors in both the TypeScript (Playwright + Next.js UI) and Rust (Axum backend) codebases. The TS/Rust compilation issues were the primary reasons tests kept flaking/failing due to missing imports, duplicate identifiers, unused Rust imports, and an incorrect call to `adminPage`. 

All CI commands like `bazelisk test //...` and `bazelisk test //src/e2e:playwright` as well as `bazelisk run //:rust_lint` now pass entirely.

---
*PR created automatically by Jules for task [3816582531100757334](https://jules.google.com/task/3816582531100757334) started by @ql-owo-lp*