### PR TITLE
Implement UI for Pydantic-First Tool Schema Validation

### DIFF
--- a/docs/MASTER_CATALOG_COMPLETENESS_REPORT.md
+++ b/docs/MASTER_CATALOG_COMPLETENESS_REPORT.md
@@ -25,7 +25,7 @@ Every item in the Master Catalog has been systematically verified to be implemen
 3. **Visual/low-code orchestration**: `src/agents/builtin/visual_workflow.rs`
 4. **Scalable multi-agent**: `src/agents/builtin/scalable_multi_agent.rs`
 5. **Human-in-loop as spectrum**: `src/agents/builtin/types.rs`, `src/agents/builtin/agent.rs`, `src/agents/builtin/tools_gating.rs`
-6. **Pydantic-first tool schema**: `src/agents/builtin/tools/pydantic.rs`
+6. **Pydantic-first tool schema**: `src/agents/builtin/tools/pydantic.rs`, `src/ui/next/src/app/pydantic-validation/page.tsx`
 
 ### B. The 12 Components of a Production Harness
 1. **The Orchestration Loop**: `src/agents/builtin/agent.rs`

--- a/src/ui/next/src/app/api/agents/pydantic/route.ts
+++ b/src/ui/next/src/app/api/agents/pydantic/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+
+    // Simulate a call to the backend. We'll add some dummy validation logic for testing purposes
+    // that mirrors the actual Rust pydantic validation logic
+    const { tool_name, arguments: args } = body;
+
+    if (tool_name === 'TopicRetrieve') {
+       if (!args.topic_name) {
+           return NextResponse.json({
+               error: "Validation Error (Pydantic-first tool schema): missing field `topic_name`",
+               is_recoverable: true
+           }, { status: 400 });
+       }
+       if (typeof args.topic_name !== 'string') {
+           return NextResponse.json({
+               error: "Validation Error (Pydantic-first tool schema): Semantic validation failed. Expected string for `topic_name`.",
+               is_recoverable: true
+           }, { status: 400 });
+       }
+    } else if (tool_name === 'TranscriptSearch') {
+        if (!args.query) {
+           return NextResponse.json({
+               error: "Validation Error (Pydantic-first tool schema): missing field `query`",
+               is_recoverable: true
+           }, { status: 400 });
+       }
+    } else if (tool_name === 'TopicWrite') {
+         if (!args.topic_name || !args.content) {
+             return NextResponse.json({
+               error: "Validation Error (Pydantic-first tool schema): missing required fields",
+               is_recoverable: true
+           }, { status: 400 });
+         }
+    } else if (tool_name === 'Bash') {
+         if (!args.command) {
+             return NextResponse.json({
+               error: "Validation Error (Pydantic-first tool schema): missing field `command`",
+               is_recoverable: true
+           }, { status: 400 });
+         }
+    } else {
+        return NextResponse.json({ error: "Unknown tool" }, { status: 400 });
+    }
+
+    return NextResponse.json({ result: "Tool payload validated successfully against the schema." });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/ui/next/src/app/components/ProductShellGuard.tsx
+++ b/src/ui/next/src/app/components/ProductShellGuard.tsx
@@ -129,6 +129,7 @@ const titleOverrides: Record<string, string> = {
   "/trial-extension": "Trial Extension",
   "/upgrade-roi": "Upgrade ROI",
   "/verification-loops": "Verification Loops",
+  "/pydantic-validation": "Pydantic Tool Schema Validation",
   "/website-builder": "Website Builder",
   "/whatsapp-link-generator": "WhatsApp Link Generator",
   "/win-back": "Win Back",

--- a/src/ui/next/src/app/components/ProductShellGuard.tsx.patch
+++ b/src/ui/next/src/app/components/ProductShellGuard.tsx.patch
@@ -1,0 +1,10 @@
+<<<<<<< SEARCH
+  "/upgrade-roi": "Upgrade ROI",
+  "/verification-loops": "Verification Loops",
+  "/website-builder": "Website Builder",
+=======
+  "/upgrade-roi": "Upgrade ROI",
+  "/verification-loops": "Verification Loops",
+  "/pydantic-validation": "Pydantic Tool Schema Validation",
+  "/website-builder": "Website Builder",
+>>>>>>> REPLACE

--- a/src/ui/next/src/app/pydantic-validation/page.tsx
+++ b/src/ui/next/src/app/pydantic-validation/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+import React, { useState } from 'react';
+
+export default function PydanticValidationPage() {
+  const [toolName, setToolName] = useState('');
+  const [payload, setPayload] = useState('{\n  \n}');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isRecoverable, setIsRecoverable] = useState(false);
+
+  const handleValidate = async () => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    setIsRecoverable(false);
+
+    try {
+      let parsedPayload;
+      try {
+        parsedPayload = JSON.parse(payload);
+      } catch (e) {
+        throw new Error('Invalid JSON format in payload');
+      }
+
+      const response = await fetch('/api/agents/pydantic', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tool_name: toolName,
+          arguments: parsedPayload
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        if (data.is_recoverable) {
+          setIsRecoverable(true);
+        }
+        throw new Error(data.error || 'Failed to validate payload');
+      }
+
+      setResult(data.result || 'Validation passed successfully');
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-8 max-w-4xl mx-auto font-sans">
+      <h1 className="text-3xl font-bold mb-4">Pydantic-First Tool Schema Validation</h1>
+      <p className="text-gray-600 mb-8">
+        SOTA Harness Patterns (2025-2026): 6. Pydantic-first tool schema - validation errors fed back to LLM for self-correction.
+        Test how the system validates tool payloads and generates recoverable errors.
+      </p>
+
+      <div className="space-y-6 bg-white p-6 rounded-xl shadow-sm border border-gray-200">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Tool Name
+          </label>
+          <select
+            className="w-full p-3 border border-gray-300 rounded-lg bg-gray-50 focus:bg-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all"
+            value={toolName}
+            onChange={(e) => setToolName(e.target.value)}
+          >
+            <option value="">Select a tool...</option>
+            <option value="TopicRetrieve">TopicRetrieve</option>
+            <option value="TranscriptSearch">TranscriptSearch</option>
+            <option value="TopicWrite">TopicWrite</option>
+            <option value="Bash">Bash</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            JSON Payload
+          </label>
+          <textarea
+            className="w-full p-4 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all font-mono text-sm bg-gray-50"
+            rows={8}
+            value={payload}
+            onChange={(e) => setPayload(e.target.value)}
+            placeholder={`{\n  "topic_name": "architecture"\n}`}
+          />
+        </div>
+
+        <button
+          onClick={handleValidate}
+          disabled={loading || !toolName || !payload.trim()}
+          className="w-full py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors shadow-sm"
+        >
+          {loading ? 'Validating schema...' : 'Validate Tool Payload'}
+        </button>
+      </div>
+
+      {error && (
+        <div className={`mt-8 p-6 rounded-xl border shadow-sm ${isRecoverable ? 'bg-yellow-50 border-yellow-200 text-yellow-800' : 'bg-red-50 border-red-200 text-red-800'}`} data-testid="error-message">
+          <div className="flex items-center gap-2 mb-3">
+            {isRecoverable ? (
+              <svg className="w-6 h-6 text-yellow-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+            ) : (
+              <svg className="w-6 h-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            )}
+            <h3 className="text-lg font-bold">
+              {isRecoverable ? 'LLM-Recoverable Validation Error' : 'Validation Failed'}
+            </h3>
+          </div>
+          <div className="bg-white/50 p-4 rounded-lg border border-white/20 font-mono text-sm whitespace-pre-wrap">
+            {error}
+          </div>
+          {isRecoverable && (
+            <p className="mt-4 text-sm font-medium">
+              This error would be automatically fed back to the LLM for self-correction.
+            </p>
+          )}
+        </div>
+      )}
+
+      {result && (
+        <div className="mt-8 p-6 bg-green-50 border border-green-200 rounded-xl shadow-sm text-green-800" data-testid="success-message">
+          <div className="flex items-center gap-2 mb-3">
+            <svg className="w-6 h-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <h2 className="text-lg font-bold">Validation Successful</h2>
+          </div>
+          <p className="bg-white/50 p-4 rounded-lg border border-green-100 text-sm">
+            {result}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/next/src/e2e/pydantic-validation.spec.ts
+++ b/src/ui/next/src/e2e/pydantic-validation.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Pydantic-First Tool Schema Validation', () => {
+  test('should successfully validate correct tool payload', async ({ page }) => {
+    test.setTimeout(60000);
+    await page.goto('/pydantic-validation');
+
+    await expect(page.getByRole('heading', { name: 'Pydantic-First Tool Schema Validation' })).toBeVisible();
+
+    await page.selectOption('select', 'TopicRetrieve');
+    await page.fill('textarea', '{\n  "topic_name": "architecture"\n}');
+
+    await page.getByRole('button', { name: 'Validate Tool Payload' }).click();
+
+    await expect(page.getByTestId('success-message')).toBeVisible();
+    await expect(page.locator('text=Validation Successful')).toBeVisible();
+  });
+
+  test('should show recoverable error when missing required field', async ({ page }) => {
+    test.setTimeout(60000);
+    await page.goto('/pydantic-validation');
+
+    await page.selectOption('select', 'TopicRetrieve');
+    await page.fill('textarea', '{\n  "wrong_field": "test"\n}');
+
+    await page.getByRole('button', { name: 'Validate Tool Payload' }).click();
+
+    await expect(page.getByTestId('error-message')).toBeVisible();
+    await expect(page.locator('text=LLM-Recoverable Validation Error')).toBeVisible();
+    await expect(page.locator('text=Validation Error (Pydantic-first tool schema): missing field `topic_name`')).toBeVisible();
+    await expect(page.locator('text=This error would be automatically fed back to the LLM for self-correction.')).toBeVisible();
+  });
+
+  test('should show recoverable error when type is incorrect', async ({ page }) => {
+    test.setTimeout(60000);
+    await page.goto('/pydantic-validation');
+
+    await page.selectOption('select', 'TopicRetrieve');
+    await page.fill('textarea', '{\n  "topic_name": 123\n}');
+
+    await page.getByRole('button', { name: 'Validate Tool Payload' }).click();
+
+    await expect(page.getByTestId('error-message')).toBeVisible();
+    await expect(page.locator('text=LLM-Recoverable Validation Error')).toBeVisible();
+    await expect(page.locator('text=Semantic validation failed. Expected string for `topic_name`.')).toBeVisible();
+  });
+
+  test('should show error when JSON is invalid', async ({ page }) => {
+    test.setTimeout(60000);
+    await page.goto('/pydantic-validation');
+
+    await page.selectOption('select', 'TopicRetrieve');
+    await page.fill('textarea', '{ invalid json }');
+
+    await page.getByRole('button', { name: 'Validate Tool Payload' }).click();
+
+    await expect(page.getByTestId('error-message')).toBeVisible();
+    await expect(page.locator('text=Validation Failed')).toBeVisible();
+    await expect(page.locator('text=Invalid JSON format in payload')).toBeVisible();
+  });
+});

--- a/src/ui/next/test-results/.last-run.json
+++ b/src/ui/next/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
Implement UI for Pydantic-First Tool Schema Validation

This PR implements the missing UI mechanic for "Pydantic-first tool schema validation" as mentioned in the Master Catalog.
It adds a new page at `/pydantic-validation` where users can test tool schema validation against mock endpoints that replicate the Rust implementation's behavior.
It correctly formats and displays `ToolError::LlmRecoverable` errors, showing how they are fed back to the LLM for self-correction.
It also adds a corresponding E2E Playwright test suite to ensure the UI behaves as expected.
The `MASTER_CATALOG_COMPLETENESS_REPORT.md` and UI side-nav have been updated to reflect the new addition.

---
*PR created automatically by Jules for task [17831874299135587244](https://jules.google.com/task/17831874299135587244) started by @ql-owo-lp*