### PR TITLE
💰 Miser: Fix E2E locators for Cost Transparency Dashboard

### DIFF
--- a/src/e2e/current_app_smoke.ts
+++ b/src/e2e/current_app_smoke.ts
@@ -46,7 +46,7 @@ export async function currentAppSmoke(page: Page, request: APIRequestContext, la
     await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' }).first()).toBeVisible({ timeout: 15000 });
     await expect(page.locator('h2', { hasText: 'Cost Transparency Dashboard' }).first()).toBeVisible();
 
-    const totalCosts = page.locator('#cost-dashboard-total');
+    const totalCosts = page.locator('#cost-dashboard-total-costs');
     await expect(totalCosts).toBeVisible();
     expect(await totalCosts.innerText()).toMatch(/^\$[\d,]+\.\d{2}$/);
 

--- a/src/e2e/my_plan_dashboard.spec.ts
+++ b/src/e2e/my_plan_dashboard.spec.ts
@@ -34,7 +34,7 @@ test.describe('My Plan and Cost Dashboard Screens', () => {
     await expect(page.locator('h1', { hasText: 'Cost Dashboard' })).toBeVisible({ timeout: 10000 });
 
     // Verify elements by id or text mapped to their metrics
-    await expect(page.locator('#cost-dashboard-total-revenue')).toBeVisible();
+    await expect(page.locator('#cost-dashboard-revenue')).toBeVisible();
     await expect(page.locator('#cost-dashboard-total-costs')).toBeVisible();
     await expect(page.locator('#cost-dashboard-projected-cost')).toBeVisible();
   });


### PR DESCRIPTION
💰 Miser: Fix E2E locators for Cost Transparency Dashboard

This pull request updates the Playwright test locators to match the actual HTML element IDs in the application for the Cost Transparency Dashboard.

**Product-use evidence:**
*   Persona: Test Runner / Automator.
*   Browser/Playwright flow attempted: Ran `bazelisk test //src/e2e:playwright`.
*   CUJ gap observed: Tests were failing because they tried to find elements with IDs `#cost-dashboard-total` and `#cost-dashboard-total-revenue`, but the actual HTML elements used `#cost-dashboard-total-costs` and `#cost-dashboard-revenue`.
*   Why a real owner/operator would need the fix: A working CI ensures stability.
*   Exact UI flow repeated after the fix: Ran `bazelisk test //src/e2e:playwright`, and the tests passed successfully.

**Interaction Audit Table:**

| Element / Locator Tested | Designed Purpose | Observed Result | Fix |
| :--- | :--- | :--- | :--- |
| `#cost-dashboard-total` | E2E Test Locator for Total Costs | Element not found / Timeout | Changed locator to `#cost-dashboard-total-costs` |
| `#cost-dashboard-total-revenue` | E2E Test Locator for Total Revenue | Element not found / Timeout | Changed locator to `#cost-dashboard-revenue` |

**Superpowers Skills Loaded:**
N/A (Standard debugging workflow).

**Testing:**
*   Ran `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"` and verified all E2E tests passed.
*   Ran `bazelisk test //...` to confirm the entire suite is green.

---
*PR created automatically by Jules for task [1123138027872907941](https://jules.google.com/task/1123138027872907941) started by @ql-owo-lp*