### PR TITLE
🤖 Implementer: Harness Upgrade - LangChain/LangGraph Compilation Phase

### DIFF
--- a/src/agents/builtin/agent.rs
+++ b/src/agents/builtin/agent.rs
@@ -1763,7 +1763,8 @@ impl Agent {
             last_message: None,
         };
 
-        match graph.pregel_run(initial_state).await {
+        let compiled = graph.compile().unwrap();
+        match compiled.pregel_run(initial_state).await {
             Ok(final_state) => {
                 let msgs = final_state.messages;
                 let last_msg = msgs.last().unwrap();

--- a/src/agents/builtin/langgraph.rs
+++ b/src/agents/builtin/langgraph.rs
@@ -78,9 +78,37 @@ impl<S: Clone + Send + Sync + 'static> StateGraph<S> {
         self.observer = Some(observer);
     }
 
+    /// Compiles the StateGraph into a CompiledStateGraph that can be executed.
+    /// This locks the graph topology and prevents further modifications.
+    pub fn compile(self) -> Result<CompiledStateGraph<S>, String> {
+        if self.entry_point.is_none() {
+            return Err("Cannot compile: Entry point not set".to_string());
+        }
+        Ok(CompiledStateGraph {
+            nodes: self.nodes,
+            edges: self.edges,
+            conditional_edges: self.conditional_edges,
+            entry_point: self.entry_point.unwrap(),
+            reducer: self.reducer,
+            observer: self.observer,
+        })
+    }
+}
+
+/// A compiled state graph that is ready to be executed.
+pub struct CompiledStateGraph<S> {
+    nodes: HashMap<String, NodeFn<S>>,
+    edges: HashMap<String, String>,
+    conditional_edges: HashMap<String, ConditionFn<S>>,
+    entry_point: String,
+    reducer: Arc<dyn Reducer<S>>,
+    observer: Option<Arc<dyn GraphObserver<S>>>,
+}
+
+impl<S: Clone + Send + Sync + 'static> CompiledStateGraph<S> {
     pub async fn run(&self, initial_state: S) -> Result<S, String> {
         let mut current_state = initial_state;
-        let mut current_node = self.entry_point.clone().ok_or("Entry point not set")?;
+        let mut current_node = self.entry_point.clone();
 
         let mut iterations = 0;
         let max_iterations = 100;
@@ -128,12 +156,9 @@ impl<S: Clone + Send + Sync + 'static> StateGraph<S> {
         Ok(current_state)
     }
 
-    /// Pregel-inspired execution model for StateGraph.
-    /// Runs all currently active nodes concurrently (super-steps),
-    /// merging their outputs via the reducer at the end of each super-step.
     pub async fn pregel_run(&self, initial_state: S) -> Result<S, String> {
         let mut current_state = initial_state;
-        let mut active_nodes = vec![self.entry_point.clone().ok_or("Entry point not set")?];
+        let mut active_nodes = vec![self.entry_point.clone()];
 
         let mut iterations = 0;
         let max_iterations = 100;
@@ -297,7 +322,8 @@ mod tests {
             has_tool_calls: false,
         };
 
-        let final_state = graph.run(initial_state).await.unwrap();
+        let compiled = graph.compile().unwrap();
+        let final_state = compiled.run(initial_state).await.unwrap();
 
         assert_eq!(final_state.messages.len(), 4);
         assert_eq!(final_state.messages[0], "user: What is the weather?");
@@ -339,6 +365,127 @@ mod tests {
             let mut ev = self.events.try_lock().unwrap();
             ev.push("graph_end".to_string());
         }
+    }
+
+    #[tokio::test]
+    async fn test_linear_graph() {
+        let mut graph = StateGraph::<TypedAgentState>::new(Arc::new(TypedReducer));
+
+        graph.add_node("node1", |state| async move {
+            Ok(TypedAgentState {
+                messages: vec!["Node 1 executed".to_string()],
+                has_tool_calls: false,
+            })
+        });
+
+        graph.add_node("node2", |state| async move {
+            Ok(TypedAgentState {
+                messages: vec!["Node 2 executed".to_string()],
+                has_tool_calls: false,
+            })
+        });
+
+        graph.add_edge("node1", "node2");
+        graph.set_entry_point("node1");
+
+        let initial_state = TypedAgentState {
+            messages: vec![],
+            has_tool_calls: false,
+        };
+
+        let compiled = graph.compile().unwrap();
+        let final_state = compiled.run(initial_state).await.unwrap();
+
+        assert_eq!(final_state.messages.len(), 2);
+        assert_eq!(final_state.messages[0], "Node 1 executed");
+        assert_eq!(final_state.messages[1], "Node 2 executed");
+    }
+
+    #[tokio::test]
+    async fn test_reducer_merge() {
+        let mut graph = StateGraph::<Value>::new(Arc::new(DefaultReducer));
+
+        graph.add_node("init", |state| async move {
+            Ok(serde_json::json!({
+                "key1": "value1",
+                "arr": ["item1"]
+            }))
+        });
+
+        graph.add_node("merge", |state| async move {
+            Ok(serde_json::json!({
+                "key2": "value2",
+                "arr": ["item2"]
+            }))
+        });
+
+        graph.add_edge("init", "merge");
+        graph.set_entry_point("init");
+
+        let initial_state = serde_json::json!({});
+        let compiled = graph.compile().unwrap();
+        let final_state = compiled.run(initial_state).await.unwrap();
+
+        assert_eq!(final_state["key1"], "value1");
+        assert_eq!(final_state["key2"], "value2");
+        assert_eq!(final_state["arr"][0], "item1");
+        assert_eq!(final_state["arr"][1], "item2");
+    }
+
+    #[tokio::test]
+    async fn test_conditional_edges() {
+        let mut graph = StateGraph::<TypedAgentState>::new(Arc::new(TypedReducer));
+
+        graph.add_node("router", |state| async move {
+            Ok(TypedAgentState {
+                messages: vec!["Router executed".to_string()],
+                has_tool_calls: state.has_tool_calls, // preserve input flag
+            })
+        });
+
+        graph.add_node("path_a", |state| async move {
+            Ok(TypedAgentState {
+                messages: vec!["Path A executed".to_string()],
+                has_tool_calls: false,
+            })
+        });
+
+        graph.add_node("path_b", |state| async move {
+            Ok(TypedAgentState {
+                messages: vec!["Path B executed".to_string()],
+                has_tool_calls: false,
+            })
+        });
+
+        graph.add_conditional_edges("router", |state| {
+            if state.has_tool_calls {
+                "path_a".to_string()
+            } else {
+                "path_b".to_string()
+            }
+        });
+
+        graph.set_entry_point("router");
+
+        let compiled = graph.compile().unwrap();
+
+        // Run Path A
+        let initial_state_a = TypedAgentState {
+            messages: vec![],
+            has_tool_calls: true, // Should route to path_a
+        };
+        let final_state_a = compiled.run(initial_state_a).await.unwrap();
+        assert_eq!(final_state_a.messages.len(), 2);
+        assert_eq!(final_state_a.messages[1], "Path A executed");
+
+        // Run Path B
+        let initial_state_b = TypedAgentState {
+            messages: vec![],
+            has_tool_calls: false, // Should route to path_b
+        };
+        let final_state_b = compiled.run(initial_state_b).await.unwrap();
+        assert_eq!(final_state_b.messages.len(), 2);
+        assert_eq!(final_state_b.messages[1], "Path B executed");
     }
 
     #[tokio::test]
@@ -387,7 +534,8 @@ mod tests {
             has_tool_calls: false,
         };
 
-        let _ = graph.run(initial_state).await.unwrap();
+        let compiled = graph.compile().unwrap();
+        let _ = compiled.run(initial_state).await.unwrap();
 
         let events = observer.events.lock().await;
         assert_eq!(

--- a/src/agents/builtin/langgraph.rs
+++ b/src/agents/builtin/langgraph.rs
@@ -156,6 +156,9 @@ impl<S: Clone + Send + Sync + 'static> CompiledStateGraph<S> {
         Ok(current_state)
     }
 
+    /// Pregel-inspired execution model for StateGraph.
+    /// Runs all currently active nodes concurrently (super-steps),
+    /// merging their outputs via the reducer at the end of each super-step.
     pub async fn pregel_run(&self, initial_state: S) -> Result<S, String> {
         let mut current_state = initial_state;
         let mut active_nodes = vec![self.entry_point.clone()];


### PR DESCRIPTION
🤖 Implementer: Harness Upgrade - LangChain/LangGraph Compilation Phase

This PR upgrades the `StateGraph` implementation in `langgraph.rs` to align with the industry-standard LangChain/LangGraph architecture. Specifically, it implements the `compile()` phase mechanic which explicitly separates the graph-building phase (adding nodes, edges, conditional edges) from the graph-execution phase.

Excerpt from the Master Catalog:
"LangChain/LangGraph: Models the harness as an explicit state graph. Mechanically: uses `llm_call` and `tool_node` connected by conditional edges... State flows as typed dictionaries with reducer functions."

Rust Implementation Mechanics:
- Modified the `StateGraph` struct to serve purely as a mutable builder.
- Added a `.compile(self) -> Result<CompiledStateGraph<S>, String>` method that locks the topology, validates the presence of an `entry_point`, and returns an immutable execution object.
- Migrated the `.run()` and `.pregel_run()` execution loops to the new `CompiledStateGraph`.
- Added 3 comprehensive tests (`test_linear_graph`, `test_reducer_merge`, `test_conditional_edges`) to guarantee routing, data reduction, and conditional execution.

Testing Instructions:
`bazelisk test //src/agents/builtin/...` must pass. All modified `langgraph.rs` tests use the new `let compiled = graph.compile().unwrap();` pattern correctly.

---
*PR created automatically by Jules for task [16814756495399108414](https://jules.google.com/task/16814756495399108414) started by @ql-owo-lp*