### PR TITLE
feat: add dedicated referral dashboard and fix routing

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6117,6 +6117,9 @@ async fn create_ui_bom_item_handler(
         .route("/calendar", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/calendar.html"))
         }))
+        .route("/referrals", axum::routing::get(|| async {
+            axum::response::Html(include_str!("../ui/tauri/src/ui/referrals.html"))
+        }))
         .route("/api/chat", axum::routing::post(|axum::Json(req): axum::Json<ChatRequest>| async move {
             let help_articles = vec![
                 ("getting started", "Welcome to One Human Corp! This is a simple app that helps you manage your small business. You can set up your store, accept payments, and hire AI helpers."),

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -807,19 +807,10 @@
         <h2>Grow Your Team</h2>
         <p>Bridge your local sovereignty with cloud-native collaboration. Invite a team member to view agents in a secure cloud tenant.</p>
 
-        <button id="generate-link-btn" data-tooltip="Click here to share access with a team member.">Get My Invite Link</button>
+        <a href="/referrals" id="generate-link-btn" class="btn-primary" style="display: block; text-align: center; text-decoration: none;" data-tooltip="Click here to go to the Referral Dashboard.">Referral Dashboard</a>
         <div style="margin-top: 15px;"><a href="embed-builder.html" class="btn-primary" style="background-color: #34C759; text-decoration: none;">Open Widget Builder</a></div>
-
-        <div class="link-container" id="link-container">
-          <input type="text" class="link-input" id="referral-link" readonly value="" />
-          <button class="btn-secondary" id="dashboard-walkthrough-btn" data-tooltip="dashboard-walkthrough-btn" onclick="window.startWalkthrough([{selector: '#dashboard-title', title: 'Welcome', text: 'Welcome to your dashboard! This is your control center.'}, {selector: '#wrapped-summary', title: 'AI Savings', text: 'Here you can see the time and effort your agents have saved you.'}])">Start Walkthrough</button>
-        <div class="action-buttons">
-            <button class="btn-secondary" id="copy-btn" data-tooltip="Copy the referral link to your clipboard.">Copy</button>
-            <button class="btn-secondary" id="share-whatsapp-btn" data-tooltip="Share your link via WhatsApp">Share on WhatsApp</button>
-            <button class="btn-secondary" id="share-x-btn" style="background-color: #1DA1F2; color: white;">Share on X (Twitter)</button>
-            <a href="changelog.html" class="btn-secondary" style="text-decoration: none; display: flex; align-items: center; justify-content: center; background-color: rgba(255, 255, 255, 0.5); color: #1d1d1f;">Changelog</a>
-          </div>
-        </div>
+        <div style="margin-top: 15px;"><button class="btn-secondary" id="dashboard-walkthrough-btn" data-tooltip="dashboard-walkthrough-btn" onclick="window.startWalkthrough([{selector: '#dashboard-title', title: 'Welcome', text: 'Welcome to your dashboard! This is your control center.'}, {selector: '#wrapped-summary', title: 'AI Savings', text: 'Here you can see the time and effort your agents have saved you.'}])">Start Walkthrough</button></div>
+        <div style="margin-top: 15px;"><a href="changelog.html" class="btn-secondary" style="text-decoration: none; display: flex; align-items: center; justify-content: center; background-color: rgba(255, 255, 255, 0.5); color: #1d1d1f;">Changelog</a></div>
       </div>
 
 
@@ -827,16 +818,9 @@
       <div class="ohc-growth-card" id="invite-earn-section">
         <h2>Invite & Earn</h2>
         <p>Invite a fellow business owner to OHC. They get 1 month free, you get $50 credit.</p>
-        <button id="dashboard-invite-btn" style="background-color: #0066FF; color: white; border: none; padding: 12px; border-radius: 8px; cursor: pointer; font-weight: 600; width: 100%; box-sizing: border-box; transition: transform 0.1s;">
-          Get My Invite Link
-        </button>
-        <div id="dashboard-invite-container" style="display: none; margin-top: 15px;">
-          <input type="text" class="link-input" id="dashboard-invite-link" readonly value="" style="width: 100%;" />
-          <div class="action-buttons" style="margin-top: 10px;">
-            <button class="btn-secondary" id="dashboard-copy-btn" style="flex: 1;">Copy</button>
-            <button class="btn-secondary" id="dashboard-share-x-btn" style="flex: 1; background-color: #1DA1F2; color: white;">Share to X</button>
-          </div>
-        </div>
+        <a href="/referrals" id="dashboard-invite-btn" style="background-color: #0066FF; color: white; border: none; padding: 12px; border-radius: 8px; cursor: pointer; font-weight: 600; width: 100%; box-sizing: border-box; transition: transform 0.1s; display: block; text-align: center; text-decoration: none;">
+          Go to Referral Dashboard
+        </a>
       </div>
 
       <div class="ohc-growth-card" id="cloud-bridge-section" style="margin-top: 20px;">

--- a/src/ui/tauri/src/ui/referrals.html
+++ b/src/ui/tauri/src/ui/referrals.html
@@ -1,0 +1,405 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>Referral Dashboard</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    body {
+      font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background-color: #f5f5f7;
+      margin: 0;
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      min-height: 100vh;
+      color: #1d1d1f;
+      background-image: radial-gradient(circle at 10% 20%, rgba(0, 102, 255, 0.05) 0%, transparent 20%), radial-gradient(circle at 90% 80%, rgba(138, 43, 226, 0.05) 0%, transparent 20%);
+    }
+
+    .container {
+      max-width: 800px;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    h1 {
+      font-family: "Outfit", sans-serif;
+      font-size: 32px;
+      font-weight: 700;
+      margin: 0 0 20px 0;
+    }
+
+    .ohc-growth-card {
+      background: rgba(255, 255, 255, 0.65);
+      backdrop-filter: blur(30px) saturate(210%);
+      -webkit-backdrop-filter: blur(30px) saturate(210%);
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      border-radius: 16px;
+      padding: 24px;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.04);
+      box-sizing: border-box;
+      width: 100%;
+    }
+
+    .ohc-growth-card h2 {
+      font-family: "Outfit", sans-serif;
+      font-size: 20px;
+      margin-top: 0;
+      margin-bottom: 12px;
+    }
+
+    .ohc-growth-card p {
+      font-size: 14px;
+      color: #555;
+      margin-bottom: 16px;
+      line-height: 1.5;
+    }
+
+    .btn-primary {
+      background-color: #0066FF;
+      color: white;
+      border: none;
+      padding: 12px 24px;
+      border-radius: 12px;
+      font-size: 16px;
+      font-weight: 600;
+      cursor: pointer;
+      width: 100%;
+      box-sizing: border-box;
+      transition: background-color 0.2s, transform 0.1s;
+      margin-bottom: 10px;
+    }
+
+    .btn-primary:active {
+      transform: scale(0.98);
+    }
+
+    .btn-secondary {
+      background-color: #f5f5f7;
+      color: #1d1d1f;
+      border: 1px solid #d2d2d7;
+      padding: 12px 24px;
+      border-radius: 12px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      width: 100%;
+      box-sizing: border-box;
+      transition: background-color 0.2s, transform 0.1s;
+      margin-bottom: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-decoration: none;
+    }
+
+    .btn-secondary:active {
+      transform: scale(0.98);
+    }
+
+    .link-input {
+      width: 100%;
+      padding: 12px;
+      border-radius: 8px;
+      border: 1px solid #d2d2d7;
+      background-color: #f5f5f7;
+      font-family: monospace;
+      font-size: 14px;
+      margin-bottom: 12px;
+      box-sizing: border-box;
+    }
+
+    .action-buttons {
+      display: flex;
+      gap: 10px;
+      flex-direction: column;
+    }
+
+    @media (min-width: 600px) {
+      .action-buttons {
+        flex-direction: row;
+      }
+      .action-buttons > * {
+        margin-bottom: 0;
+      }
+    }
+
+    .tier-progress-container {
+      width: 100%;
+      height: 12px;
+      background-color: rgba(0, 0, 0, 0.05);
+      border-radius: 6px;
+      overflow: hidden;
+      margin-top: 10px;
+      margin-bottom: 8px;
+    }
+
+    .tier-progress-bar {
+      height: 100%;
+      background-color: #0066FF;
+      width: 0%;
+      transition: width 0.5s ease-out;
+    }
+
+    .metrics-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+      margin-top: 20px;
+    }
+
+    .metric-box {
+      background: rgba(255, 255, 255, 0.5);
+      border-radius: 12px;
+      padding: 16px;
+      border: 1px solid rgba(255,255,255,0.8);
+      text-align: center;
+    }
+
+    .metric-value {
+      font-size: 24px;
+      font-weight: 700;
+      font-family: "Outfit", sans-serif;
+      margin: 0;
+      color: #1d1d1f;
+    }
+
+    .metric-label {
+      font-size: 12px;
+      color: #666;
+      margin: 4px 0 0 0;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    .header-nav {
+      display: flex;
+      align-items: center;
+      margin-bottom: 10px;
+    }
+
+    .back-btn {
+      background: none;
+      border: none;
+      font-size: 16px;
+      color: #0066FF;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      padding: 0;
+      margin-right: 15px;
+      text-decoration: none;
+    }
+
+    .back-btn svg {
+      width: 20px;
+      height: 20px;
+      margin-right: 4px;
+    }
+
+  </style>
+</head>
+<body>
+
+<div class="container">
+  <div class="header-nav">
+    <a href="/dashboard.html" class="back-btn">
+      <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path></svg>
+      Dashboard
+    </a>
+  </div>
+
+  <h1>Referral Dashboard</h1>
+
+  <div class="ohc-growth-card">
+    <h2>Your Referral Link</h2>
+    <p>Share this link with other business owners. When they sign up, you earn rewards.</p>
+
+    <div id="loading-state">
+      <p style="text-align: center; font-style: italic;">Generating your link...</p>
+    </div>
+
+    <div id="link-state" style="display: none;">
+      <input type="text" class="link-input" id="referral-link" readonly value="" />
+
+      <div class="action-buttons">
+        <button class="btn-primary" id="copy-btn">Copy Link</button>
+        <button class="btn-secondary" id="share-whatsapp-btn" style="background-color: #25D366; color: white; border: none;">Share on WhatsApp</button>
+        <button class="btn-secondary" id="share-x-btn" style="background-color: #000000; color: white; border: none;">Share on X</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="ohc-growth-card" id="referral-tier-section" style="display: none;">
+    <h2>Your Tier: <span id="tier-name">Bronze</span></h2>
+    <p id="referral-tier-subtext" style="margin-bottom: 4px;">Loading tier progress...</p>
+
+    <div class="tier-progress-container">
+      <div class="tier-progress-bar" id="referral-tier-progress"></div>
+    </div>
+  </div>
+
+  <div class="ohc-growth-card">
+    <h2>Performance Metrics</h2>
+
+    <div class="metrics-grid">
+      <div class="metric-box">
+        <p class="metric-value" id="metrics-invites">0</p>
+        <p class="metric-label">Invites Sent</p>
+      </div>
+      <div class="metric-box">
+        <p class="metric-value" id="metrics-active">0</p>
+        <p class="metric-label">Active Referrals</p>
+      </div>
+      <div class="metric-box">
+        <p class="metric-value" id="metrics-revenue">$0.00</p>
+        <p class="metric-label">Revenue Generated</p>
+      </div>
+      <div class="metric-box">
+        <p class="metric-value" id="metrics-pending">$0.00</p>
+        <p class="metric-label">Pending Rewards</p>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', async () => {
+
+    // Auth token handling
+    const getAuthHeaders = () => {
+      const token = localStorage.getItem('ohc_token');
+      return token ? { 'authorization': `Bearer ${token}` } : {};
+    };
+
+    // 1. Generate/Fetch Referral Link
+    async function fetchReferralLink() {
+      try {
+        const res = await fetch('/api/v1/growth/referrals/generate', {
+          method: 'POST',
+          headers: getAuthHeaders()
+        });
+
+        const data = await res.json();
+        let link = "";
+        if (res.ok && data.referral_link) {
+          link = data.referral_link;
+        } else {
+          // Fallback
+          const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-tenant';
+          link = `https://ohc.app/onboarding?ref=${tenantId}`;
+        }
+
+        document.getElementById('referral-link').value = link;
+        document.getElementById('loading-state').style.display = 'none';
+        document.getElementById('link-state').style.display = 'block';
+
+      } catch (e) {
+        console.error("Failed to generate referral link", e);
+        const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-tenant';
+        document.getElementById('referral-link').value = `https://ohc.app/onboarding?ref=${tenantId}`;
+        document.getElementById('loading-state').style.display = 'none';
+        document.getElementById('link-state').style.display = 'block';
+      }
+    }
+
+    // 2. Fetch Tier Data
+    async function fetchTierData() {
+      try {
+        const res = await fetch('/api/v1/growth/referrals/tier', {
+          headers: getAuthHeaders()
+        });
+
+        if (res.ok) {
+          const data = await res.json();
+          document.getElementById('referral-tier-section').style.display = 'block';
+          document.getElementById('tier-name').innerText = data.current_tier;
+
+          if (data.next_tier) {
+            const needed = data.referrals_needed_for_next;
+            // Simplified progress logic based on backend response
+            // The backend returns conversions, we need to estimate percentage
+            // Assuming tiers: Bronze (0-4), Silver (5-19), Gold (20-49), Platinum (50+)
+            let maxForTier = 5;
+            let baseForTier = 0;
+            if (data.current_tier === 'Bronze') { maxForTier = 5; baseForTier = 0; }
+            else if (data.current_tier === 'Silver') { maxForTier = 20; baseForTier = 5; }
+            else if (data.current_tier === 'Gold') { maxForTier = 50; baseForTier = 20; }
+
+            const currentInTier = data.total_conversions - baseForTier;
+            const range = maxForTier - baseForTier;
+            let pct = (currentInTier / range) * 100;
+            if (pct < 0) pct = 0;
+            if (pct > 100) pct = 100;
+
+            document.getElementById('referral-tier-progress').style.width = `${pct}%`;
+            document.getElementById('referral-tier-subtext').innerText = `${needed} more referrals needed to reach ${data.next_tier} Tier.`;
+          } else {
+            document.getElementById('referral-tier-progress').style.width = `100%`;
+            document.getElementById('referral-tier-progress').style.backgroundColor = `#FFD700`; // Gold
+            document.getElementById('referral-tier-subtext').innerText = `You have reached the highest tier!`;
+          }
+        }
+      } catch (e) {
+        console.error("Failed to fetch referral tier", e);
+      }
+    }
+
+    // 3. Fetch Metrics Data
+    async function fetchMetricsData() {
+      try {
+        const res = await fetch('/api/v1/growth/team-invites/aggregated-metrics', {
+          headers: getAuthHeaders()
+        });
+
+        if (res.ok) {
+          const data = await res.json();
+          document.getElementById('metrics-invites').innerText = data.total_invites || '0';
+          document.getElementById('metrics-active').innerText = data.metrics?.active_referrals || '0';
+          document.getElementById('metrics-revenue').innerText = '$' + (data.metrics?.revenue || 0).toFixed(2);
+          document.getElementById('metrics-pending').innerText = '$' + (data.metrics?.pending_rewards || 0).toFixed(2);
+        }
+      } catch (e) {
+        console.error("Failed to fetch metrics", e);
+      }
+    }
+
+    // Initialize fetching
+    fetchReferralLink();
+    fetchTierData();
+    fetchMetricsData();
+
+    // Button actions
+    document.getElementById('copy-btn').addEventListener('click', () => {
+      const link = document.getElementById('referral-link').value;
+      navigator.clipboard.writeText(link).then(() => {
+        const btn = document.getElementById('copy-btn');
+        const originalText = btn.innerText;
+        btn.innerText = "Copied!";
+        setTimeout(() => { btn.innerText = originalText; }, 2000);
+      });
+    });
+
+    document.getElementById('share-whatsapp-btn').addEventListener('click', () => {
+      const link = document.getElementById('referral-link').value;
+      const text = `Launch your business online instantly with OHC! Use my invite link:\n\n${link}\n\n⚡ Powered by OHC`;
+      window.open(`https://wa.me/?text=${encodeURIComponent(text)}`, '_blank');
+    });
+
+    document.getElementById('share-x-btn').addEventListener('click', () => {
+      const link = document.getElementById('referral-link').value;
+      const text = `Launch your business online instantly with OHC! Use my invite link:\n\n${link}\n\n⚡ Powered by OHC`;
+      window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`, '_blank');
+    });
+
+  });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This pull request resolves issues surrounding the missing Referral Dashboard route. It addresses the e2e test failures for `/referrals` expected by `current_app_smoke.ts` and `viral_embed.spec.ts`.

- Created `src/ui/tauri/src/ui/referrals.html` as the dedicated referral dashboard using OHC design tokens.
- Bound API endpoints `/api/v1/growth/referrals/generate`, `/api/v1/growth/referrals/tier`, and `/api/v1/growth/team-invites/aggregated-metrics` to the new referral dashboard.
- Updated `src/server/lib.rs` to serve the new HTML file.
- Corrected links inside `src/ui/tauri/src/ui/dashboard.html` to point to `/referrals`.
- Restored the previously removed "Start Walkthrough" button to `dashboard.html`.

---
*PR created automatically by Jules for task [4112304774874130021](https://jules.google.com/task/4112304774874130021) started by @ql-owo-lp*