### PR TITLE
Fix: Resolve unused variable warning in mesh.rs

### DIFF
--- a/src/server/orchestration/mesh.rs
+++ b/src/server/orchestration/mesh.rs
@@ -318,7 +318,7 @@ mod tests {
 
     #[async_trait]
     impl P2PTransport for MockP2PTransport {
-        async fn handshake(&self, peer_id: &str, spiffe_id: &str, _public_key: &str, tenant_id: &str) -> Result<bool, String> {
+        async fn handshake(&self, _peer_id: &str, spiffe_id: &str, _public_key: &str, tenant_id: &str) -> Result<bool, String> {
             if spiffe_id.starts_with("spiffe://") && tenant_id == "test_tenant" {
                 Ok(true)
             } else {


### PR DESCRIPTION
Fixed an `unused variable: peer_id` warning in `src/server/orchestration/mesh.rs` that was previously causing a compilation error. This builds on top of the previously submitted fix for the payload optimization crash for `mobile_optimized=true` endpoint logic.

---
*PR created automatically by Jules for task [4203823450180407607](https://jules.google.com/task/4203823450180407607) started by @ql-owo-lp*