### PR TITLE
fix: Offline POS optimistic UI task visibility and resolve compiler warnings

### DIFF
--- a/src/server/billing.rs
+++ b/src/server/billing.rs
@@ -265,14 +265,14 @@ impl Tracker {
 
     pub fn track_outbound_api_call(&self, tenant_id: &str, endpoint: &str) {
         tracing::info!("💰 Miser telemetry: Recording outbound API call for tenant: {}, endpoint: {}", tenant_id, endpoint);
-        if let Some(ref auditor) = self.auditor {
+        if let Some(ref _auditor) = self.auditor {
             // Future: auditor.record_api_call(tenant_id, endpoint);
         }
     }
 
     pub fn track_email_send(&self, tenant_id: &str) {
         tracing::info!("💰 Miser telemetry: Recording communication metric for tenant: {}", tenant_id);
-        if let Some(ref auditor) = self.auditor {
+        if let Some(ref _auditor) = self.auditor {
             // Future: auditor.record_email_send(tenant_id);
         }
     }

--- a/src/server/orchestration/mesh.rs
+++ b/src/server/orchestration/mesh.rs
@@ -318,7 +318,7 @@ mod tests {
 
     #[async_trait]
     impl P2PTransport for MockP2PTransport {
-        async fn handshake(&self, peer_id: &str, spiffe_id: &str, _public_key: &str, tenant_id: &str) -> Result<bool, String> {
+        async fn handshake(&self, _peer_id: &str, spiffe_id: &str, _public_key: &str, tenant_id: &str) -> Result<bool, String> {
             if spiffe_id.starts_with("spiffe://") && tenant_id == "test_tenant" {
                 Ok(true)
             } else {

--- a/src/ui/next/src/app/action-center/page.tsx
+++ b/src/ui/next/src/app/action-center/page.tsx
@@ -31,7 +31,7 @@ export default function ActionCenterPage() {
         const data = await response.json();
         // Filter for Business Advisory ("The Advisor") recommendations
         const advisoryApprovals = (data.pending_approvals || []).filter(
-          (a: ApprovalRequest) => a.department === 'business_advisory' || a.department === 'The Advisor'
+          (a: ApprovalRequest) => a.department === 'business_advisory' || a.department === 'The Advisor' || a.department === 'operations' || a.department === 'Operations'
         );
         setApprovals(advisoryApprovals);
       }

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
- Addressed an issue in the Action Center page where tasks generated under the `operations` department (e.g., from offline POS inventory sync conflicts) were being filtered out and hidden from the user.
- Updated `src/ui/next/src/app/action-center/page.tsx` to include `operations` and `Operations` in the department filter.
- Updated `src/ui/next/tsconfig.json` to change `"jsx": "react-jsx"` to `"jsx": "preserve"` to ensure proper Next.js Vitest compilation.
- Resolved unused variable warnings in the Rust backend (`src/server/billing.rs` and `src/server/orchestration/mesh.rs`) to maintain strict codebase hygiene.
- All tests (`//...`, `//src/e2e:playwright_shard_1_of_1`, and `//src/ui/next:next_vitest`) are fully passing.

Resolves #29421

---
*PR created automatically by Jules for task [6342758443268216846](https://jules.google.com/task/6342758443268216846) started by @ql-owo-lp*