### PR TITLE
Remove API reference/Advanced section from Help Center

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -85,7 +85,6 @@ pub fn get_articles() -> Vec<HelpArticle> {
         HelpArticle { category: "AI Agents".to_string(), title: "Activate AI Support".to_string(), desc: "Let our AI handle customer inquiries and triage your inbox.".to_string(), link: "/help/ai-support".to_string() },
         HelpArticle { category: "Marketing".to_string(), title: "Grow Your Audience".to_string(), desc: "Use our built-in tools to run promotions and track performance.".to_string(), link: "/help/marketing-tools".to_string() },
         HelpArticle { category: "Account & Billing".to_string(), title: "Manage Billing".to_string(), desc: "Update your subscription and payment methods.".to_string(), link: "/help/billing-settings".to_string() },
-        HelpArticle { category: "Advanced".to_string(), title: "API Reference".to_string(), desc: "Use our OpenAPI specs to integrate with OHC.".to_string(), link: "/api-docs".to_string() },
     ]
 }
 

--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -107,20 +107,6 @@ export default function HelpCenterPage() {
                  <VideoTutorialList videos={filteredVideos} loading={false} />
               </div>
             )}
-
-            <section className="mt-8 sm:mt-12 pt-6 sm:pt-8 border-t border-gray-200/50">
-              <WithTooltip id="api-docs-tooltip" defaultText="Direct API access is only for custom integrations.">
-                <div className="bg-yellow-50/50 glassmorphism p-5 sm:p-6 rounded-2xl border-yellow-200/50 shadow-sm flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-                  <div>
-                    <h3 className="text-base sm:text-lg font-bold font-outfit text-yellow-900">Advanced Users</h3>
-                    <p className="text-yellow-800/80 text-xs sm:text-sm mt-1">For users who want to use OHC's APIs directly (e.g., connect a custom checkout).</p>
-                  </div>
-                  <Link href="/api-docs" className="shrink-0 px-6 py-3 bg-yellow-100 hover:bg-yellow-200 text-yellow-900 font-semibold rounded-xl shadow-sm transition-all border border-yellow-300/50 w-full sm:w-auto text-center min-h-[44px]">
-                    API Documentation
-                  </Link>
-                </div>
-              </WithTooltip>
-            </section>
           </div>
         )}
       </div>


### PR DESCRIPTION
Removed the "Advanced Users" section in the Help Center UI and omitted the "Advanced" API Reference article from `get_articles` in the backend so it won't appear in search results either. Tests were verified to be passing.

---
*PR created automatically by Jules for task [2508219367144365074](https://jules.google.com/task/2508219367144365074) started by @ql-owo-lp*