### PR TITLE
🛡️ Sentry: [reliability fix] Add 60s ML-Resilience Timeout for Database Queue Operations

### DIFF
--- a/src/server/orchestration/queue/ohc_job_queue.rs
+++ b/src/server/orchestration/queue/ohc_job_queue.rs
@@ -74,7 +74,7 @@ impl OHCJobQueue {
             query = query.bind(jt);
         }
 
-        let job_opt = query.fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?;
+        let job_opt = tokio::time::timeout(std::time::Duration::from_secs(60), query.fetch_optional(&mut *tx)).await.map_err(|_| "Timeout fetching job from queue".to_string())?.map_err(|e| e.to_string())?;
 
         if let Some(row) = job_opt {
             use sqlx::Row;

--- a/src/server/orchestration/queue/pg_queue.rs
+++ b/src/server/orchestration/queue/pg_queue.rs
@@ -156,7 +156,7 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
         }
 
         let start_poll = std::time::Instant::now();
-        let job_opt = query.fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?;
+        let job_opt = tokio::time::timeout(std::time::Duration::from_secs(60), query.fetch_optional(&mut *tx)).await.map_err(|_| "Timeout fetching job from queue".to_string())?.map_err(|e| e.to_string())?;
 
         if start_poll.elapsed() > std::time::Duration::from_millis(100) {
             ::server_telemetry::record_task_claim_contention(::server_telemetry::get_deployment_mode());

--- a/src/server/orchestration/queue/sqlite_queue.rs
+++ b/src/server/orchestration/queue/sqlite_queue.rs
@@ -145,7 +145,7 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
         }
 
         let start_poll = std::time::Instant::now();
-        let job_opt: Option<sqlx::sqlite::SqliteRow> = query.fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?;
+        let job_opt: Option<sqlx::sqlite::SqliteRow> = tokio::time::timeout(std::time::Duration::from_secs(60), query.fetch_optional(&mut *tx)).await.map_err(|_| "Timeout fetching job from queue".to_string())?.map_err(|e| e.to_string())?;
 
         if start_poll.elapsed() > std::time::Duration::from_millis(100) {
             ::server_telemetry::record_task_claim_contention(::server_telemetry::get_deployment_mode());

--- a/src/server/queue.rs
+++ b/src/server/queue.rs
@@ -1006,7 +1006,7 @@ impl TaskQueue for SqliteTaskQueue {
             query = query.bind(role);
         }
 
-        let row = query.fetch_optional(&self.pool).await.map_err(|e| e.to_string())?;
+        let row = tokio::time::timeout(std::time::Duration::from_secs(60), query.fetch_optional(&self.pool)).await.map_err(|_| "Timeout fetching job from queue".to_string())?.map_err(|e| e.to_string())?;
 
         if let Some(row) = row {
             use sqlx::Row;


### PR DESCRIPTION
# Problem

The ML-resilience rule mandates that database sync or dequeue operations timeout gracefully at 60 seconds to prevent cascading failures under heavy load or latency. This rule was missing for database interactions during `dequeue` within the OHC ecosystem worker pool and queue implementation.

# Solution

- This PR fixes this issue by enforcing a 60-second execution time limit using `tokio::time::timeout` wrapping around database fetch executions in `src/server/orchestration/queue/pg_queue.rs`, `src/server/orchestration/queue/sqlite_queue.rs`, `src/server/orchestration/queue/ohc_job_queue.rs`, and `src/server/queue.rs`.
- The test harness is correctly handling local timeouts gracefully. 
- All functional and E2E unit tests have passed using Bazel ( `bazelisk test //...`). No regressions reported for Cloud and Standalone hybrid modes.

# Playbook

Loaded superpowers `test-driven-development` and `subagent-driven-development`.

---
*PR created automatically by Jules for task [6452461454281551229](https://jules.google.com/task/6452461454281551229) started by @ql-owo-lp*