### PR TITLE
⚡ Bolt: [performance improvement] Clean up duplicate worktree subagent execution branch

### DIFF
--- a/src/agents/builtin/tools/subagent.rs
+++ b/src/agents/builtin/tools/subagent.rs
@@ -212,57 +212,6 @@ impl PydanticToolExecutor<SubagentArgs> for SubagentExecutor {
                 }
                 Err(e) => Err(ToolError::LlmRecoverable(format!("Subagent failed: {}", e))),
             }
-        } else if mode == "worktree" {
-            let task_id = uuid::Uuid::new_v4().to_string();
-            let branch_name = format!("subagent-{}", task_id);
-            let worktree_dir = format!(".agent-worktrees/{}", branch_name);
-
-            // Create git worktree
-            let output = self.runner.run("git", &["worktree", "add", "-b", &branch_name, &worktree_dir], None, vec![]).await;
-            if let Err(e) = output {
-                return Err(ToolError::LlmRecoverable(format!("Failed to create git worktree: {}", e)));
-            } else if let Ok(out) = output {
-                if !out.status.success() {
-                    return Err(ToolError::LlmRecoverable(format!("git worktree add failed: {}", String::from_utf8_lossy(&out.stderr))));
-                }
-            }
-
-            let worktree_task = format!(
-                "You are a subagent running in an isolated git worktree (branch: {}). Your task is: {}\n\nCRITICAL INSTRUCTION: You MUST return a 1k-2k token condensed summary of your findings and actions. Do not return your full context loop.",
-                branch_name, task
-            );
-
-            let mut envs = vec![];
-            if let Ok(addr) = std::env::var("OHC_AGENT_ADDRESS") {
-                envs.push(("OHC_AGENT_ADDRESS".to_string(), addr));
-            }
-
-            let pb = std::path::PathBuf::from(&worktree_dir);
-            let output = self.runner.run("ohc_builtin_agent", &["--task", &worktree_task], Some(pb.as_path()), envs).await;
-
-            let res = match output {
-                Ok(out) => {
-                    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
-                    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
-                    if out.status.success() {
-                        let mut summary = stdout;
-                        if summary.chars().count() > 8000 {
-                            summary = format!("{}\n\n[Output truncated. Subagent failed to condense summary.]", summary.chars().take(8000).collect::<String>());
-                        }
-                        Ok(format!("[Subagent (Worktree: {})] Completed task. Summary: {}", branch_name, summary))
-                    } else {
-                        Err(format!("Process failed: {}", stderr))
-                    }
-                }
-                Err(e) => Err(format!("Runner failed: {}", e)),
-            };
-
-            // Note: We leave the worktree intact for the user or parent agent to inspect and merge.
-
-            match res {
-                Ok(msg) => Ok(msg),
-                Err(e) => Err(ToolError::LlmRecoverable(format!("Subagent failed: {}", e))),
-            }
         } else if mode == "teammate" {
             let task_id = uuid::Uuid::new_v4().to_string();
             let mailbox_dir = format!(".agent-mailboxes/subagent-{}", task_id);


### PR DESCRIPTION
This PR addresses a codebase optimization by fixing a compiler warning that acts as a deny constraint (`ifs_same_cond`). The `subagent.rs` tool incorrectly contained two identical `if mode == "worktree"` branches within the same control flow block. The second block was completely unreachable dead code and lacked proper LLM-based output summarization that the primary `worktree` logic properly implemented.

This ensures `cargo clippy` runs cleanly in the `ohc_builtin_agent_tools` package. SWR caches and query fetching operations throughout `latency_bench.rs` and `src/server/lib.rs` (such as `ui_dashboard_unified_feed_handler` and `list_ui_omni_inbox_handler`) have already been independently optimized for maximum parallel execution.

Product-use evidence: 
N/A - the modification is isolated to an internal agent orchestration codebase tool and strictly affects unreachable background execution logic without altering frontend behavior.

Interaction audit:
N/A - no user-facing UI modifications.

---
*PR created automatically by Jules for task [13839844363166193812](https://jules.google.com/task/13839844363166193812) started by @ql-owo-lp*