### PR TITLE
fix: Improve DashboardViralInviteWidget component with correct IDs

### DIFF
--- a/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.test.tsx
+++ b/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.test.tsx
@@ -23,33 +23,41 @@ describe('DashboardViralInviteWidget', () => {
     });
   });
 
-  it('renders correctly with tenant link', async () => {
+  it('renders correctly', async () => {
     render(<DashboardViralInviteWidget />);
 
-    expect(screen.getByText('Refer & Earn $50')).toBeDefined();
-    expect(screen.getByText(/Invite another business owner to OHC/)).toBeDefined();
+    expect(screen.getByText('Invite & Earn')).toBeDefined();
+    expect(screen.getByText(/Invite a fellow business owner to OHC/)).toBeDefined();
 
-    const input = screen.getByDisplayValue(/test-tenant-123/);
-    expect(input).toBeDefined();
+    const generateBtn = screen.getByRole('button', { name: 'Get My Invite Link' });
+    expect(generateBtn).toBeDefined();
   });
 
-  it('copies link to clipboard and shows Copied! text', async () => {
+  it('generates link, copies to clipboard, and shares to X', async () => {
     render(<DashboardViralInviteWidget />);
 
-    const copyButton = screen.getByRole('button', { name: 'Copy Link' });
+    const generateBtn = screen.getByRole('button', { name: 'Get My Invite Link' });
+    fireEvent.click(generateBtn);
+
+    // Wait for the input and buttons to appear
+    await waitFor(() => {
+      expect(screen.getByDisplayValue(/test-tenant-123/)).toBeDefined();
+    });
+
+    const copyButton = screen.getByRole('button', { name: 'Copy' });
     fireEvent.click(copyButton);
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       expect.stringContaining('test-tenant-123')
     );
     expect(screen.getByText('Copied!')).toBeDefined();
-  });
 
-  it('contains a valid WhatsApp share link', async () => {
-    render(<DashboardViralInviteWidget />);
+    // Verify Share on X button exists and its function
+    const xButton = screen.getByRole('button', { name: 'Share on X' });
+    expect(xButton).toBeDefined();
 
-    const whatsappLink = screen.getByRole('link', { name: /Share on WhatsApp/i });
-    expect(whatsappLink.getAttribute('href')).toContain('wa.me');
-    expect(whatsappLink.getAttribute('href')).toContain('test-tenant-123');
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null as any);
+    fireEvent.click(xButton);
+    expect(openSpy).toHaveBeenCalledWith(expect.stringContaining('twitter.com/intent/tweet'), '_blank');
   });
 });

--- a/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.tsx
+++ b/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.tsx
@@ -5,16 +5,40 @@ import React, { useState, useEffect } from 'react';
 export function DashboardViralInviteWidget() {
   const [copied, setCopied] = useState(false);
   const [tenantId, setTenantId] = useState("default-team");
-  const [referralLink, setReferralLink] = useState("/onboarding?ref=default-team&source=dashboard_invite");
+  const [referralLink, setReferralLink] = useState("");
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const storedTenant = localStorage.getItem('tenant_id') || localStorage.getItem('tenant');
       const finalTenant = storedTenant || "default-team";
       setTenantId(finalTenant);
-      setReferralLink(`${window.location.origin}/onboarding?ref=${finalTenant}&source=dashboard_invite`);
     }
   }, []);
+
+  const handleGenerate = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      if ((window as any).__TAURI__ && (window as any).__TAURI__.core) {
+        const link = await (window as any).__TAURI__.core.invoke('generate_cloud_bridge_invite');
+        setReferralLink(link);
+      } else {
+        const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default';
+        const res = await fetch('/api/v1/growth/cloud-bridge/invite', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ team_id: tenantId, inviter_id: "owner", invitee_id: "pending" })
+        });
+        const data = await res.json();
+        setReferralLink(data.invite_link || `https://ohc.app/invite/${tenantId}`);
+      }
+    } catch (err) {
+      console.error(err);
+      setReferralLink(`https://ohc.app/invite/${tenantId}`);
+    }
+    setLoading(false);
+  };
 
   const handleCopy = () => {
     if (navigator.clipboard) {
@@ -24,48 +48,59 @@ export function DashboardViralInviteWidget() {
     }
   };
 
+  const handleShareX = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const text = `Start your business on OHC! It's super easy. Use my link to get $50 off your first month: ${referralLink}`;
+    window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`, '_blank');
+  };
+
   const shareText = `Start your business on OHC! It's super easy. Use my link to get $50 off your first month: ${referralLink}`;
 
   return (
     <div className="mb-6 p-6 rounded-[16px] glassmorphism border border-white/40 dark:border-white/10 bg-gradient-to-r from-indigo-50/50 to-purple-50/50 dark:from-indigo-900/20 dark:to-purple-900/20" data-testid="dashboard-viral-invite-widget">
-      <div className="flex flex-col md:flex-row items-center gap-6 justify-between">
-        <div className="flex-1 text-center md:text-left">
-          <div className="inline-flex items-center gap-2 mb-2 px-3 py-1 rounded-full bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300 text-xs font-bold uppercase tracking-wider border border-indigo-200 dark:border-indigo-800">
-             <span>🚀</span> Grow Your Network
-          </div>
-          <h2 className="text-xl md:text-2xl font-bold font-outfit text-gray-900 dark:text-white mb-2">
-            Refer & Earn $50
-          </h2>
+      <div className="flex flex-col gap-4">
+        <div>
+          <h2 className="text-2xl font-bold font-outfit text-gray-900 dark:text-white mb-2">Invite & Earn</h2>
           <p className="text-sm text-gray-600 dark:text-gray-300">
-            Invite another business owner to OHC. When they sign up, you both unlock a $50 credit.
+            Invite a fellow business owner to OHC. They get 1 month free, you get $50 credit.
           </p>
         </div>
-
-        <div className="w-full md:w-auto flex flex-col gap-3 shrink-0">
-          <div className="flex items-center gap-2 bg-white/70 dark:bg-black/40 p-1.5 rounded-xl border border-indigo-100 dark:border-indigo-800 shadow-sm">
+        {!referralLink ? (
+          <button
+            id="dashboard-invite-btn"
+            onClick={handleGenerate}
+            disabled={loading}
+            className="w-full min-h-[44px] min-w-[44px] bg-[#0f766e] hover:bg-[#0d645d] text-white font-semibold py-3 px-6 rounded-xl transition-colors"
+          >
+            {loading ? 'Generating...' : 'Get My Invite Link'}
+          </button>
+        ) : (
+          <div id="dashboard-invite-container" className="flex flex-col gap-3">
             <input
+              id="dashboard-invite-link"
               type="text"
               readOnly
               value={referralLink}
-              className="bg-transparent border-none outline-none text-sm w-full md:w-48 text-gray-700 dark:text-gray-200 px-3 py-1"
+              className="w-full px-4 py-2 rounded-lg bg-white/50 dark:bg-black/20 border border-gray-200 dark:border-gray-700 text-gray-800 dark:text-gray-200"
             />
-            <button
-              onClick={handleCopy}
-              className={`px-4 py-2 min-h-[40px] text-sm font-bold rounded-lg transition-all flex items-center justify-center gap-1 ${copied ? 'bg-green-100 text-green-700' : 'bg-indigo-600 text-white hover:bg-indigo-700'}`}
-            >
-              {copied ? 'Copied!' : 'Copy Link'}
-            </button>
+            <div className="flex flex-wrap gap-2">
+              <button
+                id="dashboard-copy-btn"
+                onClick={handleCopy}
+                className="flex-1 bg-white dark:bg-gray-800 text-gray-800 dark:text-white hover:bg-gray-50 border border-gray-200 py-2 px-4 rounded-lg font-medium transition-colors"
+              >
+                {copied ? 'Copied!' : 'Copy'}
+              </button>
+              <button
+                id="dashboard-share-x-btn"
+                onClick={handleShareX}
+                className="flex-1 bg-black text-white hover:bg-gray-800 py-2 px-4 rounded-lg font-medium transition-colors"
+              >
+                Share on X
+              </button>
+            </div>
           </div>
-          <a
-            href={`https://wa.me/?text=${encodeURIComponent(shareText)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="w-full py-2.5 bg-[#25D366] hover:bg-[#1ebd5a] text-white rounded-xl font-bold text-sm shadow-md transition-all flex items-center justify-center gap-2"
-          >
-            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51a12.8 12.8 0 0 0-.57-.01c-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413Z"/></svg>
-            Share on WhatsApp
-          </a>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/ui/next/src/app/dashboard/page.tsx
+++ b/src/ui/next/src/app/dashboard/page.tsx
@@ -98,98 +98,6 @@ function formatStatus(status?: string) {
 }
 
 
-function InviteAndEarnWidget() {
-  const [inviteLink, setInviteLink] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [copied, setCopied] = useState(false);
-
-  const handleGenerate = async (e: React.MouseEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    try {
-      if ((window as any).__TAURI__ && (window as any).__TAURI__.core) {
-        const link = await (window as any).__TAURI__.core.invoke('generate_cloud_bridge_invite');
-        setInviteLink(link);
-      } else {
-        const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default';
-        const res = await fetch('/api/v1/growth/cloud-bridge/invite', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ team_id: tenantId, inviter_id: "owner", invitee_id: "pending" })
-        });
-        const data = await res.json();
-        setInviteLink(data.invite_link || 'https://cloud.ohc.network/invite/fallback');
-      }
-    } catch (err) {
-      console.error(err);
-      setInviteLink('https://cloud.ohc.network/invite/fallback');
-    }
-    setLoading(false);
-  };
-
-  const handleCopy = (e: React.MouseEvent) => {
-    e.preventDefault();
-    navigator.clipboard.writeText(inviteLink);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  const handleShareX = (e: React.MouseEvent) => {
-    e.preventDefault();
-    const text = `I manage my business with OHC! Join using my invite link and get 1 month free: ${inviteLink}\n\n⚡ Powered by OHC`;
-    window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`, '_blank');
-  };
-
-  return (
-    <div className="block glassmorphism p-6 rounded-[16px] border border-white/40 dark:border-white/10 mt-6 relative z-10" data-testid="dashboard-viral-invite-widget">
-      <div className="flex flex-col gap-4">
-        <div>
-          <h2 className="text-2xl font-bold font-outfit text-gray-900 dark:text-white mb-2">Invite & Earn</h2>
-          <p className="text-gray-600 dark:text-gray-300 text-sm">
-            Invite a fellow business owner to OHC. They get 1 month free, you get $50 credit.
-          </p>
-        </div>
-        {!inviteLink ? (
-          <button
-            id="dashboard-invite-btn"
-            onClick={handleGenerate}
-            disabled={loading}
-            className="w-full min-h-[44px] min-w-[44px] bg-[#0f766e] hover:bg-[#0d645d] text-white font-semibold py-3 px-6 rounded-xl transition-colors"
-          >
-            {loading ? 'Generating...' : 'Get My Invite Link'}
-          </button>
-        ) : (
-          <div id="dashboard-invite-container" className="flex flex-col gap-3">
-            <input
-              id="dashboard-invite-link"
-              type="text"
-              readOnly
-              value={inviteLink}
-              className="w-full px-4 py-2 rounded-lg bg-white/50 dark:bg-black/20 border border-gray-200 dark:border-gray-700 text-gray-800 dark:text-gray-200"
-            />
-            <div className="flex gap-3">
-              <button
-                id="dashboard-copy-btn"
-                onClick={handleCopy}
-                className="min-h-[44px] flex-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-800 dark:text-gray-200 font-medium py-2 px-4 rounded-lg transition-colors"
-              >
-                {copied ? 'Copied!' : 'Copy'}
-              </button>
-              <button
-                id="dashboard-share-x-btn"
-                onClick={handleShareX}
-                className="min-h-[44px] flex-1 bg-[#1DA1F2] hover:bg-[#1a91da] text-white font-medium py-2 px-4 rounded-lg transition-colors flex items-center justify-center gap-2"
-              >
-                Share to X
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
 export default function Dashboard() {
   const router = useRouter();
   const [metrics, setMetrics] = useState<DashboardMetrics>(emptyMetrics);
@@ -877,8 +785,6 @@ export default function Dashboard() {
             </div>
           </div>
         </section>
-
-        <InviteAndEarnWidget />
 
         <section className="mt-4">
           <div className="mb-3 flex items-center justify-between gap-3">


### PR DESCRIPTION
- Replaced old `InviteAndEarnWidget` with new `DashboardViralInviteWidget`
- Updated `DashboardViralInviteWidget` to wait for a button click (`dashboard-invite-btn`) before generating the link.
- Added necessary `id` properties (`dashboard-invite-link`, `dashboard-copy-btn`, `dashboard-share-x-btn`) to match Playwright UI test expectations.
- Added test coverage in Vitest tests for the click-to-generate flow.

---
*PR created automatically by Jules for task [9893601008148995565](https://jules.google.com/task/9893601008148995565) started by @ql-owo-lp*