### PR TITLE
Optimize Memory Consolidation Batch Size and Test Coverage

### DIFF
--- a/src/agents/builtin/memory_store.rs
+++ b/src/agents/builtin/memory_store.rs
@@ -695,7 +695,7 @@ impl VectorRepository {
                         ORDER BY b_inner.embedding <=> a.embedding
                         LIMIT 1
                     ) b ON a.embedding <=> b.embedding < 0.05
-                    LIMIT 10
+                    LIMIT 100
                 ";
                 let rows = sqlx::query(query)
                     .fetch_all(pool)
@@ -729,7 +729,7 @@ impl VectorRepository {
                             LIMIT 1
                         )
                         WHERE vec_distance_cosine(a.embedding, b.embedding) < 0.05
-                        LIMIT 10
+                        LIMIT 100
                     ";
                     let rows = sqlx::query(query)
                         .fetch_all(pool)

--- a/src/e2e/omni_context_memory_consolidation.spec.ts
+++ b/src/e2e/omni_context_memory_consolidation.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from './fixtures';
+
+test.describe('Omni Context Memory Consolidation', () => {
+  test('Agents page loads without errors', async ({ page, loginAs, defaultUser }) => {
+    await loginAs(page, defaultUser);
+    await page.goto('/agents');
+
+    // Basic smoke test to ensure the page doesn't crash
+    await expect(page.getByRole('heading', { name: 'My Agents', exact: false })).toBeVisible();
+  });
+
+  test('Memory panel renders properly', async ({ page, loginAs, defaultUser }) => {
+    await loginAs(page, defaultUser);
+    await page.goto('/agents');
+
+    // It should render the consolidated memory section header
+    await expect(page.getByText('Consolidated Memory')).toBeVisible();
+  });
+
+  test('Memory list displays empty state', async ({ page, loginAs, defaultUser }) => {
+    await loginAs(page, defaultUser);
+    await page.goto('/agents');
+
+    // Since the database is freshly spun up, there will be no memories
+    await expect(page.getByText('No consolidated memories found.')).toBeVisible();
+  });
+
+  test('Memory detail subtitle is visible', async ({ page, loginAs, defaultUser }) => {
+    await loginAs(page, defaultUser);
+    await page.goto('/agents');
+
+    await expect(page.getByText('Review and override what AI agents remember about your business.')).toBeVisible();
+  });
+
+  test('Explore panel is visible', async ({ page, loginAs, defaultUser }) => {
+    await loginAs(page, defaultUser);
+    await page.goto('/agents');
+
+    await expect(page.getByText('Explore Templates')).toBeVisible();
+    await expect(page.getByText('Make my version with one click.').first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
This pull request optimizes the `auto_resolve_conflicts` method for the memory consolidation worker. It increases the batch size of `get_conflicting_pairs` from 10 to 100 to increase conflict resolution throughput. In addition, it adds a new suite of 5 E2E Playwright tests to `src/e2e/omni_context_memory_consolidation.spec.ts` to properly verify UI components as part of the codebase optimization mandate.

---
*PR created automatically by Jules for task [3747821629340878506](https://jules.google.com/task/3747821629340878506) started by @ql-owo-lp*