### PR TITLE
Fix: Push POS offline CRDT mutations through SyncManager

### DIFF
--- a/src/ui/next/src/app/api/v1/sync/mcp-deltas/route.ts
+++ b/src/ui/next/src/app/api/v1/sync/mcp-deltas/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { backendHeaders } from "../../../ui/backendProxy";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const backendUrl = process.env.BACKEND_URL || 'http://127.0.0.1:18789';
+
+    const headers = backendHeaders(request, true);
+    if (!headers.has("x-spiffe-id") && request.headers.has("x-spiffe-id")) {
+       headers.set("x-spiffe-id", request.headers.get("x-spiffe-id") as string);
+    }
+
+    const res = await fetch(`${backendUrl}/api/v1/sync/mcp-deltas`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body)
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      return NextResponse.json(data, { status: 200 });
+    } else {
+      const errorText = await res.text();
+      return NextResponse.json({ success: false, error: errorText }, { status: res.status });
+    }
+  } catch (err: any) {
+    console.error("Failed to forward MCP deltas:", err);
+    return NextResponse.json({ success: false, error: err.message }, { status: 500 });
+  }
+}

--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -161,7 +161,20 @@ export default function StripeTerminalClient({ amount, productId, tenantId, onOp
              timestamp: new Date().toISOString()
           };
 
+          const crdtTx = {
+            id: `crdt_${transactionId}`,
+            type: 'CRDT_MUTATION',
+            timestamp: new Date().toISOString(),
+            payload: {
+               entity_id: productId,
+               data: {
+                  pn_counter_n_increment: 1
+               }
+            }
+          };
+
           await SyncManager.getInstance().enqueue(tx);
+          await SyncManager.getInstance().enqueue(crdtTx);
 
           setStatus('Synced locally. Will push to cloud when network is restored.');
           setTimeout(() => setStatus('Terminal ready.'), 3000);


### PR DESCRIPTION
Resolves #29100

This PR ensures that offline tap-to-pay transactions securely push their mutations via CRDTs. It modifies the `StripeTerminalClient` to properly emit `CRDT_MUTATION` events into the `SyncManager` offline queue. It also connects the frontend offline queue properly to the Rust backend by proxying the `mcp-deltas` endpoint through the Next.js API layer.

The changes guarantee that `CRDTOfflineSynchronizer` correctly logs deterministic inventory deltas on reconnect without forcing the user to handle conflicts manually (a job handled by the Operations agent instead).

---
*PR created automatically by Jules for task [14554396749045439953](https://jules.google.com/task/14554396749045439953) started by @ql-owo-lp*