### PR TITLE
Fix `WorkerPool` queue timeout handling to match ML-Resilience 60s rule

### DIFF
--- a/src/server/queue.rs
+++ b/src/server/queue.rs
@@ -525,8 +525,14 @@ impl WorkerPool {
                             match res {
                                 Ok(payload) => {
                                     tracing::debug!("Worker {} processing job", i);
-                                    if let Err(e) = handler.handle(payload).await {
-                                        tracing::trace!("Worker {} handler failed: {}", i, e);
+                                    let handle_res = tokio::time::timeout(
+                                        ohc_builtin_agent::agent::agent_task_timeout(),
+                                        handler.handle(payload),
+                                    ).await;
+                                    match handle_res {
+                                        Ok(Ok(())) => {}
+                                        Ok(Err(e)) => tracing::trace!("Worker {} handler failed: {}", i, e),
+                                        Err(_) => tracing::trace!("Worker {} handler timed out", i),
                                     }
                                 }
                                 Err(e) => {


### PR DESCRIPTION
Fix `WorkerPool` queue timeout handling to match ML-Resilience 60s rule

Currently, `WorkerPool::start` inside `src/server/queue.rs` simply calls `handler.handle(payload)` without enforcing any explicit timeout. This violates the platform's ML-Resilience execution constraints, which require a strict 60-second limit on AI agent jobs.

This commit updates `WorkerPool::start` to wrap the `handler.handle` invocation in a `tokio::time::timeout` using the unified `ohc_builtin_agent::agent::agent_task_timeout()`. If the job fails or times out, it is now correctly caught and appropriately traced.

---
*PR created automatically by Jules for task [11156158090991835911](https://jules.google.com/task/11156158090991835911) started by @ql-owo-lp*