### PR TITLE
fix(ui): apply OHC Premium Glassmorphism tokens to components

### DIFF
--- a/src/ui/next/src/components/LocalizationToggle.tsx
+++ b/src/ui/next/src/components/LocalizationToggle.tsx
@@ -23,7 +23,7 @@ export const LocalizationToggle: React.FC = () => {
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-white/60 backdrop-blur-xl border border-white/40 shadow-sm hover:bg-white/80 transition-all text-sm font-medium"
+        className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10 shadow-sm hover:bg-white/80 transition-all text-sm font-medium"
       >
         <span>{locales.find(l => l.code === locale)?.flag}</span>
         <span className="text-gray-900">{currency}</span>
@@ -35,7 +35,7 @@ export const LocalizationToggle: React.FC = () => {
             className="fixed inset-0 z-40"
             onClick={() => setIsOpen(false)}
           />
-          <div className="absolute top-full mt-2 right-0 w-48 rounded-2xl bg-white/70 backdrop-blur-2xl border border-white/50 shadow-2xl z-50 p-2 animate-in fade-in zoom-in duration-200">
+          <div className="absolute top-full mt-2 right-0 w-48 rounded-2xl bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10 shadow-2xl z-50 p-2 animate-in fade-in zoom-in duration-200">
             <div className="mb-2">
               <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest px-2 mb-1">Language</p>
               {locales.map((l) => (

--- a/src/ui/next/src/components/QuoteReviewModal.tsx
+++ b/src/ui/next/src/components/QuoteReviewModal.tsx
@@ -58,7 +58,7 @@ export function QuoteReviewModal({ isOpen, onClose, onApprove, initialPayload }:
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 bg-black/40 backdrop-blur-sm animate-in fade-in duration-200">
       <div
-        className="w-full max-w-lg bg-white/80 dark:bg-[#1C1C1E]/80 backdrop-blur-2xl saturate-150 rounded-t-[24px] sm:rounded-[24px] shadow-2xl border border-white/20 dark:border-white/10 flex flex-col max-h-[90vh] overflow-hidden animate-in slide-in-from-bottom duration-300"
+        className="w-full max-w-lg bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] rounded-t-[24px] sm:rounded-[24px] shadow-2xl border border-white/40 dark:border-white/10 flex flex-col max-h-[90vh] overflow-hidden animate-in slide-in-from-bottom duration-300"
         role="dialog"
         aria-modal="true"
       >

--- a/src/ui/next/src/components/TooltipRegistry.tsx
+++ b/src/ui/next/src/components/TooltipRegistry.tsx
@@ -54,7 +54,7 @@ export function TooltipProvider({ children }: { children: ReactNode }) {
       {children}
       {activeTooltip && tooltipRect && (
         <div
-          className="fixed z-[100] bg-white/50 text-gray-900 text-sm font-inter p-3 rounded-xl shadow-[0_8px_32px_rgba(0,0,0,0.12)] pointer-events-none w-64 max-w-[calc(100vw-32px)] mx-4 text-center leading-relaxed backdrop-blur-3xl saturate-[210%] border border-white/60 animate-fade-in-up"
+          className="fixed z-[100] bg-white/65 dark:bg-[#16161a]/70 text-gray-900 text-sm font-inter p-3 rounded-xl shadow-[0_8px_32px_rgba(0,0,0,0.12)] pointer-events-none w-64 max-w-[calc(100vw-32px)] mx-4 text-center leading-relaxed backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10 animate-fade-in-up"
           style={{
             top: tooltipRect.top - 10,
             left: Math.max(128, Math.min(windowWidth - 128, tooltipRect.left + tooltipRect.width / 2)),

--- a/src/ui/next/src/components/Walkthrough.tsx
+++ b/src/ui/next/src/components/Walkthrough.tsx
@@ -139,7 +139,7 @@ export function InteractiveWalkthrough({ steps, isOpen, onClose, onComplete }: W
         role="dialog"
         aria-label={`${currentStep.title} walkthrough step`}
         id="walkthrough-bubble"
-        className="ohc-walkthrough-bubble fixed z-[10000] bg-white/60 backdrop-blur-3xl saturate-[210%] border border-white/60 rounded-2xl p-6 w-[300px] max-w-[calc(100vw-32px)] font-inter animate-pop-in shadow-[0_12px_40px_rgba(0,0,0,0.15)]"
+        className="ohc-walkthrough-bubble fixed z-[10000] bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10 rounded-2xl p-6 w-[300px] max-w-[calc(100vw-32px)] font-inter animate-pop-in shadow-[0_12px_40px_rgba(0,0,0,0.15)]"
         style={bubbleStyle}
       >
         {targetRect && (


### PR DESCRIPTION
This PR updates `Walkthrough.tsx`, `LocalizationToggle.tsx`, `QuoteReviewModal.tsx`, and `TooltipRegistry.tsx` to uniformly adopt the `macOS Translucent Glass` visual CSS tokens as per the mandate. 

It replaces varied `bg-white/50`, `bg-white/60`, and `bg-white/80` classes with the unified token string: `bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10`. This ensures these components are aligned with the premium visual aesthetics of the platform. Vitest UI tests run locally and verify that nothing breaks.

---
*PR created automatically by Jules for task [13088817666842483807](https://jules.google.com/task/13088817666842483807) started by @ql-owo-lp*