### PR TITLE
fix: resolve postgres multiple statements bug and multitenant test failure

### DIFF
--- a/src/server/auth/multitenancy_isolation.rs
+++ b/src/server/auth/multitenancy_isolation.rs
@@ -87,12 +87,15 @@ async fn test_revoke_token_tenant_isolation() {
 
     // Insert an already expired token for the OTHER tenant using raw query
     let expired_time = chrono::Utc::now() - chrono::Duration::hours(1);
+    let mut tx1 = pool.begin().await.unwrap();
+    sqlx::query("SELECT set_config('app.current_tenant', 'tenant_b', false)").execute(&mut *tx1).await.unwrap();
     let _ = sqlx::query("INSERT INTO revoked_tokens (jti, expires_at, tenant_id) VALUES ($1, $2, $3) ON CONFLICT (jti, tenant_id) DO NOTHING")
         .bind("other_tenant_expired_token")
         .bind(expired_time)
         .bind(other_tenant)
-        .execute(&pool)
+        .execute(&mut *tx1)
         .await;
+    tx1.commit().await.unwrap();
 
     // Call revoke token on the CURRENT tenant
     let future_time = chrono::Utc::now() + chrono::Duration::hours(1);
@@ -100,10 +103,13 @@ async fn test_revoke_token_tenant_isolation() {
     assert!(res.is_ok(), "revoke_token should succeed");
 
     // Ensure the other tenant's expired token still exists, proving GC only cleared current_tenant
+    let mut tx2 = pool.begin().await.unwrap();
+    sqlx::query("SELECT set_config('app.current_tenant', 'tenant_b', false)").execute(&mut *tx2).await.unwrap();
     let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM revoked_tokens WHERE jti = 'other_tenant_expired_token'")
-        .fetch_one(&pool)
+        .fetch_one(&mut *tx2)
         .await
         .unwrap_or((0,));
+    tx2.commit().await.unwrap();
 
     assert_eq!(row.0, 1, "The expired token from the other tenant was incorrectly garbage collected, proving cross-tenant deletion vulnerability");
 }

--- a/src/server/common/auth_utils.rs
+++ b/src/server/common/auth_utils.rs
@@ -37,7 +37,7 @@ where
     } else {
         // We use session scope (false) because set_org_context might be called on a raw connection outside a transaction.
         // Pool hooks (before_acquire / after_release) safely wipe session states using DISCARD ALL and SET app.current_tenant = ''.
-        query("RESET ROLE; SELECT set_config('app.current_tenant', $1, false);")
+        query("SELECT set_config('app.current_tenant', $1, false);")
             .bind(org_id)
             .execute(executor)
             .await?;


### PR DESCRIPTION
Fixed `cannot insert multiple commands into a prepared statement` inside `set_org_context` by removing the redundant `RESET ROLE;` command (connection pools already issue `DISCARD ALL` via hooks).
Corrected the test `test_revoke_token_tenant_isolation` which falsely claimed a cross-tenant deletion vulnerability in `revoke_token`. The test previously failed to insert the token due to a missing RLS context, causing the subsequent query to return `COUNT(*) = 0`. The test now wraps queries in a transaction and properly sets `app.current_tenant` to assert that garbage collection is working safely.

---
*PR created automatically by Jules for task [7729155809951778909](https://jules.google.com/task/7729155809951778909) started by @ql-owo-lp*