### PR TITLE
🚀 Nova: [new growth feature] Add Powered by OHC footer to Viral Giveaway generator

### DIFF
--- a/src/e2e/viral_giveaway.spec.ts
+++ b/src/e2e/viral_giveaway.spec.ts
@@ -33,6 +33,9 @@ test.describe('Viral Giveaway Loop', () => {
     // We mock localStorage if needed, but fixtures set it.
     await page.evaluate(() => { localStorage.setItem('has_pro', 'true'); window.dispatchEvent(new Event('storage')); });
 
+    const generatorFooterLink = page.locator('a', { hasText: 'Powered by OHC' }).first();
+    await expect(generatorFooterLink).toBeVisible();
+
     const generateBtn = page.getByRole('button', { name: 'Generate Giveaway Link' });
     await expect(generateBtn).toBeEnabled();
     await generateBtn.click();

--- a/src/ui/tauri/src/ui/giveaway/index.html
+++ b/src/ui/tauri/src/ui/giveaway/index.html
@@ -141,6 +141,10 @@
   </div>
   <a href="/dashboard" class="back-link">&larr; Back to Dashboard</a>
 
+  <footer style="margin-top: 30px; text-align: center;">
+    <a href="/onboarding?ref=giveaway_footer" target="_blank" style="color: #86868b; text-decoration: none; font-size: 14px; font-weight: 500;">⚡ Powered by OHC</a>
+  </footer>
+
   <script>
     document.getElementById('generate-btn').addEventListener('click', () => {
       const title = document.getElementById('title').value.trim();


### PR DESCRIPTION
## Overview
This pull request adds a "Powered by OHC" footer to the Viral Giveaway Generator page. This serves as a viral acquisition loop, directing interested users to the onboarding flow when they see or use the tool. It helps fulfill the overarching mission of driving Product-Led Growth (PLG) loops for the platform.

## Changes
- **`src/ui/tauri/src/ui/giveaway/index.html`**: Appended a `<footer>` containing the "Powered by OHC" link pointing to the onboarding route with a tracking referral tag.
- **`src/e2e/viral_giveaway.spec.ts`**: Included an assertion to verify the visibility of the new "Powered by OHC" footer on the giveaway generator page.

## Testing & Verification
- Ran the full suite with `bazelisk test //...` which executed successfully.
- Executed the full Playwright UI test suite with `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"` which passed completely.
- Ensured all tests are hermetic and properly isolated.

## Product-Use Evidence
- **Persona:** Maya (Home Baker) looking to acquire new potential customers by sharing a link on Instagram.
- **Flow Attempted:** Logged into the dashboard, navigated to the Viral Giveaway generator page, created a new giveaway titled "Free iPad!", and generated the shareable link.
- **Observed Gap:** The giveaway generation page itself, which owners might screenshot or share visually, did not have any explicit OHC branding. Additionally, while the participant entry page *did* have the branding, reinforcing it on the generator page ensures even operators know they are part of the ecosystem and can easily navigate to onboarding.
- **Post-Fix Verification:** Navigating to `/giveaway` now displays the `⚡ Powered by OHC` link at the bottom. Clicking it appropriately routes to the onboarding screen with the proper referral tag.

---
*PR created automatically by Jules for task [4979262861844723298](https://jules.google.com/task/4979262861844723298) started by @ql-owo-lp*