### PR TITLE
Fix help tests and improve SyncManager coverage

### DIFF
--- a/src/ui/next/src/app/api/walkthrough/[page]/route.test.ts
+++ b/src/ui/next/src/app/api/walkthrough/[page]/route.test.ts
@@ -16,6 +16,7 @@ describe('Walkthrough API Route', () => {
   });
 
   it('returns empty array on error', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
     const req = new NextRequest('http://localhost:3000/api/walkthrough/test-page');

--- a/src/ui/next/src/components/SyncManagerInitializer.test.tsx
+++ b/src/ui/next/src/components/SyncManagerInitializer.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SyncManagerInitializer } from './SyncManagerInitializer';
+import { SyncManager } from '../lib/sync/SyncManager';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../lib/sync/SyncManager', () => {
+  return {
+    SyncManager: {
+      getInstance: vi.fn(),
+    },
+  };
+});
+
+describe('SyncManagerInitializer', () => {
+  it('calls SyncManager.getInstance on mount', () => {
+    render(<SyncManagerInitializer />);
+    expect(SyncManager.getInstance).toHaveBeenCalled();
+  });
+});

--- a/src/ui/next/src/components/help.test.tsx
+++ b/src/ui/next/src/components/help.test.tsx
@@ -8,6 +8,7 @@ import { TooltipProvider } from './TooltipRegistry';
 
 describe('HelpWidget', () => {
   beforeEach(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
     global.fetch = vi.fn().mockImplementation((url) => {
       if (url === '/api/walkthrough/store-setup') {
         return Promise.resolve({
@@ -43,11 +44,14 @@ describe('HelpWidget', () => {
     const user = userEvent.setup();
     await act(async () => {
       render(
-        <TooltipProvider>
-          <WalkthroughProvider>
-            <HelpWidget />
-          </WalkthroughProvider>
-        </TooltipProvider>
+        <div>
+          <div id="test-target">Mock Target</div>
+          <TooltipProvider>
+            <WalkthroughProvider>
+              <HelpWidget />
+            </WalkthroughProvider>
+          </TooltipProvider>
+        </div>
       );
     });
 

--- a/src/ui/next/src/lib/sync/SyncManager.test.ts
+++ b/src/ui/next/src/lib/sync/SyncManager.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SyncManager } from './SyncManager';
+
+describe('SyncManager', () => {
+  beforeEach(() => {
+    // Reset singleton instance between tests
+    (SyncManager as any).instance = undefined;
+    vi.clearAllMocks();
+  });
+
+  it('is a singleton', () => {
+    const instance1 = SyncManager.getInstance();
+    const instance2 = SyncManager.getInstance();
+    expect(instance1).toBe(instance2);
+  });
+
+  it('initializes with default properties', () => {
+    const instance = SyncManager.getInstance();
+    expect(instance).toBeDefined();
+    // @ts-ignore - accessing private properties for testing
+    expect(instance.syncInProgress).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR fixes broken tests in `help.test.tsx` (missing JSDOM method) and `route.test.ts` (polluted output), and proactively adds unit test coverage for `SyncManagerInitializer` and `SyncManager` as requested by the Continuous Codebase Optimization mandate.

---
*PR created automatically by Jules for task [15454863782993876271](https://jules.google.com/task/15454863782993876271) started by @ql-owo-lp*