### PR TITLE
fix: add businessGoal to onboarding wizardState

### DIFF
--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -83,7 +83,7 @@ export default function OnboardingWizard() {
     const wizardState = {
       step,
       chatStep,
-      businessDescription,
+      businessDescription, businessGoal,
       bio,
       businessName,
       whatYouSell,
@@ -144,7 +144,7 @@ export default function OnboardingWizard() {
       const wizardState = {
         step,
         chatStep,
-        businessDescription,
+        businessDescription, businessGoal,
         bio,
         businessName,
         whatYouSell,
@@ -202,6 +202,7 @@ export default function OnboardingWizard() {
         if (data.wizardState.step !== undefined) setStep(data.wizardState.step === 4 ? 3 : data.wizardState.step);
         if (data.wizardState.chatStep !== undefined) setChatStep(data.wizardState.chatStep);
         if (data.wizardState.businessDescription !== undefined) setBusinessDescription(data.wizardState.businessDescription);
+        if (data.wizardState.businessGoal !== undefined) setBusinessGoal(data.wizardState.businessGoal);
         if (data.wizardState.bio !== undefined) setBio(data.wizardState.bio);
         if (data.wizardState.businessName !== undefined) setBusinessName(data.wizardState.businessName);
         if (data.wizardState.whatYouSell !== undefined) setWhatYouSell(data.wizardState.whatYouSell);
@@ -241,7 +242,7 @@ export default function OnboardingWizard() {
     const wizardState = {
       step,
       chatStep,
-      businessDescription,
+      businessDescription, businessGoal,
       bio,
       businessName,
       whatYouSell,
@@ -270,7 +271,7 @@ export default function OnboardingWizard() {
 
     return () => clearTimeout(timer);
   }, [
-    step, chatStep, businessDescription, businessName, whatYouSell, location,
+    step, chatStep, businessDescription, businessGoal, businessName, whatYouSell, location,
     targetAudience, businessType, categories, websiteTemplate, domainChoice, firstProductName, firstProductPrice,
     adminName, adminEmail, adminPassword, aiAgents, aiAutoRespond, isLoaded
   ]);


### PR DESCRIPTION
Added `businessGoal` to the `wizardState` payload in `page.tsx` to correctly persist and sync the user's business goal in the onboarding wizard. Tests passed and reviewed.

---
*PR created automatically by Jules for task [2832877638202857943](https://jules.google.com/task/2832877638202857943) started by @ql-owo-lp*