### PR TITLE
🤖 Implementer: Harness Upgrade - Anthropic Lightweight Memory Index

### DIFF
--- a/src/agents/builtin/agent.rs
+++ b/src/agents/builtin/agent.rs
@@ -453,6 +453,7 @@ impl Agent {
                 &phase_cfg,
                 session_tools,
                 agents_md,
+                None,
             )
             .build();
 
@@ -793,6 +794,7 @@ impl Agent {
             cfg,
             session_tools,
             agents_md,
+            None,
         )
         .build();
 
@@ -1516,6 +1518,7 @@ impl Agent {
             &cfg_arc,
             &session_tools_arc,
             None,
+            None,
         )
         .build();
 
@@ -2131,6 +2134,7 @@ impl Agent {
             &planner_cfg,
             &[],
             agents_md,
+            None,
         )
         .build();
 
@@ -2517,6 +2521,7 @@ impl Agent {
             &replier_cfg,
             &[],
             agents_md,
+            None,
         )
         .build();
 
@@ -3187,6 +3192,7 @@ impl Agent {
             &final_cfg,
             &session_tools,
             agents_md,
+            None,
         )
         .build();
 
@@ -7653,7 +7659,7 @@ mod tests {
         };
 
         let prompt =
-            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &[tool], None).build();
+            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &[tool], None, None).build();
 
         let expected = "<server_system_message>\nServer System Message\n</server_system_message>\n\n<tool_definitions>\nTool: test_tool\nDescription: A test tool\nParameters: {\"type\":\"object\"}\n</tool_definitions>\n\n<developer_instructions>\nDeveloper Instructions\n</developer_instructions>\n\n<user_instructions>\nUser Instructions\n</user_instructions>";
 
@@ -7669,7 +7675,7 @@ mod tests {
         cfg.enable_lost_in_the_middle_prevention = false;
 
         let prompt =
-            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &[], None).build();
+            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &[], None, None).build();
         assert_eq!(
             prompt,
             "<server_system_message>\nServer System Message\n</server_system_message>\n\n<developer_instructions>\nDeveloper Instructions\n</developer_instructions>\n\n<user_instructions>\nUser Instructions\n</user_instructions>"
@@ -7685,7 +7691,7 @@ mod tests {
         cfg.enable_lost_in_the_middle_prevention = false;
 
         let prompt =
-            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &[], None).build();
+            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &[], None, None).build();
         assert_eq!(
             prompt,
             "<server_system_message>\nServer System Message\n</server_system_message>\n\n<user_instructions>\nUser Instructions\n</user_instructions>"
@@ -7696,7 +7702,7 @@ mod tests {
         cfg2.developer_instructions = "Dev".to_string();
         cfg2.user_instructions = "User".to_string();
         let prompt2 =
-            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg2, &[], None).build();
+            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg2, &[], None, None).build();
         assert_eq!(
             prompt2,
             "<developer_instructions>\nDev\n</developer_instructions>\n\n<user_instructions>\nUser\n</user_instructions>"
@@ -7712,7 +7718,7 @@ mod tests {
 
         // This should safely truncate without panicking using char counts
         let prompt =
-            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &[], None).build();
+            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &[], None, None).build();
         assert!(prompt.contains("<user_instructions>\n"));
         let notice = "\n... [User Instructions TRUNCATED TO 32KiB]";
 
@@ -7734,7 +7740,7 @@ mod tests {
         cfg.user_instructions.push('€');
 
         let prompt =
-            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &[], None).build();
+            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &[], None, None).build();
 
         let notice = "\n... [User Instructions TRUNCATED TO 32KiB]";
         let user_part = prompt.replace(notice, "");
@@ -9742,7 +9748,7 @@ mod hierarchical_prompt_tests {
 
         let tools = vec![];
         let builder =
-            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &tools, None);
+            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &tools, None, None);
         let prompt = builder.build();
 
         assert!(
@@ -9761,7 +9767,7 @@ mod hierarchical_prompt_tests {
 
         let tools = vec![];
         let builder =
-            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &tools, None);
+            crate::prompt_construction::HierarchicalPromptBuilder::new(&cfg, &tools, None, None);
         let prompt = builder.build();
 
         assert!(

--- a/src/agents/builtin/prompt_construction.rs
+++ b/src/agents/builtin/prompt_construction.rs
@@ -194,6 +194,7 @@ pub struct HierarchicalPromptBuilder {
     tool_definitions: String,
     developer_instructions: String,
     user_instructions: String,
+    lightweight_memory_index: Vec<String>,
 }
 
 impl HierarchicalPromptBuilder {
@@ -201,6 +202,7 @@ impl HierarchicalPromptBuilder {
         cfg: &AgentRunConfig,
         tools: &[crate::tools::Tool],
         cascading_agents_md: Option<String>,
+        lightweight_memory_index: Option<Vec<String>>,
     ) -> Self {
         let mut tool_defs = String::new();
         if !tools.is_empty() {
@@ -247,11 +249,25 @@ impl HierarchicalPromptBuilder {
             user_instr = format!("{}\n... [User Instructions TRUNCATED TO 32KiB]", truncated);
         }
 
+        let mut processed_memory_index = Vec::new();
+        if let Some(mut index) = lightweight_memory_index {
+            for entry in index.drain(..) {
+                let char_count = entry.chars().count();
+                if char_count > 150 {
+                    let truncated: String = entry.chars().take(147).collect();
+                    processed_memory_index.push(format!("{}...", truncated));
+                } else {
+                    processed_memory_index.push(entry);
+                }
+            }
+        }
+
         Self {
             server_system_message: cfg.server_system_message.clone(),
             tool_definitions: tool_defs,
             developer_instructions: cfg.developer_instructions.clone(),
             user_instructions: user_instr,
+            lightweight_memory_index: processed_memory_index,
         }
     }
 
@@ -293,6 +309,20 @@ impl HierarchicalPromptBuilder {
             combined_system.push_str("<user_instructions>\n");
             combined_system.push_str(&self.user_instructions);
             combined_system.push_str("\n</user_instructions>");
+        }
+
+        // 4.5. System Memory Index (Anthropic Lightweight Index Mechanic)
+        if !self.lightweight_memory_index.is_empty() {
+            if !combined_system.is_empty() {
+                combined_system.push_str("\n\n");
+            }
+            combined_system.push_str("<system_memory_index>\n");
+            for entry in &self.lightweight_memory_index {
+                combined_system.push_str("- ");
+                combined_system.push_str(entry);
+                combined_system.push('\n');
+            }
+            combined_system.push_str("</system_memory_index>");
         }
 
         // High-Signal Re-injection (System Anchor)
@@ -358,7 +388,7 @@ mod tests {
         let built = tokio::runtime::Runtime::new().unwrap().block_on(async {
             let agents_md = load_cascading_instructions(Some(&grandchild_dir)).await;
             let cfg = AgentRunConfig::default();
-            let builder = HierarchicalPromptBuilder::new(&cfg, &[], Some(agents_md));
+            let builder = HierarchicalPromptBuilder::new(&cfg, &[], Some(agents_md), None);
             builder.build()
         });
 
@@ -401,7 +431,7 @@ mod tests {
         let built = tokio::runtime::Runtime::new().unwrap().block_on(async {
             let agents_md = load_cascading_instructions(Some(&root_dir)).await;
             let cfg = AgentRunConfig::default();
-            let builder = HierarchicalPromptBuilder::new(&cfg, &[], Some(agents_md));
+            let builder = HierarchicalPromptBuilder::new(&cfg, &[], Some(agents_md), None);
             builder.build()
         });
 
@@ -536,7 +566,7 @@ mod tests {
         // Total will be > 4000 chars
 
         let tools = vec![];
-        let builder = HierarchicalPromptBuilder::new(&cfg, &tools, None);
+        let builder = HierarchicalPromptBuilder::new(&cfg, &tools, None, None);
         let built = builder.build();
 
         assert!(built.contains("<system_anchor_high_signal_context_reinjection>"));
@@ -591,6 +621,28 @@ mod tests {
 
         let momentum = PromptBuilder::summarize_recent_momentum(&messages);
         assert_eq!(momentum, "Recent Momentum: read_file -> ls");
+    }
+
+    #[test]
+    fn test_lightweight_memory_index_injection_and_truncation() {
+        let cfg = AgentRunConfig::default();
+        let long_entry = "A".repeat(200);
+        let normal_entry = "Just a regular memory entry".to_string();
+        let index = vec![long_entry, normal_entry.clone()];
+
+        let builder = HierarchicalPromptBuilder::new(&cfg, &[], None, Some(index));
+        let built = builder.build();
+
+        assert!(built.contains("<system_memory_index>"));
+        assert!(built.contains("</system_memory_index>"));
+
+        // Normal entry should be fully present
+        assert!(built.contains(&format!("- {}", normal_entry)));
+
+        // Long entry should be truncated to 147 chars + "..." = 150 chars
+        let truncated_long = format!("- {}...", "A".repeat(147));
+        assert!(built.contains(&truncated_long));
+        assert!(!built.contains(&"A".repeat(151)));
     }
 
     #[tokio::test]

--- a/src/agents/builtin/tool_executor_engine_tests.rs
+++ b/src/agents/builtin/tool_executor_engine_tests.rs
@@ -1,10 +1,11 @@
 mod tool_executor_engine;
-use tool_executor_engine::ToolExecutionEngine;
+
+
 
 #[cfg(test)]
 mod tests {
 
-    use super::*;
+    use crate::tool_executor_engine::ToolExecutionEngine;
     use ohc_builtin_agent_core::types::{ToolCall, ToolError};
     use ohc_builtin_agent_tools::{Tool, ToolExecutor};
     use serde_json::json;
@@ -449,13 +450,12 @@ mod tests {
 
 #[cfg(test)]
 mod additional_transient_tests {
-    use super::*;
+    use crate::tool_executor_engine::ToolExecutionEngine;
     use ohc_builtin_agent_core::types::{ToolCall, ToolError};
     use ohc_builtin_agent_tools::{Tool, ToolExecutor};
     use serde_json::json;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
-    use crate::tool_executor_engine::ToolExecutionEngine;
 
     struct TransientRetryExecutor {
         call_count: Arc<AtomicUsize>,


### PR DESCRIPTION
Implemented the Master Catalog B.3/B.5 mechanic for Anthropic's 3-Tier memory architecture by adding support for a lightweight, always-in-context memory index (~150 chars/entry) to the `HierarchicalPromptBuilder`.

Implementation Mechanics:
- Modified `HierarchicalPromptBuilder` to accept an optional `lightweight_memory_index`.
- Enforced the 150-character truncation limit using safe `char` boundary counting.
- Injected the memory index into the final system prompt under `<system_memory_index>` tags.
- Updated all existing caller instantiation sites in `agent.rs`.
- Added unit tests to `prompt_construction.rs` to verify injection and truncation logic.
- Resolved existing compilation/import errors in `tool_executor_engine_tests.rs` to ensure a 100% green build.

Testing Instructions:
Run `bazelisk test //src/agents/builtin/...` and verify all tests pass.

---
*PR created automatically by Jules for task [17478818916623598756](https://jules.google.com/task/17478818916623598756) started by @ql-owo-lp*