### PR TITLE
fix(agent): Fix JetBrains Observation Masking JSON fallback

### DIFF
--- a/src/agents/builtin/observation_masking.rs
+++ b/src/agents/builtin/observation_masking.rs
@@ -177,10 +177,11 @@ impl JetBrainsObservationMasker {
                                     } else {
                                         // Either it wasn't modified, or the modification still didn't bring it under the limit.
                                         // We replace the entire content with a safe JSON string indicating masking.
-                                        tr.content = format!(
-                                            "{{\"error\": \"[Observation Masked to save context. Output was {} bytes. Use 'RecallObservation' with ID '{}' to retrieve full output.]\"}}",
+                                        let raw_msg = format!(
+                                            "[Observation Masked to save context. Output was {} bytes. Use 'RecallObservation' with ID '{}' to retrieve full output.]",
                                             bytes, tr.tool_call_id
                                         );
+                                        tr.content = serde_json::json!({ "error": raw_msg }).to_string();
                                     }
                                     continue; // Treated as JSON, don't fall back to raw string masking
                                 }


### PR DESCRIPTION
This PR fixes a bug in `JetBrainsObservationMasker` within `src/agents/builtin/observation_masking.rs` where a raw string template was incorrectly used to generate the masked JSON response, leading to invalid JSON downstream. The implementation has been updated to use `serde_json::json!` and standard `.to_string()` serialization to guarantee safe and valid JSON.

Verified by resolving the failure in `test_json_fallback_bug` and ensuring all tests pass correctly (`bazelisk test //...`).

---
*PR created automatically by Jules for task [507807430375913302](https://jules.google.com/task/507807430375913302) started by @ql-owo-lp*