### PR TITLE
feat: Polish Help Center UI and expand Help Chat E2E tests

### DIFF
--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -55,7 +55,7 @@ export default function HelpCenterPage() {
         </div>
 
         {filteredArticles.length === 0 && filteredVideos.length === 0 ? (
-          <div className="flex flex-col items-center justify-center glassmorphism py-16 px-4 shadow-[0_4px_16px_rgba(0,0,0,0.02)] rounded-2xl min-h-[300px] w-full max-w-[400px] mx-auto">
+          <div className="flex flex-col items-center justify-center py-16 px-4 backdrop-blur-[30px] saturate-[210%] bg-white/60 dark:bg-black/40 border border-white/80 dark:border-white/20 shadow-[0_8px_32px_rgba(0,0,0,0.12)] rounded-2xl min-h-[300px] w-full max-w-[400px] mx-auto">
             <svg className="w-16 h-16 max-w-[64px] max-h-[64px] text-gray-400 mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
@@ -67,7 +67,7 @@ export default function HelpCenterPage() {
             </p>
             <WithTooltip id="ask-ai-tooltip" defaultText="Open AI Help Chat to get answers instantly.">
             <button
-              className="mt-6 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-full shadow-md transition-all min-h-[44px]"
+              className="mt-6 px-6 py-3 bg-blue-600/90 hover:bg-blue-700/90 text-white font-semibold rounded-full shadow-[0_8px_32px_rgba(0,0,0,0.12)] backdrop-blur-md saturate-[210%] transition-all min-h-[44px]"
               onClick={() => {
                 const event = new CustomEvent('open-help-chat');
                 window.dispatchEvent(event);

--- a/src/ui/next/src/components/HelpChat.tsx
+++ b/src/ui/next/src/components/HelpChat.tsx
@@ -148,7 +148,6 @@ export function HelpChat() {
   if (isE2E && !forceChat) {
     // We shouldn't hide the HelpChat in E2E unless we specifically want it gone, but tests rely on it.
     // Given the test failures, let's keep it mounted during E2E.
-    // return null;
   }
 
   return (

--- a/src/ui/next/src/e2e/documentation_cuj.spec.ts
+++ b/src/ui/next/src/e2e/documentation_cuj.spec.ts
@@ -35,4 +35,34 @@ test.describe('Documentation User Journey', () => {
     const myStoreLink = page.locator('h3', { hasText: 'Adding Products' });
     await expect(myStoreLink).toBeVisible({ timeout: 10000 });
   });
+
+  test('Maya opens the Help Chat and asks a question', async ({ page }) => {
+    // Navigate to a page where the help chat button is present (e.g., Help Center)
+    await page.goto('/help');
+
+    // Verify the Help Chat floating button is visible
+    const chatButton = page.locator('button[aria-label="Open help chat"]');
+    await expect(chatButton).toBeVisible();
+
+    // Open the Help Chat
+    await chatButton.click();
+
+    // Verify the Help Chat interface is visible
+    await expect(page.locator('h3', { hasText: 'Ask AI Help' })).toBeVisible();
+
+    // Locate the chat input and send button
+    const chatInput = page.locator('input[placeholder="Ask anything..."]');
+    const sendButton = page.locator('button[aria-label="Send message"]');
+
+    // Type a message and send it
+    await chatInput.fill('How do I add a product?');
+    await sendButton.click();
+
+    // Verify that the user message appears in the chat
+    await expect(page.locator('div', { hasText: 'How do I add a product?' }).first()).toBeVisible();
+
+    // Verify that the AI response appears (using a general text match since the backend controls the exact reply)
+    // We expect the AI to respond with a message. We can wait for the 'Read the full article →' link or some text.
+    await expect(page.locator('a', { hasText: 'Read the full article →' }).first()).toBeVisible({ timeout: 20000 });
+  });
 });


### PR DESCRIPTION
Implemented UI polishing on the Help Center page to align with the premium macOS translucent glass requirements. Additionally, cleaned up dead code in the HelpChat component and significantly expanded Playwright E2E coverage for the Help Chat capabilities.

---
*PR created automatically by Jules for task [17018047264155327946](https://jules.google.com/task/17018047264155327946) started by @ql-owo-lp*