### PR TITLE
Fix touch targets in feed page

### DIFF
--- a/src/ui/next/src/app/feed/page.tsx
+++ b/src/ui/next/src/app/feed/page.tsx
@@ -360,7 +360,7 @@ export default function FeedPage() {
           <button
              onClick={simulateAmbassadorDraft}
              data-testid="simulate-ambassador-btn"
-             className="text-xs bg-gray-200 text-gray-600 px-3 py-1 rounded"
+             className="text-xs bg-gray-200 text-gray-600 px-3 py-1 rounded min-h-[44px]"
           >
             Simulate Ambassador Draft
           </button>


### PR DESCRIPTION
Fixes the failing `test_viewport.spec.ts` test by ensuring the "Simulate Ambassador Draft" button in `src/ui/next/src/app/feed/page.tsx` has a minimum height of 44px, complying with the mobile-first design requirement.

**Product-use evidence**
- Persona: Business Owner
- Flow: Log in -> Navigate to Dashboard (`/dashboard`) -> View Agent Feed -> Check buttons
- Issue: The "Simulate Ambassador Draft" button was too small (less than 44px height), making it difficult to tap on mobile devices.
- Fix: Added `min-h-[44px]` to the button's classes.
- Result: The button is now easier to tap and passes the viewport test.

**Superpowers used**
- No specific superpowers were needed for this fix.


---
*PR created automatically by Jules for task [6692580176543144902](https://jules.google.com/task/6692580176543144902) started by @ql-owo-lp*