### PR TITLE
fix: Add missing RLS policy to business_milestones table

### DIFF
--- a/src/server/migrations/017_business_milestones.sql
+++ b/src/server/migrations/017_business_milestones.sql
@@ -9,3 +9,6 @@ CREATE TABLE IF NOT EXISTS business_milestones (
 );
 
 CREATE INDEX IF NOT EXISTS idx_business_milestones_tenant_id ON business_milestones(tenant_id);
+
+ALTER TABLE business_milestones ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_business_milestones ON business_milestones USING (tenant_id::text = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));


### PR DESCRIPTION
This PR adds missing Row Level Security (RLS) policies to the `business_milestones` table to ensure multi-tenant safety. I have successfully run all tests to verify nothing has broken.

---
*PR created automatically by Jules for task [3859964020004188007](https://jules.google.com/task/3859964020004188007) started by @ql-owo-lp*