### PR TITLE
Fix missing viral branding in background Promoter agent drafts

### DIFF
--- a/src/server/workers/department_workers.rs
+++ b/src/server/workers/department_workers.rs
@@ -1058,6 +1058,16 @@ let db_for_products = self.db.clone();
                                 if let Some(obj) = parsed.as_object_mut() {
                                     obj.insert("feature_type".to_string(), serde_json::json!("social_post_draft"));
                                     obj.insert("product_name".to_string(), serde_json::json!(product_name));
+
+                                    for platform in ["tiktok", "instagram", "facebook", "twitter", "linkedin"].iter() {
+                                        if let Some(v) = obj.get_mut(*platform) {
+                                            if let Some(s) = v.as_str() {
+                                                if !s.contains("Powered by OHC") {
+                                                    *v = serde_json::json!(format!("{}\n\n⚡ Powered by OHC", s));
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
 
                                 let task_id = Uuid::new_v4().to_string();


### PR DESCRIPTION
The Promoter worker background jobs currently generate social media marketing copy without including the `⚡ Powered by OHC` watermark, breaking the intended viral growth loop. This patch adds logic to correctly iterate over the supported platform fields (`tiktok`, `instagram`, `facebook`, `twitter`, `linkedin`) in the JSON payload, appending the watermark robustly without modifying meta-keys like `feature_type`.

Tested via full `bazel test //...` run.

---
*PR created automatically by Jules for task [7153975036219017057](https://jules.google.com/task/7153975036219017057) started by @ql-owo-lp*