### PR TITLE
test: Mock window.open in agents page test

### DIFF
--- a/src/ui/next/src/app/agents/page.test.tsx
+++ b/src/ui/next/src/app/agents/page.test.tsx
@@ -274,6 +274,9 @@ test('supports interactive tab transitions and toggling grid extensions', async 
 });
 
 test('renders paywall dialog and handles simulated upgrade flow', async () => {
+  const openSpy = vi.fn();
+  vi.stubGlobal('open', openSpy);
+
   render(<AgentsPage />);
 
   // Click Toggle Pro Mode switch to trigger paywall
@@ -286,6 +289,8 @@ test('renders paywall dialog and handles simulated upgrade flow', async () => {
   fireEvent.click(screen.getByText('Share on X to get 7 Days Free'));
   // Dialog closes and gives Pro
   expect(screen.queryByRole('heading', { name: 'Upgrade to Pro' })).toBeNull();
+  expect(openSpy).toHaveBeenCalled();
+  vi.unstubAllGlobals();
 });
 
 


### PR DESCRIPTION
Fixes an unhandled error during Vitest execution in `src/app/agents/page.test.tsx` where `window.open` was called but not implemented by the `jsdom` environment. Included cleanup via `vi.unstubAllGlobals()` to prevent test pollution.

---
*PR created automatically by Jules for task [13386497936533692661](https://jules.google.com/task/13386497936533692661) started by @wbbsuper*