### PR TITLE
✍️ Scribe: [Optimize In-App Docs Features for Mobile]

### DIFF
--- a/src/ui/next/src/components/HelpChat.tsx
+++ b/src/ui/next/src/components/HelpChat.tsx
@@ -265,7 +265,7 @@ export function HelpChat() {
           {/* Input */}
           <form
             onSubmit={handleSend}
-            className="p-3 bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] border-t border-white/40 dark:border-white/10 flex gap-2"
+            className="p-3 bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] border-t border-white/40 dark:border-white/10 flex gap-2 items-center"
           >
             <input
               type="text"
@@ -273,12 +273,12 @@ export function HelpChat() {
               onChange={(e) => setInputValue(e.target.value)}
               placeholder="Ask anything..."
               disabled={isLoading}
-              className="flex-1 bg-white/65 dark:bg-white/10 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10 rounded-xl px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/50 font-inter shadow-inner disabled:opacity-70 disabled:bg-gray-50/70"
+              className="flex-1 bg-white/65 dark:bg-white/10 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10 rounded-xl px-4 py-3 text-base min-h-[44px] focus:outline-none focus:ring-2 focus:ring-blue-500/50 font-inter shadow-inner disabled:opacity-70 disabled:bg-gray-50/70"
             />
             <button
               type="submit"
               disabled={!inputValue.trim() || isLoading}
-              className="bg-blue-600/95 backdrop-blur-[30px] text-white p-2.5 min-h-[44px] rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:bg-blue-700/95 transition-all shadow-[0_4px_12px_rgba(37,99,235,0.2)] active:scale-95"
+              className="bg-blue-600/95 backdrop-blur-[30px] text-white p-2.5 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:bg-blue-700/95 transition-all shadow-[0_4px_12px_rgba(37,99,235,0.2)] active:scale-95"
               aria-label="Send message"
             >
               {isLoading ? (

--- a/src/ui/next/src/components/TooltipRegistry.tsx
+++ b/src/ui/next/src/components/TooltipRegistry.tsx
@@ -109,6 +109,11 @@ export function WithTooltip({ children, id, defaultText }: { children: ReactNode
     }, 500); // 500ms for long press
   };
 
+  const handleTouchMove = () => {
+    // If the user scrolls, cancel the long press tooltip
+    if (timerRef.current) clearTimeout(timerRef.current);
+  };
+
   const handleTouchEnd = () => {
     if (timerRef.current) clearTimeout(timerRef.current);
     const hideTimer = setTimeout(() => {
@@ -129,6 +134,7 @@ export function WithTooltip({ children, id, defaultText }: { children: ReactNode
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
       onTouchCancel={handleTouchEnd}
       onContextMenu={(e) => e.preventDefault()}

--- a/src/ui/next/src/e2e/tooltips.spec.ts
+++ b/src/ui/next/src/e2e/tooltips.spec.ts
@@ -41,4 +41,43 @@ test.describe('Tooltips', () => {
         // Move mouse away
         await page.mouse.move(0, 0);
     });
+
+    test('handles mobile long-press and cancels on touchmove', async ({ page }) => {
+        await page.goto('/api-docs');
+
+        const tooltipTarget = page.locator('span', { hasText: 'Advanced:' });
+        await expect(tooltipTarget).toBeVisible();
+
+        // Dispatch a touchstart event
+        await tooltipTarget.dispatchEvent('touchstart');
+
+        // Wait a bit to simulate holding (less than 500ms)
+        await page.waitForTimeout(200);
+
+        // Dispatch a touchmove event to simulate scrolling
+        await tooltipTarget.dispatchEvent('touchmove');
+
+        // Wait past the 500ms threshold
+        await page.waitForTimeout(400);
+
+        // The tooltip should NOT appear because touchmove cancelled it
+        const tooltipText = page.locator('div', { hasText: 'Direct API access is only for custom integrations.' }).last();
+        await expect(tooltipText).not.toBeVisible();
+
+        // Now test successful long press
+        await tooltipTarget.dispatchEvent('touchstart');
+
+        // Wait past the 500ms threshold
+        await page.waitForTimeout(600);
+
+        // The tooltip should appear
+        await expect(tooltipText).toBeVisible();
+
+        // End the touch
+        await tooltipTarget.dispatchEvent('touchend');
+
+        // After 2 seconds, it should disappear
+        await page.waitForTimeout(2100);
+        await expect(tooltipText).not.toBeVisible();
+    });
 });

--- a/src/ui/next/src/e2e/videos.spec.ts
+++ b/src/ui/next/src/e2e/videos.spec.ts
@@ -43,6 +43,9 @@ test.describe('In-App Video Tutorials', () => {
         // Verify the video title is shown in the modal header
         await expect(modalContainer.locator('h3', { hasText: 'How to set up your first store easily' })).toBeVisible();
 
+        // Verify the video element itself is present
+        await expect(modalContainer.locator('video')).toBeVisible();
+
         // Click the close button
         const closeButton = modalContainer.locator('button[aria-label="Close video"]');
         await closeButton.click();


### PR DESCRIPTION
Polished the in-app help documentation features for mobile platforms per the "Mobile-First Non-Negotiables" guidelines. 

Changes include:
- `TooltipRegistry.tsx`: Cancel long-press tooltips on `touchmove` to avoid accidental triggering during user scrolls.
- `HelpChat.tsx`: Adjusted input field to `text-base` to prevent iOS zoom-in and increased button footprint to `min-w-[44px] min-h-[44px]`.
- Tests: Added explicit touchstart and touchmove simulations in `tooltips.spec.ts` and improved assertion reliability in `videos.spec.ts`.

---
*PR created automatically by Jules for task [8814462654682395264](https://jules.google.com/task/8814462654682395264) started by @ql-owo-lp*