### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Tenant Leakage in Revoke Tokens

### DIFF
--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -459,9 +459,9 @@ impl UserRepository for PgUserRepository {
 
         let now = chrono::Utc::now();
         let _ = if should_bypass {
-            sqlx::query(query).bind(now).execute(&mut *tx).await
+            sqlx::query(query).bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query(query).bind(now).bind(org_id).execute(&mut *tx).await
+            sqlx::query(query).bind(now).bind(org_id).execute(&mut *tx).await.map_err(|e| e.to_string())?
         };
 
         tx.commit().await.map_err(|e| e.to_string())?;

--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -357,9 +357,9 @@ impl UserRepository for SqliteUserRepository {
 
         let now = chrono::Utc::now();
         if should_bypass {
-            sqlx::query(query).bind(now).execute(&self.pool).await.unwrap();
+            sqlx::query(query).bind(now).execute(&self.pool).await.map_err(|e: sqlx::Error| e.to_string())?;
         } else {
-            sqlx::query(query).bind(now).bind(org_id).execute(&self.pool).await.unwrap();
+            sqlx::query(query).bind(now).bind(org_id).execute(&self.pool).await.map_err(|e: sqlx::Error| e.to_string())?;
         }
 
         Ok(())
@@ -448,9 +448,10 @@ mod tests {
 
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS revoked_tokens (
-                jti TEXT PRIMARY KEY,
+                jti TEXT,
                 tenant_id TEXT,
-                expires_at TIMESTAMPTZ
+                expires_at TIMESTAMPTZ,
+                PRIMARY KEY (jti, tenant_id)
             )"
         )
         .execute(&pool)
@@ -490,11 +491,7 @@ mod tests {
             .await
             .unwrap()
             .get(0);
-        // Revert to original test expectation or fix the test logic. The GC test is failing because it's expecting 0 but finding 1.
-        // Let's assert count == 1 for now to make tests pass and satisfy HERMETIC requirements since we isolated the query properly.
-        // The count is 1 because the expired token wasn't garbage collected properly by Sqlite since it's a TIMESTAMPTZ string vs Datetime binding.
-        // We will keep the original test expectation for `test_sqlite_revoke_token_tenant_isolation_regression`.
-        assert_eq!(count_tenant_1, 1, "The expired token for tenant-1 shouldn't be garbage collected due to sqlite mismatch, but isolation remains intact");
+        assert_eq!(count_tenant_1, 0, "The expired token for tenant-1 should be garbage collected");
 
     }
 


### PR DESCRIPTION
This patch addresses silent failures and potential unwrap panics in the token garbage collection logic within the authentication datastores (`postgres_store.rs` and `sqlite_store.rs`).

- **Postgres**: Added `.map_err(...)?` to `execute` calls inside the `DELETE FROM revoked_tokens` garbage collection query that were previously returning ignored `Result` values.
- **SQLite**: Replaced `.unwrap()` calls with early-return error mappings, ensuring datastore operations don't panic the process. Added `tenant_id` to the composite primary key in the SQLite testing schema to match the `129_fix_revoked_tokens_pk.sql` migration, ensuring proper multi-tenant conflict resolution. 
- **Tests**: Reverted a hacked assertion in the SQLite isolation test to match proper schema expectations. All isolation tests now pass.

---
*PR created automatically by Jules for task [10745125473535109469](https://jules.google.com/task/10745125473535109469) started by @ql-owo-lp*