### PR TITLE
chore(server): replace runtime unwrap with from_static for headers

### DIFF
--- a/src/server/builder/edge.rs
+++ b/src/server/builder/edge.rs
@@ -134,7 +134,7 @@ pub async fn handle_edge_request_impl(
         }
         response.headers_mut().insert(
             CACHE_CONTROL,
-            "public, s-maxage=60, stale-while-revalidate=86400".parse().unwrap(),
+            axum::http::HeaderValue::from_static("public, s-maxage=60, stale-while-revalidate=86400"),
         );
         if stale {
             // Spawn background regeneration logic if it was stale, but prevent thundering herd
@@ -178,7 +178,7 @@ pub async fn handle_edge_request_impl(
         }
             response.headers_mut().insert(
                 CACHE_CONTROL,
-                "public, s-maxage=60, stale-while-revalidate=86400".parse().unwrap(),
+                axum::http::HeaderValue::from_static("public, s-maxage=60, stale-while-revalidate=86400"),
             );
             return Ok(response);
         }
@@ -202,7 +202,7 @@ pub async fn handle_edge_request_impl(
     }
     response.headers_mut().insert(
         CACHE_CONTROL,
-        "public, s-maxage=60, stale-while-revalidate=86400".parse().unwrap(),
+        axum::http::HeaderValue::from_static("public, s-maxage=60, stale-while-revalidate=86400"),
     );
     Ok(response)
 }


### PR DESCRIPTION
Replaced instances of `"public, s-maxage=60, stale-while-revalidate=86400".parse().unwrap()` with `axum::http::HeaderValue::from_static("public, s-maxage=60, stale-while-revalidate=86400")` in `src/server/builder/edge.rs`. This avoids a potential runtime panic and reduces overhead by pointing directly to the static byte slice.

---
*PR created automatically by Jules for task [10403719721147596408](https://jules.google.com/task/10403719721147596408) started by @ql-owo-lp*