### PR TITLE
feat(growth): Connect Link-in-Bio to backend API

### DIFF
--- a/src/ui/next/src/app/bio/[tenant]/page.tsx
+++ b/src/ui/next/src/app/bio/[tenant]/page.tsx
@@ -20,10 +20,18 @@ export default function LinkInBioPublicPage() {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        // Attempt to load from localStorage to simulate persistence
+        // Fetch from API
         const fetchBioData = async () => {
             try {
-                if (typeof localStorage !== 'undefined') {
+                const res = await fetch(`/api/v1/growth/link-in-bio/${tenantId}`);
+                if (res.ok) {
+                    const data = await res.json();
+                    setStoreName(data.store_name || 'My Store');
+                    setBio(data.bio || 'Welcome to my storefront!');
+                    setLinks(data.links || []);
+                    setTheme(data.theme || 'gradient');
+                } else if (typeof localStorage !== 'undefined') {
+                    // Fallback to localStorage if API fails (e.g. not found)
                     const savedData = localStorage.getItem(`ohc_bio_${tenantId}`);
                     if (savedData) {
                         const parsed = JSON.parse(savedData);
@@ -32,13 +40,23 @@ export default function LinkInBioPublicPage() {
                         setLinks(parsed.links || []);
                         setTheme(parsed.theme || 'gradient');
                     } else {
-                        // Fallback generic data
                         const storedName = localStorage.getItem('business_name');
                         if (storedName) setStoreName(storedName);
                     }
                 }
             } catch (e) {
                 console.error("Error loading bio data:", e);
+                // Fallback to localStorage on network error
+                if (typeof localStorage !== 'undefined') {
+                    const savedData = localStorage.getItem(`ohc_bio_${tenantId}`);
+                    if (savedData) {
+                        const parsed = JSON.parse(savedData);
+                        setStoreName(parsed.storeName || 'My Store');
+                        setBio(parsed.bio || 'Welcome to my storefront!');
+                        setLinks(parsed.links || []);
+                        setTheme(parsed.theme || 'gradient');
+                    }
+                }
             } finally {
                 setLoading(false);
             }

--- a/src/ui/next/src/app/link-in-bio-generator/page.tsx
+++ b/src/ui/next/src/app/link-in-bio-generator/page.tsx
@@ -38,15 +38,61 @@ export default function LinkInBioGeneratorPage() {
     setLinks(links.filter(link => link.id !== id));
   };
 
-  // Save to local storage whenever settings change to simulate backend persistence
+  const [publishing, setPublishing] = useState(false);
+
+  useEffect(() => {
+    if (!tenant || tenant === 'my-store') return;
+
+    const fetchConfig = async () => {
+      try {
+        const res = await fetch(`/api/v1/growth/link-in-bio/${tenant}`);
+        if (res.ok) {
+          const data = await res.json();
+          setStoreName(data.store_name);
+          setBio(data.bio);
+          setTheme(data.theme);
+          setLinks(data.links);
+        }
+      } catch (err) {
+        console.error("Failed to load Link-in-Bio config", err);
+      }
+    };
+    fetchConfig();
+  }, [tenant]);
+
+  const handlePublish = async () => {
+    setPublishing(true);
+    try {
+      const payload = {
+        store_name: storeName,
+        bio,
+        theme,
+        links
+      };
+      const res = await fetch('/api/v1/growth/link-in-bio', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) {
+        throw new Error('Failed to publish changes');
+      }
+      alert('Changes published successfully!');
+    } catch (err) {
+      console.error("Failed to publish", err);
+      alert('Failed to publish changes.');
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  // Keep local storage write for backwards-compat during transition if needed,
+  // but main persistence is now the API via handlePublish.
   useEffect(() => {
     if (typeof localStorage !== 'undefined') {
-        const payload = {
-            storeName,
-            bio,
-            links,
-            theme
-        };
+        const payload = { storeName, bio, links, theme };
         localStorage.setItem(`ohc_bio_${tenant}`, JSON.stringify(payload));
     }
   }, [storeName, bio, links, theme, tenant]);
@@ -154,12 +200,19 @@ export default function LinkInBioGeneratorPage() {
                 <h2 className="text-xl font-semibold font-outfit mb-4" style={{ color: '#1D1D1F' }}>Publish & Share</h2>
                 <div className="flex flex-col gap-3">
                     <button
+                        onClick={handlePublish}
+                        disabled={publishing}
+                        className={`w-full py-3 rounded-lg text-sm font-semibold transition-all bg-indigo-600 text-white hover:bg-indigo-700`}
+                    >
+                        {publishing ? 'Publishing...' : 'Publish Changes'}
+                    </button>
+                    <button
                         onClick={() => {
                             navigator.clipboard.writeText(shareLink);
                             setCopied(true);
                             setTimeout(() => setCopied(false), 2000);
                         }}
-                        className={`w-full py-3 rounded-lg text-sm font-semibold transition-all ${copied ? 'bg-green-100 text-green-700' : 'bg-indigo-600 text-white hover:bg-indigo-700'}`}
+                        className={`w-full py-3 rounded-lg text-sm font-semibold transition-all ${copied ? 'bg-green-100 text-green-700' : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50'}`}
                     >
                         {copied ? 'Copied Link!' : 'Copy Link-in-Bio URL'}
                     </button>

--- a/src/ui/next/src/e2e/link_in_bio.spec.ts
+++ b/src/ui/next/src/e2e/link_in_bio.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Link-in-Bio Generator E2E', () => {
+  test('User can create and publish link in bio, then view it publicly', async ({ page }) => {
+    // 1. Navigate to the link-in-bio generator page
+    await page.goto('/link-in-bio-generator');
+
+    // 2. Wait for the page to be ready (ensure "Publish Changes" button is visible)
+    const publishButton = page.locator('button', { hasText: 'Publish Changes' });
+    await expect(publishButton).toBeVisible();
+
+    // 3. Update the business name and bio
+    const businessNameInput = page.getByRole('textbox', { name: 'Business name' });
+    await businessNameInput.fill('Playwright Test Bakery');
+
+    const bioInput = page.getByRole('textbox', { name: 'Bio tagline' });
+    await bioInput.fill('We bake the best E2E cakes!');
+
+    // 4. Update the first link
+    const linkTitleInput = page.locator('input[placeholder="Title (e.g. Visit my Shop)"]').first();
+    await linkTitleInput.fill('Our Menu');
+
+    const linkUrlInput = page.locator('input[placeholder="URL (e.g. https://...)"]').first();
+    await linkUrlInput.fill('https://example.com/menu');
+
+    // We can't rely on `window.alert` directly without setting up a listener,
+    // so we handle the alert. Playwright automatically dismisses dialogs unless specified,
+    // but let's be explicit.
+    page.on('dialog', dialog => dialog.accept());
+
+    // 5. Publish changes
+    await publishButton.click();
+
+    // Wait a brief moment for the save
+    await page.waitForTimeout(500);
+
+    // 6. Navigate to the public bio page
+    // By default, the generator uses 'my-store' as the default tenant id in localStorage if none is set
+    await page.goto('/bio/my-store');
+
+    // 7. Verify the changes are visible on the public page
+    // Using a more specific selector, as Next.js layout might have other h1s (like "Bio" in the header)
+    await expect(page.locator('h1.font-outfit.text-3xl')).toHaveText('Playwright Test Bakery');
+    await expect(page.locator('p.leading-relaxed')).toHaveText('We bake the best E2E cakes!');
+
+    const publishedLink = page.locator('a:has-text("Our Menu")');
+    await expect(publishedLink).toBeVisible();
+    await expect(publishedLink).toHaveAttribute('href', 'https://example.com/menu');
+  });
+});


### PR DESCRIPTION
Connects the existing Link-in-Bio growth loop feature to the actual backend API endpoints for saving and loading tenant bio configurations (`/api/v1/growth/link-in-bio`). Adds an end-to-end test to verify the functionality of the generator and the public link-in-bio page.

---
*PR created automatically by Jules for task [7110321841709930824](https://jules.google.com/task/7110321841709930824) started by @ql-owo-lp*