### PR TITLE
⚡ Bolt: [performance improvement] Parallelized supply and cache fetches in unified feed handler

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -4827,15 +4827,19 @@ async fn ui_dashboard_unified_feed_handler(
     let cache_key = format!("ui_dashboard_unified:{}:mobile:{}", tenant_id, mobile_optimized);
     let cache = UI_UNIFIED_FEED_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(get_redis_client()));
 
+    let cache_future = cache.get_with_swr(&cache_key);
+    let supply_future = load_ui_supply_from_db(&db, &tenant_id, mobile_optimized);
+    let (cache_res, supply_res) = tokio::join!(cache_future, supply_future);
+    let supply_val = supply_res.unwrap_or_else(|_| serde_json::json!({}));
+
     // Check cache
-    if let Some((cached, is_stale)) = cache.get_with_swr(&cache_key).await {
+    if let Some((cached, is_stale)) = cache_res {
         if !is_stale {
             // Supply should not be cached because it changes continuously (inventory counts),
             // so we fetch supply and merge it on cache hit.
-            let supply_res = load_ui_supply_from_db(&db, &tenant_id, mobile_optimized).await.unwrap_or_else(|_| serde_json::json!({}));
             let mut final_cached = cached.clone();
             if let Some(obj) = final_cached.as_object_mut() {
-                obj.insert("supply".to_string(), supply_res);
+                obj.insert("supply".to_string(), supply_val.clone());
             }
             return (axum::http::StatusCode::OK, axum::Json(final_cached)).into_response();
         }
@@ -4852,12 +4856,10 @@ async fn ui_dashboard_unified_feed_handler(
             let db6 = db_bg.clone(); let t6 = t_bg.clone();
             let db7 = db_bg.clone(); let t7 = t_bg.clone();
 
-            let db8 = db_bg.clone(); let t8 = t_bg.clone();
-            let (metrics_res, orders_res, messages_res, supply_res, triage_res, approvals_res, agent_feed_res, priority_tasks_res) = tokio::join!(
+            let (metrics_res, orders_res, messages_res, triage_res, approvals_res, agent_feed_res, priority_tasks_res) = tokio::join!(
                 tokio::spawn(async move { load_ui_dashboard_metrics(&db1, &t1, mobile_optimized).await }),
                 tokio::spawn(async move { load_ui_orders_from_db(&db2, &t2, mobile_optimized).await }),
                 tokio::spawn(async move { load_ui_inbox_from_db(&db3, &t3, mobile_optimized).await }),
-                tokio::spawn(async move { load_ui_supply_from_db(&db8, &t8, mobile_optimized).await }),
                 tokio::spawn(async move { load_ui_triage_from_db(&db4, &t4, mobile_optimized).await }),
                 tokio::spawn(async move { load_ui_agent_approvals_from_db(&db5, &t5, mobile_optimized).await }),
                 tokio::spawn(async move { load_ui_agent_feed_from_db(&db6, &t6, mobile_optimized).await }),
@@ -4870,9 +4872,6 @@ async fn ui_dashboard_unified_feed_handler(
             let approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
             let agent_feed = agent_feed_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
             let priority_tasks = priority_tasks_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-
-
-            let _supply = supply_res.unwrap_or_else(|_| Ok(serde_json::json!({}))).unwrap_or_default();
             let result = serde_json::json!({
                 "metrics": metrics_res.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound)).map(|m| serde_json::to_value(m).unwrap_or_default()).unwrap_or_default(),
                 "orders": orders,
@@ -4889,10 +4888,9 @@ async fn ui_dashboard_unified_feed_handler(
 
         // Supply should not be cached because it changes continuously (inventory counts),
         // so we fetch supply and merge it on cache hit.
-        let supply_res = load_ui_supply_from_db(&db, &tenant_id, mobile_optimized).await.unwrap_or_else(|_| serde_json::json!({}));
         let mut final_cached = cached.clone();
         if let Some(obj) = final_cached.as_object_mut() {
-            obj.insert("supply".to_string(), supply_res);
+            obj.insert("supply".to_string(), supply_val.clone());
         }
         return (axum::http::StatusCode::OK, axum::Json(final_cached)).into_response();
     }
@@ -4900,17 +4898,15 @@ async fn ui_dashboard_unified_feed_handler(
     let db1 = db.clone(); let t1 = tenant_id.clone();
     let db2 = db.clone(); let t2 = tenant_id.clone();
     let db3 = db.clone(); let t3 = tenant_id.clone();
-    let db4 = db.clone(); let t4 = tenant_id.clone();
     let db5 = db.clone(); let t5 = tenant_id.clone();
     let db6 = db.clone(); let t6 = tenant_id.clone();
     let db7 = db.clone(); let t7 = tenant_id.clone();
     let db8 = db.clone(); let t8 = tenant_id.clone();
 
-    let (metrics_res, orders_res, messages_res, supply_res, triage_res, approvals_res, agent_feed_res, priority_tasks_res) = tokio::join!(
+    let (metrics_res, orders_res, messages_res, triage_res, approvals_res, agent_feed_res, priority_tasks_res) = tokio::join!(
         tokio::spawn(async move { load_ui_dashboard_metrics(&db1, &t1, mobile_optimized).await }),
         tokio::spawn(async move { load_ui_orders_from_db(&db2, &t2, mobile_optimized).await }),
         tokio::spawn(async move { load_ui_inbox_from_db(&db3, &t3, mobile_optimized).await }),
-        tokio::spawn(async move { load_ui_supply_from_db(&db4, &t4, mobile_optimized).await }),
         tokio::spawn(async move { load_ui_triage_from_db(&db5, &t5, mobile_optimized).await }),
         tokio::spawn(async move { load_ui_agent_approvals_from_db(&db6, &t6, mobile_optimized).await }),
         tokio::spawn(async move { load_ui_agent_feed_from_db(&db7, &t7, mobile_optimized).await }),
@@ -4923,7 +4919,6 @@ async fn ui_dashboard_unified_feed_handler(
     let approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
     let agent_feed = agent_feed_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
     let priority_tasks = priority_tasks_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-    let supply = supply_res.unwrap_or_else(|_| Ok(serde_json::json!({}))).unwrap_or_default();
 
 
     let cacheable_result = serde_json::json!({
@@ -4941,7 +4936,7 @@ async fn ui_dashboard_unified_feed_handler(
     // Add supply to the final result
     let mut final_result = cacheable_result;
     if let Some(obj) = final_result.as_object_mut() {
-        obj.insert("supply".to_string(), supply);
+        obj.insert("supply".to_string(), supply_val);
     }
 
     (axum::http::StatusCode::OK, axum::Json(final_result)).into_response()


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Parallelized supply and cache fetches in unified feed handler to improve mobile API latency

**What was optimized**:
- Parallelized the SWR cache lookup (`cache.get_with_swr`) and the required `load_ui_supply_from_db` database query in `ui_dashboard_unified_feed_handler`. 
- Previously, these operations ran sequentially (cache check first, then DB query). Now they run concurrently using `tokio::join!`.
- Eliminated redundant background database queries for supply during cache misses and stale hits, since supply is never cached and can be reused from the concurrent foreground fetch.

**Why it matters to the user**:
- Reduces the overall p50 latency for loading the unified owner feed, especially on high-latency mobile connections.
- Reduces unnecessary load on the database by avoiding redundant background queries for non-cacheable data.

**Expected improvement**:
- Faster load times for the main owner dashboard.
- Reduced database CPU usage and connection contention during traffic spikes.

**Superpowers skills loaded**:
- systematic-debugging
- test-driven-development

---
*PR created automatically by Jules for task [9449957619333214096](https://jules.google.com/task/9449957619333214096) started by @ql-owo-lp*