### PR TITLE
🗺️ Guide: Fix onboarding keyboard friction E2E test

### DIFF
--- a/src/e2e/onboarding_keyboard_friction.spec.ts
+++ b/src/e2e/onboarding_keyboard_friction.spec.ts
@@ -33,7 +33,7 @@ test.describe('Onboarding Keyboard Friction Mitigation', () => {
     await expect(page.locator('#step-context')).toHaveClass(/active/);
 
     // Step Context
-    await page.locator('input[value="Local Service"]').check({ force: true });
+    await page.getByTestId('context-local').click();
     await page.keyboard.press('Enter');
     await expect(page.locator('#step-categories')).toHaveClass(/active/);
 
@@ -50,6 +50,7 @@ test.describe('Onboarding Keyboard Friction Mitigation', () => {
 
     // Step Assistant
     await page.locator('#assistant-name').fill('Jarvis');
+    await page.locator('#assistant-tone').selectOption('Professional');
     await page.locator('#assistant-name').press('Enter');
     await expect(page.locator('#step-admin')).toHaveClass(/active/);
 


### PR DESCRIPTION
Fixes the `onboarding_keyboard_friction.spec.ts` test suite by correcting a broken element locator (`input[value="Local Service"]`) which was visually hidden and inaccessible to Playwright. Uses `getByTestId('context-local')` to interact with the correct label. Additionally adds a missing `selectOption('Professional')` to ensure validation conditions are met when advancing the stepper via the Enter key.

---
*PR created automatically by Jules for task [9465933468976421625](https://jules.google.com/task/9465933468976421625) started by @ql-owo-lp*