### PR TITLE
🤖 Implementer: Harness Upgrade - LLM-Recoverable ToolMessages

### DIFF
--- a/src/agents/builtin/agent.rs
+++ b/src/agents/builtin/agent.rs
@@ -4837,7 +4837,7 @@ mod tests {
                     // Check if the prompt contains the recoverable error
                     let last_msg = _req.messages.last().unwrap();
                     let expected_error = crate::types::format_llm_recoverable_error(
-                        "Validation Error (Pydantic-first tool schema): Failing for test",
+                        &crate::types::format_pydantic_error_string("Failing for test", Some("{}"), None)
                     );
                     let has_error = last_msg.tool_results.iter().any(|r| {
                         r.content.contains("LLM-Recoverable Error")
@@ -4899,7 +4899,7 @@ mod tests {
 
         // Verify the ToolCall event has the LlmRecoverable message
         let expected_error = crate::types::format_llm_recoverable_error(
-            "Validation Error (Pydantic-first tool schema): Failing for test",
+            &crate::types::format_pydantic_error_string("Failing for test", Some("{}"), None)
         );
         let has_recoverable_event = events.iter().any(|e| {
             if let AgentEvent::ToolCall { result, .. } = e {

--- a/src/agents/builtin/tool_executor_engine.rs
+++ b/src/agents/builtin/tool_executor_engine.rs
@@ -52,13 +52,17 @@ impl ToolExecutionEngine {
                 }
                 Err(ToolError::LlmRecoverable(msg)) => {
                     // 2) LLM-recoverable: returned to the model so it can self-correct.
-                    let formatted_msg =
-                        if msg.contains("Validation Error (Pydantic-first tool schema)") {
-                            msg
-                        } else {
-                            format!("Validation Error (Pydantic-first tool schema): {}", msg)
-                        };
+                    // Instead of appending a prefix if it's missing, we pass the error exactly as formatted
+                    // by the Pydantic parser logic, ensuring semantic details remain intact for the LLM.
+                    let formatted_msg = if !msg.contains("Validation Error (Pydantic-first tool schema)") {
+                        let arg_str = tc.arguments.to_string();
+                        ohc_builtin_agent_core::types::format_pydantic_error_string(&msg, Some(arg_str.as_str()), None)
+                    } else {
+                        msg
+                    };
                     info!("LLM-recoverable error encountered: {}", formatted_msg);
+                    // Master Catalog B.6. Output Parsing: fallback mechanic (RetryWithErrorOutputParser logic)
+                    // The error is routed directly back as a ToolMessage (via the orchestrator)
                     return Err(ToolError::LlmRecoverable(formatted_msg));
                 }
                 Err(ToolError::UserFixable(msg)) => {

--- a/src/agents/builtin/tool_executor_engine_tests.rs
+++ b/src/agents/builtin/tool_executor_engine_tests.rs
@@ -299,7 +299,10 @@ mod tests {
         let res = ToolExecutionEngine::execute_tool_with_langgraph_mechanics(&tool, &tc, 2).await;
         assert!(res.is_err());
         match res.unwrap_err() {
-            ToolError::LlmRecoverable(msg) => assert_eq!(msg, "Validation Error (Pydantic-first tool schema): parse error"),
+            ToolError::LlmRecoverable(msg) => {
+                assert!(msg.contains("Validation Error (Pydantic-first tool schema)"));
+                assert!(msg.contains("parse error"));
+            },
             _ => panic!("Expected LlmRecoverable error"),
         }
     }


### PR DESCRIPTION
🤖 Implementer: Harness Upgrade - LLM-Recoverable ToolMessages

This PR implements the SOTA Harness Pattern:
"Pydantic-first tool schema -> validation errors fed back to LLM for self-correction".

Master Catalog Extract:
"Error Handling (Compounding Error Prevention): LLM-recoverable (return the raw error as a ToolMessage directly to the model so it can self-correct)"

Implementation Details:
Refactored `ToolExecutionEngine::execute_tool_with_langgraph_mechanics` to explicitly capture tool arguments (`tc.arguments.to_string()`) and pipe them into the structured `format_pydantic_error_string`. This prevents context rot by ensuring the LLM sees the exact arguments it passed when a validation error occurs, rather than just a generic string match. Updated `agent.rs` and `tool_executor_engine_tests.rs` to reflect the rich Pydantic error formatting loop.

Tested via `bazelisk test //...` and `bazelisk test //src/e2e:playwright_spec_coverage`.

---
*PR created automatically by Jules for task [16527632830847362255](https://jules.google.com/task/16527632830847362255) started by @ql-owo-lp*