### PR TITLE
Automated Product Subscriptions & Replenishment

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -88,6 +88,7 @@ pub fn router<S: Clone + Send + Sync + 'static>(hub: Arc<Hub>) -> axum::Router<S
 pub struct CreateCheckoutSessionRequest {
     pub tier: Option<String>,
     pub is_subscription: Option<bool>,
+    pub subscription_interval: Option<String>,
     pub product_id: Option<String>,
     pub quantity: Option<i32>,
     pub ttl_seconds: Option<i32>,
@@ -112,8 +113,9 @@ pub async fn create_checkout_session_handler(
     let body_bytes = axum::body::to_bytes(request.into_body(), 1024 * 64).await.map_err(|_| StatusCode::BAD_REQUEST)?;
     let req: CreateCheckoutSessionRequest = serde_json::from_slice(&body_bytes).map_err(|_| StatusCode::BAD_REQUEST)?;
 
-    let amount_usd;
+    let mut amount_usd;
     let item_name;
+    let mut actual_interval: Option<String> = None;
 
     if let Some(tier) = &req.tier {
         amount_usd = match tier.to_lowercase().as_str() {
@@ -123,6 +125,9 @@ pub async fn create_checkout_session_handler(
             _ => return Err(StatusCode::BAD_REQUEST),
         };
         item_name = tier.clone();
+        if req.is_subscription.unwrap_or(false) {
+            actual_interval = Some("month".to_string());
+        }
     } else if let Some(product_id) = &req.product_id {
         let mut conn = hub.pool.acquire().await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         let row = sqlx::query("SELECT title, price_cents FROM products WHERE id = $1 AND tenant_id = $2")
@@ -137,6 +142,30 @@ pub async fn create_checkout_session_handler(
         let quantity = req.quantity.unwrap_or(1);
         amount_usd = (price_cents as f64 / 100.0) * quantity as f64;
         item_name = title;
+
+        if req.is_subscription.unwrap_or(false) {
+            // Check subscription_plans table for discount and interval
+            let plan_row = sqlx::query("SELECT interval, discount_percentage FROM subscription_plans WHERE product_id = $1 AND tenant_id = $2")
+                .bind(product_id)
+                .bind(&tenant_id)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+            if let Some(plan) = plan_row {
+                let interval: String = plan.try_get("interval").unwrap_or_else(|_| "month".to_string());
+                let discount_percentage: i32 = plan.try_get("discount_percentage").unwrap_or(0);
+                actual_interval = Some(interval);
+
+                if discount_percentage > 0 {
+                    amount_usd = amount_usd * (1.0 - (discount_percentage as f64 / 100.0));
+                }
+            } else if let Some(fallback_interval) = &req.subscription_interval {
+                actual_interval = Some(fallback_interval.clone());
+            } else {
+                actual_interval = Some("month".to_string());
+            }
+        }
     } else {
         return Err(StatusCode::BAD_REQUEST);
     }
@@ -162,7 +191,7 @@ pub async fn create_checkout_session_handler(
 
     if let Some(client) = &hub.tracker().stripe_client {
         // Assume price_id corresponds to the tier directly or is generated. We pass the tier name as the price_id for now.
-        match client.create_checkout_session(&item_name, &tenant_id, amount_usd, req.is_subscription.unwrap_or(false)).await {
+        match client.create_checkout_session(&item_name, &tenant_id, amount_usd, actual_interval).await {
             Ok(url) => Ok(Json(CreateCheckoutSessionResponse { checkout_url: url })),
             Err(_) => {
                 // Explicitly release the lock if the stripe session creation fails
@@ -676,6 +705,7 @@ mod department_tier_usage_tests {
         let req = CreateCheckoutSessionRequest {
             tier: Some("starter".to_string()),
             is_subscription: Some(false),
+            subscription_interval: None,
             product_id: Some("prod_123".to_string()),
             quantity: Some(1),
             ttl_seconds: Some(300),

--- a/src/server/api/quotes.rs
+++ b/src/server/api/quotes.rs
@@ -356,7 +356,7 @@ async fn approve_quote(
         &format!("Quote #{}", quote.id),
         &quote.customer_id.to_string(),
         amount_usd,
-        false
+        None
     ).await {
         Ok(url) => {
             let _ = sqlx::query("UPDATE quotes SET checkout_url = $1 WHERE id = $2")

--- a/src/server/integrations/stripe/client.rs
+++ b/src/server/integrations/stripe/client.rs
@@ -53,7 +53,7 @@ impl StripeClient {
         std::env::var("STRIPE_API_BASE").unwrap_or_else(|_| "https://api.stripe.com".to_string())
     }
 
-    pub async fn create_checkout_session(&self, price_id_or_name: &str, customer_id: &str, amount_usd: f64, is_subscription: bool) -> Result<String, String> {
+    pub async fn create_checkout_session(&self, price_id_or_name: &str, customer_id: &str, amount_usd: f64, subscription_interval: Option<String>) -> Result<String, String> {
         let pm = PaymentRouter::optimize_payment_method(amount_usd);
         let savings = PaymentRouter::calculate_fee_savings(amount_usd);
         tracing::info!("💰 Miser telemetry: Payment method optimized. Saved ${} in fees", savings);
@@ -99,9 +99,9 @@ impl StripeClient {
         let mut form = std::collections::HashMap::new();
         form.insert("success_url".to_string(), "https://example.com/success".to_string());
         form.insert("cancel_url".to_string(), "https://example.com/cancel".to_string());
-        if is_subscription {
+        if let Some(interval) = subscription_interval {
             form.insert("mode".to_string(), "subscription".to_string());
-            form.insert("line_items[0][price_data][recurring][interval]".to_string(), "month".to_string());
+            form.insert("line_items[0][price_data][recurring][interval]".to_string(), interval);
         } else {
             form.insert("mode".to_string(), "payment".to_string());
         }

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -1484,7 +1484,7 @@ impl HubService for MyHubService {
         } else if let Some(mp_client) = mercadopago_client.filter(|_| is_latam) {
             mp_client.create_checkout_preference(&req.plan_id, &tenant_id).await
         } else {
-            client.create_checkout_session(&req.plan_id, &tenant_id, amount, true).await
+            client.create_checkout_session(&req.plan_id, &tenant_id, amount, Some("month".to_string())).await
         }
             .map_err(|e| tonic::Status::internal(e))?;
 

--- a/src/server/orchestration/departments/orchestrator.rs
+++ b/src/server/orchestration/departments/orchestrator.rs
@@ -885,7 +885,7 @@ impl DepartmentOrchestrator {
 
                         let api_key = std::env::var("STRIPE_SECRET_KEY").unwrap_or_else(|_| "sk_test_123".to_string());
                         let stripe = crate::integrations::stripe::client::StripeClient::new(api_key);
-                        let stripe_link = stripe.create_checkout_session(&quote_id, &customer_id_to_use, price * 0.20, false).await.unwrap_or_default();
+                        let stripe_link = stripe.create_checkout_session(&quote_id, &customer_id_to_use, price * 0.20, None).await.unwrap_or_default();
 
 
                         let mut generated_reply = payload.get("generated_response").and_then(|v| v.as_str()).unwrap_or("").to_string();

--- a/src/server/orchestration/departments/sales_agent.rs
+++ b/src/server/orchestration/departments/sales_agent.rs
@@ -258,7 +258,7 @@ impl Department for SalesAgent {
                             std::env::var("STRIPE_API_KEY").unwrap_or_else(|_| "sk_test_123".to_string()),
                         );
 
-                        match stripe_client.create_checkout_session("price_dummy", "cus_dummy", deposit_amount, false).await {
+                        match stripe_client.create_checkout_session("price_dummy", "cus_dummy", deposit_amount, None).await {
                             Ok(url) => {
                                 tracing::info!("Generated deposit link: {}", url);
                                 // Optional: Update timeline or send a message

--- a/src/server/services/quoting/mod.rs
+++ b/src/server/services/quoting/mod.rs
@@ -201,7 +201,7 @@ async fn approve_quote(
                 &format!("Quote #{}", q.id),
                 &q.customer_id.to_string(),
                 amount_usd,
-                false
+                None
             ).await {
                 Ok(url) => {
                     q.stripe_payment_link = Some(url.clone());


### PR DESCRIPTION
This PR resolves the issue #29230 for adding automated product subscriptions and replenishment features.

### Key Changes
- Updated the `create_checkout_session` function signature inside `src/server/integrations/stripe/client.rs` to accept `subscription_interval: Option<String>` instead of a hardcoded boolean, which correctly passes the user-selected interval to Stripe during a subscription checkout.
- Modified `create_checkout_session_handler` in `src/server/api/billing_api.rs` to check if a product is a subscription, then dynamically queries the database table `subscription_plans` to fetch the specific interval and discount percentage instead of defaulting to `"month"` and full price.
- Updated calls targeting `create_checkout_session` inside `src/server/api/quotes.rs`, `src/server/orchestration/departments/sales_agent.rs`, `src/server/orchestration/departments/orchestrator.rs`, and `src/server/lib.rs` to pass `None` or an appropriate string default (`"month"`) replacing the previous deprecated bool signatures.

Resolves #29230

---
*PR created automatically by Jules for task [1417669390677913347](https://jules.google.com/task/1417669390677913347) started by @ql-owo-lp*