### PR TITLE
Refine regex for PII leakage checking

### DIFF
--- a/src/server/pii_leakage_check.sh
+++ b/src/server/pii_leakage_check.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Strict bash mode
 set -euo pipefail
 
 # This script is run via Bazel sh_test to ensure no PII leakage in logging statements
@@ -26,7 +25,7 @@ for FILE in $FILES; do
 
     # We grep all matches first. The issue reviewer mentioned ".*? with grep -E is not supported",
     # so we should use a simpler pattern for the {}
-    MATCHES=$(grep -iE "tracing::(info|debug|warn|error)!\(.*\{[^\}]*\}[^;]*($PII_KEYWORDS)[^a-zA-Z0-9_]|tracing::(info|debug|warn|error)!\(.*($PII_KEYWORDS)[^a-zA-Z0-9_].*\{[^\}]*\}" "$FILE" || true)
+    MATCHES=$(grep -iE "tracing::(info|debug|warn|error)!\(.*\{[^\}]*\}[^;]*(^|[^a-zA-Z0-9_])($PII_KEYWORDS)([^a-zA-Z0-9_]|$)|tracing::(info|debug|warn|error)!\((.*[^a-zA-Z0-9_])?($PII_KEYWORDS)([^a-zA-Z0-9_]|$)[^;]*\{[^\}]*\}" "$FILE" || true)
 
     if [ -n "$MATCHES" ]; then
         # Check if the matched line has an explicit opt-out // pii-safe


### PR DESCRIPTION
This patch addresses an issue in `pii_leakage_check.sh` where false positives were being triggered by variables or strings containing PII keywords as substrings (such as `non_pii` matching `pii`).

The regular expression has been refined to effectively simulate word boundary checks (like `\b`) while retaining POSIX ERE compatibility so it functions perfectly across different implementations of `grep -E` (GNU, BSD).

The regex also fixes a bug discovered during code review where the regex would fail to match if the keyword was the very first argument provided to the macro.

To accomplish this safely, the regex branches into two checks:
1. `tracing::(info|debug|warn|error)!\(.*\{[^\}]*\}[^;]*(^|[^a-zA-Z0-9_])($PII_KEYWORDS)([^a-zA-Z0-9_]|$)` - Safely ensures word boundaries for keywords following a `{}` interpolation block.
2. `tracing::(info|debug|warn|error)!\((.*[^a-zA-Z0-9_])?($PII_KEYWORDS)([^a-zA-Z0-9_]|$)[^;]*\{[^\}]*\}` - Utilizes an optional capture group matching preceding non-word boundaries allowing the keyword to safely bind if it appears immediately after the `!` macro parenthesis.

---
*PR created automatically by Jules for task [968342758753409694](https://jules.google.com/task/968342758753409694) started by @ql-owo-lp*