### PR TITLE
🛡️ Sentinel: Fix Tenant Leakage and Local DB Truncation

### DIFF
--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -197,7 +197,7 @@ impl ModeEnforcer for StandaloneModeEnforcer {
                 match OpenOptions::new()
                     .read(true)
                     .write(true)
-                    .create(true).truncate(true)
+                    .create(true)
                     .mode(0o600)
                     .open(db_path)
                 {

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -746,6 +746,7 @@ impl DB {
                     );
                     CREATE TABLE IF NOT EXISTS swarm_truth_embeddings (
                         memory_id TEXT PRIMARY KEY,
+                        tenant_id TEXT NOT NULL,
                         context TEXT NOT NULL,
                         embedding BLOB,
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -1387,13 +1388,20 @@ impl DB {
     ) -> Result<(), Box<dyn std::error::Error>> {
         match &self.store {
             DbStore::Sqlite(sqlite_pool) => {
-                sqlx::query("INSERT INTO swarm_truth_embeddings (memory_id, context, embedding) VALUES (?, ?, ?) ON CONFLICT(memory_id) DO UPDATE SET context=EXCLUDED.context, embedding=EXCLUDED.embedding").bind(memory_id).bind(context).bind(embedding).execute(sqlite_pool).await?;
+                sqlx::query("INSERT INTO swarm_truth_embeddings (memory_id, tenant_id, context, embedding) VALUES (?, ?, ?, ?) ON CONFLICT(memory_id) DO UPDATE SET context=EXCLUDED.context, embedding=EXCLUDED.embedding")
+                    .bind(memory_id)
+                    .bind(tenant_id)
+                    .bind(context)
+                    .bind(embedding)
+                    .execute(sqlite_pool)
+                    .await?;
             }
             DbStore::Postgres => {
                 let mut tx = self.pool.begin().await?;
                 ::server_common::auth_utils::set_org_context(&mut *tx, tenant_id).await?;
-                sqlx::query("INSERT INTO swarm_truth_embeddings (memory_id, context, embedding) VALUES ($1, $2, $3) ON CONFLICT(memory_id) DO UPDATE SET context=EXCLUDED.context, embedding=EXCLUDED.embedding")
+                sqlx::query("INSERT INTO swarm_truth_embeddings (memory_id, tenant_id, context, embedding) VALUES ($1, $2, $3, $4) ON CONFLICT(memory_id) DO UPDATE SET context=EXCLUDED.context, embedding=EXCLUDED.embedding")
                 .bind(memory_id)
+                .bind(tenant_id)
                 .bind(context)
                 .bind(embedding)
                 .execute(&mut *tx)

--- a/src/server/migrations/137_swarm_truth_tenant_id.sql
+++ b/src/server/migrations/137_swarm_truth_tenant_id.sql
@@ -1,0 +1,10 @@
+ALTER TABLE swarm_truth_embeddings ADD COLUMN IF NOT EXISTS tenant_id TEXT;
+UPDATE swarm_truth_embeddings SET tenant_id = 'default' WHERE tenant_id IS NULL;
+ALTER TABLE swarm_truth_embeddings ALTER COLUMN tenant_id SET NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_swarm_truth_embeddings_tenant_id ON swarm_truth_embeddings(tenant_id);
+
+DROP POLICY IF EXISTS tenant_isolation_swarm_truth_embeddings ON swarm_truth_embeddings;
+CREATE POLICY tenant_isolation_swarm_truth_embeddings
+    ON swarm_truth_embeddings
+    USING (tenant_id::text = current_setting('app.current_tenant', true))
+    WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));

--- a/src/server/orchestration/hybrid_sync/daemon_test.rs
+++ b/src/server/orchestration/hybrid_sync/daemon_test.rs
@@ -51,6 +51,7 @@ mod tests {
         sqlx::query(
             "CREATE TABLE swarm_truth_embeddings (
                 memory_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
                 context TEXT,
                 embedding TEXT,
                 escalation_required INTEGER DEFAULT 0,
@@ -101,8 +102,9 @@ mod tests {
         })
         .to_string();
 
-        sqlx::query("INSERT INTO swarm_truth_embeddings (memory_id, context, escalation_required, sync_status) VALUES (?, ?, 1, 'PENDING')")
+        sqlx::query("INSERT INTO swarm_truth_embeddings (memory_id, tenant_id, context, escalation_required, sync_status) VALUES (?, ?, ?, 1, 'PENDING')")
             .bind("test_mem_1")
+            .bind("test_tenant")
             .bind(&raw_context)
             .execute(&sqlite_pool)
             .await
@@ -308,6 +310,7 @@ async fn test_hybrid_sync_clears_error_on_success() {
 
     sqlx::query("CREATE TABLE swarm_truth_embeddings (
             memory_id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
             context TEXT,
             embedding TEXT,
             escalation_required INTEGER DEFAULT 0,
@@ -369,8 +372,9 @@ async fn test_hybrid_sync_clears_error_on_success() {
     })
     .to_string();
 
-    sqlx::query("INSERT INTO swarm_truth_embeddings (memory_id, context, escalation_required, sync_status, sync_error) VALUES (?, ?, 1, 'PENDING', 'previous error')")
+    sqlx::query("INSERT INTO swarm_truth_embeddings (memory_id, tenant_id, context, escalation_required, sync_status, sync_error) VALUES (?, ?, ?, 1, 'PENDING', 'previous error')")
         .bind("test_mem_error_clear")
+        .bind("test_tenant")
         .bind(&raw_context)
         .execute(&sqlite_pool)
         .await


### PR DESCRIPTION
This PR hardens the security and robustness of the OHC platform. First, it addresses a tenant leakage vulnerability by adding a `tenant_id` column to `swarm_truth_embeddings`, preventing cross-tenant data access. A PostgreSQL migration was also provided to configure the RLS policy. Secondly, it resolved a severe local data loss issue where the standalone mode SQLite DB was truncated on every application startup.

---
*PR created automatically by Jules for task [2523789024400116146](https://jules.google.com/task/2523789024400116146) started by @ql-owo-lp*