### PR TITLE
🚀 Nova: [new growth feature] Sovereign-to-Cloud Bridge Referral Loop

### DIFF
--- a/src/ui/next/src/app/components/GrowthReferralWidget.tsx
+++ b/src/ui/next/src/app/components/GrowthReferralWidget.tsx
@@ -15,7 +15,7 @@ export default function GrowthReferralWidget() {
       const tenantId = typeof window !== 'undefined' ? (localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team') : 'default-team';
       const inviterId = typeof window !== 'undefined' ? (localStorage.getItem('user_id') || 'local-user') : 'local-user';
 
-      const res = await fetch('/api/v1/growth/team-invites', {
+      const res = await fetch('/api/v1/growth/cloud-bridge/invite', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -2280,7 +2280,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
               try {
                   const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default';
-                  const res = await fetch('/api/v1/growth/team-invites', {
+                  const res = await fetch('/api/v1/growth/cloud-bridge/invite', {
                       method: 'POST',
                       headers: { 'Content-Type': 'application/json' },
                       body: JSON.stringify({ team_id: tenantId, inviter_id: "current-user", invitee_id: email })


### PR DESCRIPTION
🚀 Nova: [new growth feature] Sovereign-to-Cloud Bridge Referral Loop

### Description

This pull request implements the requested "Sovereign-to-Cloud Bridge" viral referral loop.

It updates the `fetch` API endpoint inside the Growth Referral Widget and the static `dashboard.html` to point to `/api/v1/growth/cloud-bridge/invite` instead of the legacy `team-invites` endpoint. The payload previously sent matches perfectly with what the backend expects (`CloudBridgeInviteRequest` with `team_id`, `inviter_id`, and `invitee_id`).

### Product-use evidence
- **Persona:** Principal Growth Engineer & Strategist / Nora (Agency Principal)
- **Browser/Playwright UI flow attempted:** I navigated the Dashboard and attempted to click "Generate Cloud Invite" under the "Cloud Bridge Invite" section. 
- **CUJ gap observed:** The referral generated by the UI sent requests to `/api/v1/growth/team-invites` which is the generic tenant invite loop rather than the viral cloud-native provision loop (`/api/v1/growth/cloud-bridge/invite`). This fails to deliver the promised "Zero Data Leakage" Standalone-to-Cloud expansion experience.
- **Why a real owner/operator would need the fix:** Owners who want to maintain a local-first SQLite application but still occasionally invite collaborators to a multi-tenant cloud context need this exact endpoint to dynamically provision a cloud tenant bridging from their standalone sovereignty context.
- **UI flow repeated after fix:** Now clicking "Generate Cloud Invite" routes the `CloudBridgeInviteRequest` to `/api/v1/growth/cloud-bridge/invite` correctly and produces the appropriate deep-link for the new cloud provision workflow. Verified that Playwright suite passes.

---
*PR created automatically by Jules for task [16568963025449531412](https://jules.google.com/task/16568963025449531412) started by @ql-owo-lp*