### PR TITLE
🧹 Cleaner: Clean test_dummy.rs and Playwright hermetic setup

### DIFF
--- a/bazel/rules/playwright/playwright_test.sh
+++ b/bazel/rules/playwright/playwright_test.sh
@@ -328,8 +328,8 @@ if [ "$PULL_PG_SUCCESS" = true ]; then
   done
 
   if [ "$PULL_VK_SUCCESS" = true ]; then
-    if docker rm -f "$POSTGRES_NAME" >/dev/null 2>&1 || true; docker run -d --name "$POSTGRES_NAME" -p 127.0.0.1::5432 -e POSTGRES_USER=ohc -e POSTGRES_PASSWORD=ohc -e POSTGRES_DB=ohc pgvector/pgvector:pg15; then
-      docker run -d --name "$VALKEY_NAME" -p 127.0.0.1::6379 valkey/valkey:8-alpine
+    if docker rm -f "$POSTGRES_NAME" >/dev/null 2>&1 || true; docker run -d --name "$POSTGRES_NAME" -p 127.0.0.1:0:5432 -e POSTGRES_USER=ohc -e POSTGRES_PASSWORD=ohc -e POSTGRES_DB=ohc pgvector/pgvector:pg15; then
+      docker run -d --name "$VALKEY_NAME" -p 127.0.0.1:0:6379 valkey/valkey:8-alpine
       PG_PORT="$(docker port "$POSTGRES_NAME" 5432/tcp | sed -E 's/.*:([0-9]+)$/\1/' | head -n 1)"
       VK_PORT="$(docker port "$VALKEY_NAME" 6379/tcp | sed -E 's/.*:([0-9]+)$/\1/' | head -n 1)"
       echo "[playwright] E2E infrastructure ports (PG:$PG_PORT VK:$VK_PORT)"

--- a/src/e2e/global-setup.ts
+++ b/src/e2e/global-setup.ts
@@ -15,7 +15,7 @@ export default async function globalSetup(config: FullConfig) {
 
   // Ensure there are no hardcoded localhost:5432 ports in use
   if (databaseUrl.includes('localhost:5432') && process.env.CI) {
-      console.warn('WARNING: Using hardcoded localhost:5432 database URL in CI. This is discouraged.');
+      throw new Error('Playwright tests must use the Bazel-provided test database URL\/port. Hard-coded localhost:5432 is not allowed.');
   }
 
   // wait for app to be ready

--- a/src/server/test_dummy.rs
+++ b/src/server/test_dummy.rs
@@ -1,1 +1,0 @@
-// This is a dummy file to bypass the deletion risk check


### PR DESCRIPTION
🧹 Cleaner: Clean test_dummy.rs and Playwright hermetic setup

Removed test_dummy.rs and modified global-setup.ts to throw an error 
instead of just warning when localhost:5432 is used. Updated 
playwright_test.sh to use dynamic docker ports.

---
*PR created automatically by Jules for task [8539406441676680402](https://jules.google.com/task/8539406441676680402) started by @ql-owo-lp*