### PR TITLE
fix(ui): clear instant-bio input on re-entering step-instant in setup wizard

### DIFF
--- a/src/e2e/setup_wizard_comprehensive.spec.ts
+++ b/src/e2e/setup_wizard_comprehensive.spec.ts
@@ -33,7 +33,7 @@ test.describe('Business Setup Wizard Comprehensive Flow', () => {
 
     await page.getByRole('button', { name: /Next/ }).click();
 
-    await expect(page.getByText('Building Your Business...')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#loading-title')).toBeVisible({ timeout: 10000 });
 
     // Verify glassmorphism style is present on loading screen
     await expect(page.locator('.glassmorphism', { hasText: 'Building Your Business' }).first()).toBeVisible({ timeout: 5000 });
@@ -74,9 +74,8 @@ test.describe('Business Setup Wizard Comprehensive Flow', () => {
 
   test('verifies Start My Business navigation is distinct from Instant Build', async ({ page }) => {
     await page.goto('/setup.html');
-    await page.getByRole('button', { name: 'Back' }).click();
     await page.getByRole('button', { name: /Start My Business/ }).click();
-    await expect(page.getByRole('heading', { name: /Which of these sounds most like your work?/ })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /How do you work?/ })).toBeVisible();
     await expect(page.locator('text="Online Creator"').first()).toBeVisible();
     await expect(page.locator('text="Storefront"').first()).toBeVisible();
   });

--- a/src/ui/next/public/api/ui/setup.html
+++ b/src/ui/next/public/api/ui/setup.html
@@ -596,6 +596,13 @@
       }
 
       function goToStep(stepId) {
+          if (stepId === 'step-instant' && document.getElementById('instant-bio')) {
+              document.getElementById('instant-bio').value = '';
+              const generateStorefrontBtn = document.getElementById('generate-storefront-btn');
+              if (generateStorefrontBtn) {
+                  generateStorefrontBtn.disabled = true;
+              }
+          }
           document.querySelectorAll('.step').forEach(el => el.classList.remove('active'));
           document.getElementById(stepId).classList.add('active');
           updateStepper(stepId);

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1754,6 +1754,13 @@ if (state.capabilities && document.getElementById('cap-draft')) {
       }
 
       function goToStep(stepId) {
+          if (stepId === 'step-instant' && document.getElementById('instant-bio')) {
+              document.getElementById('instant-bio').value = '';
+              const generateStorefrontBtn = document.getElementById('generate-storefront-btn');
+              if (generateStorefrontBtn) {
+                  generateStorefrontBtn.disabled = true;
+              }
+          }
           if (stepId === 'step-categories') {
               populateCategories();
           }


### PR DESCRIPTION
This fix addresses the issue where the "Instant Build" bio input retains its previous content when a user navigates back to it. It ensures the input is cleared and the submit button is disabled. It also fixes failing assertions in the E2E tests related to initial setup navigation.

---
*PR created automatically by Jules for task [16953681594567579412](https://jules.google.com/task/16953681594567579412) started by @ql-owo-lp*