### PR TITLE
chore: fix vitest configuration and dependencies

### DIFF
--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
- Updated `MODULE.bazel` to specify `aspect_bazel_lib@2.22.5` to eliminate the dependency drift warning.
- Installed `jsdom` and updated `next` to `14.2.35` in `src/ui/next/package.json` to resolve Vitest module loading failures.
- Updated `src/ui/next/tsconfig.json` to use `react-jsx` instead of `preserve` to fix JSX parsing errors in Vitest.
- Verified all Bazel tests and Playwright E2E tests are passing.

---
*PR created automatically by Jules for task [4167787255281664977](https://jules.google.com/task/4167787255281664977) started by @ql-owo-lp*