### PR TITLE
Fix unused `supply` variable warning in server lib

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -4812,6 +4812,7 @@ async fn ui_dashboard_unified_feed_handler(
                 "pending_approvals": approvals,
                 "agent_feed": agent_feed,
                 "priority_tasks": priority_tasks,
+                "supply": supply,
             });
             if let Some(c) = UI_UNIFIED_FEED_CACHE.get() {
                 c.set(&cache_key_bg, result, std::time::Duration::from_secs(10)).await;

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -4866,17 +4866,12 @@ async fn ui_dashboard_unified_feed_handler(
         "pending_approvals": approvals,
         "agent_feed": agent_feed,
         "priority_tasks": priority_tasks,
+        "supply": supply,
     });
 
     let _ = cache.set(&cache_key, cacheable_result.clone(), std::time::Duration::from_secs(10)).await;
 
-    // Add supply to the final result
-    let mut final_result = cacheable_result;
-    if let Some(obj) = final_result.as_object_mut() {
-        obj.insert("supply".to_string(), supply);
-    }
-
-    (axum::http::StatusCode::OK, axum::Json(final_result)).into_response()
+    (axum::http::StatusCode::OK, axum::Json(cacheable_result)).into_response()
 }
 
 async fn ui_dashboard_unified_agent_feed_handler(


### PR DESCRIPTION
Resolved an unused variable warning (`supply`) in `src/server/lib.rs` by utilizing it correctly in the `serde_json::json!` response. This improves code quality and correctly propagates the supply data through the UI unified feed handler. All tests are passing and the solution is idiomatic Rust.

---
*PR created automatically by Jules for task [9480689255045152553](https://jules.google.com/task/9480689255045152553) started by @ql-owo-lp*