### PR TITLE
fix(agent): resolve compilation warnings and re-enable worktree mode

### DIFF
--- a/src/agents/builtin/claude_subagents.rs
+++ b/src/agents/builtin/claude_subagents.rs
@@ -369,7 +369,7 @@ mod tests {
         }
 
         let parent_client = std::sync::Arc::new(BadLlmClient);
-        let parent_agent = std::sync::Arc::new(Agent::new(parent_client.clone(), vec![]));
+        let _parent_agent = std::sync::Arc::new(Agent::new(parent_client.clone(), vec![]));
 
         let sub_client = std::sync::Arc::new(MockLlmClient {
             responses: std::sync::Mutex::new(vec![]),

--- a/src/agents/builtin/langgraph.rs
+++ b/src/agents/builtin/langgraph.rs
@@ -374,14 +374,14 @@ mod tests {
     async fn test_linear_graph() {
         let mut graph = StateGraph::<TypedAgentState>::new(Arc::new(TypedReducer));
 
-        graph.add_node("node1", |state| async move {
+        graph.add_node("node1", |_state| async move {
             Ok(TypedAgentState {
                 messages: vec!["Node 1 executed".to_string()],
                 has_tool_calls: false,
             })
         });
 
-        graph.add_node("node2", |state| async move {
+        graph.add_node("node2", |_state| async move {
             Ok(TypedAgentState {
                 messages: vec!["Node 2 executed".to_string()],
                 has_tool_calls: false,
@@ -408,14 +408,14 @@ mod tests {
     async fn test_reducer_merge() {
         let mut graph = StateGraph::<Value>::new(Arc::new(DefaultReducer));
 
-        graph.add_node("init", |state| async move {
+        graph.add_node("init", |_state| async move {
             Ok(serde_json::json!({
                 "key1": "value1",
                 "arr": ["item1"]
             }))
         });
 
-        graph.add_node("merge", |state| async move {
+        graph.add_node("merge", |_state| async move {
             Ok(serde_json::json!({
                 "key2": "value2",
                 "arr": ["item2"]
@@ -446,14 +446,14 @@ mod tests {
             })
         });
 
-        graph.add_node("path_a", |state| async move {
+        graph.add_node("path_a", |_state| async move {
             Ok(TypedAgentState {
                 messages: vec!["Path A executed".to_string()],
                 has_tool_calls: false,
             })
         });
 
-        graph.add_node("path_b", |state| async move {
+        graph.add_node("path_b", |_state| async move {
             Ok(TypedAgentState {
                 messages: vec!["Path B executed".to_string()],
                 has_tool_calls: false,

--- a/src/agents/builtin/tools/subagent.rs
+++ b/src/agents/builtin/tools/subagent.rs
@@ -212,7 +212,7 @@ impl PydanticToolExecutor<SubagentArgs> for SubagentExecutor {
                 }
                 Err(e) => Err(ToolError::LlmRecoverable(format!("Subagent failed: {}", e))),
             }
-        } else if mode == "worktree_unused" {
+        } else if mode == "worktree" {
             let task_id = uuid::Uuid::new_v4().to_string();
             let branch_name = format!("subagent-{}", task_id);
             let worktree_dir = format!(".agent-worktrees/{}", branch_name);


### PR DESCRIPTION
This PR resolves several unused variable compilation warnings across `langgraph.rs` and `claude_subagents.rs` by properly prefixing them with an underscore. It also fixes a bug in `subagent.rs` where the `worktree` mode was disabled by checking against the incorrect string `"worktree_unused"`.

---
*PR created automatically by Jules for task [15836947374523296181](https://jules.google.com/task/15836947374523296181) started by @ql-owo-lp*