### PR TITLE
feat: Add viral share-to-unlock loop to Work Intake Widget soft paywall

### DIFF
--- a/src/e2e/work_intake_viral_loop.spec.ts
+++ b/src/e2e/work_intake_viral_loop.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from './fixtures';
+
+test.describe('Work-Intake Widget Viral Loop', () => {
+  test('should display the soft paywall modal and handle share bypass', async ({ page, request, loginAs, adminUser }) => {
+    await loginAs(page, adminUser);
+    await page.goto('/work-intake-widget');
+
+    // 1. Verify the page header
+    await expect(page.getByRole('heading', { name: 'Work-Intake Widget 📋' })).toBeVisible();
+
+    // 2. Click the remove branding checkbox (Note: it is a fake checkbox that opens a modal, so use .click())
+    const removeBrandingCheckbox = page.getByLabel('Remove "Powered by OHC" branding');
+    await removeBrandingCheckbox.click();
+
+    // 3. Verify the soft paywall modal appears
+    const modalHeading = page.getByRole('heading', { name: 'Upgrade to Pro' });
+    await expect(modalHeading).toBeVisible();
+    await expect(page.getByText('Make the Work Intake Widget 100% yours. Upgrade to Pro to remove the "Powered by OHC" watermark.')).toBeVisible();
+
+    // 4. Mock window.open to prevent opening a new tab
+    await page.evaluate(() => {
+        window.open = function() { return window; };
+    });
+
+    // 5. Click the share button to trigger the bypass API call
+    const shareButton = page.getByRole('button', { name: /Share on X to Unlock/i });
+    await expect(shareButton).toBeVisible();
+    await shareButton.click();
+
+    // 6. Verify the loading state
+    await expect(page.getByText(/Verifying Share.../i)).toBeVisible();
+
+    // 7. Verify the success state and modal disappearance
+    await expect(modalHeading).not.toBeVisible({ timeout: 5000 });
+
+    // 8. Verify the branding is actually removed in the code snippet
+    const getCodeBtn = page.getByRole('button', { name: 'Get Widget Code' });
+    await getCodeBtn.click();
+    const textarea = page.locator('textarea');
+    const codeValue = await textarea.inputValue();
+    expect(codeValue).not.toContain('Powered by OHC');
+  });
+});

--- a/src/ui/next/src/app/work-intake-widget/page.test.tsx
+++ b/src/ui/next/src/app/work-intake-widget/page.test.tsx
@@ -44,7 +44,7 @@ describe('WorkIntakeWidgetPage', () => {
     expect(textarea.value).toContain('Powered by OHC');
   });
 
-  it('shows soft paywall when checkbox is checked', () => {
+  it('shows soft paywall when checkbox is checked and includes viral loop option', () => {
     render(<WorkIntakeWidgetPage />);
 
     // Click checkbox
@@ -53,6 +53,9 @@ describe('WorkIntakeWidgetPage', () => {
 
     // Check if soft paywall shows up
     expect(screen.getAllByText('Upgrade to Pro')).toBeDefined();
+
+    // Check if viral loop option is present
+    expect(screen.getByText('Share on X to Unlock')).toBeDefined();
 
     // Checkbox should be un-checked
     expect((checkbox as HTMLInputElement).checked).toBe(false);

--- a/src/ui/next/src/app/work-intake-widget/page.tsx
+++ b/src/ui/next/src/app/work-intake-widget/page.tsx
@@ -12,6 +12,7 @@ export default function WorkIntakeWidgetPage() {
   const [showModal, setShowModal] = useState(false);
   const [removeBranding, setRemoveBranding] = useState(false);
   const [showSoftPaywall, setShowSoftPaywall] = useState(false);
+  const [isUnlocking, setIsUnlocking] = useState(false);
 
   useEffect(() => {
     if (typeof localStorage !== 'undefined') {
@@ -23,6 +24,37 @@ export default function WorkIntakeWidgetPage() {
 
   const embedUrl = `https://ohc.app/api/v1/growth/work-intake/embed?tenant=${tenant}&theme=${theme}&title=${encodeURIComponent(title)}`;
   const embedCode = `<iframe src="${embedUrl}" width="320" height="400" frameborder="0" scrolling="no" style="border:none; overflow:hidden; border-radius:16px;"></iframe>` + (removeBranding ? '' : `\n<div style="font-family: sans-serif; text-align: center; font-size: 12px; margin-top: 8px;"><a href="/api/v1/growth/referrals/click?target=/onboarding&ref=${tenant}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a></div>`);
+
+  const handleShareToUnlock = async () => {
+    setIsUnlocking(true);
+    try {
+      let referralLink = `${window.location.origin}/onboarding?ref=${tenant}`;
+      try {
+        const res = await fetch("/api/v1/growth/referrals/generate", { method: "POST" });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.referral_link) {
+            referralLink = data.referral_link;
+          }
+        }
+      } catch (err) {
+        console.warn("Failed to generate referral link, using fallback", err);
+      }
+
+      const text = `I just built a custom Work Intake widget for my business on OneHumanCorp! 🚀\n\nStart your own business and get $50 off: ${referralLink}`;
+      window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`, "_blank");
+
+      // Simulate a verification delay
+      setTimeout(() => {
+        setRemoveBranding(true);
+        setShowSoftPaywall(false);
+        setIsUnlocking(false);
+      }, 1500);
+    } catch (e) {
+      console.error(e);
+      setIsUnlocking(false);
+    }
+  };
 
   const handleCopy = () => {
     navigator.clipboard.writeText(embedCode);
@@ -208,6 +240,15 @@ export default function WorkIntakeWidgetPage() {
               className="w-full py-4 rounded-[16px] min-h-[44px] min-w-[44px] font-bold text-white mb-4 transition-all shadow-md hover:shadow-lg hover:opacity-90 bg-indigo-600 hover:bg-indigo-700"
             >
               Upgrade to Pro
+            </button>
+            <p className="text-sm font-medium text-gray-500 mb-3">or</p>
+            <button
+              onClick={handleShareToUnlock}
+              disabled={isUnlocking}
+              className="w-full py-4 rounded-[16px] min-h-[44px] min-w-[44px] font-bold text-gray-700 bg-gray-100 hover:bg-gray-200 transition-all flex items-center justify-center gap-2"
+            >
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.008 5.94H5.078z"/></svg>
+              {isUnlocking ? 'Verifying Share...' : 'Share on X to Unlock'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
**Problem:**
The product needs more viral growth loops to acquire users. The current paywall for removing the "Powered by OHC" branding from the Work Intake Widget only offers a paid upgrade path, missing an opportunity for social virality.

**Solution:**
Implemented the "Agent Upsell Soft Paywall Loop" growth feature. 
- Added a "Share on X to Unlock" button to the soft paywall modal in `WorkIntakeWidgetPage`.
- Added logic (`handleShareToUnlock`) to fetch a unique referral link via the existing API, open a Twitter share intent, and simulate verification before granting the feature.
- Enhanced the Vitest suite to assert the new UI elements.
- Created a Playwright E2E test (`src/e2e/work_intake_viral_loop.spec.ts`) that clicks through the flow, triggers the share bypass, and verifies that the embed code correctly updates without the OHC branding.

**Superpowers used:**
Followed UI validation best practices by thoroughly verifying the interactive elements using automated E2E tests instead of relying solely on code inspection. No mock data was added to the UI code.

---
*PR created automatically by Jules for task [5926655737141005060](https://jules.google.com/task/5926655737141005060) started by @ql-owo-lp*