### PR TITLE
Fix help center article routing

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -155,7 +155,7 @@ pub fn get_article(id: &str) -> Option<HelpArticleDetail> {
       </div>
             "#.to_string()
         }),
-        "my-store" => Some(HelpArticleDetail {
+        "add-products" => Some(HelpArticleDetail {
             title: "Managing My Store".to_string(),
             content_html: r#"
       <p class="text-gray-700 mb-4 leading-relaxed text-lg">
@@ -175,7 +175,7 @@ pub fn get_article(id: &str) -> Option<HelpArticleDetail> {
       </p>
             "#.to_string()
         }),
-        "marketing" => Some(HelpArticleDetail {
+        "marketing-tools" => Some(HelpArticleDetail {
             title: "Finding Customers".to_string(),
             content_html: r#"
       <p class="text-gray-700 mb-4 leading-relaxed text-lg">
@@ -195,7 +195,7 @@ pub fn get_article(id: &str) -> Option<HelpArticleDetail> {
       </p>
             "#.to_string()
         }),
-        "account-billing" => Some(HelpArticleDetail {
+        "billing-settings" => Some(HelpArticleDetail {
             title: "Account & Billing".to_string(),
             content_html: r#"
       <p class="text-gray-700 mb-4 leading-relaxed text-lg">
@@ -215,7 +215,7 @@ pub fn get_article(id: &str) -> Option<HelpArticleDetail> {
       </p>
             "#.to_string()
         }),
-        "payments" => Some(HelpArticleDetail {
+        "accept-payments" => Some(HelpArticleDetail {
             title: "Getting Paid".to_string(),
             content_html: r#"
       <p class="text-gray-700 mb-4 leading-relaxed text-lg">
@@ -235,7 +235,7 @@ pub fn get_article(id: &str) -> Option<HelpArticleDetail> {
       </p>
             "#.to_string()
         }),
-        "ai-agents" => Some(HelpArticleDetail {
+        "ai-support" => Some(HelpArticleDetail {
             title: "Your AI Helpers".to_string(),
             content_html: r#"
       <p class="text-gray-700 mb-4 leading-relaxed text-lg">


### PR DESCRIPTION
This fixes an issue where viewing help articles from the help center lead to a "Oops! Article not found" screen because the server was matching different slugs than what was defined. I updated the URLs matched inside `src/server/api/docs.rs` to align with the expected values.

---
*PR created automatically by Jules for task [3075355007779012286](https://jules.google.com/task/3075355007779012286) started by @ql-owo-lp*