### PR TITLE
fix(ui): use QuoteReviewModal in UnifiedAgentFeed for quote drafts

### DIFF
--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -6,7 +6,7 @@ import { WorkTriageFeed } from "../components/WorkTriageFeed";
 import { enqueueAction, getActions, removeAction } from "../utils/offlineQueue";
 import { AmbassadorReplyCard } from './AmbassadorReplyCard';
 import { InstagramDMCard } from './InstagramDMCard';
-
+import { QuoteReviewModal } from '../../components/QuoteReviewModal';
 
 type TriageItem = {
   id: string;
@@ -76,6 +76,8 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
   const [queuedActionIds, setQueuedActionIds] = useState<Set<string>>(new Set());
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState<string>("");
+  const [isQuoteModalOpen, setIsQuoteModalOpen] = useState(false);
+  const [selectedQuoteApproval, setSelectedQuoteApproval] = useState<AgentFeedItem | null>(null);
 
   const tenantId = () => {
     if (typeof window === "undefined") return "default";
@@ -1118,14 +1120,17 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
                       >
                         Approve & Send
                       </button>
-                      <a
-                        href={`/quotes/${(approval.proposed_action || approval.context_payload)?.quote_id || approval.id}`}
+                      <button
+                        onClick={() => {
+                          setSelectedQuoteApproval(approval);
+                          setIsQuoteModalOpen(true);
+                        }}
                         className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
-                        aria-label="Edit Draft"
-                        data-testid="edit-quote-draft"
+                        aria-label="Review Draft"
+                        data-testid="review-quote-draft"
                       >
-                        Edit Draft
-                      </a>
+                        Review Draft
+                      </button>
                     </div>
                   ) : (approval.proposed_action || approval.context_payload)?.context?.smart_pricing === true ? (
                     <div className="flex flex-col sm:flex-row gap-3 w-full">
@@ -1342,6 +1347,21 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
           </>
         )}
       </div>
+      {selectedQuoteApproval && (
+        <QuoteReviewModal
+          isOpen={isQuoteModalOpen}
+          onClose={() => {
+            setIsQuoteModalOpen(false);
+            setSelectedQuoteApproval(null);
+          }}
+          onApprove={(updatedPayload) => {
+            handleDecision(selectedQuoteApproval.id, true, JSON.stringify(updatedPayload));
+            setIsQuoteModalOpen(false);
+            setSelectedQuoteApproval(null);
+          }}
+          initialPayload={selectedQuoteApproval.proposed_action || selectedQuoteApproval.context_payload}
+        />
+      )}
     </section>
   );
 }


### PR DESCRIPTION
Fixes an issue where clicking the 'Edit Draft' button on a quote draft card inside the Unified Agent Feed resulted in a redirect to a separate page, rather than opening the `QuoteReviewModal` inline as designed in the CUJ. 

- Modified `UnifiedAgentFeed.tsx` to import `QuoteReviewModal`.
- Added state handlers `isQuoteModalOpen` and `selectedQuoteApproval` in the `UnifiedAgentFeed` to manage the modal.
- Updated the 'Edit Draft' (now labeled 'Review Draft' with the same 'review-quote-draft' test-id) button rendering for quote drafts to open the modal and set the selected approval data.
- Placed the `QuoteReviewModal` component at the bottom of the feed tree, using the `proposed_action` / `context_payload` data.
- When the modal is approved, it calls the standard `handleDecision(id, true, JSON.stringify(updatedPayload))` method on the feed to pass data back to the server and advance the action flow.

All UI components tested and hermetic playright E2E tests have passed.

---
*PR created automatically by Jules for task [3069119451991624414](https://jules.google.com/task/3069119451991624414) started by @ql-owo-lp*

Resolves #29354