### PR TITLE
fix(queue): Fix timezone format bug in job queue backoff for Postgres

### DIFF
--- a/src/server/orchestration/queue/ohc_job_queue.rs
+++ b/src/server/orchestration/queue/ohc_job_queue.rs
@@ -173,7 +173,7 @@ impl OHCJobQueue {
             } else {
                 // Exponential backoff
                 let backoff_seconds = 1 << next_retry;
-                let new_run_after = (chrono::Utc::now() + chrono::Duration::seconds(backoff_seconds as i64)).to_rfc3339();
+                let new_run_after = chrono::Utc::now() + chrono::Duration::seconds(backoff_seconds as i64);
                 sqlx::query("UPDATE ohc_job_queue SET status = 'PENDING', retry_count = $1, next_retry_at = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $3")
                     .bind(next_retry)
                     .bind(new_run_after)


### PR DESCRIPTION
Fixes a bug where `ohc_job_queue` was trying to bind an RFC3339 string to a Postgres timestamp column during job failure/retry backoff, leading to database errors in Cloud mode.

We now correctly bind the `chrono::DateTime<Utc>` object directly, which sqlx correctly translates into the underlying database types. This restores mode parity between Cloud (Postgres) and Standalone (SQLite).

---
*PR created automatically by Jules for task [15148153195914204004](https://jules.google.com/task/15148153195914204004) started by @ql-owo-lp*