### PR TITLE
🚀 Nova: Update cloud bridge invite endpoint for team growth loop

### DIFF
--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1535,7 +1535,7 @@
         } else {
           try {
             const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default';
-            const res = await fetch('/api/v1/growth/cloud-bridge/invite', {
+            const res = await fetch('/api/v1/growth/team-invites', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ team_id: tenantId, inviter_id: "owner", invitee_id: "pending" })
@@ -2212,7 +2212,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
               try {
                   const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default';
-                  const res = await fetch('/api/v1/growth/cloud-bridge/invite', {
+                  const res = await fetch('/api/v1/growth/team-invites', {
                       method: 'POST',
                       headers: { 'Content-Type': 'application/json' },
                       body: JSON.stringify({ team_id: tenantId, inviter_id: "current-user", invitee_id: email })
@@ -2265,7 +2265,7 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
               try {
                   const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default';
-                  const res = await fetch('/api/v1/growth/cloud-bridge/invite', {
+                  const res = await fetch('/api/v1/growth/team-invites', {
                       method: 'POST',
                       headers: { 'Content-Type': 'application/json' },
                       body: JSON.stringify({ team_id: tenantId, inviter_id: "owner", invitee_id: "pending" })


### PR DESCRIPTION
- **Product-use evidence**:
  - **Persona**: Standalone User acting as a Team Owner.
  - **Attempted Flow**: Visit the Dashboard, locate the "Cloud Bridge Invite" section or the "Grow Your Team" section, and attempt to generate an invite link to bring a collaborator onto a shared cloud-native tenant.
  - **CUJ Gap Observed**: The frontend previously made a `POST` request to `/api/v1/growth/cloud-bridge/invite`, but the actual backend implementation is mapped to the `/api/v1/growth/team-invites` route inside the `growth.rs` API layer. Clicking "Generate Cloud Invite" would fail or hit the fallback link unexpectedly since the endpoint did not match.
  - **User-experience reason for the fix**: Users trying to upgrade from standalone to a cloud-team collaboration environment must be able to generate referral invite links. When this breaks, the primary network expansion loop is stalled.
  - **Post-fix UI flow**: The user can now click "Get My Invite Link" or "Generate Cloud Invite" from the dashboard, correctly receive the provisioned referral URL from the newly updated endpoint, and successfully onboard a collaborator.
- **Changes**: Updated the `fetch` API endpoint within `src/ui/tauri/src/ui/dashboard.html` from `/api/v1/growth/cloud-bridge/invite` to `/api/v1/growth/team-invites`.

---
*PR created automatically by Jules for task [3283443917627219931](https://jules.google.com/task/3283443917627219931) started by @ql-owo-lp*