### PR TITLE
fix: retain original job ID in dead letter queue

### DIFF
--- a/src/server/orchestration/queue/ohc_job_queue.rs
+++ b/src/server/orchestration/queue/ohc_job_queue.rs
@@ -155,7 +155,7 @@ impl OHCJobQueue {
                 let payload: serde_json::Value = r.try_get("payload").unwrap_or_else(|_| serde_json::json!({}));
                 let payload_str = serde_json::to_string(&payload).unwrap_or_default();
                 sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) VALUES ($1, $2, $3, $4, $5, $6)")
-                    .bind(uuid::Uuid::new_v4().to_string())
+                    .bind(job_id)
                     .bind(&tenant_id)
                     .bind("job_failed")
                     .bind("job_queue")

--- a/src/server/orchestration/queue/pg_queue.rs
+++ b/src/server/orchestration/queue/pg_queue.rs
@@ -236,7 +236,7 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
                 let payload: serde_json::Value = r.try_get("payload").unwrap_or_else(|_| serde_json::json!({}));
                 let payload_str = serde_json::to_string(&payload).unwrap_or_default();
                 sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) VALUES ($1, $2, $3, $4, $5, $6)")
-                    .bind(uuid::Uuid::new_v4().to_string())
+                    .bind(job_id)
                     .bind(&tenant_id)
                     .bind("job_failed")
                     .bind("job_queue")

--- a/src/server/orchestration/queue/sqlite_queue.rs
+++ b/src/server/orchestration/queue/sqlite_queue.rs
@@ -223,7 +223,7 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
                 let tenant_id: String = r.try_get("tenant_id").unwrap_or_default();
                 let payload: String = r.try_get("payload").unwrap_or_else(|_| String::from("{}"));
                 sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) VALUES (?, ?, ?, ?, ?, ?)")
-                    .bind(uuid::Uuid::new_v4().to_string())
+                    .bind(job_id)
                     .bind(&tenant_id)
                     .bind("job_failed")
                     .bind("job_queue")


### PR DESCRIPTION
**Overview**
This PR fixes an issue where failed jobs that are moved to the dead letter queue are assigned a random UUID instead of their original Job ID. 

**Changes**
* Updated `src/server/orchestration/queue/pg_queue.rs` to use `job_id` instead of `uuid::Uuid::new_v4().to_string()` when inserting into `department_dead_letters`.
* Updated `src/server/orchestration/queue/sqlite_queue.rs` to use `job_id`.
* Updated `src/server/orchestration/queue/ohc_job_queue.rs` to use `job_id`.

**Rationale**
Retaining the original `job_id` in the dead letter queue makes it easier to trace failures and correlate them with logs. It also adds a layer of idempotency if an unexpected issue happens during the transaction handling the dead letter insertion.

**Testing**
* Ran `npx @bazel/bazelisk test //...` which verified the `server_orchestration_queue_test` target and others passed successfully.
* Verified UI stability via the Playwright test suite `npx @bazel/bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"`.

**Superpowers used:**
This change aligns with SRE best practices to "Improve Observability Stack" by retaining critical tracing information (the job ID) across state boundaries.

---
*PR created automatically by Jules for task [6880224507720941885](https://jules.google.com/task/6880224507720941885) started by @ql-owo-lp*