### PR TITLE
🚀 Nova: [Interactive Embed Widget Viral Growth Loop]

### DIFF
--- a/src/e2e/embed_widget.spec.ts
+++ b/src/e2e/embed_widget.spec.ts
@@ -36,6 +36,8 @@ test.describe('Growth Loop: Interactive Embed Widget Builder', () => {
             const apiHtml = await apiResponse.text();
             expect(apiHtml).toContain('Request a quote');
             expect(apiHtml).toContain('Workspace: test-merchant-xyz');
+            expect(apiHtml).toContain('https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref=test-merchant-xyz');
+            expect(apiHtml).toContain('⚡ Powered by OHC');
         }
     }
   });

--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -2800,6 +2800,10 @@ pub async fn handle_embed_widget(
   <p>Workspace: {}</p>
   <button id="start-btn" data-type="{}">Start {}</button>
 
+  <div style="font-family: sans-serif; text-align: center; font-size: 12px; margin-top: 16px;">
+    <a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref={}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a>
+  </div>
+
   <script>
     document.getElementById('start-btn').addEventListener('click', function() {{
       alert('Demand captured for ' + this.getAttribute('data-type'));
@@ -2807,7 +2811,7 @@ pub async fn handle_embed_widget(
   </script>
 </body>
 </html>"#,
-        bg_color, text_color, escaped_type, escaped_tenant, escaped_type, escaped_type
+        bg_color, text_color, escaped_type, escaped_tenant, escaped_type, escaped_type, escaped_tenant
     );
     axum::response::Html(html)
 }


### PR DESCRIPTION
Implemented a viral growth loop for the interactive embed widgets generated by the `Interactive Embed Widget Builder` by appending a "Powered by OHC" footer to the generated iframe HTML. This footer includes a referral link (`/api/v1/growth/referrals/click?target=/onboarding&ref={tenant}`) pointing back to OHC, tracking the tenant as the referrer. E2E tests in `src/e2e/embed_widget.spec.ts` were also updated to verify the loop's presence.

---
*PR created automatically by Jules for task [2564896758828148570](https://jules.google.com/task/2564896758828148570) started by @ql-owo-lp*