### PR TITLE
fix: TableDropper async behavior and unused variable mutability

### DIFF
--- a/src/server/api/catalog.rs
+++ b/src/server/api/catalog.rs
@@ -299,7 +299,6 @@ pub fn router<S: Clone + Send + Sync + 'static>(hub: Arc<Hub>) -> Router<S> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
 
     #[test]
     fn test_token_reduction_integration() {

--- a/src/server/chaos.rs
+++ b/src/server/chaos.rs
@@ -1263,6 +1263,7 @@ mod tests {
             // we will evaluate the counts, run the asserts, and drop the table.
             // A better way is to do the assertions, but catch panics or just drop table manually inside a Drop trait.
 
+
             // To ensure cleanup, let's create a struct with Drop trait.
             struct TableDropper {
                 table_name: String,
@@ -1272,9 +1273,11 @@ mod tests {
                 fn drop(&mut self) {
                     let table_name = self.table_name.clone();
                     let pool = self.pool.clone();
-                    tokio::spawn(async move {
-                        let drop_query = format!("DROP TABLE IF EXISTS {}", table_name);
-                        let _ = sqlx::query(&drop_query).execute(&*pool).await;
+                    tokio::task::block_in_place(|| {
+                        tokio::runtime::Handle::current().block_on(async move {
+                            let drop_query = format!("DROP TABLE IF EXISTS {}", table_name);
+                            let _ = sqlx::query(&drop_query).execute(&*pool).await;
+                        });
                     });
                 }
             }

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -4665,11 +4665,11 @@ async fn ui_dashboard_unified_feed_handler(
                 tokio::spawn(async move { load_ui_priority_tasks_from_db(&db7, &t7, mobile_optimized).await })
             );
 
-            let mut orders = orders_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-            let mut inbox = messages_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-            let mut triage = triage_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-            let mut approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-            let mut agent_feed = agent_feed_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+            let orders = orders_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+            let inbox = messages_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+            let triage = triage_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+            let approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+            let agent_feed = agent_feed_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
             let priority_tasks = priority_tasks_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
 
 
@@ -4715,11 +4715,11 @@ async fn ui_dashboard_unified_feed_handler(
         tokio::spawn(async move { load_ui_priority_tasks_from_db(&db8, &t8, mobile_optimized).await })
     );
 
-    let mut orders = orders_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-    let mut inbox = messages_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-    let mut triage = triage_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-    let mut approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-    let mut agent_feed = agent_feed_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+    let orders = orders_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+    let inbox = messages_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+    let triage = triage_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+    let approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+    let agent_feed = agent_feed_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
     let priority_tasks = priority_tasks_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
     let supply = supply_res.unwrap_or_else(|_| Ok(serde_json::json!({}))).unwrap_or_default();
 
@@ -4769,8 +4769,8 @@ async fn ui_dashboard_unified_agent_feed_handler(
                 tokio::spawn({ let db = db.clone(); let t = t.clone(); async move { load_ui_ledger_from_db(&db, &t, mobile_optimized).await } })
             );
 
-            let mut pending_approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-            let mut entries = ledger_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+            let pending_approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+            let entries = ledger_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
 
 
             let result = serde_json::json!({
@@ -4789,8 +4789,8 @@ async fn ui_dashboard_unified_agent_feed_handler(
         tokio::spawn({ let db = db.clone(); let t = tenant_id.clone(); async move { load_ui_ledger_from_db(&db, &t, mobile_optimized).await } })
     );
 
-    let mut pending_approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-    let mut entries = ledger_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+    let pending_approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+    let entries = ledger_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
 
 
     let result = serde_json::json!({


### PR DESCRIPTION
Fixes an issue with `TableDropper` asynchronous behavior inside the `Drop` implementation in `src/server/chaos.rs`. Replaced `tokio::spawn` with `tokio::task::block_in_place` wrapped around `tokio::runtime::Handle::current().block_on` to ensure synchronous wait, solving race condition bugs during tests cleanup. Also fixes code quality warnings from `lib.rs` with unused mutable variables and an unused import from `api/catalog.rs`.

---
*PR created automatically by Jules for task [9281661317817586963](https://jules.google.com/task/9281661317817586963) started by @ql-owo-lp*