### PR TITLE
Fix cost dashboard e2e test navigation and ui bug

### DIFF
--- a/src/ui/next/src/e2e/cost-dashboard.spec.ts
+++ b/src/ui/next/src/e2e/cost-dashboard.spec.ts
@@ -32,7 +32,7 @@ test.describe('Cost Dashboard Loop', () => {
     await expect(page.locator('span', { hasText: 'Outbound API Calls' })).toBeVisible();
 
     // Check navigation works
-    await page.locator('a', { hasText: 'Back to My Plan' }).click();
-    await expect(page.url()).toContain('/plan.html');
+    await page.locator('button', { hasText: 'Back to My Plan' }).click();
+    await expect(page.url()).toContain('/dashboard.html');
   });
 });

--- a/src/ui/tauri/src/ui/cost-dashboard.html
+++ b/src/ui/tauri/src/ui/cost-dashboard.html
@@ -401,7 +401,7 @@
                     document.getElementById('budget-health-alert').style.display = 'flex';
                     document.getElementById('budget-health-alert-text').innerText = `Your projected monthly cost (${formatCents(costData.projected_monthly_cost)}) is exceeding your typical baseline. Consider reviewing your agent usage or upgrading your tier for better bulk rates.`;
                 } else {
-                    document.getElementById('budget-health-alert').style.display = 'flex';
+                    document.getElementById('budget-health-alert').style.display = 'none';
                 }
 
                 document.getElementById('llm-cost').innerText = formatCents(costData.llm_cost || 0);


### PR DESCRIPTION
Fix cost dashboard e2e test navigation and ui bug

- Update `cost-dashboard.spec.ts` to expect a button instead of an anchor tag for navigating back to the dashboard, preventing a timeout.
- Update `cost-dashboard.html` to correctly hide the budget health alert when there's no alert.

---
*PR created automatically by Jules for task [9473745756163574605](https://jules.google.com/task/9473745756163574605) started by @ql-owo-lp*