### PR TITLE
Fix missing closing brace for startWalkthrough onclick handler

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2752,6 +2752,7 @@ function initWalkthrough() {
                     currentStep++;
                     renderStep();
                 }
+            };
 
 
             if (target) {


### PR DESCRIPTION
- Added missing `};` to close the `document.getElementById('wt-next').onclick = () => {` block in `src/ui/tauri/src/ui/setup.html`.
- Also checked other HTML and JS files in `src/ui/tauri/src/ui/` using a python script to ensure they all correctly close this block.

---
*PR created automatically by Jules for task [9039896415014573379](https://jules.google.com/task/9039896415014573379) started by @ql-owo-lp*