### PR TITLE
🤖 Implementer: Harness Upgrade - [Error Handling: LLM-Recoverable ToolMessages]

### DIFF
--- a/src/agents/builtin/agent.rs
+++ b/src/agents/builtin/agent.rs
@@ -4852,7 +4852,7 @@ mod tests {
                     // Check if the prompt contains the recoverable error
                     let last_msg = _req.messages.last().unwrap();
                     let expected_error = crate::types::format_llm_recoverable_error(
-                        "Validation Error (Pydantic-first tool schema): Failing for test",
+                        "Failing for test",
                     );
                     let has_error = last_msg.tool_results.iter().any(|r| {
                         r.content.contains("LLM-Recoverable Error")
@@ -4914,7 +4914,7 @@ mod tests {
 
         // Verify the ToolCall event has the LlmRecoverable message
         let expected_error = crate::types::format_llm_recoverable_error(
-            "Validation Error (Pydantic-first tool schema): Failing for test",
+            "Failing for test",
         );
         let has_recoverable_event = events.iter().any(|e| {
             if let AgentEvent::ToolCall { result, .. } = e {

--- a/src/agents/builtin/tool_executor_engine.rs
+++ b/src/agents/builtin/tool_executor_engine.rs
@@ -52,14 +52,8 @@ impl ToolExecutionEngine {
                 }
                 Err(ToolError::LlmRecoverable(msg)) => {
                     // 2) LLM-recoverable: returned to the model so it can self-correct.
-                    let formatted_msg =
-                        if msg.contains("Validation Error (Pydantic-first tool schema)") {
-                            msg
-                        } else {
-                            format!("Validation Error (Pydantic-first tool schema): {}", msg)
-                        };
-                    info!("LLM-recoverable error encountered: {}", formatted_msg);
-                    return Err(ToolError::LlmRecoverable(formatted_msg));
+                    info!("LLM-recoverable error encountered: {}", msg);
+                    return Err(ToolError::LlmRecoverable(msg));
                 }
                 Err(ToolError::UserFixable(msg)) => {
                     // 3) User-fixable: immediately bubble up to the orchestrator to request human-in-loop input.

--- a/src/agents/builtin/tool_executor_engine_tests.rs
+++ b/src/agents/builtin/tool_executor_engine_tests.rs
@@ -301,7 +301,7 @@ mod tests {
         let res = ToolExecutionEngine::execute_tool_with_langgraph_mechanics(&tool, &tc, 2).await;
         assert!(res.is_err());
         match res.unwrap_err() {
-            ToolError::LlmRecoverable(msg) => assert_eq!(msg, "Validation Error (Pydantic-first tool schema): parse error"),
+            ToolError::LlmRecoverable(msg) => assert_eq!(msg, "parse error"),
             _ => panic!("Expected LlmRecoverable error"),
         }
     }


### PR DESCRIPTION
🤖 Implementer: Harness Upgrade - [Error Handling: LLM-Recoverable ToolMessages]

* **Mechanic Chosen:** "Error Handling (Compounding Error Prevention): LLM-recoverable (return the raw error as a ToolMessage directly to the model so it can self-correct)"
* **Rationale & Implementation Details:** The previous implementation forcefully prefixed all LLM-recoverable errors with "Validation Error (Pydantic-first tool schema): ". This masked legitimate, non-schema recoverable errors (like transient timeouts converted to recoverable, or generic internal tool failures that an LLM could fix, like a missing flag in a bash command) under a misleading label. The engine should trust the tool's formatting. The `PydanticAdapter` already formats Pydantic validation errors correctly, so the engine now propagates the raw error directly.
* **Superpowers Loaded:** `superpowers:systematic-debugging` (to trace the exact point where the error prefix was injected), `superpowers:test-driven-development` (to adapt the tests before modifying the source), `superpowers:verification-before-completion` (to ensure all `bazel test` outputs passed without failure).
* **Testing Instructions:** Ran `bazelisk test //src/agents/builtin/...` ensuring all tests completed successfully, including the updated `test_llm_recoverable` and `test_llm_recoverable_tool_messages_agent_loop` tests which were modified to expect the new clean raw strings.

---
*PR created automatically by Jules for task [11544480896001884793](https://jules.google.com/task/11544480896001884793) started by @ql-owo-lp*