### PR TITLE
🔗 Link: Implement Triage Action Feed UI to Centralize OHC Owner Daily Work

### DIFF
--- a/src/e2e/omni_inbox_triage.spec.ts
+++ b/src/e2e/omni_inbox_triage.spec.ts
@@ -20,7 +20,7 @@ test.describe('OHC Multi-Channel Messaging Hub (Work Triage Agent)', () => {
         expect(response.ok()).toBeTruthy();
 
         // Step 3: Navigate to Work Triage UI
-        await page.goto('/ui/triage.html');
+        await page.goto('/triage');
 
         // Wait for feed to load
         await page.waitForSelector('.app-list-item');

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -3431,6 +3431,17 @@ pub async fn update_ui_triage_action_handler(
                                 Some(action.to_string())
                             });
                         }
+                    } else {
+                        // Try omni_inbox_messages
+                        if let Ok(Some(row)) = sqlx::query("SELECT draft_reply FROM omni_inbox_messages WHERE id = $1 AND tenant_id = $2")
+                            .bind(&payload.triage_item_id)
+                            .bind(&tenant_id)
+                            .fetch_optional(&mut *tx)
+                            .await
+                        {
+                            action_type_opt = Some("Draft Reply".to_string());
+                            action_payload_opt = Some(row.try_get::<String, _>("draft_reply").unwrap_or_default());
+                        }
                     }
                 }
 
@@ -3577,6 +3588,13 @@ pub async fn update_ui_triage_action_handler(
                 .execute(&mut *tx)
                 .await;
 
+            let _ = sqlx::query("UPDATE omni_inbox_messages SET status = $1 WHERE id = $2 AND tenant_id = $3")
+                .bind(status)
+                .bind(&payload.triage_item_id)
+                .bind(&tenant_id)
+                .execute(&mut *tx)
+                .await;
+
             match sqlx::query("UPDATE triage_items SET status = $1 WHERE id = $2 AND tenant_id = $3").bind(status).bind(&payload.triage_item_id).bind(&tenant_id).execute(&mut *tx).await {
                 Ok(_) => {
                     let _ = tx.commit().await;
@@ -3635,6 +3653,17 @@ pub async fn update_ui_triage_action_handler(
                                 Some(action.to_string())
                             });
                         }
+                    } else {
+                        // Try omni_inbox_messages
+                        if let Ok(Some(row)) = sqlx::query("SELECT draft_reply FROM omni_inbox_messages WHERE id = ? AND tenant_id = ?")
+                            .bind(&payload.triage_item_id)
+                            .bind(&tenant_id)
+                            .fetch_optional(&mut *tx)
+                            .await
+                        {
+                            action_type_opt = Some("Draft Reply".to_string());
+                            action_payload_opt = Some(row.try_get::<String, _>("draft_reply").unwrap_or_default());
+                        }
                     }
                 }
 
@@ -3659,6 +3688,13 @@ pub async fn update_ui_triage_action_handler(
             let lifecycle_state = if payload.approved { "APPROVED_EXECUTION_QUEUED" } else { "DISMISSED" };
             let _ = sqlx::query("UPDATE agent_feed_items SET lifecycle_state = ? WHERE id = ? AND tenant_id = ?")
                 .bind(lifecycle_state)
+                .bind(&payload.triage_item_id)
+                .bind(&tenant_id)
+                .execute(&mut *tx)
+                .await;
+
+            let _ = sqlx::query("UPDATE omni_inbox_messages SET status = ? WHERE id = ? AND tenant_id = ?")
+                .bind(status)
                 .bind(&payload.triage_item_id)
                 .bind(&tenant_id)
                 .execute(&mut *tx)

--- a/src/ui/next/src/app/triage/page.tsx
+++ b/src/ui/next/src/app/triage/page.tsx
@@ -127,7 +127,7 @@ export default function TriagePage() {
       ]}
     >
       {actionStatus && (
-        <div className="mb-4 app-badge good" role="status">
+        <div id="action-status" className="mb-4 app-badge good" role="status">
           {actionStatus}
         </div>
       )}
@@ -238,11 +238,11 @@ export default function TriagePage() {
 
                 {/* Draft Proposal */}
                 {selected.action_type && (
-                  <div className="p-4 bg-[#0066FF]/5 dark:bg-[#0066FF]/10 flex flex-col gap-2">
+                  <div className="detail-group p-4 bg-[#0066FF]/5 dark:bg-[#0066FF]/10 flex flex-col gap-2">
                     <div className="text-xs uppercase tracking-wider font-semibold text-[#0066FF] dark:text-[#3388FF]">
                       Proposed Action: {selected.action_type}
                     </div>
-                    <div className="rounded-[12px] border border-[#0066FF]/20 dark:border-[#0066FF]/30 bg-white/80 dark:bg-black/40 p-4 text-sm leading-6 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium whitespace-pre-wrap break-words">
+                    <div className="proposed-action rounded-[12px] border border-[#0066FF]/20 dark:border-[#0066FF]/30 bg-white/80 dark:bg-black/40 p-4 text-sm leading-6 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium whitespace-pre-wrap break-words">
                       {selected.action_payload || "No specific payload"}
                     </div>
                   </div>


### PR DESCRIPTION
Superpowers skills applied: Full UI testing verification and backend routing compliance.
Resolves #29285

Product-use evidence:
Persona: Maya (Home Baker) / Carlos (Field Service).
The CUJ requires opening the OHC app, viewing incoming inquiries in the triage Action Feed, and seamlessly approving AI draft replies. The previous implementation missed fetching from `omni_inbox_messages` and failed to handle approval actions specifically for this table. Now, the system fetches these messages into the feed and correctly resolves them when the user approves or dismisses the action. Tests were updated to reflect accurate URL structures (`/triage`).

---
*PR created automatically by Jules for task [8972169321230121971](https://jules.google.com/task/8972169321230121971) started by @ql-owo-lp*