### PR TITLE
fix(pos): update offline receipt text to fix E2E assertions

### DIFF
--- a/src/ui/tauri/src/ui/pos.html
+++ b/src/ui/tauri/src/ui/pos.html
@@ -771,7 +771,7 @@
           // In real flow, we'd confirm the intent and sync offline txs.
           // We simulate the offline sync for E2E validation:
           if (!navigator.onLine) {
-              document.querySelector('.receipt-text').innerText = "Payment saved offline. Will sync when network is restored.";
+              document.querySelector('.receipt-text').innerText = "Offline Quick Charge Saved.";
               enqueueOfflineMutation({
                   type: 'tap_to_pay',
                   id: 'tx_' + Date.now(),


### PR DESCRIPTION
Resolves #29494

**Product-use evidence:** 
- **Persona:** Fatima the Food Cart Operator.
- **Workflow:** Set app to offline mode, entered Quick Charge, and processed payment.
- **Gap:** The receipt text "Payment saved offline. Will sync when network is restored." did not match what E2E tests expected ("Offline Quick Charge Saved.").
- **Fix:** Edited `pos.html` to output the exact string expected by the Playwright validation when offline.

**Superpowers used:**
None specific to this frontend text edit, but followed strict zero-mock data and testing policies.

**Interaction Audit:**
- Quick Charge button -> verified click offline results in correct DOM update.

All tests, including `terminal_pos.spec.ts`, passed successfully after this string reconciliation.

---
*PR created automatically by Jules for task [10162377972755261577](https://jules.google.com/task/10162377972755261577) started by @ql-owo-lp*