### PR TITLE
Fix: Align Config Sync with mcp_config_sync_log schema

### DIFF
--- a/src/server/tools/config_sync/server.rs
+++ b/src/server/tools/config_sync/server.rs
@@ -1,6 +1,6 @@
 use crate::ohc::orchestration::{McpInvokeRequest, McpInvokeResponse, McpToolProto};
-use sha2::{Sha256, Digest};
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use sqlx::Row;
 
 pub struct ConfigSyncServer {
@@ -28,15 +28,25 @@ impl ConfigSyncServer {
         }]
     }
 
-    pub async fn invoke_tool(&self, req: &McpInvokeRequest) -> Result<McpInvokeResponse, tonic::Status> {
+    pub async fn invoke_tool(
+        &self,
+        req: &McpInvokeRequest,
+    ) -> Result<McpInvokeResponse, tonic::Status> {
         if req.tool_id != "mcp_config_sync" {
             return Err(tonic::Status::invalid_argument("Invalid tool_id"));
         }
 
-        let parsed = ::server_auth::parse_spiffe_id(&req.spiffe_id).map_err(|_| tonic::Status::unauthenticated("invalid spiffe id"))?;
+        let parsed = ::server_auth::parse_spiffe_id(&req.spiffe_id)
+            .map_err(|_| tonic::Status::unauthenticated("invalid spiffe id"))?;
         let tenant_id = parsed.0;
+        let agent_id = req.agent_id.clone();
         if tenant_id.is_empty() {
-            return Err(tonic::Status::unauthenticated("empty tenant ID in SPIFFE ID"));
+            return Err(tonic::Status::unauthenticated(
+                "empty tenant ID in SPIFFE ID",
+            ));
+        }
+        if agent_id.is_empty() {
+            return Err(tonic::Status::unauthenticated("empty agent ID in request"));
         }
 
         let params: SyncParams = serde_json::from_str(&req.params)
@@ -44,22 +54,35 @@ impl ConfigSyncServer {
 
         match params.action.as_str() {
             "get_hash" => {
-                let row = sqlx::query("SELECT hash FROM user_configs WHERE spiffe_id = $1")
-                    .bind(&req.spiffe_id)
-                    .fetch_optional(&self.db)
-                    .await
-                    .map_err(|e| tonic::Status::internal(format!("DB error: {}", e)))?;
+                let row = sqlx::query(
+                    r#"
+                    SELECT metadata->>'hash' as hash
+                    FROM mcp_config_sync_log
+                    WHERE tenant_id = $1 AND config_key = 'standalone_config'
+                    "#,
+                )
+                .bind(&tenant_id)
+                .fetch_optional(&self.db)
+                .await
+                .map_err(|e| tonic::Status::internal(format!("DB error: {}", e)))?;
 
-                let hash: String = row.map(|r| r.get("hash")).unwrap_or_else(|| "".to_string());
+                let hash: String = row
+                    .and_then(|r| r.try_get::<Option<String>, _>("hash").ok().flatten())
+                    .unwrap_or_else(|| "".to_string());
 
                 let resp_payload = serde_json::to_string(&serde_json::json!({
                     "status": "success",
                     "hash": hash,
-                })).unwrap_or_else(|_| "".to_string());
-                Ok(McpInvokeResponse { payload: resp_payload })
+                }))
+                .unwrap_or_else(|_| "".to_string());
+                Ok(McpInvokeResponse {
+                    payload: resp_payload,
+                })
             }
             "push_config" => {
-                let mut payload = params.payload.ok_or_else(|| tonic::Status::invalid_argument("Missing payload"))?;
+                let mut payload = params
+                    .payload
+                    .ok_or_else(|| tonic::Status::invalid_argument("Missing payload"))?;
 
                 let max_size: usize = std::env::var("MAX_CONFIG_SIZE")
                     .unwrap_or_else(|_| (1024 * 1024).to_string())
@@ -69,7 +92,10 @@ impl ConfigSyncServer {
                 if let serde_json::Value::Object(ref mut map) = payload {
                     if let Some(pwd) = map.get("local_proxy_password").and_then(|v| v.as_str()) {
                         let encrypted = crate::crypto::encrypt_deterministic(pwd);
-                        map.insert("local_proxy_password".to_string(), serde_json::Value::String(encrypted));
+                        map.insert(
+                            "local_proxy_password".to_string(),
+                            serde_json::Value::String(encrypted),
+                        );
                     }
                 }
 
@@ -82,22 +108,29 @@ impl ConfigSyncServer {
                 hasher.update(config_str.as_bytes());
                 let hash = format!("{:x}", hasher.finalize());
 
+                let metadata = serde_json::json!({
+                    "hash": hash
+                });
+
                 let now = chrono::Utc::now().naive_utc();
 
                 sqlx::query(
                     r#"
-                    INSERT INTO user_configs (spiffe_id, config_json, updated_at, hash)
-                    VALUES ($1, $2, $3, $4)
-                    ON CONFLICT (spiffe_id) DO UPDATE SET
-                        config_json = EXCLUDED.config_json,
-                        updated_at = EXCLUDED.updated_at,
-                        hash = EXCLUDED.hash
+                    INSERT INTO mcp_config_sync_log (tenant_id, agent_id, config_key, config_value, metadata, updated_at)
+                    VALUES ($1, $2, $3, $4, $5, $6)
+                    ON CONFLICT (tenant_id, config_key) DO UPDATE SET
+                        agent_id = EXCLUDED.agent_id,
+                        config_value = EXCLUDED.config_value,
+                        metadata = EXCLUDED.metadata,
+                        updated_at = EXCLUDED.updated_at
                     "#
                 )
-                .bind(&req.spiffe_id)
+                .bind(&tenant_id)
+                .bind(&agent_id)
+                .bind("standalone_config")
                 .bind(&config_str)
+                .bind(metadata)
                 .bind(now)
-                .bind(&hash)
                 .execute(&self.db)
                 .await
                 .map_err(|e| tonic::Status::internal(format!("DB error: {}", e)))?;
@@ -105,8 +138,11 @@ impl ConfigSyncServer {
                 let resp_payload = serde_json::to_string(&serde_json::json!({
                     "status": "success",
                     "merged": true,
-                })).unwrap_or_else(|_| "".to_string());
-                Ok(McpInvokeResponse { payload: resp_payload })
+                }))
+                .unwrap_or_else(|_| "".to_string());
+                Ok(McpInvokeResponse {
+                    payload: resp_payload,
+                })
             }
             _ => Err(tonic::Status::invalid_argument("Invalid action")),
         }

--- a/src/server/tools/config_sync/tests.rs
+++ b/src/server/tools/config_sync/tests.rs
@@ -1,4 +1,3 @@
-
 use super::server::ConfigSyncServer;
 use crate::ohc::orchestration::McpInvokeRequest;
 use serde_json::json;
@@ -12,7 +11,7 @@ async fn test_config_sync_unauthenticated() {
     let req = McpInvokeRequest {
         tool_id: "mcp_config_sync".to_string(),
         action: "".to_string(),
-        agent_id: "".to_string(),
+        agent_id: "test-agent-123".to_string(),
         spiffe_id: "".to_string(), // Empty means unauthenticated
         params: json!({"action": "get_hash"}).to_string(),
     };
@@ -31,7 +30,7 @@ async fn test_config_sync_invalid_tool_id() {
     let req = McpInvokeRequest {
         tool_id: "wrong_tool_id".to_string(),
         action: "".to_string(),
-        agent_id: "".to_string(),
+        agent_id: "test-agent-123".to_string(),
         spiffe_id: "spiffe://test".to_string(),
         params: json!({"action": "get_hash"}).to_string(),
     };
@@ -54,8 +53,8 @@ fn test_config_sync_push_too_large() {
             let req = McpInvokeRequest {
                 tool_id: "mcp_config_sync".to_string(),
                 action: "".to_string(),
-                agent_id: "".to_string(),
-                spiffe_id: "spiffe://test".to_string(),
+                agent_id: "test-agent-123".to_string(),
+                spiffe_id: "spiffe://test/tenant/test-tenant".to_string(),
                 params: json!({
                     "action": "push_config",
                     "payload": {
@@ -76,24 +75,16 @@ async fn test_config_sync_push_and_get() {
     if std::env::var("OHC_DATABASE_URL").is_err() { return; }
     let pool = crate::db::get_pool();
 
-    // Migrate db to have the user_configs table
-    sqlx::query(
-        "CREATE TABLE IF NOT EXISTS user_configs (
-            spiffe_id VARCHAR PRIMARY KEY,
-            config_json TEXT NOT NULL,
-            updated_at TIMESTAMP NOT NULL,
-            hash VARCHAR NOT NULL
-        )"
-    ).execute(&pool).await.unwrap();
+    // The table mcp_config_sync_log is created by migrations in DB setup for tests.
 
     let server = ConfigSyncServer::new(pool.clone());
-    let spiffe_id = "spiffe://local_test";
+    let spiffe_id = "spiffe://local_test/tenant/test-tenant-123";
 
     // Push Config
     let push_req = McpInvokeRequest {
         tool_id: "mcp_config_sync".to_string(),
         action: "".to_string(),
-        agent_id: "".to_string(),
+        agent_id: "agent-123".to_string(),
         spiffe_id: spiffe_id.to_string(),
         params: json!({
             "action": "push_config",
@@ -113,7 +104,7 @@ async fn test_config_sync_push_and_get() {
     let get_req = McpInvokeRequest {
         tool_id: "mcp_config_sync".to_string(),
         action: "".to_string(),
-        agent_id: "".to_string(),
+        agent_id: "agent-123".to_string(),
         spiffe_id: spiffe_id.to_string(),
         params: json!({
             "action": "get_hash"


### PR DESCRIPTION
Refactored `ConfigSyncServer` to align with the correct `mcp_config_sync_log` schema.
Extracted `tenant_id` properly from `spiffe_id` and verified `agent_id`.
Updated the SQL interactions for `get_hash` and `push_config` properly.
Updated the tests to match the new schema and added missing parameters.

---
*PR created automatically by Jules for task [7777318099817933122](https://jules.google.com/task/7777318099817933122) started by @ql-owo-lp*