### PR TITLE
🚀 Nova: [UX Polish] Work Intake Widget Glassmorphism

### DIFF
--- a/src/e2e/work_intake_widget.spec.ts
+++ b/src/e2e/work_intake_widget.spec.ts
@@ -18,6 +18,9 @@ test.describe('Work-Intake Widget Growth Loop', () => {
     // 1. Verify the page header
     await expect(page.getByRole('heading', { name: 'Work-Intake Widget 📋' })).toBeVisible();
 
+    // 1.5 Verify that the new glass-card glassmorphism UI is active
+    await expect(page.locator('.glass-card').first()).toBeVisible();
+
     // 2. Change Tenant ID
     const tenantInput = page.locator('input[placeholder="e.g. my-business"]');
     await tenantInput.fill('e2e-tenant');

--- a/src/ui/next/package-lock.json
+++ b/src/ui/next/package-lock.json
@@ -43,7 +43,7 @@
         "autoprefixer": "^10.5.0",
         "jsdom": "^29.1.1",
         "next": "^14.2.35",
-        "playwright": "^1.60.0",
+        "playwright": "^1.61.0",
         "postcss": "^8.5.15",
         "tailwindcss": "^3.4.19",
         "typescript": "^5.0.0",

--- a/src/ui/next/package.json
+++ b/src/ui/next/package.json
@@ -44,7 +44,7 @@
     "autoprefixer": "^10.5.0",
     "jsdom": "^29.1.1",
     "next": "^14.2.35",
-    "playwright": "^1.60.0",
+    "playwright": "^1.61.0",
     "postcss": "^8.5.15",
     "tailwindcss": "^3.4.19",
     "typescript": "^5.0.0",

--- a/src/ui/next/src/app/work-intake-widget/page.tsx
+++ b/src/ui/next/src/app/work-intake-widget/page.tsx
@@ -38,7 +38,7 @@ export default function WorkIntakeWidgetPage() {
   };
 
   return (
-    <div className="flex flex-col min-h-screen font-inter" style={{ backgroundColor: '#F5F5F7' }}>
+    <div className="flex flex-col min-h-screen font-inter bg-gradient-to-br from-indigo-50/50 via-white/50 to-blue-50/50">
       {/* Header */}
       <header className="px-6 py-4 flex items-center justify-between border-b" style={{ background: 'rgba(255, 255, 255, 0.65)', backdropFilter: 'blur(30px) saturate(210%)', borderBottom: '1px solid rgba(255, 255, 255, 0.4)', position: 'sticky', top: 0, zIndex: 50 }}>
          <div className="flex items-center gap-3">
@@ -55,7 +55,7 @@ export default function WorkIntakeWidgetPage() {
       <main className="p-6 md:p-8 flex-1 max-w-6xl mx-auto w-full flex flex-col md:flex-row gap-8">
         {/* Editor Sidebar */}
         <div className="w-full md:w-1/3 flex flex-col gap-6">
-            <div className="p-6 rounded-[16px]" style={{ background: 'rgba(255, 255, 255, 0.65)', backdropFilter: 'blur(30px) saturate(210%)', border: '1px solid rgba(255, 255, 255, 0.4)', boxShadow: '0 4px 24px rgba(0,0,0,0.04)' }}>
+            <div className="p-6 rounded-[16px] glass-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 shadow-lg">
                 <h2 className="text-lg font-semibold font-outfit mb-4">Widget Settings</h2>
 
                 <div className="mb-6">
@@ -84,7 +84,7 @@ export default function WorkIntakeWidgetPage() {
                         type="text"
                         value={tenant}
                         onChange={(e) => setTenant(e.target.value)}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-[16px] min-h-[44px] min-w-[44px] focus:outline-none focus:ring-2 focus:ring-[#0066FF]"
+                        className="w-full px-3 py-2 bg-white/50 dark:bg-black/20 border border-gray-200 dark:border-gray-700 rounded-[8px] min-h-[44px] min-w-[44px] focus:outline-none focus:ring-2 focus:ring-[#0066FF] backdrop-blur-md transition-all"
                         placeholder="e.g. my-business"
                     />
                 </div>
@@ -95,7 +95,7 @@ export default function WorkIntakeWidgetPage() {
                         type="text"
                         value={title}
                         onChange={(e) => setTitle(e.target.value)}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-[16px] min-h-[44px] min-w-[44px] focus:outline-none focus:ring-2 focus:ring-[#0066FF]"
+                        className="w-full px-3 py-2 bg-white/50 dark:bg-black/20 border border-gray-200 dark:border-gray-700 rounded-[8px] min-h-[44px] min-w-[44px] focus:outline-none focus:ring-2 focus:ring-[#0066FF] backdrop-blur-md transition-all"
                         placeholder="e.g. Work Request"
                     />
                 </div>
@@ -121,7 +121,7 @@ export default function WorkIntakeWidgetPage() {
                 </div>
             </div>
 
-            <div className="p-6 rounded-[16px] bg-white border border-gray-200 shadow-sm flex flex-col justify-center gap-4">
+            <div className="p-6 rounded-[16px] glass-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 shadow-lg flex flex-col justify-center gap-4">
                <h3 className="font-semibold text-gray-900">Embed on Your Website</h3>
                <p className="text-sm text-gray-600">Copy this code snippet to add the widget directly to your own site, Notion document, or blog.</p>
                <button
@@ -138,7 +138,7 @@ export default function WorkIntakeWidgetPage() {
              <h2 className="text-xl font-semibold font-outfit self-start" style={{ color: '#1D1D1F' }}>Live Preview</h2>
 
              {/* Realistic environment wrapper */}
-             <div className="w-full max-w-2xl bg-white rounded-[16px] min-h-[44px] min-w-[44px] overflow-hidden border border-gray-300 shadow-2xl relative mt-4">
+             <div className="w-full max-w-2xl glass-card bg-white/70 backdrop-blur-xl saturate-200 rounded-[16px] min-h-[44px] min-w-[44px] overflow-hidden border border-white/40 shadow-2xl relative mt-4">
                  <div className="bg-gray-100 border-b border-gray-300 px-4 py-3 flex items-center gap-2">
                      <div className="flex gap-1.5">
                          <div className="w-3 h-3 rounded-full bg-red-400"></div>


### PR DESCRIPTION
- **Persona:** SMB Owner (e.g. Maya) trying to easily set up a lead generation work-intake widget.
- **Observed Gap:** While running the `deploy_dev` stack and manually reviewing screenshots via playwright, I observed that the Work-Intake Widget configuration page used hardcoded, opaque backgrounds and basic borders instead of the standardized macOS Translucent Glass `.glass-card` styling required by OHC guidelines.
- **Implemented Fix:** Upgraded `src/ui/next/src/app/work-intake-widget/page.tsx` containers and inputs to utilize `.glass-card` and standard translucent CSS utility classes (e.g., `bg-white/50`, `backdrop-blur-xl`).
- **Test:** Added E2E verification in `src/e2e/work_intake_widget.spec.ts` asserting `.glass-card` visibility. Ensured 100% test passing locally.
- **UX Evidence:** The updated UI screenshot locally matches OHC premium guidelines, providing a much cleaner owner experience.

---
*PR created automatically by Jules for task [7483727198057005231](https://jules.google.com/task/7483727198057005231) started by @ql-owo-lp*