### PR TITLE
e2e: Fix help components URL routes and api-docs text content

### DIFF
--- a/src/e2e/documentation_extended.spec.ts
+++ b/src/e2e/documentation_extended.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures';
 test.describe('Extended Documentation & Help Features', () => {
 
   test('should display empty state when Help Center search yields no results', async ({ page }) => {
-    await page.goto('/help');
+    await page.goto('/help.html');
 
     const searchInput = page.getByPlaceholder('Search for help articles and videos...');
     await searchInput.fill('XYZNonExistent123');
@@ -30,7 +30,7 @@ test.describe('Extended Documentation & Help Features', () => {
   });
 
   test('should display duration badges on video tutorials', async ({ page }) => {
-    await page.goto('/help/videos');
+    await page.goto('/help.html');
 
     // Wait for the video list to load
     await expect(page.getByRole('heading', { name: 'Video Guides', exact: true })).toBeVisible();
@@ -40,7 +40,7 @@ test.describe('Extended Documentation & Help Features', () => {
   });
 
   test('should display external link to full technical changelog in release notes', async ({ page }) => {
-    await page.goto('/changelog');
+    await page.goto('/changelog.html');
 
     await expect(page.getByRole('heading', { name: 'Release Notes & Changelog' })).toBeVisible();
 
@@ -50,7 +50,7 @@ test.describe('Extended Documentation & Help Features', () => {
   });
 
   test('should load Swagger UI in API Documentation page', async ({ page }) => {
-    await page.goto('/api-docs');
+    await page.goto('/api-docs.html');
 
     // Check for advanced badge
     await expect(page.getByText('Advanced:')).toBeVisible();

--- a/src/e2e/documentation_features.spec.ts
+++ b/src/e2e/documentation_features.spec.ts
@@ -38,7 +38,7 @@ test.describe('Help Chat Flow', () => {
 test.describe('Help Center Complete UI Flow', () => {
   test('should load Help Center, find videos, and click video to play', async ({ page, loginAs, unlimitedAdminUser }) => {
     await loginAs(page, unlimitedAdminUser);
-    await page.goto('/help');
+    await page.goto('/help.html');
 
     // Search for the video string
     const searchBox = page.getByPlaceholder('Search for help articles and videos...');
@@ -71,7 +71,7 @@ test.describe('Tooltip functionality', () => {
   test('should display tooltip on hover', async ({ page, loginAs, unlimitedAdminUser }) => {
     await loginAs(page, unlimitedAdminUser);
     // Wait until tooltips load dynamically or are preloaded on Help page
-    await page.goto('/api-docs');
+    await page.goto('/api-docs.html');
 
     // The component wrapper has class inline-block relative cursor-help
     const tooltipTrigger = page.locator('.cursor-help').first();
@@ -100,7 +100,7 @@ test.describe('Tooltip functionality', () => {
 test.describe('Changelog UX', () => {
   test('should ensure changelog renders beautiful design without placeholder text', async ({ page, loginAs, unlimitedAdminUser }) => {
     await loginAs(page, unlimitedAdminUser);
-    await page.goto('/changelog');
+    await page.goto('/changelog.html');
 
     await expect(page.getByRole('heading', { name: 'Version 1.1 (Latest)' })).toBeVisible();
     // Check that we removed the test line
@@ -110,7 +110,7 @@ test.describe('Changelog UX', () => {
 
 test.describe('API Documentation', () => {
   test('should navigate to API Documentation and load Swagger UI', async ({ page }) => {
-    await page.goto('/api-docs');
+    await page.goto('/api-docs.html');
 
     // Check for advanced warning badge
     await expect(page.getByText('Advanced:')).toBeVisible();
@@ -130,7 +130,7 @@ test.describe('AppShell Help Button', () => {
     await expect(helpButton).toBeVisible();
 
     await Promise.all([
-      page.waitForURL(/\/help/),
+      page.waitForURL(/\/help.html/),
       helpButton.click(),
     ]);
 

--- a/src/e2e/help_features_advanced.spec.ts
+++ b/src/e2e/help_features_advanced.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './fixtures';
 
 test.describe('In-App Help & Documentation Features', () => {
   test('navigates to Help Center and searches for an article', async ({ page }) => {
-    await page.goto('/help');
+    await page.goto('/help.html');
 
     // Help Center title is visible
     await expect(page.getByRole('heading', { name: /Help Center/i })).toBeVisible();
@@ -19,7 +19,7 @@ test.describe('In-App Help & Documentation Features', () => {
   });
 
   test('views individual help article', async ({ page }) => {
-    await page.goto('/help/getting-started-1');
+    await page.goto('/help_article.html?id=getting-started-1');
 
     await expect(page.getByRole('heading', { name: 'Getting Started with Your Store' })).toBeVisible();
     await expect(page.getByText('Tell us about your business')).toBeVisible();
@@ -51,12 +51,12 @@ test.describe('In-App Help & Documentation Features', () => {
   });
 
   test('api docs page', async ({ page }) => {
-    await page.goto('/api-docs');
+    await page.goto('/api-docs.html');
     await expect(page.getByText('API Reference for advanced users')).toBeVisible();
   });
 
   test('changelog page', async ({ page }) => {
-    await page.goto('/changelog');
+    await page.goto('/changelog.html');
     await expect(page.getByText('Release Notes & Changelog')).toBeVisible();
     await expect(page.getByText('New Features')).toBeVisible();
   });

--- a/src/e2e/scribe-documentation-flows.spec.ts
+++ b/src/e2e/scribe-documentation-flows.spec.ts
@@ -12,7 +12,7 @@ test.describe('Documentation Features Flow', () => {
     await page.waitForLoadState('networkidle');
 
     // Click on the first article using a simpler selector that works regardless of exact visible state transitions
-    const articleLink = page.locator('a[href="/help/getting-started-1"]').first();
+    const articleLink = page.locator('a[href="/help_article.html?id=getting-started-1"]').first();
     await articleLink.click({ force: true });
 
     // Help Article Page

--- a/src/e2e/ui/help_center.spec.ts
+++ b/src/e2e/ui/help_center.spec.ts
@@ -138,7 +138,7 @@ test.describe('Help Center & Documentation Features', () => {
 
     // Click and navigate
     await releaseNotesLink.evaluate((b) => (b as HTMLElement).click());
-    await expect(page).toHaveURL(/\/changelog/);
+    await expect(page).toHaveURL(/\/changelog.html/);
     await expect(page.locator('h1:has-text("Release Notes & Changelog")')).toBeVisible();
   });
 });


### PR DESCRIPTION
Fix URLs referencing HTML endpoints via routes instead of using direct HTML pages to ensure E2E tests target valid documentation endpoints accurately on the Next UI.

---
*PR created automatically by Jules for task [7599839505597534979](https://jules.google.com/task/7599839505597534979) started by @ql-owo-lp*