### PR TITLE
Fix setup wizard initial step routing

### DIFF
--- a/src/ui/next/next-env.d.ts
+++ b/src/ui/next/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1413,7 +1413,7 @@
 
 
       if (state.step === undefined || state.step === 0) {
-         goToStep('step-chat');
+         goToStep('step-initial');
       } else {
          const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'];
          if (state.step < steps.length) {


### PR DESCRIPTION
Fixes a bug where the setup wizard would direct users to the `step-chat` screen initially instead of the `step-initial` screen when their state is undefined or 0.

---
*PR created automatically by Jules for task [4891179328157398665](https://jules.google.com/task/4891179328157398665) started by @ql-owo-lp*