### PR TITLE
🗺️ Guide: Fix initial step redirect in setup wizard

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1409,7 +1409,7 @@
 
 
       if (state.step === undefined || state.step === 0) {
-         goToStep('step-chat');
+         goToStep('step-initial');
       } else {
          const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'];
          if (state.step < steps.length) {


### PR DESCRIPTION
Fixes a bug where new users entering the setup wizard were immediately redirected to the `step-chat` step rather than starting at the beginning (`step-initial`).

This change ensures a correct user flow from the first screen of the wizard and resolves the failing `ui_setup.spec.ts` end-to-end test.

## Product-use evidence
- **Persona**: Real non-technical owner/operator starting a new business context.
- **Browser/Playwright UI flow attempted**: Opening `setup.html` as a new user with no existing session/saved draft state, and attempting to click "Start My Business".
- **CUJ gap observed**: The onboarding wizard immediately jumped to `step-chat`, skipping `step-initial` ("Start My Business") and subsequent UI setup form steps.
- **Reason for fix**: Real owners/operators need the guided wizard flow initially. They were losing the contextual step by step UI since it was improperly redirecting to the chat interface.
- **Post-fix UI flow**: The UI successfully initializes at `step-initial`. Clicking "Start My Business" transitions properly to the category setup step and the E2E tests for form setup pass successfully.

---
*PR created automatically by Jules for task [9924550699272461412](https://jules.google.com/task/9924550699272461412) started by @ql-owo-lp*