### PR TITLE
🔗 Link: Stabilize Agentic Storefront Editor E2E Test

### DIFF
--- a/src/e2e/agentic-storefront-editor.spec.ts
+++ b/src/e2e/agentic-storefront-editor.spec.ts
@@ -1,7 +1,9 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Agentic Storefront Editor', () => {
-  test('Maya can use the Marketing Agent to edit her storefront', async ({ page }) => {
+  test('Maya can use the Marketing Agent to edit her storefront', async ({ page, adminUser, loginAs }) => {
+    await loginAs(page, adminUser);
+
     // Navigate to the storefront builder page
     await page.goto('/storefront-builder');
 
@@ -15,7 +17,7 @@ test.describe('Agentic Storefront Editor', () => {
     await page.click('button:has-text("Build My Storefront")');
 
     // Wait for generation to finish and preview mode to appear
-    await expect(page.locator('text=Preview Mode')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=Preview Mode')).toBeVisible({ timeout: 15000 });
 
     // Click on "Ask Agent to Edit"
     await page.click('button:has-text("Ask Agent to Edit")');
@@ -27,9 +29,9 @@ test.describe('Agentic Storefront Editor', () => {
     await page.fill('textarea[placeholder="e.g. Add a new product..."]', 'Add a new vegan chocolate cake for $45');
 
     // Click send (the SVG icon button)
-    await page.click('button:has-text("Marketing Agent") ~ div:last-child button');
+    await page.locator('button:has-text("Marketing Agent") ~ div:last-child button').click();
 
     // Wait for generation to finish and return to preview mode
-    await expect(page.locator('text=Preview Mode')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=Preview Mode')).toBeVisible({ timeout: 15000 });
   });
 });


### PR DESCRIPTION
**Owner/Operator Persona Context**: Maya the Home Baker needs to build her storefront quickly and predictably. The UI automated tests need to be robust enough to handle the generation wait times correctly, representing realistic generation conditions without timing out prematurely.

**Browser/Playwright Flow Verified**: 
- Validated the E2E setup for `agentic-storefront-editor.spec.ts`.
- The generation step could take slightly longer than the hardcoded 10 seconds. Increased the wait time to 15 seconds.
- Replaced ambiguous `page.click` for the chat submission button with an explicit `page.locator().click()`.
- Ensured authentication flow is present in the test to ensure proper access to the storefront editor.

**Changes**:
- Increased Playwright E2E timeouts for preview visibility to 15000ms.
- Fixed the button click action to properly query the locator tree for the Marketing Agent send button.
- Brought `adminUser` and `loginAs` fixtures into the test.

Resolves #29551

---
*PR created automatically by Jules for task [12237911949120768478](https://jules.google.com/task/12237911949120768478) started by @ql-owo-lp*