### PR TITLE
🗺️ Guide: Fix onboarding keyboard friction testing and Enter key progression

### DIFF
--- a/src/e2e/onboarding_keyboard_friction.spec.ts
+++ b/src/e2e/onboarding_keyboard_friction.spec.ts
@@ -33,7 +33,7 @@ test.describe('Onboarding Keyboard Friction Mitigation', () => {
     await expect(page.locator('#step-context')).toHaveClass(/active/);
 
     // Step Context
-    await page.locator('input[value="Local Service"]').check({ force: true });
+    await page.locator('label[data-testid="context-local"]').click();
     await page.keyboard.press('Enter');
     await expect(page.locator('#step-categories')).toHaveClass(/active/);
 
@@ -50,6 +50,7 @@ test.describe('Onboarding Keyboard Friction Mitigation', () => {
 
     // Step Assistant
     await page.locator('#assistant-name').fill('Jarvis');
+    await page.locator('#assistant-tone').selectOption('Professional');
     await page.locator('#assistant-name').press('Enter');
     await expect(page.locator('#step-admin')).toHaveClass(/active/);
 

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2278,6 +2278,12 @@ document.addEventListener('DOMContentLoaded', () => {
                       return;
                   }
                   e.preventDefault();
+
+                  // Check validation before proceeding
+                  if (!validateStep(activeStep.id)) {
+                      return;
+                  }
+
                   const nextBtn = activeStep.querySelector('.next-step-btn');
                   if (nextBtn) {
                       nextBtn.click();


### PR DESCRIPTION
This PR addresses the issue where the "Enter" key allowed users to bypass form validation checks during the onboarding flow. 

It fixes `setup.html`'s `keydown` listener to correctly check `validateStep(activeStep.id)` before advancing to the next step. If validation fails, the progression is halted and the error is displayed. 

Additionally, it updates the `onboarding_keyboard_friction.spec.ts` E2E test to properly reflect these changes by correctly simulating the required inputs (like `#assistant-tone`) and using more reliable locators (`label[data-testid="context-local"]`).

All unit and E2E tests have been verified to pass via Bazel.

---
*PR created automatically by Jules for task [123082684431443321](https://jules.google.com/task/123082684431443321) started by @ql-owo-lp*