### PR TITLE
feat(growth): implement branding removal soft paywall for Customer Referral widget

### DIFF
--- a/src/e2e/customer-referral.spec.ts
+++ b/src/e2e/customer-referral.spec.ts
@@ -46,4 +46,47 @@ test.describe('Customer Referral Program Growth Loop', () => {
         const html = await response.text();
         expect(html).toContain('Give $20, Get $25');
     });
+
+    test('should show soft paywall when attempting to remove branding without pro', async ({ page }) => {
+        await page.goto('/customer-referral-program');
+        await page.evaluate(() => {
+            localStorage.setItem('tenant', 'e2e-test-store');
+            localStorage.setItem('has_pro', 'false');
+        });
+        await page.reload();
+
+        const toggle = page.locator('input[type="checkbox"]');
+        await toggle.click({ force: true }); // It's hidden behind styling
+
+        // Soft paywall should appear
+        await expect(page.locator('text=Pro Feature')).toBeVisible();
+        await expect(page.locator('text=Upgrade to Pro')).toBeVisible();
+    });
+
+    test('should hide branding when pro is enabled and toggle is clicked', async ({ page }) => {
+        await page.goto('/customer-referral-program');
+        await page.evaluate(() => {
+            localStorage.setItem('tenant', 'e2e-test-store');
+            localStorage.setItem('has_pro', 'true');
+        });
+        await page.reload();
+
+        const toggle = page.locator('input[type="checkbox"]');
+        await toggle.click({ force: true });
+
+        // Soft paywall should not appear
+        await expect(page.locator('text=Pro Feature')).not.toBeVisible();
+
+        // Preview section should hide the branding
+        await expect(page.locator('text=⚡ Powered by OHC')).not.toBeVisible();
+
+        await page.locator('button', { hasText: 'Generate Widget Embed' }).click();
+        const modal = page.locator('.fixed.inset-0').first();
+        await expect(modal).toBeVisible();
+
+        // The textarea code should NOT include the branding
+        const preCode = await page.locator('pre').innerText();
+        expect(preCode).not.toContain('>⚡ Powered by OHC</a></div>`'); // The static html part
+        expect(preCode).toContain('hideBranding=true');
+    });
 });

--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -1156,10 +1156,11 @@ pub struct CustomerReferralEmbedQuery {
     pub give: Option<String>,
     pub get: Option<String>,
     pub theme: Option<String>,
+    pub hide_branding: Option<String>,
 }
 
 async fn handle_customer_referral_embed(
-    Extension(_state): Extension<GrowthState>,
+    Extension(state): Extension<GrowthState>,
     axum::extract::Query(query): axum::extract::Query<CustomerReferralEmbedQuery>,
 ) -> impl IntoResponse {
     let escape_html = |s: &str| {
@@ -1176,6 +1177,24 @@ async fn handle_customer_referral_embed(
     let bg_color = if query.theme.as_deref() == Some("dark") { "#111827" } else { "#ffffff" };
     let text_color = if query.theme.as_deref() == Some("dark") { "#ffffff" } else { "#1f2937" };
     let border_color = if query.theme.as_deref() == Some("dark") { "#374151" } else { "#e5e7eb" };
+    let mut has_pro = false;
+    if query.hide_branding.as_deref() == Some("true") {
+        // Validate pro status in DB
+        let is_pro_res = sqlx::query_scalar::<_, bool>("SELECT has_pro FROM tenants WHERE tenant_id = $1")
+            .bind(&tenant)
+            .fetch_optional(&state.pool)
+            .await;
+
+        if let Ok(Some(true)) = is_pro_res {
+            has_pro = true;
+        }
+    }
+
+    let branding = if has_pro {
+        "".to_string()
+    } else {
+        format!(r#"<div style="font-family: sans-serif; text-align: center; font-size: 12px; margin-top: 8px;"><a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref={}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a></div>"#, tenant)
+    };
 
     let html = format!(
         r#"<!DOCTYPE html>
@@ -1242,7 +1261,7 @@ async fn handle_customer_referral_embed(
         <h2>Give ${give}, Get ${get}</h2>
         <p>Give your friends ${give} off their first order, and get ${get} when they purchase.</p>
         <button class="button" onclick="window.open('https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref={tenant}', '_blank')">Share your link</button>
-        <div style="font-family: sans-serif; text-align: center; font-size: 12px; margin-top: 8px;"><a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref={tenant}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a></div>
+        {branding}
     </div>
 </body>
 </html>"#
@@ -2609,7 +2628,7 @@ mod cloud_bridge_tests {
         let hub = Arc::new(crate::hub::Hub::new(event_tx, pool.clone()));
         let state = GrowthState { pool: pool.clone(), hub: hub.clone() };
 
-        let query = super::CustomerReferralEmbedQuery { tenant: Some("test-tenant".to_string()), give: Some("15".to_string()), get: Some("20".to_string()), theme: None };
+        let query = super::CustomerReferralEmbedQuery { tenant: Some("test-tenant".to_string()), give: Some("15".to_string()), get: Some("20".to_string()), theme: None, hide_branding: None };
         let res = super::handle_customer_referral_embed(Extension(state.clone()), axum::extract::Query(query)).await.into_response();
 
         let body_bytes = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();

--- a/src/ui/next/src/app/customer-referral-program/page.test.tsx
+++ b/src/ui/next/src/app/customer-referral-program/page.test.tsx
@@ -73,6 +73,7 @@ describe('CustomerReferralProgramPage', () => {
     });
   });
 
+
   it('navigates back', async () => {
     render(<CustomerReferralProgramPage />);
     const backBtn = screen.getByText('Back to Dashboard');
@@ -81,4 +82,58 @@ describe('CustomerReferralProgramPage', () => {
     });
     // Check navigation
   });
+
+  it('renders Powered by OHC branding in preview by default', () => {
+    render(<CustomerReferralProgramPage />);
+    const brandingElements = screen.getAllByText(/Powered by OHC/i);
+    expect(brandingElements.length).toBeGreaterThan(0);
+  });
+
+  it('shows soft paywall when attempting to remove branding without pro', async () => {
+    const localStorageMock = {
+      getItem: vi.fn((key) => {
+        if (key === 'has_pro') return 'false';
+        return null;
+      }),
+    };
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+    });
+
+    render(<CustomerReferralProgramPage />);
+
+    const toggle = screen.getByRole('checkbox', { name: /Remove "Powered by OHC"/i });
+
+    await act(async () => {
+        fireEvent.click(toggle);
+    });
+
+    expect(screen.getByText('Pro Feature')).toBeDefined();
+    expect(screen.getByText(/Upgrade to Pro to remove/i)).toBeDefined();
+  });
+
+  it('removes branding when pro is true and toggle is clicked', async () => {
+    const localStorageMock = {
+      getItem: vi.fn((key) => {
+        if (key === 'has_pro') return 'true';
+        return null;
+      }),
+    };
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+    });
+
+    render(<CustomerReferralProgramPage />);
+
+    const toggle = screen.getByRole('checkbox', { name: /Remove "Powered by OHC"/i });
+
+    await act(async () => {
+        fireEvent.click(toggle);
+    });
+
+    expect(screen.queryByText('Pro Feature')).toBeNull();
+    // The exact text "⚡ Powered by OHC" in the preview should be removed
+    expect(screen.queryByText('⚡ Powered by OHC')).toBeNull();
+  });
+
 });

--- a/src/ui/next/src/app/customer-referral-program/page.tsx
+++ b/src/ui/next/src/app/customer-referral-program/page.tsx
@@ -10,15 +10,22 @@ export default function CustomerReferralProgramPage() {
   const [tenant, setTenant] = useState('my-store');
   const [showModal, setShowModal] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [removeBranding, setRemoveBranding] = useState(false);
+  const [hasPro, setHasPro] = useState(false);
+  const [showSoftPaywall, setShowSoftPaywall] = useState(false);
 
   useEffect(() => {
     const tid = typeof window !== 'undefined' ? (localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'my-store') : 'my-store';
     setTenant(tid);
+    if (typeof window !== 'undefined') {
+      setHasPro(localStorage.getItem('has_pro') === 'true');
+    }
   }, []);
 
-  const embedUrl = `https://ohc.app/api/v1/growth/customer-referral/embed?tenant=${tenant}&give=${encodeURIComponent(giveAmount)}&get=${encodeURIComponent(getAmount)}`;
+  const embedUrl = `https://ohc.app/api/v1/growth/customer-referral/embed?tenant=${tenant}&give=${encodeURIComponent(giveAmount)}&get=${encodeURIComponent(getAmount)}&hideBranding=${removeBranding}`;
 
-  const embedCode = `<iframe src="${embedUrl}" width="100%" height="250" frameborder="0" scrolling="no" style="border:none; overflow:hidden; border-radius:16px;"></iframe>\n<div style="font-family: sans-serif; text-align: center; font-size: 12px; margin-top: 8px;"><a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref=${tenant}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a></div>`;
+  const embedCode = `<iframe src="${embedUrl}" width="100%" height="250" frameborder="0" scrolling="no" style="border:none; overflow:hidden; border-radius:16px;"></iframe>` + (removeBranding ? '' : `
+<div style="font-family: sans-serif; text-align: center; font-size: 12px; margin-top: 8px;"><a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref=${tenant}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a></div>`);
 
   const handleGenerate = () => {
     setShowModal(true);
@@ -83,6 +90,32 @@ export default function CustomerReferralProgramPage() {
                   </div>
                 </div>
 
+
+                <div className="pt-2 border-t border-gray-100 dark:border-gray-800">
+                  <label className="flex items-center gap-3 cursor-pointer group">
+                    <div className="relative">
+                      <input
+                        type="checkbox"
+                        className="sr-only"
+                        checked={removeBranding}
+                        onChange={(e) => {
+                          if (!hasPro && e.target.checked) {
+                            setShowSoftPaywall(true);
+                          } else {
+                            setRemoveBranding(e.target.checked);
+                          }
+                        }}
+                      />
+                      <div className={`block w-12 h-6 rounded-full transition-colors ${removeBranding ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-700'}`}></div>
+                      <div className={`absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition-transform ${removeBranding ? 'translate-x-6' : 'translate-x-0'}`}></div>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">Remove "Powered by OHC" Badge (Pro)</span>
+                      <span className="text-xs text-gray-500">Make the widget 100% white-labeled</span>
+                    </div>
+                  </label>
+                </div>
+
                 <div className="pt-4">
                   <button
                     onClick={handleGenerate}
@@ -92,6 +125,11 @@ export default function CustomerReferralProgramPage() {
                     Generate Widget Embed
                   </button>
                 </div>
+                {!removeBranding && (
+                    <div className="mt-6 pt-4 border-t border-gray-100 dark:border-gray-700 text-center">
+                        <span className="text-xs font-semibold tracking-wide" style={{ color: '#6b7280' }}>⚡ Powered by OHC</span>
+                    </div>
+                )}
               </div>
             </div>
           </div>
@@ -103,7 +141,7 @@ export default function CustomerReferralProgramPage() {
 
               <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-6">Give ${giveAmount}, Get ${getAmount}</h3>
 
-              <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-700 text-center">
+              <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-700 text-center relative">
                 <div className="w-16 h-16 mx-auto bg-emerald-100 dark:bg-emerald-900/30 rounded-full flex items-center justify-center text-3xl mb-4">
                   🎁
                 </div>
@@ -119,7 +157,7 @@ export default function CustomerReferralProgramPage() {
                   </button>
                 </div>
 
-                <div className="flex items-center justify-center gap-3">
+                <div className="flex items-center justify-center gap-3 mb-6">
                   <button className="w-10 h-10 rounded-full bg-[#25D366] text-white flex items-center justify-center hover:opacity-90 transition-opacity">
                      <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/></svg>
                   </button>
@@ -136,6 +174,41 @@ export default function CustomerReferralProgramPage() {
         </div>
 
       </div>
+
+      {/* Soft Paywall Modal */}
+      {showSoftPaywall && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm animate-in fade-in">
+          <div className="bg-white dark:bg-[#1D1D1F] rounded-3xl p-6 md:p-8 max-w-md w-full shadow-2xl border border-white/20 relative animate-in zoom-in-95">
+            <button
+              onClick={() => setShowSoftPaywall(false)}
+              className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center rounded-full bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-500 transition-colors"
+            >
+              ✕
+            </button>
+            <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-amber-400 to-orange-500 flex items-center justify-center text-white text-3xl mb-6 shadow-lg">
+              ✨
+            </div>
+            <h3 className="text-2xl font-bold font-outfit text-gray-900 dark:text-white mb-2">Pro Feature</h3>
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
+              Make the Customer Referral Program 100% yours. Upgrade to Pro to remove the "Powered by OHC" watermark and unlock full white-label customization.
+            </p>
+            <div className="space-y-3">
+              <button
+                onClick={() => router.push('/pricing')}
+                className="w-full py-3.5 bg-gray-900 dark:bg-white text-white dark:text-gray-900 font-bold rounded-xl shadow-lg hover:scale-[1.02] transition-all"
+              >
+                Upgrade to Pro
+              </button>
+              <button
+                onClick={() => setShowSoftPaywall(false)}
+                className="w-full py-3.5 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 font-semibold rounded-xl hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+              >
+                Keep Branding
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Code Generation Modal */}
       {showModal && (


### PR DESCRIPTION
Implemented a soft paywall mechanism allowing Pro users to remove the 'Powered by OHC' branding from the Customer Referral Program widget. Ensured the implementation uses secure backend database checks to prevent client-side bypass. Extended E2E and unit test coverage accordingly.

---
*PR created automatically by Jules for task [2214111019269757276](https://jules.google.com/task/2214111019269757276) started by @wbbsuper*