### PR TITLE
test(e2e): fix help widget selector after component swap

### DIFF
--- a/src/e2e/documentation_full.spec.ts
+++ b/src/e2e/documentation_full.spec.ts
@@ -16,7 +16,7 @@ test.describe('Documentation full suite', () => {
     await searchInput.fill('Test search');
 
     // Chat widget open interaction
-    const chatBtn = page.locator('#ohc-help-btn');
+    const chatBtn = page.locator('#ohc-floating-help-btn');
     await expect(chatBtn).toBeVisible();
     await chatBtn.click();
 

--- a/src/e2e/walkthrough_tooltips.spec.ts
+++ b/src/e2e/walkthrough_tooltips.spec.ts
@@ -100,7 +100,7 @@ test.describe('Walkthrough and Tooltips features', () => {
     await expect(results).toBeVisible();
 
     // The chat widget should also be there
-    const chatBtn = page.locator('#ohc-help-btn');
+    const chatBtn = page.locator('#ohc-floating-help-btn');
     await expect(chatBtn).toBeVisible();
   });
 });


### PR DESCRIPTION
Fixes failing Playwright E2E tests by updating the help button selector from `#ohc-help-btn` to `#ohc-floating-help-btn` in `documentation_full.spec.ts` and `walkthrough_tooltips.spec.ts`, reflecting recent UI updates. All E2E tests now pass.

---
*PR created automatically by Jules for task [2985833693079034329](https://jules.google.com/task/2985833693079034329) started by @ql-owo-lp*