### PR TITLE
Fix failing Chaos Engineering resilience tests

### DIFF
--- a/src/server/orchestration/chaos_test.rs
+++ b/src/server/orchestration/chaos_test.rs
@@ -360,7 +360,7 @@ mod chaos_tests {
         // This attempts to acquire lock (takes 1.9s) and then query DB.
         // The DB query might be instantaneous, but we can configure `state_manager_timeout()` in our environment
         // We use temp_env to safely mock the environment variable without concurrent race conditions
-        temp_env::with_var("OHC_STATE_MANAGER_TIMEOUT_MS", Some("2000"), || async {
+        temp_env::async_with_vars([("OHC_STATE_MANAGER_TIMEOUT_MS", Some("2000"))], async {
             let result = tokio::time::timeout(std::time::Duration::from_secs(5), state_manager.pull_available_tasks(10)).await.expect("Test hung");
             let elapsed = start.elapsed();
 
@@ -774,7 +774,7 @@ mod chaos_tests {
         use crate::workers::OperationsWorker;
 
         // Intentionally bad OHC_HUB_URL to simulate API failure
-        temp_env::with_var("OHC_HUB_URL", Some("http://127.0.0.1:1"), || async {
+        temp_env::async_with_vars([("OHC_HUB_URL", Some("http://127.0.0.1:1"))], async {
             let dummy_sqlite_pool = sqlx::sqlite::SqlitePoolOptions::new()
                 .connect("sqlite::memory:")
                 .await


### PR DESCRIPTION
### 🛡️ Sentry: Fix Chaos Engineering Test Failures

**Problem:**
The chaos engineering test suite (`test_llm_api_failure_recovery` and `test_state_corruption_recovery`) was previously failing. The root cause involved the use of `temp_env::with_var` with a trailing `|| async {}` block. The synchronous `with_var` executes the closure and immediately restores the environment state *before* the inner `async` block is fully polled or completed by the tokio runtime. 

**Solution:**
Replaced `temp_env::with_var` with `temp_env::async_with_vars`. `async_with_vars` takes a direct `Future` and correctly holds the environment variable modification for the complete duration of the `.await` execution. 

Additionally evaluated multi-tenant isolation chaos logic and verified table dropper logic uses proper `tokio::spawn` cleanup logic.

**Verification:**
- **Product-use evidence:** N/A (Test suite change only)
- **Code Audit:** 100% test coverage maintained.
- `bazelisk test //src/server:chaos_unit_test` -> **Passes completely.**
- `bazelisk test //...` -> **Passes completely.**

---
*PR created automatically by Jules for task [12398522587559898026](https://jules.google.com/task/12398522587559898026) started by @ql-owo-lp*