### PR TITLE
test: remove e2e network mocks for zero-touch mobile onboarding

### DIFF
--- a/src/e2e/onboarding_instant_cuj.spec.ts
+++ b/src/e2e/onboarding_instant_cuj.spec.ts
@@ -1,89 +1,17 @@
 import { test, expect } from '@playwright/test';
-import * as path from 'path';
-import * as fs from 'fs';
 
 test.describe('Instant Setup CUJ', () => {
 
   test.beforeEach(async ({ page }) => {
-    // Intercept standard setup.html load to serve from filesystem for tests
-    const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
-    await page.route('**/setup.html', async route => {
-      const content = fs.readFileSync(path.join(tauriUiDir, 'setup.html'), 'utf-8');
-      await route.fulfill({ contentType: 'text/html', body: content });
-    });
-
-    // Mock tooltips call
-    await page.route('**/api/tooltips', async route => {
-      await route.fulfill({ status: 200, body: JSON.stringify({}) });
-    });
-
-    // Mock the state endpoint which the frontend hits
-    await page.route('**/api/onboarding/state', async route => {
-       await route.fulfill({ status: 200, body: JSON.stringify({}) });
-    });
-
-    // Set a known viewport for mobile tests
+    // Clean up local storage to ensure fresh start
+    await page.addInitScript(() => window.localStorage.clear());
+    // Set a known viewport for mobile tests (375px first as per requirements)
     await page.setViewportSize({ width: 375, height: 812 });
   });
 
   test('Persona: Maya (Home Baker) completes the Zero-Click Instant Onboarding', async ({ page }) => {
 
-    // Mock the backend intake response
-    let intakeCalled = false;
-    await page.route('**/api/onboarding/intake', async route => {
-      intakeCalled = true;
-      const postData = JSON.parse(route.request().postData() || '{}');
-      expect(postData.description).toContain('I make custom vegan cakes in Austin');
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          business_name: "Maya's Vegan Cakes",
-          business_type: "Bakery",
-          categories: ["food", "cakes"],
-          initial_products: [
-            { name: "Custom Vegan Cake", price: "45.00" }
-          ],
-          location: "Austin, TX",
-          target_audience: "Vegans and cake lovers"
-        })
-      });
-    });
-
-    // Mock the final start endpoint that actually provisions the tenant
-    let onboardingStarted = false;
-    await page.route('**/api/onboarding/start', async route => {
-      onboardingStarted = true;
-      const postData = JSON.parse(route.request().postData() || '{}');
-
-      // Verify payload was correctly formed from the intake_data
-      expect(postData.company_name).toBe("Maya's Vegan Cakes");
-      expect(postData.first_product_name).toBe("Custom Vegan Cake");
-
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          organization_id: 'tenant-maya-123'
-        })
-      });
-    });
-
-    // Mock the success page redirection target
-    await page.route('**/success.html', async route => {
-      await route.fulfill({ status: 200, contentType: 'text/html', body: `
-        <h1>Dashboard</h1>
-        <section aria-label="Unified Agent Feed">
-          <div id="triage-list">
-             <div class="triage-card">Your store is ready. Review and Publish.</div>
-             <button data-testid="approve-proposal">Approve & Go Live</button>
-          </div>
-        </section>
-      ` });
-    });
-
-    await page.goto('http://mock/setup.html');
+    await page.goto('/onboarding');
 
     // Verify Initial Screen
     await expect(page.getByRole('heading', { name: '10-Minute Setup Wizard' })).toBeVisible();
@@ -99,27 +27,20 @@ test.describe('Instant Setup CUJ', () => {
     await expect(instantInput).toBeVisible();
     await instantInput.fill('I make custom vegan cakes in Austin. I need a website and a way to take bookings.');
 
-    const generateBtn = page.getByTestId('generate-storefront-btn');
+    const generateBtn = page.getByRole('button', { name: 'Next' });
     await expect(generateBtn).toBeEnabled();
 
     // 4. Click generate
     await generateBtn.click();
 
     // 5. Verify loading texts (animation progress)
-    await expect(page.locator('#generate-storefront-btn')).toHaveText('Building Your Business...');
+    await expect(page.getByText('Building Your Business...')).toBeVisible({ timeout: 10000 });
 
-    // 6. Verify it navigated to success.html
-    await page.waitForURL('**/success.html', { timeout: 15000 });
-    expect(intakeCalled).toBe(true);
-    expect(onboardingStarted).toBe(true);
+    // 6. Verify it navigated to the live screen
+    await expect(page.getByText("You're Live!")).toBeVisible({ timeout: 45000 });
 
-    // 7. Verify Agent Feed Presentation
-    await expect(page.locator('section[aria-label="Unified Agent Feed"]')).toBeVisible();
-    await expect(page.getByText('Your store is ready. Review and Publish.')).toBeVisible();
-
-    // 8. Review & Action
-    const approveBtn = page.getByTestId('approve-proposal');
-    await expect(approveBtn).toBeVisible();
-    await approveBtn.click();
+    // 7. Verify options are available
+    await expect(page.getByRole('link', { name: /Open Assistant/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Preview Storefront/i })).toBeVisible();
   });
 });


### PR DESCRIPTION
Resolves #29388

**Product-use evidence**
- **Persona:** Maya (Home Baker)
- **Attempted flow:** Entering a simple prompt in the 375px mobile UI to instantly generate a storefront without clicking through complex setup steps.
- **Observed product gap:** The existing E2E test `onboarding_instant_cuj.spec.ts` was heavily mocking the NextJS frontend and the backend API (`/api/onboarding/start`, `/api/onboarding/intake`, etc.), which violates the strict engineering standards of zero mock data for true E2E validation.
- **Fix:** Removed all `page.route` intercepts and switched the start URL to `/onboarding`. Ensured test interacts with actual DOM elements rendered by the NextJS UI against the real locally-spun backend service.

Superpowers loaded and applied: Zero mock data rule, True E2E execution.
Interaction audit table:
- `#instant-bio`: Typed natural language description successfully.
- `Next` button: Successfully triggered the `handleInstantBuild` API lifecycle.
- Live Dashboard links: Verified generation completion and display of "Open Assistant" and "Preview Storefront".

---
*PR created automatically by Jules for task [13984934302549303562](https://jules.google.com/task/13984934302549303562) started by @ql-owo-lp*