### PR TITLE
Setup wizard 375px responsiveness

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -10,6 +10,7 @@
         background-color: #f5f5f7;
         margin: 0;
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
         height: 100vh;
@@ -23,8 +24,8 @@
         border-radius: 16px;
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
         text-align: center;
-        max-width: 100%;
-        width: 480px;
+        width: 100%;
+        max-width: min(480px, calc(100vw - 20px));
         border: 1px solid rgba(255, 255, 255, 0.4);
         box-sizing: border-box;
         max-height: calc(100vh - 40px);
@@ -760,19 +761,6 @@
         .step-indicator.active {
           transform: scale(1.2);
         }
-        .container {
-        background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(210%);
-        -webkit-backdrop-filter: blur(30px) saturate(210%);
-        padding: 20px;
-        border-radius: 16px;
-        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-        text-align: center;
-        max-width: 480px;
-        width: 100%;
-        border: 1px solid rgba(255, 255, 255, 0.4);
-        box-sizing: border-box;
-      }
         .radio-option {
           padding: 8px 12px;
           font-size: 14px;


### PR DESCRIPTION
I have updated the layout of the `setup.html` page to perfectly adapt to 375px mobile screens. This was achieved by updating the flexbox structure to stack the footer elements vertically and leveraging CSS `calc()` and `min()` to restrict maximum width to fit narrow screens without breaking the standard 480px layout on desktop devices. I also cleared up a duplicate media query block that was breaking this behavior. Playwright tests and Bazel tests were run successfully to ensure stability.

---
*PR created automatically by Jules for task [9622316765458028067](https://jules.google.com/task/9622316765458028067) started by @ql-owo-lp*