### PR TITLE
🎥 Lens Audit: fix cost-dashboard mock data and routing

### DIFF
--- a/src/e2e/fixtures.ts
+++ b/src/e2e/fixtures.ts
@@ -25,7 +25,7 @@ async function loginAs(page: Page, user: E2EUser) {
   // The actual tenant_id comes from a header or cookie in a real deployment.
   // In the real system, it's determined by the login session. But in our e2e fixture,
   // we can use Playwright to set the context or navigate.
-  await page.goto('/dashboard');
+  await page.goto('/dashboard.html');
 }
 
 function rejectNetworkStubbing(context: BrowserContext, page?: Page) {

--- a/src/e2e/test_ui.spec.ts
+++ b/src/e2e/test_ui.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './fixtures';
 
 test('Cost Soft Limit friendly prompt shows', async ({ page, loginAs, unlimitedAdminUser }) => {
   await loginAs(page, unlimitedAdminUser);
-  await page.goto('/cost-dashboard');
+  await page.goto('/cost-dashboard.html');
   await page.waitForLoadState('networkidle');
   // We cannot easily assert the limit reached text without a specific tenant setup in DB.
   // But we must at least assert that the plan page loads fully for the E2E.

--- a/src/ui/tauri/src/ui/cost-dashboard.html
+++ b/src/ui/tauri/src/ui/cost-dashboard.html
@@ -243,7 +243,7 @@
 
             <div style="margin-bottom: 24px;">
               <span class="stat-title" style="display:block; margin: 0; font-size: 14px; font-weight: 500; color: #86868b;">AI actions used this month</span>
-              <div class="stat-value" id="ai-actions-text">0 / Unlimited</div>
+              <div class="stat-value" id="ai-actions-text">Loading...</div>
               <div class="progress-bar-bg">
                 <div class="progress-bar-fill" id="ai-actions-bar" style="width: 0%;"></div>
               </div>
@@ -251,7 +251,7 @@
 
             <div style="margin-bottom: 24px;">
               <div class="stat-title">Storage used</div>
-              <div class="stat-value" id="storage-text">0 GB / Unlimited</div>
+              <div class="stat-value" id="storage-text">Loading...</div>
               <div class="progress-bar-bg">
                 <div class="progress-bar-fill" id="storage-bar" style="width: 0%;"></div>
               </div>
@@ -259,7 +259,7 @@
 
             <div style="margin-bottom: 24px;">
               <h2 class="stat-title" style="margin: 0; font-size: 14px; font-weight: 500; color: #86868b;">Estimated Next Bill:</h2>
-              <div class="stat-value" id="my-plan-next-bill" style="color: #34C759;">$0.00</div>
+              <div class="stat-value" id="my-plan-next-bill" style="color: #34C759;">Loading...</div>
             </div>
 
             <button class="btn-primary" onclick="window.location.href='pricing.html'">Upgrade Plan</button>
@@ -279,15 +279,15 @@
             <div class="metrics-grid">
                <div class="metric-box">
                   <div class="stat-title">Total Revenue</div>
-                  <div class="stat-value" id="cost-dashboard-revenue" style="color: #34C759; font-size: 20px;">$0.00</div>
+                  <div class="stat-value" id="cost-dashboard-revenue" style="color: #34C759; font-size: 20px;">Loading...</div>
                </div>
                <div class="metric-box">
                   <h2 class="stat-title" style="margin: 0; font-size: 14px; font-weight: 500; color: #86868b;">Total Costs</h2>
-                  <div class="stat-value" id="cost-dashboard-total" style="font-size: 20px;">$0.00</div>
+                  <div class="stat-value" id="cost-dashboard-total" style="font-size: 20px;">Loading...</div>
                </div>
                <div class="metric-box">
                   <div class="stat-title">Projected Monthly Cost</div>
-                  <div class="stat-value" id="projected-monthly-cost" style="font-size: 20px;">$0.00</div>
+                  <div class="stat-value" id="projected-monthly-cost" style="font-size: 20px;">Loading...</div>
                </div>
             </div>
 
@@ -297,42 +297,42 @@
                 </svg>
                 <div>
                     <h3 style="margin: 0 0 4px 0; font-size: 14px; font-weight: 600; color: #92400e;">Soft Limit Approaching</h3>
-                    <p id="budget-health-alert-text" style="margin: 0; font-size: 14px; color: #b45309;">Your projected monthly cost is exceeding your typical baseline. Consider reviewing your agent usage or upgrading your tier for better bulk rates.</p>
+                    <p id="budget-health-alert-text" style="margin: 0; font-size: 14px; color: #b45309;">Your projected monthly cost is exceeding your typical baseline. Consider reviewing your agent usage or upgrading your plan.</p>
                 </div>
             </div>
 
             <h2 style="margin-top: 24px; font-weight: 600; margin-bottom: 12px; font-size: 18px;">Cost Breakdown</h2>
             <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
                 <span style="color: #86868b;">LLM Usage</span>
-                <span id="cost-dashboard-llm" style="font-weight: 500;">$0.00</span>
+                <span id="cost-dashboard-llm" style="font-weight: 500;">Loading...</span>
             </div>
             <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
                 <span style="color: #86868b;">Storage</span>
-                <span id="cost-dashboard-storage" style="font-weight: 500;">$0.00</span>
+                <span id="cost-dashboard-storage" style="font-weight: 500;">Loading...</span>
             </div>
             <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
                 <span style="color: #86868b;">Payment Fees</span>
-                <span id="cost-dashboard-payment-fees" style="font-weight: 500;">$0.00</span>
+                <span id="cost-dashboard-payment-fees" style="font-weight: 500;">Loading...</span>
             </div>
             <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
                 <span style="color: #86868b;">Network & Storage Savings</span>
-                <span id="cost-dashboard-total-savings" style="font-weight: 500; color: #34C759;">$0.00</span>
+                <span id="cost-dashboard-total-savings" style="font-weight: 500; color: #34C759;">Loading...</span>
             </div>
             <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
                 <span style="color: #86868b;">Compute Usage</span>
-                <span id="compute-cost" style="font-weight: 500;">$0.00</span>
+                <span id="compute-cost" style="font-weight: 500;">Loading...</span>
             </div>
             <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
                 <span style="color: #86868b;">Network Cost</span>
-                <span id="cost-dashboard-network" style="font-weight: 500;">$0.00</span>
+                <span id="cost-dashboard-network" style="font-weight: 500;">Loading...</span>
             </div>
             <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
                 <span style="color: #86868b;">Email Sends</span>
-                <span id="email-cost" style="font-weight: 500;">$0.00</span>
+                <span id="email-cost" style="font-weight: 500;">Loading...</span>
             </div>
             <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
                 <span style="color: #86868b;">Outbound API Calls</span>
-                <span id="api-cost" style="font-weight: 500;">$0.00</span>
+                <span id="api-cost" style="font-weight: 500;">Loading...</span>
             </div>
 
             <h3 style="margin-top: 24px; font-weight: 600; margin-bottom: 12px; font-size: 16px;">Agent & Feature Costs</h3>
@@ -451,7 +451,7 @@
 
                 if (costData.budget_health_alert) {
                     document.getElementById('budget-health-alert').style.display = 'flex';
-                    document.getElementById('budget-health-alert-text').innerText = `Your projected monthly cost (${formatCents(costData.projected_monthly_cost)}) is exceeding your typical baseline. Consider reviewing your agent usage or upgrading your tier for better bulk rates.`;
+                    document.getElementById('budget-health-alert-text').innerText = `Your projected monthly cost (${formatCents(costData.projected_monthly_cost)}) is exceeding your typical baseline. Consider reviewing your agent usage or upgrading your plan.`;
                 } else {
                     document.getElementById('budget-health-alert').style.display = 'none';
                 }


### PR DESCRIPTION
This PR enforces "Visual Truth" and "Data Truth" on the Cost Dashboard by:
- Replacing hardcoded `0`, `$0.00`, and `Unlimited` metrics with a truthful `Loading...` state, allowing the API fetch to populate the real data.
- Removing technical jargon like "tier" and "bulk rates" from the budget health warning, replacing it with plain language ("plan").
- Adjusting Playwright routing (`/cost-dashboard.html` instead of `/cost-dashboard`) so the E2E test passes hermetically against the static site setup.

---
*PR created automatically by Jules for task [257712106022184116](https://jules.google.com/task/257712106022184116) started by @ql-owo-lp*