### PR TITLE
feat: Integrate WhatsApp Business Cloud API for Automated Work Intake

### DIFF
--- a/src/server/api/meta_webhook.rs
+++ b/src/server/api/meta_webhook.rs
@@ -145,10 +145,13 @@ async fn process_omnichannel_message(state: &MetaWebhookState, tenant_id: String
     let inbox_id = Uuid::new_v4().to_string();
     let pool = &state.db.pool;
 
+    // 1. Resolve Identity
+    let customer_id = crate::api::omnichannel_webhook::resolve_identity(&state.db, &tenant_id, &source, &sender_id).await;
+
     let insert_result = match &state.db.store {
         crate::db::DbStore::Postgres => {
-            sqlx::query(
-                "INSERT INTO inbox_messages (id, tenant_id, source, original_content, content, status, sender_id, created_at) VALUES ($1, $2, $3, $4, $5, 'unread', $6, NOW())"
+            let res = sqlx::query(
+                "INSERT INTO inbox_messages (id, tenant_id, source, original_content, content, draft_reply, status, sender_id, created_at) VALUES ($1, $2, $3, $4, $5, '', 'unread', $6, NOW())"
             )
             .bind(&inbox_id)
             .bind(&tenant_id)
@@ -157,11 +160,29 @@ async fn process_omnichannel_message(state: &MetaWebhookState, tenant_id: String
             .bind(&text)
             .bind(&sender_id)
             .execute(pool)
-            .await.map(|_| ())
+            .await;
+
+            if res.is_ok() {
+                if let Err(e) = sqlx::query(
+                    "INSERT INTO omni_inbox_messages (id, tenant_id, source, original_content, translated_content, target_language, draft_reply, status, sender_id, customer_id, created_at) VALUES ($1, $2, $3, $4, $5, 'English', '', 'unread', $6, $7, NOW())"
+                )
+                .bind(&inbox_id)
+                .bind(&tenant_id)
+                .bind(&source)
+                .bind(&text)
+                .bind(&text)
+                .bind(&sender_id)
+                .bind(&customer_id)
+                .execute(pool)
+                .await {
+                    tracing::error!("Failed to insert omni_inbox_messages: {}", e);
+                }
+            }
+            res.map(|_| ())
         },
         crate::db::DbStore::Sqlite(sqlite_pool) => {
-            sqlx::query(
-                "INSERT INTO inbox_messages (id, tenant_id, source, original_content, content, status, sender_id, created_at) VALUES (?, ?, ?, ?, ?, 'unread', ?, CURRENT_TIMESTAMP)"
+            let res = sqlx::query(
+                "INSERT INTO inbox_messages (id, tenant_id, source, original_content, content, draft_reply, status, sender_id, created_at) VALUES (?, ?, ?, ?, ?, '', 'unread', ?, CURRENT_TIMESTAMP)"
             )
             .bind(&inbox_id)
             .bind(&tenant_id)
@@ -170,29 +191,50 @@ async fn process_omnichannel_message(state: &MetaWebhookState, tenant_id: String
             .bind(&text)
             .bind(&sender_id)
             .execute(sqlite_pool)
-            .await.map(|_| ())
+            .await;
+
+            if res.is_ok() {
+                if let Err(e) = sqlx::query(
+                    "INSERT INTO omni_inbox_messages (id, tenant_id, source, original_content, translated_content, target_language, draft_reply, status, sender_id, customer_id, created_at) VALUES (?, ?, ?, ?, ?, 'English', '', 'unread', ?, ?, CURRENT_TIMESTAMP)"
+                )
+                .bind(&inbox_id)
+                .bind(&tenant_id)
+                .bind(&source)
+                .bind(&text)
+                .bind(&text)
+                .bind(&sender_id)
+                .bind(&customer_id)
+                .execute(sqlite_pool)
+                .await {
+                    tracing::error!("Failed to insert omni_inbox_messages (SQLite): {}", e);
+                }
+            }
+            res.map(|_| ())
         }
     };
 
     if let Err(e) = insert_result {
-        tracing::error!("Failed to insert inbox_messages: {}", e);
+        tracing::error!("Failed to insert omnichannel inbox message: {}", e);
     }
 
     let job_id = Uuid::new_v4().to_string();
-    let payload = serde_json::json!({
+    let mut payload_json = serde_json::json!({
         "message_id": inbox_id,
         "source": source,
         "content": text,
         "sender_id": sender_id
     });
-    // In future iterations, customer_id can be looked up and included in payload
+
+    if let Some(c_id) = &customer_id {
+        payload_json["customer_id"] = serde_json::json!(c_id);
+    }
 
     let enqueue_result = match &state.db.store {
         crate::db::DbStore::Postgres => {
             sqlx::query("INSERT INTO ohc_job_queue (id, tenant_id, job_type, payload, status) VALUES ($1, $2, 'message_triage', $3, 'PENDING')")
                 .bind(&job_id)
                 .bind(&tenant_id)
-                .bind(payload.to_string())
+                .bind(payload_json.to_string())
                 .execute(pool)
                 .await
                 .map(|_| ())
@@ -201,7 +243,7 @@ async fn process_omnichannel_message(state: &MetaWebhookState, tenant_id: String
             sqlx::query("INSERT INTO ohc_job_queue (id, tenant_id, job_type, payload, status) VALUES (?, ?, 'message_triage', ?, 'PENDING')")
                 .bind(&job_id)
                 .bind(&tenant_id)
-                .bind(payload.to_string())
+                .bind(payload_json.to_string())
                 .execute(sqlite_pool)
                 .await
                 .map(|_| ())
@@ -216,7 +258,7 @@ async fn process_omnichannel_message(state: &MetaWebhookState, tenant_id: String
         id: Uuid::new_v4().to_string(),
         tenant_id: tenant_id.clone(),
         event_type: "tenant.omnichannel.message.received".to_string(),
-        payload: payload.clone(),
+        payload: payload_json.clone(),
     };
 
     let orchestrator_clone = state.orchestrator.clone();

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -5857,6 +5857,12 @@ async fn create_ui_bom_item_handler(
                 "checkout_url": url
             }))
         }))
+        .route("/api/integrations/whatsapp_cloud_api/connect", axum::routing::post(|| async move {
+            axum::response::Json(serde_json::json!({
+                "success": true,
+                "message": "Connected WhatsApp Cloud API successfully"
+            }))
+        }))
         .route("/api/checkout/delivery-quote", axum::routing::post({
             let settings_store = settings_store.clone();
             move |axum::Json(req): axum::Json<serde_json::Value>| async move {

--- a/src/ui/next/src/app/integrations/page.tsx
+++ b/src/ui/next/src/app/integrations/page.tsx
@@ -123,11 +123,30 @@ export default function Integrations() {
   };
 
   const saveWhatsAppCloudApiIntegration = async () => {
-    // Mock API call to save connection status
-    setTimeout(() => {
+    try {
+      // Simulate OAuth or call backend if needed
+      // Currently, mimicking the connection state update:
+      const res = await fetch(`/api/integrations/whatsapp_cloud_api/connect`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          integration_id: 'whatsapp_cloud_api',
+        })
+      });
+
+      if (!res.ok) {
+        setStatusMessage("Failed to connect WhatsApp Cloud API.");
+        return;
+      }
+
+      setIntegrations(prev => prev.map(integration =>
+        integration.id === 'whatsapp_cloud_api' ? { ...integration, status: "connected" } : integration
+      ));
       setShowWhatsAppCloudApiModal(false);
       setStatusMessage("WhatsApp Cloud API connected.");
-    }, 500);
+    } catch (e) {
+      setStatusMessage("Failed to connect WhatsApp Cloud API.");
+    }
   };
 
   return (


### PR DESCRIPTION
This PR integrates the WhatsApp Business Cloud API to allow owners to connect their WhatsApp business numbers to the Workbuddy-like OHC platform. 

It handles routing Meta webhooks to the unified inbox and provides a UI flow for connection. It sets up the scaffolding for future expansion with true Meta OAuth by mocking the final save connection API while building out the UI modal. E2E tests have been verified to cover this integration loop.

---
*PR created automatically by Jules for task [686303142395537380](https://jules.google.com/task/686303142395537380) started by @ql-owo-lp*

Resolves #29527