### PR TITLE
fix(e2e): update instant build test button selector

### DIFF
--- a/src/ui/next/src/e2e/onboarding.spec.ts
+++ b/src/ui/next/src/e2e/onboarding.spec.ts
@@ -279,7 +279,7 @@ test.describe('OnboardingWizard CUJ', () => {
     const bioInput = page.getByPlaceholder(/e.g. I run a local bakery/i);
     await bioInput.fill('I am Maya, I run a local bakery making custom vegan cakes in Portland, OR.');
 
-    await page.getByRole('button', { name: 'Generate Storefront' }).click();
+    await page.getByRole('button', { name: 'Next' }).click();
 
     // Expect it to eventually reach "You're Live!" screen
     await expect(page.getByText("You're Live!")).toBeVisible({ timeout: 15000 });
@@ -298,7 +298,7 @@ test.describe('OnboardingWizard CUJ', () => {
     // Intercept the API route to fail
     await context.route('/api/onboarding/intake', route => route.abort('failed'));
 
-    await page.getByRole('button', { name: 'Generate Storefront' }).click();
+    await page.getByRole('button', { name: 'Next' }).click();
 
     // Should display a real error message, not mock data
     await expect(page.getByText(/Failed to launch. Please try again./i)).toBeVisible();

--- a/src/ui/next/src/e2e/verify-ui.spec.ts
+++ b/src/ui/next/src/e2e/verify-ui.spec.ts
@@ -95,6 +95,6 @@ test('Verify Instant Build UI', async ({ page }) => {
   await page.goto('/onboarding');
   await page.locator('button:has-text("Instant Build")').click();
   await page.locator('textarea[placeholder="e.g. I run a local bakery that sells custom vegan cakes..."]').fill('I run a test business');
-  await page.locator('button:has-text("Generate Storefront")').click();
+  await page.locator('button:has-text("Next")').click();
   await expect(page.locator('text="You\'re Live!"')).toBeVisible();
 });


### PR DESCRIPTION
This PR fixes a bug in the E2E tests for the Onboarding wizard's "Instant Build" functionality. 

The Playwright tests were previously trying to click a button with the text "Generate Storefront", but the UI was updated to use a simpler "Next" button in `src/ui/next/src/app/onboarding/page.tsx` during the onboarding redesign. The tests have been updated to expect `page.getByRole('button', { name: 'Next' })` and `page.locator('button:has-text("Next")')` respectively, and the tests now pass successfully.

---
*PR created automatically by Jules for task [701848945982565205](https://jules.google.com/task/701848945982565205) started by @ql-owo-lp*