### PR TITLE
fix: Increase db retry timeout for tests to allow exhaustion

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -641,7 +641,7 @@ impl DB {
         #[cfg(not(test))]
         let timeout_duration = std::time::Duration::from_secs(60);
         #[cfg(test)]
-        let timeout_duration = std::time::Duration::from_millis(60);
+        let timeout_duration = std::time::Duration::from_millis(2000);
 
         loop {
             if start_time.elapsed() > timeout_duration {


### PR DESCRIPTION
Fixes a failing test `test_execute_with_retry_chaos_exhaustion` where the test would timeout before exhausting its retries. The test timeout in `src/server/db.rs` was set to `60ms`, which was not enough time for 10 retry attempts with an exponential backoff starting at `1ms` (which takes over `1023ms`). This change increases the test timeout to `2000ms`.

---
*PR created automatically by Jules for task [11392665611172457195](https://jules.google.com/task/11392665611172457195) started by @ql-owo-lp*