### PR TITLE
chore: fix missing rls on tables

### DIFF
--- a/src/server/db/migrations/039_a_consolidated_memory.sql
+++ b/src/server/db/migrations/039_a_consolidated_memory.sql
@@ -19,3 +19,6 @@ CREATE TABLE IF NOT EXISTS consolidated_memory (
 
 CREATE INDEX IF NOT EXISTS consolidated_memory_tenant_id_idx ON consolidated_memory(tenant_id);
 CREATE INDEX IF NOT EXISTS consolidated_memory_embedding_idx ON consolidated_memory USING hnsw (embedding vector_cosine_ops);
+
+
+ALTER TABLE consolidated_memory ENABLE ROW LEVEL SECURITY;

--- a/src/server/db/migrations/130_documentation_schema.sql
+++ b/src/server/db/migrations/130_documentation_schema.sql
@@ -51,3 +51,12 @@ CREATE TABLE IF NOT EXISTS walkthrough_steps (
 
 CREATE INDEX IF NOT EXISTS idx_walkthrough_steps_tenant_id ON walkthrough_steps(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_walkthrough_steps_page ON walkthrough_steps(page);
+
+
+ALTER TABLE help_articles ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE video_tutorials ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE tooltips ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE walkthrough_steps ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Identified and fixed `consolidated_memory` and `130_documentation_schema.sql` tables that were missing the row-level-security enablement statement. Addressed code review feedback and kept tests hermetic and passing.

---
*PR created automatically by Jules for task [8498838140821006702](https://jules.google.com/task/8498838140821006702) started by @ql-owo-lp*