### PR TITLE
fix: use relative path for backendUrl in setup.html

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1364,7 +1364,7 @@
         }
 
         // Fetch from API to support cross-device resume
-        const backendUrl = (window.location.origin.includes('localhost') || window.location.protocol === 'file:') ? 'http://127.0.0.1:18789' : '';
+        const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
         const tenantId = localStorage.getItem('tenant_id') || 'e2e-tenant';
         const userId = localStorage.getItem('user_id') || 'e2e-admin-user';
 
@@ -1512,7 +1512,7 @@
               window.__TAURI__.core.invoke("save_onboarding_state", { state, tenantId, userId }).catch(console.error);
           } else {
               localStorage.setItem('onboardingState', JSON.stringify(state));
-              const backendUrl = (window.location.origin.includes('localhost') || window.location.protocol === 'file:') ? 'http://127.0.0.1:18789' : '';
+              const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
               fetch(`${backendUrl}/api/onboarding/draft`, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json', 'X-Tenant-ID': tenantId, 'X-User-ID': userId },
@@ -1807,7 +1807,7 @@
           chatSendBtn.disabled = true;
 
           try {
-              const backendUrl = (window.location.origin.includes('localhost') || window.location.protocol === 'file:') ? 'http://127.0.0.1:18789' : '';
+              const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
               const res = await fetch(`${backendUrl}/api/onboarding/chat`, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
@@ -1885,7 +1885,7 @@
               approvePublishBtn.innerHTML = '<div class="spinner"></div>Publishing...';
 
               try {
-                  const backendUrl = (window.location.origin.includes('localhost') || window.location.protocol === 'file:') ? 'http://127.0.0.1:18789' : '';
+                  const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
                   if (window.__TAURI__ && window.__TAURI__.core) {
                       await goToStep('step-loading');
                       const startData = await window.__TAURI__.core.invoke("start_onboarding", { req });
@@ -1971,7 +1971,7 @@
               generateStorefrontBtn.innerHTML = '<div class="spinner"></div>Building Your Business...';
 
               try {
-                  const backendUrl = (window.location.origin.includes('localhost') || window.location.protocol === 'file:') ? 'http://127.0.0.1:18789' : '';
+                  const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
                   const tenantIdStr = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'e2e-tenant';
                   const userIdStr = localStorage.getItem('user_id') || 'e2e-admin-user';
 
@@ -2098,7 +2098,7 @@
             e.target.innerText = "Saving...";
             e.target.disabled = true;
 
-            const backendUrl = (window.location.origin.includes("localhost") || window.location.protocol === "file:") ? "http://127.0.0.1:18789" : "";
+            const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
             const tenantId = localStorage.getItem("tenant_id") || "e2e-tenant";
             const userId = localStorage.getItem("user_id") || "e2e-admin-user";
 
@@ -2217,7 +2217,7 @@
                } else {
                  finishBtn.disabled = true;
                  finishBtn.innerHTML = '<div class="spinner"></div>Saving...';
-                 const backendUrl = (window.location.origin.includes('localhost') || window.location.protocol === 'file:') ? 'http://127.0.0.1:18789' : '';
+                 const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
                  fetch(`${backendUrl}/api/onboarding/start`, {
                      method: 'POST',
                      headers: {


### PR DESCRIPTION
The `onboarding_chat_cuj.spec.ts` was failing with "Failed to connect." because the `setup.html` was incorrectly hardcoding the backend URL to `127.0.0.1:18789` for any localhost origin, breaking the relative path connection for tests hosted on `localhost:18789`.
This PR updates the `backendUrl` condition to explicitly only check for common dev ports and `file:` protocol, falling back to relative paths for testing environments.

**Product-use evidence:**
- Persona: Maya (Home Baker)
- E2E flow: Run `onboarding_chat_cuj.spec.ts` using `npx playwright test`. The wizard failed to connect when making chat requests.
- The change fixes the URL connection to the backend and passes the test.

---
*PR created automatically by Jules for task [16266546894943572708](https://jules.google.com/task/16266546894943572708) started by @ql-owo-lp*