### PR TITLE
fix: Update tsconfig to support vitest coverage

### DIFF
--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Original TS configuration used `"jsx": "preserve"`. This is generally recommended but breaks with vitest as vitest throws a fatal error because it is unable to handle JSX correctly out of the box with the swc plugin for NEXT. Given vitest configuration already includes a SWC plugin for react, changing the NextJS `tsconfig.json` to have `"jsx": "react-jsx"` provides the necessary transformation so vitest runs correctly while retaining all existing functionalities as Next.js doesn't specifically require `"jsx": "preserve"` for correct compilation. E2E tests passing.

---
*PR created automatically by Jules for task [7001880183972694723](https://jules.google.com/task/7001880183972694723) started by @ql-owo-lp*