### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Fix Tenant Leakage & Harden Standalone Local Database

### DIFF
--- a/src/server/common/auth_utils.rs
+++ b/src/server/common/auth_utils.rs
@@ -4,7 +4,7 @@ pub async fn set_system_context<'a, E>(executor: E) -> Result<(), sqlx::Error>
 where
     E: Executor<'a, Database = Postgres>,
 {
-    query("SET LOCAL ROLE ohc_bypassrls")
+    query("SET ROLE ohc_bypassrls")
         .execute(executor)
         .await?;
     Ok(())
@@ -30,13 +30,14 @@ where
         // Wait, we can use `query` instead of `executor.execute`, because `query` takes `executor` which we can borrow if we used `&mut executor`, but wait, we had errors with `&mut executor` too because E doesn't implement `Executor` for `&mut E`.
         // The right way is to use a single SQL function, or use an anonymous DO block if we want multiple statements!
         // But DO blocks can't be used with extended query protocol either? Actually they can!
-        // Another option: "SET LOCAL ROLE ohc_bypassrls" is all we need! We don't strictly *need* to set current_tenant to empty.
-        query("SET LOCAL ROLE ohc_bypassrls")
+        // Another option: "SET ROLE ohc_bypassrls" is all we need! We don't strictly *need* to set current_tenant to empty.
+        query("SET ROLE ohc_bypassrls")
             .execute(executor)
             .await?;
     } else {
-        // No need to RESET ROLE since SET LOCAL is transaction scoped.
-        query("SELECT set_config('app.current_tenant', $1, true)")
+        // We use session scope (false) because set_org_context might be called on a raw connection outside a transaction.
+        // Pool hooks (before_acquire / after_release) safely wipe session states using DISCARD ALL and SET app.current_tenant = ''.
+        query("RESET ROLE; SELECT set_config('app.current_tenant', $1, false);")
             .bind(org_id)
             .execute(executor)
             .await?;

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -205,6 +205,11 @@ impl DB {
                 })
                 .connect_lazy("postgres://postgres:postgres@localhost:5432/test")?;
 
+            let mut conn_opts = SqliteConnectOptions::from_str(&database_url)?;
+            // Force create_if_missing to false to avoid insecure creation by sqlx
+            // Only our manual secure creation below will be allowed to create it.
+            conn_opts = conn_opts.create_if_missing(false);
+
             // Ensure secure directory creation for SQLite database in Standalone mode
             let path_str_opt = if let Some(p) = database_url.strip_prefix("sqlite://") {
                 Some(p)
@@ -316,12 +321,6 @@ impl DB {
                     }
                 }
             }
-
-
-            let mut conn_opts =
-                SqliteConnectOptions::from_str(&database_url)?.create_if_missing(true);
-
-
 
 
             // sqlite-vec is optional at runtime. The memory repository probes for


### PR DESCRIPTION
🛡️ Sentinel: [Hybrid Security Fix]
Fix Tenant Leakage & Harden Standalone Local Database

- Updated `set_org_context` in `src/server/common/auth_utils.rs` to persist the bypass role cleanly using session-level (`SET ROLE` instead of `SET LOCAL ROLE`) and ensuring session scope for `set_config` (`is_local = false`). Added `RESET ROLE` before applying to prevent privilege escalation.
- Set `create_if_missing(false)` inside `DB::new()` to disable insecure default SQLite DB file creation by `sqlx`, ensuring it strictly goes through the secure creation block with `0o600` permissions.

---
*PR created automatically by Jules for task [5002463972865829516](https://jules.google.com/task/5002463972865829516) started by @ql-owo-lp*