### PR TITLE
fix: fix missing items in UnifiedAgentFeed

### DIFF
--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -234,7 +234,6 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
             combinedItems.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
 
             setItems(combinedItems.filter((i: any) => i.lifecycle_state !== "APPROVED" && i.lifecycle_state !== "DISMISSED"));
-            setItems(unifiedData.items.filter((i: any) => i.lifecycle_state !== "APPROVED" && i.lifecycle_state !== "DISMISSED"));
 
             // Map items for activity feed as well
             const mappedActivities = combinedItems.filter((i: any) => i.lifecycle_state === "APPROVED" || i.lifecycle_state === "DISMISSED").map((a: any) => ({


### PR DESCRIPTION
Removed an accidental `setItems(unifiedData.items...)` call that overrode the correctly calculated `combinedItems` containing priority tasks, orders, and triage items. This ensures the unified feed accurately displays all actionable work as originally intended.

---
*PR created automatically by Jules for task [10090982357268361985](https://jules.google.com/task/10090982357268361985) started by @ql-owo-lp*