### PR TITLE
💰 Miser: Pricing Page Dynamic Current Plan Selection

### DIFF
--- a/src/ui/next/src/app/pricing/page.test.tsx
+++ b/src/ui/next/src/app/pricing/page.test.tsx
@@ -26,6 +26,17 @@ describe('PricingPage', () => {
     (useRouter as any).mockReturnValue({ push: mockPush });
     global.fetch = vi.fn();
 
+    (global.fetch as any).mockImplementation(async (url) => {
+      if (url === '/api/billing/my-plan') {
+        return {
+          ok: true,
+          json: async () => ({ current_plan: 'Free' }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+
     // Mock window.location.href
     originalWindowLocation = window.location;
     delete (window as any).location;
@@ -47,13 +58,25 @@ describe('PricingPage', () => {
 
   it('initiates checkout session when upgrading to Starter', async () => {
     const mockCheckoutUrl = 'https://checkout.stripe.com/pay/test_session_123';
-    (global.fetch as any).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ checkout_url: mockCheckoutUrl }),
+    (global.fetch as any).mockImplementation(async (url, options) => {
+      if (url === '/api/billing/my-plan') {
+        return {
+          ok: true,
+          json: async () => ({ current_plan: 'Free' }),
+        };
+      }
+      if (url === '/api/billing/create-checkout-session' && options?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({ checkout_url: mockCheckoutUrl }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
     });
 
+
     render(<PricingPage />);
-    const upgradeButton = screen.getByText('Upgrade to Starter via Stripe');
+    const upgradeButton = await screen.findByText('Upgrade to Starter via Stripe');
     fireEvent.click(upgradeButton);
 
     // Wait for the async logic to finish
@@ -70,12 +93,24 @@ describe('PricingPage', () => {
   });
 
   it('handles upgrade errors gracefully', async () => {
-    (global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
+    (global.fetch as any).mockImplementation(async (url, options) => {
+      if (url === '/api/billing/my-plan') {
+        return {
+          ok: true,
+          json: async () => ({ current_plan: 'Free' }),
+        };
+      }
+      if (url === '/api/billing/create-checkout-session' && options?.method === 'POST') {
+        throw new Error('Network error');
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
     const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(<PricingPage />);
-    const upgradeButton = screen.getByText('Upgrade to Starter via Stripe');
+    const upgradeButton = await screen.findByText('Upgrade to Starter via Stripe');
     fireEvent.click(upgradeButton);
 
     await vi.waitFor(() => {

--- a/src/ui/next/src/app/pricing/page.tsx
+++ b/src/ui/next/src/app/pricing/page.tsx
@@ -1,13 +1,37 @@
 "use client";
 
 // Pricing Page Implementation
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { WithTooltip } from '../../components/TooltipRegistry';
 import { PoweredByOHC } from '../components/PoweredByOHC';
 
 export default function PricingPage() {
   const router = useRouter();
+
+  const [currentPlan, setCurrentPlan] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPlanData = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        const response = await fetch('/api/billing/my-plan', {
+          headers: token ? { 'Authorization': `Bearer ${token}` } : {}
+        });
+        if (response.ok) {
+          const json = await response.json();
+          setCurrentPlan(json.current_plan);
+        }
+      } catch (error) {
+        console.error('Failed to fetch plan data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPlanData();
+  }, []);
 
   const handleUpgrade = async (tier: string) => {
     try {
@@ -64,9 +88,19 @@ export default function PricingPage() {
                 <li className="flex items-center gap-2"><span>✓</span> 10 Products Limit</li>
               </ul>
             </div>
-            <button className="w-full min-h-[44px] px-4 py-2 bg-gray-200 text-gray-800 rounded-xl font-medium flex items-center justify-center cursor-not-allowed" disabled>
-              Current Plan
-            </button>
+            {loading ? (
+              <button className="w-full min-h-[44px] px-4 py-2 bg-gray-200 text-gray-500 rounded-xl font-medium flex items-center justify-center cursor-not-allowed" disabled>
+                Loading...
+              </button>
+            ) : currentPlan === 'Free' || !currentPlan ? (
+              <button className="w-full min-h-[44px] px-4 py-2 bg-gray-200 text-gray-800 rounded-xl font-medium flex items-center justify-center cursor-not-allowed" disabled>
+                Current Plan
+              </button>
+            ) : (
+              <button className="w-full min-h-[44px] px-4 py-2 bg-gray-200 text-gray-800 rounded-xl font-medium flex items-center justify-center cursor-not-allowed" disabled>
+                Downgrade to Free
+              </button>
+            )}
           </div>
 
           {/* Starter Tier */}
@@ -83,9 +117,19 @@ export default function PricingPage() {
                 <li className="flex items-center gap-2"><span>✓</span> 100 Products Limit</li>
               </ul>
             </div>
-            <button onClick={() => handleUpgrade('Starter')} className="w-full min-h-[44px] px-4 py-2 bg-indigo-600 text-white rounded-xl font-medium hover:bg-indigo-700 transition-colors shadow-sm flex items-center justify-center">
-              Upgrade to Starter via Stripe
-            </button>
+            {loading ? (
+              <button className="w-full min-h-[44px] px-4 py-2 bg-gray-200 text-gray-500 rounded-xl font-medium flex items-center justify-center cursor-not-allowed" disabled>
+                Loading...
+              </button>
+            ) : currentPlan === 'Starter' ? (
+              <button className="w-full min-h-[44px] px-4 py-2 bg-gray-200 text-gray-800 rounded-xl font-medium flex items-center justify-center cursor-not-allowed" disabled>
+                Current Plan
+              </button>
+            ) : (
+              <button onClick={() => handleUpgrade('Starter')} className="w-full min-h-[44px] px-4 py-2 bg-indigo-600 text-white hover:bg-indigo-700 rounded-xl font-medium transition-colors shadow-sm flex items-center justify-center">
+                Upgrade to Starter via Stripe
+              </button>
+            )}
           </div>
 
           {/* Pro Tier */}
@@ -100,9 +144,19 @@ export default function PricingPage() {
                 <li className="flex items-center gap-2"><span>✓</span> Unlimited Products</li>
               </ul>
             </div>
-            <button onClick={() => handleUpgrade('Pro')} className="w-full min-h-[44px] px-4 py-2 bg-gray-900 text-white rounded-xl font-medium hover:bg-black transition-colors shadow-sm flex items-center justify-center">
-              Upgrade to Pro via Stripe
-            </button>
+            {loading ? (
+              <button className="w-full min-h-[44px] px-4 py-2 bg-gray-200 text-gray-500 rounded-xl font-medium flex items-center justify-center cursor-not-allowed" disabled>
+                Loading...
+              </button>
+            ) : currentPlan === 'Pro' ? (
+              <button className="w-full min-h-[44px] px-4 py-2 bg-gray-200 text-gray-800 rounded-xl font-medium flex items-center justify-center cursor-not-allowed" disabled>
+                Current Plan
+              </button>
+            ) : (
+              <button onClick={() => handleUpgrade('Pro')} className="w-full min-h-[44px] px-4 py-2 bg-gray-900 text-white hover:bg-black rounded-xl font-medium transition-colors shadow-sm flex items-center justify-center">
+                Upgrade to Pro via Stripe
+              </button>
+            )}
           </div>
 
           {/* Business Tier */}
@@ -117,9 +171,19 @@ export default function PricingPage() {
                 <li className="flex items-center gap-2"><span>✓</span> Unlimited Products</li>
               </ul>
             </div>
-            <button onClick={() => handleUpgrade('Business')} className="w-full min-h-[44px] px-4 py-2 bg-gray-900 text-white rounded-xl font-medium hover:bg-black transition-colors shadow-sm flex items-center justify-center">
-              Upgrade to Business via Stripe
-            </button>
+            {loading ? (
+              <button className="w-full min-h-[44px] px-4 py-2 bg-gray-200 text-gray-500 rounded-xl font-medium flex items-center justify-center cursor-not-allowed" disabled>
+                Loading...
+              </button>
+            ) : currentPlan === 'Business' ? (
+              <button className="w-full min-h-[44px] px-4 py-2 bg-gray-200 text-gray-800 rounded-xl font-medium flex items-center justify-center cursor-not-allowed" disabled>
+                Current Plan
+              </button>
+            ) : (
+              <button onClick={() => handleUpgrade('Business')} className="w-full min-h-[44px] px-4 py-2 bg-gray-900 text-white hover:bg-black rounded-xl font-medium transition-colors shadow-sm flex items-center justify-center">
+                Upgrade to Business via Stripe
+              </button>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
This change updates the Pricing Page (`src/ui/next/src/app/pricing/page.tsx`) to dynamically fetch the user's current plan and reflect it correctly on the UI. Instead of hardcoding 'Free' as the current plan, it now retrieves the plan via the `/api/billing/my-plan` endpoint, changes the "Upgrade" button text to "Current Plan", and disables it if the tier matches the user's current subscription. The test suite has also been updated to mock the new API call and ensure assertions pass.

---
*PR created automatically by Jules for task [8132519501669037985](https://jules.google.com/task/8132519501669037985) started by @ql-owo-lp*