### PR TITLE
Fix Agent Feed State & Payload bugs on approval

### DIFF
--- a/src/server/api/agent_feed.rs
+++ b/src/server/api/agent_feed.rs
@@ -77,6 +77,8 @@ pub struct PaginationQuery {
 #[derive(Deserialize)]
 pub struct UpdateStateRequest {
     pub state: String,
+    pub proposed_action: Option<serde_json::Value>,
+    pub context_payload: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize)]
@@ -316,6 +318,12 @@ async fn update_feed_item_state(
     };
 
     let repo = AgentFeedRepository::new(pool.clone());
+
+    if payload.proposed_action.is_some() || payload.context_payload.is_some() {
+        let proposed = payload.proposed_action.clone().map(sqlx::types::Json);
+        let context = payload.context_payload.clone().map(sqlx::types::Json);
+        let _ = repo.update_payloads(&tenant_id, &id, context, proposed).await;
+    }
 
     match repo.update_state(&tenant_id, &id, &payload.state).await {
         Ok(updated_item) => {

--- a/src/server/domain/repository/agent_feed_repo.rs
+++ b/src/server/domain/repository/agent_feed_repo.rs
@@ -47,7 +47,37 @@ impl AgentFeedRepository {
 
     pub async fn get(&self, tenant_id: &str, id: &str) -> Result<Option<AgentFeedItem>, sqlx::Error> {
         let rec = sqlx::query_as::<_, AgentFeedItem>(
-            "SELECT * FROM agent_feed_items WHERE tenant_id = $1 AND id = $2"
+            r#"
+            SELECT
+                id,
+                tenant_id,
+                event_source,
+                context_payload,
+                proposed_action,
+                lifecycle_state,
+                created_at,
+                updated_at
+            FROM agent_feed_items
+            WHERE tenant_id = $1 AND id = $2
+
+            UNION ALL
+
+            SELECT
+                id,
+                tenant_id,
+                department as event_source,
+                jsonb_build_object('description', description) as context_payload,
+                payload as proposed_action,
+                CASE
+                    WHEN status = 'DRAFT' THEN 'PENDING_APPROVAL'
+                    WHEN status = 'REJECTED' THEN 'DISMISSED'
+                    ELSE status
+                END as lifecycle_state,
+                created_at,
+                updated_at
+            FROM agent_approvals
+            WHERE tenant_id = $1 AND id = $2
+            "#
         )
         .bind(tenant_id)
         .bind(id)
@@ -152,10 +182,66 @@ impl AgentFeedRepository {
         .bind(new_state)
         .bind(tenant_id)
         .bind(id)
-        .fetch_one(&self.pool)
+        .fetch_optional(&self.pool)
         .await?;
 
-        Ok(rec)
+        if let Some(r) = rec {
+            return Ok(r);
+        }
+
+        // Fallback to agent_approvals
+        let legacy_status = if new_state == "APPROVED" { "APPROVED" } else if new_state == "DISMISSED" { "REJECTED" } else { "DRAFT" };
+        sqlx::query("UPDATE agent_approvals SET status = $1, updated_at = NOW() WHERE tenant_id = $2 AND id = $3")
+            .bind(legacy_status)
+            .bind(tenant_id)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+        let fetched = self.get(tenant_id, id).await?;
+        if let Some(f) = fetched {
+            return Ok(f);
+        }
+
+        Err(sqlx::Error::RowNotFound)
+    }
+
+    pub async fn update_payloads(&self, tenant_id: &str, id: &str, context_payload: Option<sqlx::types::Json<serde_json::Value>>, proposed_action: Option<sqlx::types::Json<serde_json::Value>>) -> Result<(), sqlx::Error> {
+        let res = sqlx::query(
+            r#"
+            UPDATE agent_feed_items
+            SET context_payload = $1, proposed_action = $2, updated_at = NOW()
+            WHERE tenant_id = $3 AND id = $4
+            "#
+        )
+        .bind(&context_payload)
+        .bind(&proposed_action)
+        .bind(tenant_id)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+
+        if res.rows_affected() > 0 {
+            return Ok(());
+        }
+
+        // Fallback for agent_approvals
+        if let Some(action) = proposed_action {
+            sqlx::query(
+                r#"
+                UPDATE agent_approvals
+                SET payload = $1, updated_at = NOW()
+                WHERE tenant_id = $2 AND id = $3
+                "#
+            )
+            .bind(action)
+            .bind(tenant_id)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/ui/next/src/app/feed/page.tsx
+++ b/src/ui/next/src/app/feed/page.tsx
@@ -100,25 +100,36 @@ export default function FeedPage() {
     setEditValue(textToEdit || "");
   };
 
-  const saveEdit = (id: string) => {
-    setItems((prev) => prev.map((item) => {
-      if (item.id === id) {
-        return {
-          ...item,
-          proposed_action: {
-            ...item.proposed_action,
-            description: item.proposed_action?.feature_type === 'ambassador_reply' ? item.proposed_action.description : editValue,
-            generated_response: item.proposed_action?.feature_type === 'ambassador_reply' ? editValue : item.proposed_action?.generated_response,
-          },
-          context_payload: {
-            ...item.context_payload,
-            summary: item.context_payload?.feature_type === 'ambassador_reply' ? item.context_payload.summary : editValue,
-            generated_response: item.context_payload?.feature_type === 'ambassador_reply' ? editValue : item.context_payload?.generated_response,
-          }
-        };
+  const saveEdit = async (id: string) => {
+    const item = items.find(i => i.id === id);
+    if (!item) return;
+
+    const isAmbassador = item.proposed_action?.feature_type === 'ambassador_reply' || item.context_payload?.feature_type === 'ambassador_reply';
+
+    const updatedProposed = {
+        ...item.proposed_action,
+        description: isAmbassador ? item.proposed_action?.description : editValue,
+        generated_response: isAmbassador ? editValue : item.proposed_action?.generated_response,
+    };
+
+    const updatedContext = {
+        ...item.context_payload,
+        summary: isAmbassador ? item.context_payload?.summary : editValue,
+        generated_response: isAmbassador ? editValue : item.context_payload?.generated_response,
+    };
+
+    setItems((prev) => prev.map((i) => {
+      if (i.id === id) {
+        return { ...i, proposed_action: updatedProposed, context_payload: updatedContext };
       }
-      return item;
+      return i;
     }));
+
+    if (isAmbassador) {
+       await handleAction(id, 'APPROVED', updatedProposed, updatedContext);
+    } else {
+       await handleAction(id, 'PENDING_APPROVAL', updatedProposed, updatedContext);
+    }
     setEditingId(null);
   };
 
@@ -126,7 +137,7 @@ export default function FeedPage() {
     setEditingId(null);
   };
 
-  const handleAction = async (id: string, state: string) => {
+  const handleAction = async (id: string, state: string, updatedProposed?: any, updatedContext?: any) => {
     const item = items.find(i => i.id === id);
     if (state === 'APPROVED' && item?.proposed_action?.action_type === 'Draft Quote') {
       router.push(`/quotes/${item.proposed_action.quote_id}`);
@@ -135,15 +146,25 @@ export default function FeedPage() {
 
     try {
       setProcessingId(id);
+
+      const bodyPayload: any = { state };
+      const proposed = updatedProposed || item?.proposed_action;
+      const context = updatedContext || item?.context_payload;
+
+      if (proposed) bodyPayload.proposed_action = proposed;
+      if (context) bodyPayload.context_payload = context;
+
       const res = await fetch(`/api/agent-feed/${id}/state`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ state }),
+        body: JSON.stringify(bodyPayload),
       });
       if (!res.ok) throw new Error('Action failed');
 
       // Update UI optimistically or refetch
-      setItems((prev) => prev.filter((item) => item.id !== id));
+      if (state === 'APPROVED' || state === 'DISMISSED') {
+          setItems((prev) => prev.filter((item) => item.id !== id));
+      }
     } catch (err: any) {
       alert(err.message);
     } finally {


### PR DESCRIPTION
This PR fixes 500 errors when approving tasks that originated from legacy `agent_approvals` in the unified feed, and fixes a UI bug where edits were not being saved.
  - `AgentFeedRepository::get` and `update_state` were updated to support fetching and updating from both `agent_feed_items` and legacy `agent_approvals` using `UNION ALL`.
  - Added a method `update_payloads` to `AgentFeedRepository` to persist payload changes.
  - Fixed Agent Feed API to accept updated payloads on state updates.
  - Fixed Frontend `FeedPage` "Save & Send" "No-effect" UX bug. `saveEdit` now conditionally dispatches to the API to "APPROVE" immediately if it's an Ambassador item, or PUT the updated payloads while keeping the "PENDING" state. `handleAction` also pushes the latest `proposed_action` from React state.
  - All tests passed.

---
*PR created automatically by Jules for task [2779918815633751253](https://jules.google.com/task/2779918815633751253) started by @ql-owo-lp*