### PR TITLE
fix(e2e): update expert-team test locator to match UI changes

### DIFF
--- a/src/e2e/expert-team.spec.ts
+++ b/src/e2e/expert-team.spec.ts
@@ -4,7 +4,7 @@ test.describe('Expert Team Feature CUJ', () => {
 
   test('Persona: Business Owner uses Expert Team successfully', async ({ page }) => {
     await page.goto('/expert-team');
-    await expect(page.getByRole('heading', { name: /Expert Team/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Collaborative Expert Team/i })).toBeVisible();
 
     // 2. Owner enters task
     const input = page.getByPlaceholder(/e.g. Write a comprehensive/i);


### PR DESCRIPTION
The E2E test was failing due to a strict mode violation when looking for the heading "Expert Team". This updates the locator to match "Collaborative Expert Team" to uniquely identify the main content heading.

---
*PR created automatically by Jules for task [14300943138591705592](https://jules.google.com/task/14300943138591705592) started by @ql-owo-lp*