### PR TITLE
fix: use authenticated org_id for team invite tenant isolation

### DIFF
--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -2053,9 +2053,9 @@ async fn handle_team_invite_accept(
     let tracker = crate::services::growth::invites::InviteTracker::new(repo.clone());
 
     // Before accepting, fetch the invite to get the team_id to invalidate cache
-    let (team_id_opt, invitee_id_opt) = match repo.get_invite(&req.id).await {
-        Ok(Some(invite)) => (Some(invite.team_id), Some(invite.invitee_id)),
-        _ => (None, None),
+    let (tenant_id_opt, team_id_opt, invitee_id_opt) = match repo.get_invite(&req.id).await {
+        Ok(Some(invite)) => (Some(invite.tenant_id), Some(invite.team_id), Some(invite.invitee_id)),
+        _ => (None, None, None),
     };
 
     match tracker.accept_invite(&req.id).await {
@@ -2068,9 +2068,10 @@ async fn handle_team_invite_accept(
                 // Note: We invalidate specifically the first page commonly fetched. For robust cache invalidation across all pages, consider tag-based invalidation or shorter TTLs. We will rely on the short 30s TTL for subsequent pages.
                 let cache = TEAM_INVITES_CACHE.get_or_init(|| HybridCache::new(None));
                 cache.invalidate(&format!("{}None", cache_key_prefix)).await;
-
+            }
+            if let Some(tenant_id) = tenant_id_opt {
                 let metrics_cache = METRICS_CACHE.get_or_init(|| HybridCache::new(None));
-                metrics_cache.invalidate(&format!("aggregated_metrics_{}", team_id)).await;
+                metrics_cache.invalidate(&format!("aggregated_metrics_{}", tenant_id)).await;
             }
 
             let msg = state.hub.sanitize_hub_event(serde_json::json!({ "type": "growth.team_invite_accepted", "id": req.id }));
@@ -2084,12 +2085,13 @@ async fn handle_team_invite_accept(
 
 async fn handle_create_team_invite(
     Extension(state): Extension<GrowthState>,
+    axum::extract::Extension(auth_info): axum::extract::Extension<::server_auth::orchestration::AuthInfo>,
     Json(req): Json<CreateTeamInviteRequest>,
 ) -> Result<Json<CreateTeamInviteResponse>, StatusCode> {
     let repo = std::sync::Arc::new(crate::services::growth::invites::InviteRepository::new(state.pool.clone()));
     let tracker = crate::services::growth::invites::InviteTracker::new(repo);
 
-    match tracker.record_invite(&req.team_id, &req.inviter_id, &req.invitee_id).await {
+    match tracker.record_invite(&auth_info.org_id, &req.team_id, &req.inviter_id, &req.invitee_id).await {
         Ok(invite) => {
             state.viral_loop_tracker.record_invite_sent(&req.inviter_id);
             let cache_key_prefix = format!("team_invites:{}:", req.team_id);
@@ -2097,9 +2099,9 @@ async fn handle_create_team_invite(
             cache.invalidate(&format!("{}None", cache_key_prefix)).await;
 
             let metrics_cache = METRICS_CACHE.get_or_init(|| HybridCache::new(None));
-            metrics_cache.invalidate(&format!("aggregated_metrics_{}", req.team_id)).await;
+            metrics_cache.invalidate(&format!("aggregated_metrics_{}", auth_info.org_id)).await;
 
-            let msg = state.hub.sanitize_hub_event(serde_json::json!({ "type": "growth.team_invite_created", "team_id": req.team_id, "inviter_id": req.inviter_id, "invitee_id": req.invitee_id }));
+            let msg = state.hub.sanitize_hub_event(serde_json::json!({ "type": "growth.team_invite_created", "tenant_id": auth_info.org_id, "team_id": req.team_id, "inviter_id": req.inviter_id, "invitee_id": req.invitee_id }));
             state.hub.append_recent_event(msg);
 
             let invite_link = format!("https://ohc.app/invite/{}", invite.id);
@@ -2169,8 +2171,14 @@ mod tests {
             invitee_id: "user-abc".to_string(),
         };
 
+        let auth_info = ::server_auth::orchestration::AuthInfo {
+            spiffe_id: "spiffe://ohc.app/test".to_string(),
+            agent_id: "agent-xyz".to_string(),
+            org_id: "org-123".to_string(),
+        };
+
         // Call create handler directly
-        let res = handle_create_team_invite(Extension(state.clone()), Json(req)).await;
+        let res = handle_create_team_invite(Extension(state.clone()), Extension(auth_info.clone()), Json(req)).await;
         assert!(res.is_ok());
         let create_res_json = res.unwrap().0;
         assert!(create_res_json.invite_link.starts_with("https://ohc.app/invite/inv-"));
@@ -2709,12 +2717,13 @@ pub struct CloudBridgeInviteResponse {
 
 async fn handle_cloud_bridge_invite(
     Extension(state): Extension<GrowthState>,
+    axum::extract::Extension(auth_info): axum::extract::Extension<::server_auth::orchestration::AuthInfo>,
     Json(req): Json<CloudBridgeInviteRequest>,
 ) -> Result<Json<CloudBridgeInviteResponse>, StatusCode> {
     let repo = std::sync::Arc::new(crate::services::growth::invites::InviteRepository::new(state.pool.clone()));
     let tracker = crate::services::growth::invites::InviteTracker::new(repo);
 
-    match tracker.record_invite(&req.team_id, &req.inviter_id, &req.invitee_id).await {
+    match tracker.record_invite(&auth_info.org_id, &req.team_id, &req.inviter_id, &req.invitee_id).await {
         Ok(invite) => {
             state.viral_loop_tracker.record_invite_sent(&req.inviter_id);
             let cache_key_prefix = format!("team_invites:{}:", req.team_id);
@@ -2723,9 +2732,9 @@ async fn handle_cloud_bridge_invite(
             cache.invalidate(&format!("{}None", cache_key_prefix)).await;
 
             let metrics_cache = METRICS_CACHE.get_or_init(|| HybridCache::new(None));
-            metrics_cache.invalidate(&format!("aggregated_metrics_{}", req.team_id)).await;
+            metrics_cache.invalidate(&format!("aggregated_metrics_{}", auth_info.org_id)).await;
 
-            let msg = state.hub.sanitize_hub_event(serde_json::json!({ "type": "growth.cloud_bridge_invite_created", "team_id": req.team_id, "inviter_id": req.inviter_id, "invitee_id": req.invitee_id }));
+            let msg = state.hub.sanitize_hub_event(serde_json::json!({ "type": "growth.cloud_bridge_invite_created", "tenant_id": auth_info.org_id, "team_id": req.team_id, "inviter_id": req.inviter_id, "invitee_id": req.invitee_id }));
             state.hub.append_recent_event(msg);
 
             let invite_link = format!("https://ohc.app/invite/{}", invite.id);
@@ -2783,7 +2792,13 @@ mod cloud_bridge_tests {
             invitee_id: "invitee-xyz".to_string(),
         };
 
-        let res = handle_cloud_bridge_invite(Extension(state.clone()), Json(req)).await;
+        let auth_info = ::server_auth::orchestration::AuthInfo {
+            spiffe_id: "spiffe://ohc.app/test".to_string(),
+            agent_id: "agent-xyz".to_string(),
+            org_id: "org-123".to_string(),
+        };
+
+        let res = handle_cloud_bridge_invite(Extension(state.clone()), Extension(auth_info.clone()), Json(req)).await;
         assert!(res.is_ok());
 
         let res_json = res.unwrap().0;

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -2364,13 +2364,14 @@ async fn get_pending_approvals(
         &self,
         request: Request<InviteRequest>,
     ) -> Result<Response<InviteResponse>, Status> {
+        let tenant_id = request.metadata().get("x-ohc-tenant-id").map(|v| v.to_str().unwrap_or("")).unwrap_or("").to_string();
         let req = request.into_inner();
         
         if req.team_id.is_empty() || req.inviter_id.is_empty() || req.invitee_id.is_empty() {
             return Err(Status::invalid_argument("Missing required fields"));
         }
 
-        self.invite_tracker.record_invite(&req.team_id, &req.inviter_id, &req.invitee_id).await
+        self.invite_tracker.record_invite(if tenant_id.is_empty() { &req.team_id } else { &tenant_id }, &req.team_id, &req.inviter_id, &req.invitee_id).await
             .map_err(|e| Status::internal(format!("Failed to record invite: {}", e)))?;
 
         self.viral_loop_tracker.record_invite_sent(&req.inviter_id);

--- a/src/server/services/growth/invites.rs
+++ b/src/server/services/growth/invites.rs
@@ -165,10 +165,10 @@ impl InviteTracker {
         InviteTracker { repo }
     }
 
-    pub async fn record_invite(&self, team_id: &str, inviter_id: &str, invitee_id: &str) -> Result<TeamInvite, String> {
+    pub async fn record_invite(&self, tenant_id: &str, team_id: &str, inviter_id: &str, invitee_id: &str) -> Result<TeamInvite, String> {
         let invite = TeamInvite {
             id: format!("inv-{}", Utc::now().timestamp_nanos_opt().unwrap_or(0)),
-            tenant_id: team_id.to_string(), // Ensure isolation mapping
+            tenant_id: tenant_id.to_string(), // Ensure isolation mapping
             team_id: team_id.to_string(),
             inviter_id: inviter_id.to_string(),
             invitee_id: invitee_id.to_string(),
@@ -198,12 +198,12 @@ impl InviteTracker {
         self.repo.get_total_invites_count(tenant_id).await
     }
 
-    pub async fn record_invites(&self, team_id: &str, inviter_id: &str, invitee_ids: &[String]) -> Result<(), String> {
+    pub async fn record_invites(&self, tenant_id: &str, team_id: &str, inviter_id: &str, invitee_ids: &[String]) -> Result<(), String> {
         let mut invites = Vec::new();
         for invitee_id in invitee_ids {
             invites.push(TeamInvite {
                 id: format!("inv-{}-{}", Utc::now().timestamp_nanos_opt().unwrap_or(0), invitee_id),
-                tenant_id: team_id.to_string(),
+                tenant_id: tenant_id.to_string(),
                 team_id: team_id.to_string(),
                 inviter_id: inviter_id.to_string(),
                 invitee_id: invitee_id.clone(),


### PR DESCRIPTION
Resolves an issue where "Invites Sent" was not accurately recorded under the authenticated user's `tenant_id` in multi-tenant environments. Waitlists and metrics now appropriately associate growth data based on `auth_info.org_id`. Tested and verified that the E2E viral loop suite (`//src/e2e:playwright`) now passes.

---
*PR created automatically by Jules for task [3975982570200097576](https://jules.google.com/task/3975982570200097576) started by @ql-owo-lp*