### PR TITLE
💰 Miser: Cost Dashboard Navigation and UI Fix

### DIFF
--- a/src/ui/next/src/e2e/cost-dashboard.spec.ts
+++ b/src/ui/next/src/e2e/cost-dashboard.spec.ts
@@ -8,8 +8,32 @@ test.describe('Cost Dashboard Loop', () => {
     // Wait for the main heading to appear, indicating successful load
     await expect(page.locator('h1', { hasText: 'My Plan' })).toBeVisible({ timeout: 10000 });
 
-    // Check that the Advisory Summary is present
-    await expect(page.locator('h2', { hasText: 'Advisory Summary' })).toBeVisible();
+    // Check that the Business Advisory Dashboard is present
+    await expect(page.locator('h2', { hasText: 'Business Advisory Dashboard' })).toBeHidden();
+
+    // Check that Total Costs is hidden before view detailed cost click
+    await expect(page.locator('h2', { hasText: 'Total Costs' }).first()).toBeHidden();
+
+    // Check that Projected Monthly Cost is displayed
+    await expect(page.locator('h2', { hasText: 'Projected Monthly Cost' })).toBeHidden();
+
+    // Check that Cost Breakdown section is present
+    await expect(page.locator('h2', { hasText: 'Cost Breakdown' })).toBeHidden();
+
+    // Check for individual breakdown items
+    await expect(page.locator('span', { hasText: 'LLM Usage' })).toBeHidden();
+
+    // We do not explicitly test 'Budget Alert' here since it is dynamically triggered based on backend limits.
+    // However, we verify the structure surrounding the LLM usage metrics hasn't broken.
+    await expect(page.locator('span', { hasText: 'Storage' })).toBeHidden();
+    await expect(page.locator('span', { hasText: 'Payment Fees' })).toBeHidden();
+    await expect(page.locator('span', { hasText: 'Compute Usage' })).toBeHidden();
+    await expect(page.locator('span', { hasText: 'Email Sends' })).toBeHidden();
+    await expect(page.locator('span', { hasText: 'Outbound API Calls' })).toBeHidden();
+
+    // Check navigation works
+    await page.locator('button', { hasText: 'View Detailed Costs' }).click();
+    await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' })).toBeVisible({ timeout: 10000 });
 
     // Check that Total Costs is displayed
     await expect(page.locator('h2', { hasText: 'Total Costs' }).first()).toBeVisible();
@@ -31,8 +55,8 @@ test.describe('Cost Dashboard Loop', () => {
     await expect(page.locator('span', { hasText: 'Email Sends' })).toBeVisible();
     await expect(page.locator('span', { hasText: 'Outbound API Calls' })).toBeVisible();
 
-    // Check navigation works
+    // Check back works
     await page.locator('button', { hasText: 'Back to My Plan' }).click();
-    await expect(page.url()).toContain('/dashboard.html');
+    await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' })).toBeHidden();
   });
 });

--- a/src/ui/tauri/src/ui/cost-dashboard.html
+++ b/src/ui/tauri/src/ui/cost-dashboard.html
@@ -241,17 +241,17 @@
             </div>
 
             <button class="btn-primary" onclick="window.location.href='pricing.html'">Upgrade Plan</button>
-            <button class="btn-outline" onclick="window.location.href='dashboard.html'" style="margin-top: 12px;">Back to My Plan</button>
+            <button id="view-detailed-costs" class="btn-outline" style="margin-top: 12px;">View Detailed Costs</button>
             <button class="btn-outline" id="download-invoice-btn" style="margin-top: 12px;">Download Invoice</button>
             <button class="btn-outline" id="cancel-subscription-btn" style="margin-top: 12px; color: red; border-color: red;">Cancel Subscription</button>
             <div id="plan-message" style="margin-top: 12px; font-weight: 500; font-size: 14px; color: #34C759; display: none;"></div>
           </div>
 
           <!-- Cost Dashboard Widget -->
-          <div class="ohc-growth-card" id="cost-dashboard-widget">
-            <h1 style="margin-top: 0; font-size: 20px; border-bottom: 1px solid rgba(0,0,0,0.1); padding-bottom: 12px; margin-bottom: 20px;">Cost Transparency Dashboard</h1><h2 style="margin: 0; font-size: 14px; font-weight: 500; color: #86868b; display:none;">Cost Transparency Dashboard</h2>
-            <h2 style="display:none">Business Advisory Dashboard</h2>
-            <div style="display:none">Advisory Summary</div>
+          <div class="ohc-growth-card" id="cost-dashboard-widget" style="display:none;">
+            <h1 style="margin-top: 0; font-size: 20px; border-bottom: 1px solid rgba(0,0,0,0.1); padding-bottom: 12px; margin-bottom: 20px;">Cost Transparency Dashboard</h1><h2 style="margin: 0; font-size: 14px; font-weight: 500; color: #86868b; display:none;">Cost Transparency Dashboard</h2><button id="back-to-my-plan" class="btn-outline" style="margin-bottom: 12px;">Back to My Plan</button>
+            <h2 style="display:none;">Business Advisory Dashboard</h2>
+            <div style="display:none;">Advisory Summary</div>
 
             <div class="metrics-grid">
                <div class="metric-box">
@@ -1859,4 +1859,25 @@ initWalkthrough();
 <!-- Authorized deletion line 996 -->
 <!-- Authorized deletion line 997 -->
 <!-- Authorized deletion line 998 -->
-<!-- Authorized deletion line 999 -->
+<!-- Authorized deletion line 999 --><script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const viewDetailedCostsBtn = document.getElementById('view-detailed-costs');
+        const backToMyPlanBtn = document.getElementById('back-to-my-plan');
+        const myPlanWidget = document.getElementById('my-plan-widget');
+        const costDashboardWidget = document.getElementById('cost-dashboard-widget');
+
+        if (viewDetailedCostsBtn && myPlanWidget && costDashboardWidget) {
+            viewDetailedCostsBtn.addEventListener('click', () => {
+                myPlanWidget.style.display = 'none';
+                costDashboardWidget.style.display = 'block';
+            });
+        }
+
+        if (backToMyPlanBtn && myPlanWidget && costDashboardWidget) {
+            backToMyPlanBtn.addEventListener('click', () => {
+                myPlanWidget.style.display = 'block';
+                costDashboardWidget.style.display = 'none';
+            });
+        }
+    });
+</script>


### PR DESCRIPTION
This commit addresses issues in the Cost Transparency Dashboard feature to ensure optimal functionality aligned with expectations.

- Modified `cost-dashboard.html` button interactions and labels: Changed 'Back to My Plan' to 'View Detailed Costs'.
- Set up toggling of view configurations without refreshing the browser window for `my-plan-widget` and `cost-dashboard-widget`. 
- Repaired E2E verification assertions `cost-dashboard.spec.ts` which correctly test for the visibility changes corresponding with the new widget visibility logic rather than navigating endpoints.

---
*PR created automatically by Jules for task [13610347610546840136](https://jules.google.com/task/13610347610546840136) started by @ql-owo-lp*