### PR TITLE
fix: remove mock data from instant quote UI

### DIFF
--- a/src/ui/tauri/src/ui/instant-quote.html
+++ b/src/ui/tauri/src/ui/instant-quote.html
@@ -360,12 +360,8 @@
 
                 // Fallback rules if empty
                 if (!rules || rules.length === 0) {
-                    basePrice = 5000; // $50 base
-                    rules = [
-                        { id: 'rush', name: 'Rush Delivery (Next Day)', adjustment_percent: 20, description: 'Get it faster' },
-                        { id: 'vegan', name: 'Vegan Ingredients', adjustment_cents: 1500, description: 'Special dietary preparation' },
-                        { id: 'weekend', name: 'Weekend Service', adjustment_cents: 2500, description: 'Saturday/Sunday' }
-                    ];
+                    basePrice = 0;
+                    rules = [];
                 }
 
                 pricingRules = rules;
@@ -380,6 +376,12 @@
         function renderOptions() {
             const container = document.getElementById('options-container');
             container.innerHTML = '';
+
+            if (pricingRules.length === 0) {
+                container.innerHTML = '<div class="toggle-item text-center text-muted">No service options available</div>';
+                document.getElementById('submit-btn').disabled = true;
+                return;
+            }
 
             pricingRules.forEach(rule => {
                 const item = document.createElement('label');


### PR DESCRIPTION
This pull request removes the hardcoded mock pricing rules from the `instant-quote.html` UI in the Tauri app. Instead of falling back to mock data when no rules are returned from the backend, it now properly implements a truthful empty state by setting `basePrice` to 0, displaying a "No service options available" message, and disabling the submit button. This aligns with the platform's mandate of "ZERO mock data in the UI".

---
*PR created automatically by Jules for task [6729998986842005737](https://jules.google.com/task/6729998986842005737) started by @ql-owo-lp*