### PR TITLE
chore(ui): wire customer subscriptions and kitchen UI to database

### DIFF
--- a/src/e2e/customer-subscription-wire.spec.ts
+++ b/src/e2e/customer-subscription-wire.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Customer Subscription Portal', () => {
+  test('loads subscription from backend and handles actions', async ({ page }) => {
+    // Navigate to a potentially non-existent subscription just to verify the real network loading
+    // Since we don't have a guaranteed seeded subscription ID, we will check if it handles "not found"
+    // correctly from the backend rather than the mock data.
+    const fakeId = 'sub_9999999999';
+    await page.goto(`/customer/subscriptions/${fakeId}`);
+
+    // The UI should show "Subscription not found." if it correctly hit the backend and got 404
+    await expect(page.locator('text="Subscription not found."')).toBeVisible();
+  });
+});

--- a/src/e2e/kitchen-wire.spec.ts
+++ b/src/e2e/kitchen-wire.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Kitchen Command Center Flow', () => {
+  test('loads orders and menu from backend without mock data', async ({ page }) => {
+    // 1. Visit the Kitchen Command Center
+    await page.goto('/kitchen');
+
+    // 2. Wait for the API calls to finish and UI to render
+    // Instead of waiting for network requests explicitly, wait for UI elements
+    await page.waitForSelector('h1:has-text("Kitchen Command Center")');
+
+    // 3. Verify Active Orders section exists
+    await expect(page.locator('h2:has-text("Active Orders")')).toBeVisible();
+
+    // 4. Verify Daily Menu section exists
+    await expect(page.locator('h2:has-text("Daily Menu")')).toBeVisible();
+
+    // 5. Ensure the mock seed event is gone and we are relying on real backend data
+    // The "Seed mock" listener was removed, so any data shown must be real.
+    // Check if there are either orders or the empty state "No active orders"
+    const activeOrders = page.locator('text="No active orders"');
+    const orderCards = page.locator('text="Mark Ready & Notify"');
+
+    // Either empty state is visible or order cards are visible
+    const isOrdersEmpty = await activeOrders.isVisible();
+    const hasOrderCards = await orderCards.count() > 0;
+
+    expect(isOrdersEmpty || hasOrderCards).toBeTruthy();
+  });
+});

--- a/src/server/api/subscription.rs
+++ b/src/server/api/subscription.rs
@@ -335,6 +335,101 @@ pub fn router<S: Clone + Send + Sync + 'static>(hub: Arc<Hub>) -> Router<S> {
     router_with_orchestrator(hub, None)
 }
 
+async fn get_subscription_by_id(
+    Extension(hub): Extension<Arc<Hub>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    let tenant_id = ::server_common::auth_utils::get_default_tenant();
+
+    let mut conn = match hub.pool.acquire().await {
+        Ok(c) => c,
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, "DB Error").into_response(),
+    };
+
+    let result = sqlx::query(
+        "SELECT
+            s.id,
+            p.title as productName,
+            sp.interval as frequency,
+            s.status,
+            s.current_period_end as nextDeliveryDate,
+            p.price_cents as price,
+            sp.discount_percentage
+         FROM subscriptions s
+         JOIN subscription_plans sp ON s.plan_id = sp.id
+         JOIN products p ON sp.product_id = p.id
+         WHERE s.id = $1 AND s.tenant_id = $2"
+    )
+    .bind(&id)
+    .bind(tenant_id)
+    .fetch_optional(&mut *conn)
+    .await;
+
+    match result {
+        Ok(Some(r)) => {
+            use sqlx::Row;
+            let price: i64 = r.try_get("price").unwrap_or(0);
+            let discount_percentage: i32 = r.try_get("discount_percentage").unwrap_or(0);
+            let price_f64 = (price as f64) / 100.0;
+            let discounted_price = price_f64 * (1.0 - (discount_percentage as f64 / 100.0));
+
+            let next_date: chrono::DateTime<chrono::Utc> = r.try_get("nextDeliveryDate").unwrap_or_else(|_| chrono::Utc::now());
+
+            let sub = serde_json::json!({
+                "id": r.try_get::<String, _>("id").unwrap_or_default(),
+                "productName": r.try_get::<String, _>("productName").unwrap_or_default(),
+                "frequency": r.try_get::<String, _>("frequency").unwrap_or_default(),
+                "status": r.try_get::<String, _>("status").unwrap_or_default(),
+                "nextDeliveryDate": next_date.format("%Y-%m-%d").to_string(),
+                "price": price_f64,
+                "discountedPrice": discounted_price,
+            });
+            (StatusCode::OK, Json(sub)).into_response()
+        },
+        Ok(None) => (StatusCode::NOT_FOUND, "Subscription not found").into_response(),
+        Err(e) => {
+            tracing::error!("Failed to fetch subscription by id: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "DB Error").into_response()
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct SubscriptionActionRequest {
+    pub action: String, // "pause", "skip", "cancel"
+}
+
+async fn subscription_action(
+    Extension(hub): Extension<Arc<Hub>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+    Json(payload): Json<SubscriptionActionRequest>,
+) -> impl IntoResponse {
+    let tenant_id = ::server_common::auth_utils::get_default_tenant();
+
+    let mut conn = match hub.pool.acquire().await {
+        Ok(c) => c,
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, "DB Error").into_response(),
+    };
+
+    let update = match payload.action.as_str() {
+        "pause" => sqlx::query("UPDATE subscriptions SET status = 'paused' WHERE id = $1 AND tenant_id = $2")
+            .bind(&id).bind(&tenant_id).execute(&mut *conn).await,
+        "cancel" => sqlx::query("UPDATE subscriptions SET status = 'canceled' WHERE id = $1 AND tenant_id = $2")
+            .bind(&id).bind(&tenant_id).execute(&mut *conn).await,
+        "skip" => sqlx::query("UPDATE subscriptions SET current_period_end = current_period_end + interval '1 month' WHERE id = $1 AND tenant_id = $2")
+            .bind(&id).bind(&tenant_id).execute(&mut *conn).await,
+        _ => return (StatusCode::BAD_REQUEST, "Invalid action").into_response(),
+    };
+
+    match update {
+        Ok(_) => (StatusCode::OK, Json(serde_json::json!({ "success": true }))).into_response(),
+        Err(e) => {
+            tracing::error!("Failed to update subscription: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "DB Error").into_response()
+        }
+    }
+}
+
 pub fn router_with_orchestrator<S: Clone + Send + Sync + 'static>(
     hub: Arc<Hub>,
     orchestrator: Option<Arc<DepartmentOrchestrator>>,
@@ -344,6 +439,8 @@ pub fn router_with_orchestrator<S: Clone + Send + Sync + 'static>(
         .route("/subscribers", get(get_subscribers))
         .route("/fulfillment-batches", get(get_fulfillment_batches).post(create_fulfillment_batch))
         .route("/magic-link", post(handle_magic_link))
+        .route("/{id}", get(get_subscription_by_id))
+        .route("/{id}/action", post(subscription_action))
         .layer(Extension(orchestrator))
         .layer(Extension(hub))
 }

--- a/src/ui/next/src/app/customer/subscriptions/[id]/page.test.tsx
+++ b/src/ui/next/src/app/customer/subscriptions/[id]/page.test.tsx
@@ -15,11 +15,33 @@ vi.mock('../../../components/PoweredByOHC', () => ({
 describe('CustomerSubscriptionPortal', () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
+    // Mock global fetch for testing
+    global.fetch = vi.fn((url: string | URL | Request) => {
+      if (url.toString().includes('/action')) {
+         return Promise.resolve({
+           ok: true,
+           json: () => Promise.resolve({ success: true }),
+         });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          id: 'sub_123',
+          productName: 'Artisan Coffee Blend',
+          frequency: 'Monthly',
+          status: 'active',
+          nextDeliveryDate: '2023-11-15',
+          price: 24.00,
+          discountedPrice: 21.60,
+        }),
+      });
+    }) as any;
   });
 
   afterEach(() => {
     vi.runOnlyPendingTimers();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('renders loading state initially', async () => {
@@ -64,6 +86,28 @@ describe('CustomerSubscriptionPortal', () => {
     });
 
     const skipButton = screen.getByText('Skip Next Delivery');
+
+    // Make the mock return the skipped date for the second fetch
+    (global.fetch as any).mockImplementationOnce((url: string | URL | Request) => {
+        return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ success: true })
+        });
+    }).mockImplementationOnce((url: string | URL | Request) => {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            id: 'sub_123',
+            productName: 'Artisan Coffee Blend',
+            frequency: 'Monthly',
+            status: 'active',
+            nextDeliveryDate: '2023-12-15',
+            price: 24.00,
+            discountedPrice: 21.60,
+          }),
+        });
+    });
+
     fireEvent.click(skipButton);
 
     await act(async () => {

--- a/src/ui/next/src/app/customer/subscriptions/[id]/page.tsx
+++ b/src/ui/next/src/app/customer/subscriptions/[id]/page.tsx
@@ -13,51 +13,79 @@ export default function CustomerSubscriptionPortal() {
   const [isProcessing, setIsProcessing] = useState(false);
 
   useEffect(() => {
-    // Simulate fetching subscription details
-    setTimeout(() => {
-      setSubscription({
-        id: subscriptionId,
-        productName: 'Artisan Coffee Blend',
-        frequency: 'Monthly',
-        status: 'active',
-        nextDeliveryDate: '2023-11-15',
-        price: 24.00,
-        discountedPrice: 21.60,
-      });
-      setLoading(false);
-    }, 500);
+    const fetchSubscription = async () => {
+      try {
+        const tenantId = localStorage.getItem("tenant_id") || "default";
+        const res = await fetch(`/api/subscriptions/${subscriptionId}`, {
+          headers: { "x-tenant-id": tenantId }
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setSubscription(data);
+        }
+      } catch (err) {
+        console.error("Failed to fetch subscription", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchSubscription();
   }, [subscriptionId]);
 
-  const handleAction = (action: 'pause' | 'skip' | 'cancel') => {
+  const handleAction = async (action: 'pause' | 'skip' | 'cancel') => {
     setIsProcessing(true);
     setActionStatus(null);
 
-    // Simulate API call to handle action
-    setTimeout(() => {
-      let updatedStatus = subscription.status;
-      let nextDate = subscription.nextDeliveryDate;
-      let message = '';
-
-      if (action === 'pause') {
-        updatedStatus = 'paused';
-        message = 'Your subscription has been paused.';
-      } else if (action === 'skip') {
-        // Simple mock of adding 1 month
-        nextDate = '2023-12-15';
-        message = 'Your next delivery has been skipped.';
-      } else if (action === 'cancel') {
-        updatedStatus = 'cancelled';
-        message = 'Your subscription has been cancelled.';
-      }
-
-      setSubscription({
-        ...subscription,
-        status: updatedStatus,
-        nextDeliveryDate: nextDate,
+    try {
+      const tenantId = localStorage.getItem("tenant_id") || "default";
+      const res = await fetch(`/api/subscriptions/${subscriptionId}/action`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-tenant-id": tenantId,
+        },
+        body: JSON.stringify({ action }),
       });
+
+      if (res.ok) {
+        let updatedStatus = subscription.status;
+        let message = '';
+
+        if (action === 'pause') {
+          updatedStatus = 'paused';
+          message = 'Your subscription has been paused.';
+        } else if (action === 'skip') {
+          message = 'Your next delivery has been skipped.';
+        } else if (action === 'cancel') {
+          updatedStatus = 'canceled'; // or 'cancelled' based on backend
+          message = 'Your subscription has been cancelled.';
+        }
+
+        // Optimistically update
+        setSubscription({
+          ...subscription,
+          status: updatedStatus,
+        });
+        setActionStatus({ message, type: 'success' });
+
+        // Re-fetch to get correct nextDeliveryDate if skipped
+        if (action === 'skip') {
+           const refresh = await fetch(`/api/subscriptions/${subscriptionId}`, {
+              headers: { "x-tenant-id": tenantId }
+           });
+           if (refresh.ok) {
+              setSubscription(await refresh.json());
+           }
+        }
+      } else {
+        setActionStatus({ message: 'Failed to update subscription.', type: 'error' });
+      }
+    } catch (err) {
+      console.error(err);
+      setActionStatus({ message: 'An error occurred.', type: 'error' });
+    } finally {
       setIsProcessing(false);
-      setActionStatus({ message, type: 'success' });
-    }, 1000);
+    }
   };
 
   if (loading) {
@@ -82,6 +110,7 @@ export default function CustomerSubscriptionPortal() {
         return <span className="px-2.5 py-1 text-xs font-bold rounded-full bg-green-100 text-green-800 border border-green-200">Active</span>;
       case 'paused':
         return <span className="px-2.5 py-1 text-xs font-bold rounded-full bg-orange-100 text-orange-800 border border-orange-200">Paused</span>;
+      case 'canceled':
       case 'cancelled':
         return <span className="px-2.5 py-1 text-xs font-bold rounded-full bg-red-100 text-red-800 border border-red-200">Cancelled</span>;
       default:
@@ -121,7 +150,7 @@ export default function CustomerSubscriptionPortal() {
           <div className="space-y-4 mb-8">
             <div className="flex justify-between items-center py-2 border-b border-gray-100/50">
               <span className="text-sm font-semibold text-gray-500 uppercase tracking-wider">Next Delivery</span>
-              <span className="font-bold text-gray-900">{subscription.status === 'cancelled' ? '-' : subscription.nextDeliveryDate}</span>
+              <span className="font-bold text-gray-900">{subscription.status === 'cancelled' || subscription.status === 'canceled' ? '-' : subscription.nextDeliveryDate}</span>
             </div>
             <div className="flex justify-between items-center py-2 border-b border-gray-100/50">
               <span className="text-sm font-semibold text-gray-500 uppercase tracking-wider">Frequency</span>
@@ -130,13 +159,13 @@ export default function CustomerSubscriptionPortal() {
             <div className="flex justify-between items-center py-2">
               <span className="text-sm font-semibold text-gray-500 uppercase tracking-wider">Price</span>
               <div className="text-right">
-                <span className="font-bold text-gray-900 text-lg">${subscription.discountedPrice.toFixed(2)}</span>
-                <span className="block text-xs text-gray-400 line-through">${subscription.price.toFixed(2)}</span>
+                <span className="font-bold text-gray-900 text-lg">${(subscription.discountedPrice || 0).toFixed(2)}</span>
+                <span className="block text-xs text-gray-400 line-through">${(subscription.price || 0).toFixed(2)}</span>
               </div>
             </div>
           </div>
 
-          {subscription.status !== 'cancelled' && (
+          {subscription.status !== 'cancelled' && subscription.status !== 'canceled' && (
             <div className="space-y-3 pt-2">
                <button
                   onClick={() => handleAction('skip')}
@@ -176,7 +205,7 @@ export default function CustomerSubscriptionPortal() {
             </div>
           )}
 
-          {subscription.status === 'cancelled' && (
+          {(subscription.status === 'cancelled' || subscription.status === 'canceled') && (
              <div className="pt-2">
                 <p className="text-center text-sm text-gray-500 mb-4">You have cancelled this subscription.</p>
              </div>

--- a/src/ui/next/src/app/kitchen/page.tsx
+++ b/src/ui/next/src/app/kitchen/page.tsx
@@ -51,16 +51,8 @@ export default function KitchenView() {
     updateCount();
     window.addEventListener("ohc_queue_updated", updateCount);
 
-    // Seed test data for E2E missing db data scenarios
-    const seedMock = (e: any) => {
-        if(e.detail.orders && orders.length === 0) setOrders(e.detail.orders);
-        if(e.detail.menu && menu.length === 0) setMenu(e.detail.menu);
-    };
-    window.addEventListener('seed_mock', seedMock);
-
     return () => {
       window.removeEventListener("ohc_queue_updated", updateCount);
-      window.removeEventListener('seed_mock', seedMock);
     };
   }, []);
 
@@ -117,11 +109,14 @@ export default function KitchenView() {
                     <div className="bg-[#FF9500]/10 border border-[#FF9500]/20 rounded-lg p-3 mb-4">
                       <p className="text-sm font-medium text-[#FF9500] mb-1">Customer Notes:</p>
                       <p className="text-sm italic mb-2">"{order.notes}"</p>
-                      {/* Operations Agent translation simulated for E2E */}
-                      <p className="text-sm font-medium text-[#0071E3] mb-1">AI Translation:</p>
-                      <p className="text-sm font-bold text-lg" dir="rtl">
-                        {order.notes.toLowerCase().includes('no onions') ? 'بدون بصل' : (order.notes.toLowerCase().includes('extra pita') ? 'خبز إضافي' : 'ملاحظة: ' + order.notes)}
-                      </p>
+                      {order.translated_notes && (
+                        <>
+                          <p className="text-sm font-medium text-[#0071E3] mb-1 mt-2">AI Translation:</p>
+                          <p className="text-sm font-bold text-lg" dir="rtl">
+                            {order.translated_notes}
+                          </p>
+                        </>
+                      )}
                     </div>
                   )}
                   <button


### PR DESCRIPTION
This PR aims to remove mock data from the Customer Subscriptions Portal and the Kitchen Command Center, and wire them up to the real backend database, fulfilling the Auditor agent mandate to enforce "Data Truth".

**Changes Made:**
1. **Kitchen Command Center (`src/ui/next/src/app/kitchen/page.tsx`)**:
   - Removed `seedMock` UI injection and the `seed_mock` event listener.
   - Replaced simulated UI AI translations with the `translated_notes` field retrieved directly from the POS backend (`/api/pos/orders`).

2. **Backend API (`src/server/api/subscription.rs`)**:
   - Added `GET /api/subscriptions/{id}` endpoint to query the `subscriptions`, `subscription_plans`, and `products` tables.
   - Added `POST /api/subscriptions/{id}/action` endpoint to mutate `status` (pause, cancel) or `current_period_end` (skip).

3. **Customer Subscription Portal (`src/ui/next/src/app/customer/subscriptions/[id]/page.tsx`)**:
   - Replaced `setTimeout` fake delays with standard `fetch` calls to the newly created backend subscription endpoints.
   - Removed statically mocked subscription state.
   - Implemented optimistic updates for UI actions with error fallbacks.

4. **Testing (`src/e2e/` & `src/ui/next/src/app/customer/subscriptions/[id]/page.test.tsx`)**:
   - Fixed a `TypeError` in the React unit test for the subscriptions page.
   - Wrote Playwright E2E tests (`customer-subscription-wire.spec.ts` and `kitchen-wire.spec.ts`) to ensure data flows through the application layers.
   - Verified functionality by passing all tests using `bazelisk test //...`.

---
*PR created automatically by Jules for task [6893269158417249418](https://jules.google.com/task/6893269158417249418) started by @ql-owo-lp*