### PR TITLE
Fix Playwright test coverage glob to include nested UI specs

### DIFF
--- a/src/e2e/BUILD.bazel
+++ b/src/e2e/BUILD.bazel
@@ -98,7 +98,7 @@ define_playwright_tests(
         "//src/ui/tauri/src/ui:all_files",
     ],
     server = "//src/server:server",
-    specs = glob(["*.spec.ts"]) + _NEXT_UI_E2E_SPECS,
+    specs = glob(["*.spec.ts", "ui/*.spec.ts"]) + _NEXT_UI_E2E_SPECS,
 )
 
 sh_test(


### PR DESCRIPTION
Fixes the `playwright_spec_coverage` validation failure.

**Root cause:**
The glob expression in `src/e2e/BUILD.bazel` was defined as `glob(["*.spec.ts"])`. This meant that `.spec.ts` files under subdirectories, notably `src/e2e/ui/*.spec.ts`, were not discovered and fed to the Playwright targets, resulting in a discrepancy between expected test coverage and actual test coverage which made `//src/e2e:playwright_spec_coverage` fail.

**Changes:**
Updated the `glob(["*.spec.ts"])` expression in `src/e2e/BUILD.bazel` to `glob(["*.spec.ts", "ui/*.spec.ts"])` to include the nested UI tests.

**Superpowers used:**
`test-driven-development`, `verification-before-completion`, `systematic-debugging`.

**Validation:**
Ran `bazel test //...` and `bazel test //src/e2e/...` to verify all tests pass completely and correctly. All previously orphaned tests in `src/e2e/ui/` are now appropriately executed.

---
*PR created automatically by Jules for task [17659537091958547109](https://jules.google.com/task/17659537091958547109) started by @ql-owo-lp*