### PR TITLE
🔗 Link: [interop improvement] Implement SQLite fallback for create_ui_triage_item_handler

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -3042,8 +3042,60 @@ pub async fn create_ui_triage_item_handler(
 
             (axum::http::StatusCode::CREATED, axum::Json(serde_json::json!({"id": new_id, "status": "success"}))).into_response()
         }
-        crate::db::DbStore::Sqlite(_) => {
-            (axum::http::StatusCode::NOT_IMPLEMENTED, axum::Json(serde_json::json!({"error": "Sqlite not supported"}))).into_response()
+        crate::db::DbStore::Sqlite(sqlite_pool) => {
+            let mut tx = match sqlite_pool.begin().await {
+                Ok(tx) => tx,
+                Err(e) => {
+                    tracing::error!("Failed to begin sqlite transaction: {:?}", e);
+                    return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({"error": e.to_string()}))).into_response();
+                }
+            };
+
+            let new_id = format!("triage-{}", uuid::Uuid::new_v4());
+            let source = payload.source.unwrap_or_else(|| "Unknown".to_string());
+            let priority = payload.priority.unwrap_or_else(|| "normal".to_string());
+            let context = payload.context.unwrap_or_else(|| "".to_string());
+
+            if let Err(e) = sqlx::query(
+                "INSERT INTO triage_items (id, tenant_id, customer_id, source, priority, context, status) VALUES (?, ?, ?, ?, ?, ?, 'pending')"
+            )
+            .bind(&new_id)
+            .bind(&tenant_id)
+            .bind(&payload.customer_id)
+            .bind(&source)
+            .bind(&priority)
+            .bind(&context)
+            .execute(&mut *tx).await {
+                tracing::error!("Failed to insert triage item (sqlite): {:?}", e);
+                return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({"error": e.to_string()}))).into_response();
+            }
+
+            if let Some(action_type) = payload.action_type {
+                let action_id = format!("act-{}", uuid::Uuid::new_v4());
+                if let Err(e) = sqlx::query(
+                    "INSERT INTO triage_proposed_actions (id, triage_item_id, tenant_id, action_type, payload) VALUES (?, ?, ?, ?, ?)"
+                )
+                .bind(&action_id)
+                .bind(&new_id)
+                .bind(&tenant_id)
+                .bind(&action_type)
+                .bind(&payload.action_payload)
+                .execute(&mut *tx).await {
+                    tracing::error!("Failed to insert triage action (sqlite): {:?}", e);
+                    return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({"error": e.to_string()}))).into_response();
+                }
+            }
+
+            if let Err(e) = tx.commit().await {
+                tracing::error!("Failed to commit sqlite transaction: {:?}", e);
+                return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({"error": e.to_string()}))).into_response();
+            }
+
+            let cache = UI_TRIAGE_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(get_redis_client()));
+            cache.invalidate(&format!("ui_triage:{}:mobile:false", tenant_id)).await;
+            cache.invalidate(&format!("ui_triage:{}:mobile:true", tenant_id)).await;
+
+            (axum::http::StatusCode::CREATED, axum::Json(serde_json::json!({"id": new_id, "status": "success"}))).into_response()
         }
     }
 }


### PR DESCRIPTION
Implement SQLite fallback for `create_ui_triage_item_handler` in `src/server/lib.rs`. The `update_ui_triage_action_handler` already has SQLite support, and `list_ui_triage_handler` uses a shared function `load_ui_triage_from_db` that also has SQLite support.

This fixes the issue where `create_ui_triage_item_handler` would return `NOT_IMPLEMENTED` in Standalone mode.

---
*PR created automatically by Jules for task [6817094405787027098](https://jules.google.com/task/6817094405787027098) started by @wbbsuper*