### PR TITLE
🚀 Nova: Fix missing vitest imports in cloud bridge invite test

### DIFF
--- a/src/ui/next/src/app/api/v1/growth/cloud-bridge/invite/route.test.ts
+++ b/src/ui/next/src/app/api/v1/growth/cloud-bridge/invite/route.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { POST } from './route';
 
 describe('POST /api/v1/growth/cloud-bridge/invite', () => {


### PR DESCRIPTION
fix(tests): add missing vitest imports in cloud bridge invite test

Added the required vitest imports (describe, it, expect, vi, beforeEach, afterEach)
to `src/ui/next/src/app/api/v1/growth/cloud-bridge/invite/route.test.ts`
to fix a ReferenceError during test execution.

---
*PR created automatically by Jules for task [11839937845522757455](https://jules.google.com/task/11839937845522757455) started by @ql-owo-lp*