### PR TITLE
fix(tests): align redis queue names and commands in chaos test

### DIFF
--- a/src/server/orchestration/queue/ohc_job_queue_test.rs
+++ b/src/server/orchestration/queue/ohc_job_queue_test.rs
@@ -314,18 +314,20 @@ async fn test_chaos_redis_mailbox_corruption() {
     };
 
     let tenant_id = "tenant_chaos_mailbox";
-    let mailbox_key = format!("ohc:mailbox:{}", tenant_id);
+    let queue_name = "test_queue";
 
-    // Corrupt the mailbox by pushing a non-JSON / invalid string
-    let _: () = redis::cmd("LPUSH")
-        .arg(&mailbox_key)
+    // Corrupt the queue by pushing a non-JSON / invalid string
+    // RedisTaskQueue uses a sorted set (ZSET), so we use ZADD.
+    let _: () = redis::cmd("ZADD")
+        .arg(queue_name)
+        .arg(0)
         .arg("THIS_IS_CORRUPT_DATA_NOT_JSON!!!")
         .query_async(&mut conn)
         .await
         .unwrap();
 
     // Now try to dequeue from Redis queue. Assuming we test the resilience of RedisTaskQueue
-    let queue = super::RedisTaskQueue::new(&redis_url, "test_queue").unwrap();
+    let queue = super::RedisTaskQueue::new(&redis_url, queue_name).unwrap();
 
     // Attempting to dequeue should gracefully handle the corrupt data (e.g., skip it or return error, but NOT panic)
     // Actually, RedisTaskQueue dequeues using LPOP and then parsing.


### PR DESCRIPTION
This submission addresses an issue where the backend test `test_chaos_redis_mailbox_corruption` was failing. The test was written to simulate a scenario where `RedisTaskQueue` retrieves corrupted data, but it inadvertently introduced mismatched Redis types and keys.

Specifically, it was using `LPUSH` (a List operation) to push corrupted data to a generic `ohc:mailbox:*` key, but then it initialized a `RedisTaskQueue` polling `test_queue`. Because `RedisTaskQueue` relies on `ZPOPMIN` (a Sorted Set operation), when the keys mismatched or if the queue type was wrong, it caused a test failure/crash.

This commit unifies the keys and uses `ZADD` to correctly insert corrupted data directly into the `test_queue`'s sorted set, verifying that the deserialization and error resilience of `RedisTaskQueue::dequeue` behaves correctly without crashing the test framework. All 84 backend Bazel test targets are now compiling and passing successfully.

---
*PR created automatically by Jules for task [2718727240843739349](https://jules.google.com/task/2718727240843739349) started by @ql-owo-lp*