### PR TITLE
Fix Redis LockGuard safe drop issue

### DIFF
--- a/src/server/orchestration/locks.rs
+++ b/src/server/orchestration/locks.rs
@@ -12,13 +12,23 @@ pub struct LockGuard {
     _local_guard: Option<OwnedMutexGuard<()>>,
     redis_client: Option<redis::Client>,
     redis_key: Option<String>,
+    redis_val: Option<String>,
 }
 
 impl Drop for LockGuard {
     fn drop(&mut self) {
-        if let (Some(client), Some(key)) = (&self.redis_client, &self.redis_key) {
+        if let (Some(client), Some(key), Some(val)) = (&self.redis_client, &self.redis_key, &self.redis_val) {
             if let Ok(mut conn) = client.get_connection() {
-                let _: redis::RedisResult<()> = redis::cmd("DEL").arg(key).query(&mut conn);
+                let script = redis::Script::new(
+                    r#"
+                    if redis.call("get", KEYS[1]) == ARGV[1] then
+                        return redis.call("del", KEYS[1])
+                    else
+                        return 0
+                    end
+                    "#,
+                );
+                let _: redis::RedisResult<()> = script.key(key).arg(val).invoke(&mut conn);
             }
         }
     }
@@ -51,6 +61,7 @@ impl DistributedLock for StandaloneLock {
             _local_guard: Some(guard),
             redis_client: None,
             redis_key: None,
+            redis_val: None,
         })
     }
 
@@ -68,6 +79,7 @@ impl DistributedLock for StandaloneLock {
             _local_guard: Some(guard),
             redis_client: None,
             redis_key: None,
+            redis_val: None,
         })
     }
 }
@@ -87,10 +99,11 @@ impl DistributedLock for RedisLock {
     async fn acquire(&self, task_id: &str) -> Result<LockGuard, String> {
         let mut conn = self.client.get_multiplexed_async_connection().await.map_err(|e| e.to_string())?;
         let key = format!("ohc:lock:task:{}", task_id);
+        let val = uuid::Uuid::new_v4().to_string();
 
         let acquired: bool = redis::cmd("SET")
             .arg(&key)
-            .arg("1")
+            .arg(&val)
             .arg("NX")
             .arg("EX")
             .arg(5)
@@ -106,6 +119,7 @@ impl DistributedLock for RedisLock {
             _local_guard: None,
             redis_client: Some(self.client.clone()),
             redis_key: Some(key),
+            redis_val: Some(val),
         })
     }
 
@@ -113,10 +127,11 @@ impl DistributedLock for RedisLock {
         let mut conn = self.client.get_multiplexed_async_connection().await.map_err(|e| e.to_string())?;
 
         let key = format!("ohc:lock:{}:{}:{}", tenant_id, resource_type, resource_id);
+        let val = uuid::Uuid::new_v4().to_string();
 
         let acquired: bool = redis::cmd("SET")
             .arg(&key)
-            .arg("1")
+            .arg(&val)
             .arg("NX")
             .arg("EX")
             .arg(5)
@@ -132,6 +147,7 @@ impl DistributedLock for RedisLock {
             _local_guard: None,
             redis_client: Some(self.client.clone()),
             redis_key: Some(key),
+            redis_val: Some(val),
         })
     }
 }

--- a/src/server/orchestration/locks_test.rs
+++ b/src/server/orchestration/locks_test.rs
@@ -1,4 +1,4 @@
-use super::locks::{StandaloneLock, DistributedLock};
+use super::locks::{StandaloneLock, DistributedLock, RedisLock};
 
 #[tokio::test]
 async fn test_standalone_lock_acquire() {
@@ -29,4 +29,46 @@ async fn test_acquire_resource_standalone_lock() {
     drop(lock_clone);
 
     // Dropping guard1 should release the lock eventually, but StandaloneLock doesn't remove it from map
+}
+
+#[tokio::test]
+async fn test_redis_lock_guard_drop_safety() {
+    let redis_url = std::env::var("OHC_REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let client = match redis::Client::open(redis_url.clone()) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    // Only proceed if Redis is reachable
+    let mut conn = match client.get_multiplexed_tokio_connection().await {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let lock = RedisLock::new(client.clone());
+    let task_id = "test_drop_safety";
+    let key = format!("ohc:lock:task:{}", task_id);
+
+    // Clean up before test
+    let _: () = redis::cmd("DEL").arg(&key).query_async(&mut conn).await.unwrap();
+
+    let guard = lock.acquire(task_id).await.unwrap();
+
+    // Verify it is locked in Redis
+    let val1: Option<String> = redis::cmd("GET").arg(&key).query_async(&mut conn).await.unwrap();
+    assert!(val1.is_some(), "Lock should be set");
+
+    // Simulate lock expiration and another process acquiring it by manually overwriting the key
+    let other_val = "other_process_uuid";
+    let _: () = redis::cmd("SET").arg(&key).arg(other_val).query_async(&mut conn).await.unwrap();
+
+    // Now drop the guard. It should try to delete the lock, but fail because the value doesn't match
+    drop(guard);
+
+    // Verify the other process's lock is still there
+    let val2: Option<String> = redis::cmd("GET").arg(&key).query_async(&mut conn).await.unwrap();
+    assert_eq!(val2.unwrap(), other_val, "Lock should not be deleted by the expired guard");
+
+    // Clean up after test
+    let _: () = redis::cmd("DEL").arg(&key).query_async(&mut conn).await.unwrap();
 }


### PR DESCRIPTION
Fixes a critical lock release bug in `RedisLock` and `LockGuard`. Prior to this fix, the value of the lock was hard-coded to "1", and `Drop` blindly executed a `DEL` command. If the lock expired while still held in memory, and another process took the same lock, the drop of the first `LockGuard` would delete the second process's lock.

Now, a UUID is generated upon lock acquisition and stored as the lock value. The `Drop` implementation safely executes a Lua script to delete the lock only if the value in Redis still matches the UUID.

Also added `test_redis_lock_guard_drop_safety` to `src/server/orchestration/locks_test.rs` to verify this behavior. All tests passed.

---
*PR created automatically by Jules for task [2628130360447278042](https://jules.google.com/task/2628130360447278042) started by @ql-owo-lp*