### PR TITLE
fix: restore bio object saving in wizardState payload and resolve tests

### DIFF
--- a/src/ui/next/src/app/onboarding/page.test.tsx
+++ b/src/ui/next/src/app/onboarding/page.test.tsx
@@ -52,7 +52,7 @@ describe('OnboardingWizard', () => {
     });
 
     global.fetch = vi.fn().mockImplementation((url) => {
-        return Promise.resolve({ ok: true, json: async () => ({ wizardState: {} }) });
+        return Promise.resolve({ ok: true, json: async () => ({ wizardState: { bio: "Draft Bio" } }) });
     }) as any;
   });
 
@@ -85,7 +85,7 @@ describe('OnboardingWizard', () => {
           })
         });
       }
-      return Promise.resolve({ ok: true, json: async () => ({ wizardState: {} }) });
+      return Promise.resolve({ ok: true, json: async () => ({ wizardState: { bio: "Draft Bio" } }) });
     });
 
     await renderOnboardingWizard();
@@ -191,7 +191,7 @@ describe('OnboardingWizard', () => {
           json: async () => ({ message: "Success!" })
         });
       }
-      return Promise.resolve({ ok: true, json: async () => ({ wizardState: {} }) });
+      return Promise.resolve({ ok: true, json: async () => ({ wizardState: { bio: "Draft Bio" } }) });
     });
 
     await renderOnboardingWizard();
@@ -290,7 +290,7 @@ describe('OnboardingWizard', () => {
       if (url === '/api/onboarding/intake' || url === '/api/onboarding/start') {
         return Promise.resolve({ ok: false, json: async () => ({ error: "Failed to process business details" }) });
       }
-      return Promise.resolve({ ok: true, json: async () => ({ wizardState: {} }) });
+      return Promise.resolve({ ok: true, json: async () => ({ wizardState: { bio: "Draft Bio" } }) });
     });
 
     await renderOnboardingWizard();
@@ -350,7 +350,7 @@ describe('OnboardingWizard', () => {
       if (url === '/api/onboarding/intake' || url === '/api/onboarding/start') {
         return Promise.resolve({ ok: false, status: 500, clone: () => ({ json: async () => ({ error: "Failed to start onboarding" }) }), json: async () => ({ error: "Failed to start onboarding" }) });
       }
-      return Promise.resolve({ ok: true, json: async () => ({ wizardState: {} }) });
+      return Promise.resolve({ ok: true, json: async () => ({ wizardState: { bio: "Draft Bio" } }) });
     });
 
     await renderOnboardingWizard();
@@ -557,7 +557,7 @@ describe('OnboardingWizard', () => {
         }
         return Promise.resolve({ ok: true, json: async () => ({}) });
       }
-      return Promise.resolve({ ok: true, json: async () => ({ wizardState: {} }) });
+      return Promise.resolve({ ok: true, json: async () => ({ wizardState: { bio: "Draft Bio" } }) });
     });
 
     act(() => {
@@ -583,6 +583,7 @@ describe('OnboardingWizard', () => {
           ok: true,
           json: async () => ({
             wizardState: {
+              bio: "Draft Bio",
               step: 1,
               chatStep: 2,
               businessName: 'Draft Business Name',
@@ -594,7 +595,7 @@ describe('OnboardingWizard', () => {
       if (url === '/api/onboarding/state') {
         return Promise.resolve({
           ok: true,
-          json: async () => ({ wizardState: {} })
+          json: async () => ({ wizardState: { bio: "Draft Bio" } })
         });
       }
       return Promise.resolve({ ok: true, json: async () => ({}) });
@@ -647,7 +648,7 @@ describe('OnboardingWizard', () => {
           json: async () => ({})
         });
       }
-      return Promise.resolve({ ok: true, json: async () => ({ wizardState: {} }) });
+      return Promise.resolve({ ok: true, json: async () => ({ wizardState: { bio: "Draft Bio" } }) });
     });
 
     // Start at Step 2
@@ -735,7 +736,7 @@ describe('OnboardingWizard', () => {
     // Mock the draft save success
     (global.fetch as any).mockImplementation((url: string) => {
       if (url === '/api/onboarding/draft') { return Promise.resolve({ ok: true, json: async () => ({}) }); }
-      return Promise.resolve({ ok: true, json: async () => ({ wizardState: {} }) });
+      return Promise.resolve({ ok: true, json: async () => ({ wizardState: { bio: "Draft Bio" } }) });
     });
 
     await renderOnboardingWizard();

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -111,6 +111,7 @@ export default function OnboardingWizard() {
       step,
       chatStep,
       businessDescription,
+      bio,
       businessName,
       whatYouSell,
       location,
@@ -171,6 +172,7 @@ export default function OnboardingWizard() {
         step,
         chatStep,
         businessDescription,
+        bio,
         businessName,
         whatYouSell,
         location,
@@ -227,6 +229,7 @@ export default function OnboardingWizard() {
         if (data.wizardState.step !== undefined) setStep(data.wizardState.step === 4 ? 3 : data.wizardState.step);
         if (data.wizardState.chatStep !== undefined) setChatStep(data.wizardState.chatStep);
         if (data.wizardState.businessDescription !== undefined) setBusinessDescription(data.wizardState.businessDescription);
+        if (data.wizardState.bio !== undefined) setBio(data.wizardState.bio);
         if (data.wizardState.businessName !== undefined) setBusinessName(data.wizardState.businessName);
         if (data.wizardState.whatYouSell !== undefined) setWhatYouSell(data.wizardState.whatYouSell);
         if (data.wizardState.location !== undefined) setLocation(data.wizardState.location);
@@ -266,6 +269,7 @@ export default function OnboardingWizard() {
       step,
       chatStep,
       businessDescription,
+      bio,
       businessName,
       whatYouSell,
       location,


### PR DESCRIPTION
This fixes an issue where the `bio` component of the setup `wizardState` does not correctly save to draft APIs and sync states in `src/ui/next/src/app/onboarding/page.tsx` for the onboarding dashboard, and fixes respective Playwright E2E unit tests failing correctly.

---
*PR created automatically by Jules for task [1507699654848482120](https://jules.google.com/task/1507699654848482120) started by @ql-owo-lp*