### PR TITLE
fix: Update quote editing routing and tests

### DIFF
--- a/src/e2e/playwright/quote_edit.spec.ts
+++ b/src/e2e/playwright/quote_edit.spec.ts
@@ -1,34 +1,59 @@
 import { test, expect } from '../fixtures';
 
 test.describe('Quote Edit E2E', () => {
-  test('verify editing a quote works naturally', async ({ page }) => {
-    // Start from home/login
-    await page.goto('/login');
-    await page.getByPlaceholder('Email').fill('test@example.com');
-    await page.getByPlaceholder('Password').fill('password123');
-    await page.getByRole('button', { name: 'Sign in' }).click();
+  test('verify editing a quote works naturally', async ({ page, loginAs, adminUser }) => {
+    await loginAs(page, adminUser);
 
-    // Wait for the dashboard to load
-    await page.waitForURL('**/dashboard**');
+    // To follow the Real Owner/Operator E2E Standard, the UI must navigate as a user
+    // Start from Dashboard after login
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // Make sure we have a mock quote created so we can interact with it in the dashboard.
+    // Navigate to create a quote or rely on deterministic fixtures.
+    const createQuoteRes = await page.request.post('/api/quotes', {
+      headers: {
+        'x-tenant-id': 'tenant-1'
+      },
+      data: {
+        tenant_id: 'tenant-1',
+        customer_id: '00000000-0000-0000-0000-000000000000',
+        total_amount: 50000,
+        required_deposit: 10000,
+        line_items: [
+          {
+            description: "Plumbing work",
+            unit_price_cents: 50000,
+            quantity: 1,
+            is_optional: false
+          }
+        ]
+      }
+    });
+
+    expect(createQuoteRes.ok()).toBeTruthy();
+
+    // The mock data setup above should trigger a UI update on dashboard if needed,
+    // but the actual action should start purely via navigation. Let's make sure dashboard is fresh.
+    await page.goto('/dashboard');
     await page.waitForLoadState('networkidle');
 
     // Switch to proposals tab naturally
-    const proposalsTab = page.locator('.triage-tab').filter({ hasText: 'Proposals' }).first();
+    const proposalsTab = page.locator('button', { hasText: /Proposals/ }).first();
+    await expect(proposalsTab).toBeVisible({ timeout: 15000 });
     await proposalsTab.click();
 
-    // Find the edit quote button inside the triage feed
+    // Verify draft quote is visible
     const editQuoteBtn = page.getByTestId('edit-quote-draft').first();
     await expect(editQuoteBtn).toBeVisible({ timeout: 15000 });
 
-    // Click to navigate to the quote page naturally
+    // Click edit quote to navigate
     await editQuoteBtn.click();
-
-    // Wait for the quote page to load
     await page.waitForLoadState('networkidle');
 
     // Open edit sheet
     const editBtn = page.locator('#edit-quote-btn');
-    await expect(editBtn).toBeVisible({ timeout: 5000 });
+    await expect(editBtn).toBeVisible({ timeout: 10000 });
     await editBtn.click();
 
     // Save edits

--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -1078,7 +1078,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
                         Approve & Send
                       </button>
                       <a
-                        href={`/quoting?id=${(approval.proposed_action || approval.context_payload)?.quote_id || approval.id}`}
+                        href={`/quotes/${(approval.proposed_action || approval.context_payload)?.quote_id || approval.id}`}
                         className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
                         aria-label="Edit Draft"
                         data-testid="edit-quote-draft"
@@ -1154,7 +1154,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
                       </button>
                       <div className="flex flex-col sm:flex-row gap-3 w-full">
                         <a
-                          href={`/quoting?id=${(approval.proposed_action || approval.context_payload)?.quote_id || approval.id}`}
+                          href={`/quotes/${(approval.proposed_action || approval.context_payload)?.quote_id || approval.id}`}
                           className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
                           aria-label="Edit Draft"
                           data-testid="edit-proposal"

--- a/src/ui/next/src/app/quotes/[id]/page.tsx
+++ b/src/ui/next/src/app/quotes/[id]/page.tsx
@@ -115,7 +115,7 @@ export default function QuoteReviewPage() {
             <div className="flex justify-between items-center">
               <h3 className="text-[11px] font-bold uppercase tracking-wider text-gray-400">Line Items</h3>
               {quote.status === 'DRAFT' && !isEditing && (
-                <button onClick={() => setIsEditing(true)} className="text-[10px] text-[#0066FF] font-bold">EDIT</button>
+                <button onClick={() => setIsEditing(true)} id="edit-quote-btn" className="text-[10px] text-[#0066FF] font-bold">EDIT</button>
               )}
             </div>
             {quote.line_items?.map((item) => (
@@ -164,6 +164,7 @@ export default function QuoteReviewPage() {
         {quote.status === 'DRAFT' && (
           isEditing ? (
             <button
+              id="btn-save-edits"
               onClick={saveQuoteChanges}
               disabled={approving}
               className="w-full min-h-[44px] bg-[#0066FF] text-white font-bold rounded-[16px] shadow-lg hover:bg-[#0052CC] transition-all disabled:opacity-50"


### PR DESCRIPTION
This PR updates the quote routing in `UnifiedAgentFeed.tsx` from the legacy `/quoting?id=` to `/quotes/[id]`, adds test IDs to the edit and save buttons on the quote page (`edit-quote-btn` and `btn-save-edits`), and implements a deterministic real data E2E test `quote_edit.spec.ts` bypassing `isVisible` and manually testing the correct critical user journey as outlined.

**Resolves #29253**

---
*PR created automatically by Jules for task [891786272391059999](https://jules.google.com/task/891786272391059999) started by @ql-owo-lp*