### PR TITLE
🛡️ Sentry: [reliability fix] Enforce 3-attempt ML-Resilience rule

### DIFF
--- a/docs/superpowers/plans/2026-06-17-ml-resilience-plan.md
+++ b/docs/superpowers/plans/2026-06-17-ml-resilience-plan.md
@@ -1,0 +1,14 @@
+1. **Modify `src/server/db.rs`**
+   - Locate `execute_with_retry` function.
+   - Change `let max_attempts = 10;` to `let max_attempts = 3;`.
+
+2. **Modify `src/server/orchestration/state/parity_test.rs`**
+   - Update `test_execute_with_retry_chaos_exhaustion` to assert 3 instead of 10.
+
+3. **Verify**
+   - Run `cargo test -p ohc-mono --manifest-path Cargo.toml -- orchestration::state::parity_test::test_execute_with_retry_chaos_exhaustion` to ensure tests pass.
+   - Run `bazelisk test //src/server/orchestration/state:parity_test` if possible.
+
+4. **Pre-commit Check**
+   - Run pre-commit instructions and apply formatting/linting as necessary.
+   - Ensure the `bazelisk test //...` is green.

--- a/docs/superpowers/specs/2026-06-17-ml-resilience-design.md
+++ b/docs/superpowers/specs/2026-06-17-ml-resilience-design.md
@@ -1,0 +1,16 @@
+# Spec: ML-Resilience 60-Second Timeout Rule
+## Overview
+The ML-Resilience rules require that AI agent jobs have a 60-second timeout with automatic retry (max 3 attempts). This rule applies to both Cloud and Standalone mode (Mode Parity).
+
+Currently, `src/server/db.rs` specifies `let max_attempts = 10;`. Also, testing code `src/server/orchestration/state/parity_test.rs` specifically tests for `max_attempts = 10` for `execute_with_retry`.
+
+This specification outlines changing `max_attempts` to 3 to comply with the ML-Resilience rules, and verifying the change via the parity test.
+
+## Changes
+1. Modify `src/server/db.rs` -> `execute_with_retry` method to use `let max_attempts = 3;` instead of `10`.
+2. Update tests in `src/server/orchestration/state/parity_test.rs`:
+   - Change assertions checking for 10 attempts to check for 3.
+   - Example: `assert_eq!(*attempts.lock().unwrap(), 10);` -> `assert_eq!(*attempts.lock().unwrap(), 3);` in `test_execute_with_retry_chaos_exhaustion`.
+
+## Trade-offs
+None - this is explicitly requested as an absolute requirement in the prompt.

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -630,7 +630,7 @@ impl DB {
         E: std::fmt::Debug + std::fmt::Display + From<String>,
     {
         let mut attempt = 0;
-        let max_attempts = 10;
+        let max_attempts = 3;
         #[cfg(not(test))]
         let mut backoff = std::time::Duration::from_millis(50);
         #[cfg(test)]

--- a/src/server/orchestration/state/parity_test.rs
+++ b/src/server/orchestration/state/parity_test.rs
@@ -811,8 +811,8 @@ mod parity_tests {
 
         assert!(res.is_err());
         assert!(res.unwrap_err().contains("Database retry exhausted"));
-        // execute_with_retry makes 1 initial attempt + 9 retries (max_attempts = 10)
-        assert_eq!(*attempts.lock().unwrap(), 10);
+        // execute_with_retry makes 1 initial attempt + 2 retries (max_attempts = 3)
+        assert_eq!(*attempts.lock().unwrap(), 3);
 
         let pg_db = setup_postgres_db().await;
         if let Some(db) = pg_db {
@@ -830,7 +830,7 @@ mod parity_tests {
 
             assert!(res.is_err());
             assert!(res.unwrap_err().contains("Database retry exhausted"));
-            assert_eq!(*attempts.lock().unwrap(), 10);
+            assert_eq!(*attempts.lock().unwrap(), 3);
         }
     }
 


### PR DESCRIPTION
This commit updates `execute_with_retry` in `src/server/db.rs` to limit database retries to 3 attempts, down from 10, to comply with the ML-Resilience rule for 60-second timeout with max 3 attempts. It also updates the chaos engineering parity tests in `src/server/orchestration/state/parity_test.rs` to reflect this change.

Superpowers skills used: `brainstorming`, `writing-plans`.

---
*PR created automatically by Jules for task [4938303798533884465](https://jules.google.com/task/4938303798533884465) started by @ql-owo-lp*