### PR TITLE
🤖 Implementer: Harness Upgrade - Pydantic-first tool schema

### DIFF
--- a/src/agents/builtin/tools/pydantic.rs
+++ b/src/agents/builtin/tools/pydantic.rs
@@ -63,11 +63,32 @@ impl<T: DeserializeOwned + Send + Sync, E: PydanticToolExecutor<T>> ToolExecutor
                     Err(_) => "<unprintable>".to_string(),
                 };
 
+                let err_str = e.to_string();
+                let mut detailed_instruction = self.custom_instruction.clone();
+
+                // Provide specific hints for common serde errors
+                if err_str.contains("missing field") {
+                    let field_name = err_str.split('`').nth(1).unwrap_or("unknown");
+                    let hint = format!("The required field '{}' is missing. Please provide it.", field_name);
+                    detailed_instruction = Some(detailed_instruction.map_or(hint.clone(), |mut instr| {
+                        instr.push_str("\nHint: ");
+                        instr.push_str(&hint);
+                        instr
+                    }));
+                } else if err_str.contains("invalid type") {
+                    let hint = "There is a type mismatch. Ensure strings are quoted, numbers are not quoted, and arrays/objects are formatted correctly as JSON.";
+                    detailed_instruction = Some(detailed_instruction.map_or(hint.to_string(), |mut instr| {
+                        instr.push_str("\nHint: ");
+                        instr.push_str(hint);
+                        instr
+                    }));
+                }
+
                 return Err(ToolError::LlmRecoverable(
                     ohc_builtin_agent_core::types::format_pydantic_error(
                         &e,
                         Some(args_str.as_str()),
-                        self.custom_instruction.as_deref(),
+                        detailed_instruction.as_deref(),
                     ),
                 ));
             }
@@ -118,8 +139,8 @@ mod tests {
         if let Err(ToolError::LlmRecoverable(msg)) = result {
             assert!(msg.contains("Validation Error (Pydantic-first tool schema)"));
             assert!(msg.contains("invalid type"));
-            assert!(msg.contains("invalid type"));
             assert!(msg.contains("not a number"));
+            assert!(msg.contains("There is a type mismatch"));
         } else {
             panic!("Expected LlmRecoverable error with detailed semantic validation feedback");
         }
@@ -134,6 +155,7 @@ mod tests {
         if let Err(ToolError::LlmRecoverable(msg)) = result {
             assert!(msg.contains("Validation Error (Pydantic-first tool schema)"));
             assert!(msg.contains("missing field `bar`"));
+            assert!(msg.contains("The required field 'bar' is missing."));
         } else {
             panic!("Expected LlmRecoverable error about missing field");
         }
@@ -201,7 +223,7 @@ mod tests_custom {
         if let Err(ToolError::LlmRecoverable(msg)) = result {
             assert!(msg.contains("Validation Error (Pydantic-first tool schema)"));
             assert!(msg.contains("Please provide an integer for bar"));
-            assert!(!msg.contains("Please strictly follow the tool's JSON schema and try again."));
+            assert!(msg.contains("Hint: There is a type mismatch."));
         } else {
             panic!("Expected LlmRecoverable error with custom instruction");
         }

--- a/src/agents/builtin/tools/pydantic_test.rs
+++ b/src/agents/builtin/tools/pydantic_test.rs
@@ -5,9 +5,15 @@ use ohc_builtin_agent_tools::pydantic::{PydanticToolExecutor, PydanticAdapter};
 use ohc_builtin_agent_tools::ToolExecutor;
 
 #[derive(Deserialize)]
+struct NestedArgs {
+    nested_str: String,
+}
+
+#[derive(Deserialize)]
 struct MyArgs {
     foo: String,
     bar: u32,
+    nested: Option<NestedArgs>,
 }
 
 struct MyExecutor;
@@ -15,7 +21,11 @@ struct MyExecutor;
 #[async_trait::async_trait]
 impl PydanticToolExecutor<MyArgs> for MyExecutor {
     async fn execute_typed(&self, args: MyArgs) -> Result<String, ToolError> {
-        Ok(format!("{}-{}", args.foo, args.bar))
+        if let Some(n) = args.nested {
+            Ok(format!("{}-{}-{}", args.foo, args.bar, n.nested_str))
+        } else {
+            Ok(format!("{}-{}", args.foo, args.bar))
+        }
     }
 }
 
@@ -27,13 +37,42 @@ async fn test_pydantic_adapter_success() {
 }
 
 #[tokio::test]
-async fn test_pydantic_adapter_failure() {
+async fn test_pydantic_adapter_failure_missing_field() {
+    let adapter = PydanticAdapter::new(MyExecutor);
+    let result = adapter.execute(serde_json::json!({ "foo": "test" })).await;
+    assert!(result.is_err());
+
+    if let Err(ToolError::LlmRecoverable(msg)) = result {
+        assert!(msg.contains("Validation Error (Pydantic-first tool schema)"));
+        assert!(msg.contains("The required field 'bar' is missing. Please provide it."));
+    } else {
+        panic!("Expected LlmRecoverable error for self-correction");
+    }
+}
+
+#[tokio::test]
+async fn test_pydantic_adapter_failure_invalid_type() {
     let adapter = PydanticAdapter::new(MyExecutor);
     let result = adapter.execute(serde_json::json!({ "foo": "test", "bar": "not a number" })).await;
     assert!(result.is_err());
 
     if let Err(ToolError::LlmRecoverable(msg)) = result {
         assert!(msg.contains("Validation Error (Pydantic-first tool schema)"));
+        assert!(msg.contains("There is a type mismatch. Ensure strings are quoted, numbers are not quoted, and arrays/objects are formatted correctly as JSON."));
+    } else {
+        panic!("Expected LlmRecoverable error for self-correction");
+    }
+}
+
+#[tokio::test]
+async fn test_pydantic_adapter_failure_nested_missing_field() {
+    let adapter = PydanticAdapter::new(MyExecutor);
+    let result = adapter.execute(serde_json::json!({ "foo": "test", "bar": 123, "nested": {} })).await;
+    assert!(result.is_err());
+
+    if let Err(ToolError::LlmRecoverable(msg)) = result {
+        assert!(msg.contains("Validation Error (Pydantic-first tool schema)"));
+        assert!(msg.contains("The required field 'nested_str' is missing. Please provide it."));
     } else {
         panic!("Expected LlmRecoverable error for self-correction");
     }


### PR DESCRIPTION
🤖 Implementer: Harness Upgrade - Pydantic-first tool schema -> validation errors fed back to LLM for self-correction

### Description
"Pydantic-first tool schema -> validation errors fed back to LLM for self-correction"

This PR implements the industry standard for returning specific semantic validation errors back to the LLM agent. 

### Implementation details:
1. Modified `PydanticAdapter::execute` in `src/agents/builtin/tools/pydantic.rs`.
2. Added specific `serde` string matching logic for "missing field" and "invalid type" to inject helpful hints into the `LlmRecoverable` error payload.
3. Updated all corresponding unit tests.
4. Added new tests for nested structure validation errors inside `src/agents/builtin/tools/pydantic_test.rs`.

### Verification instructions:
`bazel test //src/agents/builtin/...` and `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"`
All tests pass. No E2E impact.

### Superpowers:
None.

---
*PR created automatically by Jules for task [1516642783546132700](https://jules.google.com/task/1516642783546132700) started by @ql-owo-lp*