### PR TITLE
fix(ui): update "AI actions used" text to "AI actions used this month"

### DIFF
--- a/src/e2e/test_ui.spec.ts
+++ b/src/e2e/test_ui.spec.ts
@@ -6,5 +6,5 @@ test('Cost Soft Limit friendly prompt shows', async ({ page, loginAs, unlimitedA
   await page.waitForLoadState('networkidle');
   // We cannot easily assert the limit reached text without a specific tenant setup in DB.
   // But we must at least assert that the plan page loads fully for the E2E.
-  await expect(page.getByText('AI actions used').first()).toBeVisible();
+  await expect(page.getByText('AI actions used this month').first()).toBeVisible();
 });

--- a/src/ui/next/src/app/cost-dashboard/page.test.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.test.tsx
@@ -120,7 +120,7 @@ describe('CostDashboardPage', () => {
     // My Plan assertions
     expect(screen.getByText('My Plan')).toBeDefined();
     expect(screen.getByText('Starter')).toBeDefined();
-    // AI actions used: 150 / 1000. Text split.
+    // AI actions used this month: 150 / 1000. Text split.
     expect(screen.getAllByText(/150/)[0]).toBeDefined();
     expect(screen.getAllByText(/\/ 1000/)[0]).toBeDefined();
     // Storage used

--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -186,7 +186,7 @@ export default function CostDashboardPage() {
                       <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">{myPlanData?.current_plan || 'Free'}</p>
                   </div>
                   <div className="p-4 rounded-xl app-card glassmorphism ohc-growth-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 dark:border-white/10">
-                      <h3 className="text-sm font-medium text-gray-500">AI actions used</h3>
+                      <h3 className="text-sm font-medium text-gray-500">AI actions used this month</h3>
                       <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">{myPlanData?.ai_actions_used || 0} <span className="text-sm text-gray-500 font-normal">{myPlanData?.ai_actions_limit != null ? `/ ${myPlanData.ai_actions_limit}` : '/ Unlimited'}</span></p>
                   </div>
                   <div className="p-4 rounded-xl app-card glassmorphism ohc-growth-card bg-white/70 backdrop-blur-xl saturate-200 border border-white/40 dark:border-white/10">


### PR DESCRIPTION
This commit updates the text in the cost dashboard from "AI actions used" to "AI actions used this month" to be more descriptive and consistent with other text in the UI such as the plan page. It also updates the corresponding E2E and unit tests to expect this new text.

---
*PR created automatically by Jules for task [4775504196111678400](https://jules.google.com/task/4775504196111678400) started by @ql-owo-lp*