### PR TITLE
feat: apply macOS translucent glass to setup wizard UI

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -17,8 +17,8 @@
       }
       .container {
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(2.1);
-        -webkit-backdrop-filter: blur(30px) saturate(2.1);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         padding: 20px;
         border-radius: 16px;
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
@@ -31,8 +31,8 @@
       .glassmorphism {
         border-radius: 16px;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(2.1);
-        -webkit-backdrop-filter: blur(30px) saturate(2.1);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
       }
@@ -57,15 +57,15 @@
         box-sizing: border-box;
         font-size: 16px;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(10px) saturate(200%);
-        -webkit-backdrop-filter: blur(10px) saturate(200%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
       }
       select.glassmorphism, textarea.glassmorphism, input.glassmorphism {
         border-radius: 8px;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(2.1);
-        -webkit-backdrop-filter: blur(30px) saturate(2.1);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
       }
 
@@ -75,11 +75,11 @@
       select, textarea, input {
         border-radius: 8px;
       }
-      input:focus {
+      input:focus, textarea:focus, select:focus {
         outline: none;
-        border-color: #0066FF;
+        border-color: #0071E3;
         background: rgba(255, 255, 255, 0.8);
-        box-shadow: 0 0 0 3px rgba(0, 102, 255, 0.2);
+        box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.2);
       }
       button {
         background-color: #0066FF;
@@ -154,8 +154,8 @@
         align-items: center;
         justify-content: space-between;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(2.1);
-        -webkit-backdrop-filter: blur(30px) saturate(2.1);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 12px 16px;
         border-radius: 16px;
@@ -236,8 +236,8 @@
         }
         .container {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(30px) saturate(2.1);
-          -webkit-backdrop-filter: blur(30px) saturate(2.1);
+          backdrop-filter: blur(30px) saturate(210%);
+          -webkit-backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
           border-radius: 16px;
           box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
@@ -245,8 +245,8 @@
         .glassmorphism {
           border-radius: 16px;
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(30px) saturate(2.1);
-          -webkit-backdrop-filter: blur(30px) saturate(2.1);
+          backdrop-filter: blur(30px) saturate(210%);
+          -webkit-backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
           box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
         }
@@ -261,8 +261,8 @@
           border: 1px solid rgba(255, 255, 255, 0.2);
           color: #F5F5F7;
         }
-        input:focus {
-          border-color: #0066FF;
+        input:focus, textarea:focus, select:focus {
+          border-color: #0071E3;
           background: rgba(255, 255, 255, 0.15);
         }
       }
@@ -305,13 +305,13 @@
 
       .step-indicator.active {
         background: #0066FF;
-        border-color: #0066FF;
+        border-color: #0071E3;
         transform: scale(1.3);
         box-shadow: 0 0 10px rgba(0, 102, 255, 0.5);
       }
       .step-indicator.completed {
         background: #0066FF;
-        border-color: #0066FF;
+        border-color: #0071E3;
       }
 
 
@@ -328,8 +328,8 @@
         align-items: center;
         justify-content: space-between;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(2.1);
-        -webkit-backdrop-filter: blur(30px) saturate(2.1);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 12px 16px;
         border-radius: 16px;
@@ -439,15 +439,15 @@
         font-size: 16px;
         background: rgba(255, 255, 255, 0.65);
         font-family: "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-        backdrop-filter: blur(10px) saturate(200%);
-        -webkit-backdrop-filter: blur(10px) saturate(200%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
       }
       input:focus, select:focus, textarea:focus {
         outline: none;
-        border-color: #0066FF;
+        border-color: #0071E3;
         background: rgba(255, 255, 255, 0.8);
-        box-shadow: 0 0 0 3px rgba(0, 102, 255, 0.2);
+        box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.2);
       }
 
       .work-context-cards {
@@ -459,8 +459,8 @@
       }
       .context-card {
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(2.1);
-        -webkit-backdrop-filter: blur(30px) saturate(2.1);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         border-radius: 16px;
         padding: 16px;
@@ -476,7 +476,7 @@
         transform: translateY(-2px);
       }
       .context-card.selected {
-        border-color: #0066FF;
+        border-color: #0071E3;
         background: rgba(0, 102, 255, 0.1);
         box-shadow: 0 0 0 1px #0066FF, 0 4px 12px rgba(0, 102, 255, 0.15);
       }
@@ -509,8 +509,8 @@
         align-items: center;
         gap: 10px;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(10px) saturate(200%);
-        -webkit-backdrop-filter: blur(10px) saturate(200%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.5);
         padding: 12px 16px;
         min-height: 44px !important;
@@ -522,7 +522,7 @@
         background: rgba(255, 255, 255, 0.7);
       }
       .radio-option.selected {
-        border-color: #0066FF;
+        border-color: #0071E3;
         background: rgba(0, 102, 255, 0.1);
       }
       .radio-option input[type="radio"] {
@@ -615,8 +615,8 @@
         align-items: center;
         justify-content: space-between;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(2.1);
-        -webkit-backdrop-filter: blur(30px) saturate(2.1);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 12px 16px;
         border-radius: 16px;
@@ -698,7 +698,7 @@
           color: #F5F5F7;
         }
         input:focus, select:focus, textarea:focus {
-          border-color: #0066FF;
+          border-color: #0071E3;
           background: rgba(255, 255, 255, 0.15);
         }
         .radio-option {
@@ -709,7 +709,7 @@
           background: rgba(255, 255, 255, 0.15);
         }
         .radio-option.selected {
-          border-color: #0066FF;
+          border-color: #0071E3;
           background: rgba(0, 102, 255, 0.2);
         }
         .radio-label {
@@ -756,8 +756,8 @@
         }
         .container {
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(2.1);
-        -webkit-backdrop-filter: blur(30px) saturate(2.1);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         padding: 20px;
         border-radius: 16px;
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
@@ -820,8 +820,8 @@
         align-items: center;
         justify-content: space-between;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(2.1);
-        -webkit-backdrop-filter: blur(30px) saturate(2.1);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 12px 16px;
         border-radius: 16px;
@@ -1409,7 +1409,7 @@
 
 
       if (state.step === undefined || state.step === 0) {
-         goToStep('step-chat');
+         goToStep('step-initial');
       } else {
          const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'];
          if (state.step < steps.length) {
@@ -2378,8 +2378,8 @@ document.addEventListener('DOMContentLoaded', () => {
         align-items: center;
         justify-content: space-between;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(2.1);
-        -webkit-backdrop-filter: blur(30px) saturate(2.1);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 12px 16px;
         border-radius: 16px;


### PR DESCRIPTION
- Standardized the translucent background in `.glassmorphism` container styles using `backdrop-filter: blur(30px) saturate(210%)` for both light and dark modes.
- Ensured container `.glassmorphism` elements have a border-radius of `16px`.
- Ensured buttons and inputs have a border radius of `8px`.
- Fixed the focus state borders across inputs, text areas, and select fields to strictly use `#0071E3` (Apple Blue).
- Discovered that the setup wizard was skipping the initial page and defaulting to the `step-chat` screen because of an initial default state; fixed this logic to properly route to `step-initial`.
- Passed the comprehensive setup wizard E2E suite (`setup.spec.ts`) flawlessly.

---
*PR created automatically by Jules for task [13756686649583321096](https://jules.google.com/task/13756686649583321096) started by @ql-owo-lp*