### PR TITLE
🎨 Canvas: Offline-First SQLite Sync Engine

### DIFF
--- a/src/ui/next/src/app/utils/offlineQueue.ts
+++ b/src/ui/next/src/app/utils/offlineQueue.ts
@@ -1,4 +1,6 @@
 /// <reference types="node" />
+import { getSystemPowerSync } from '../../lib/powersync/db';
+
 export interface OfflineAction {
   id: string; // The action request ID or a UUID
   type: string; // E.g., 'approve_agent_feed'
@@ -6,48 +8,21 @@ export interface OfflineAction {
   timestamp: number;
 }
 
-const DB_NAME = "OHC_Offline_Queue";
-const STORE_NAME = "actions";
-const DB_VERSION = 1;
-
-function getDB(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-
-    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
-
-    request.onerror = (event) => {
-      // Suppress error log if IndexedDB is intentionally unavailable in tests
-      if (process.env.NODE_ENV !== 'test') {
-        console.error("IndexedDB error", event);
-      }
-      reject(request.error);
-    };
-
-    request.onsuccess = (event) => {
-      resolve((event.target as IDBOpenDBRequest).result);
-    };
-
-    request.onupgradeneeded = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result;
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME, { keyPath: "id" });
-      }
-    };
-  });
-}
-
 export async function enqueueAction(action: OfflineAction): Promise<void> {
-  if (typeof window === "undefined" || !window.indexedDB) return;
+  if (typeof window === "undefined") return;
   try {
-    const db = await getDB();
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([STORE_NAME], "readwrite");
-      const store = transaction.objectStore(STORE_NAME);
-      const request = store.put(action);
-
-      request.onsuccess = () => resolve();
-      request.onerror = () => reject(request.error);
-    });
+    const db = await getSystemPowerSync();
+    await db.execute(
+      'INSERT OR REPLACE INTO pending_actions (id, type, payload, timestamp, status, retry_count) VALUES (?, ?, ?, ?, ?, ?)',
+      [
+        action.id,
+        action.type,
+        JSON.stringify(action.payload),
+        action.timestamp,
+        'pending',
+        0
+      ]
+    );
   } catch (err) {
     if (process.env.NODE_ENV !== 'test') {
       console.error("Failed to enqueue action", err);
@@ -56,19 +31,18 @@ export async function enqueueAction(action: OfflineAction): Promise<void> {
 }
 
 export async function getActions(): Promise<OfflineAction[]> {
-  if (typeof window === "undefined" || !window.indexedDB) return [];
+  if (typeof window === "undefined") return [];
   try {
-    const db = await getDB();
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([STORE_NAME], "readonly");
-      const store = transaction.objectStore(STORE_NAME);
-      const request = store.getAll();
-
-      request.onsuccess = () => {
-        resolve(request.result as OfflineAction[]);
-      };
-      request.onerror = () => reject(request.error);
-    });
+    const db = await getSystemPowerSync();
+    const result = await db.getAll('SELECT * FROM pending_actions ORDER BY timestamp ASC');
+    return result.map((row: any) => ({
+      id: row.id,
+      type: row.type,
+      payload: typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload,
+      timestamp: row.timestamp,
+      status: row.status,
+      retry_count: row.retry_count
+    }));
   } catch (err) {
     if (process.env.NODE_ENV !== 'test') {
       console.error("Failed to get actions", err);
@@ -78,17 +52,10 @@ export async function getActions(): Promise<OfflineAction[]> {
 }
 
 export async function removeAction(id: string): Promise<void> {
-  if (typeof window === "undefined" || !window.indexedDB) return;
+  if (typeof window === "undefined") return;
   try {
-    const db = await getDB();
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([STORE_NAME], "readwrite");
-      const store = transaction.objectStore(STORE_NAME);
-      const request = store.delete(id);
-
-      request.onsuccess = () => resolve();
-      request.onerror = () => reject(request.error);
-    });
+    const db = await getSystemPowerSync();
+    await db.execute('DELETE FROM pending_actions WHERE id = ?', [id]);
   } catch (err) {
     if (process.env.NODE_ENV !== 'test') {
       console.error("Failed to remove action", err);

--- a/src/ui/next/src/e2e/offline_sync.spec.ts
+++ b/src/ui/next/src/e2e/offline_sync.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Offline Sync with SQLite', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test('should queue actions in SQLite optimistically when offline', async ({ page, context }) => {
+    test.setTimeout(180000);
+
+    await page.goto('/dashboard');
+    await expect(page.locator('h1', { hasText: 'Dashboard' }).first()).toBeVisible({ timeout: 25000 });
+
+    const approveBtn = page.getByTestId('approve-proposal').first();
+    const isVisible = await approveBtn.isVisible({ timeout: 15000 }).catch(() => false);
+
+    if (isVisible) {
+      // 1. Go offline
+      await context.setOffline(true);
+      await page.evaluate(() => window.dispatchEvent(new Event('offline')));
+
+      // Verify offline banner
+      await expect(page.locator('text=You are offline. Actions will sync when online.')).toBeVisible();
+
+      const cardParent = approveBtn.locator('xpath=./../../..');
+
+      // 2. Tap approve
+      await approveBtn.click();
+
+      // 3. The item should optimistically disappear
+      await expect(cardParent).not.toBeVisible({ timeout: 2000 });
+
+      // Check the pending sync banner count
+      await expect(page.locator('text=Pending Sync (1)')).toBeVisible({ timeout: 5000 });
+
+      // 4. Go back online
+      await context.setOffline(false);
+      await page.evaluate(() => window.dispatchEvent(new Event('online')));
+
+      // Verify offline banner goes away
+      await expect(page.locator('text=You are offline. Actions will sync when online.')).not.toBeVisible();
+
+      // Verify pending sync banner goes away after sync
+      await expect(page.locator('text=Pending Sync')).not.toBeVisible({ timeout: 10000 });
+    }
+  });
+});

--- a/src/ui/next/src/lib/powersync/AppSchema.ts
+++ b/src/ui/next/src/lib/powersync/AppSchema.ts
@@ -25,7 +25,16 @@ const omniInboxMessages = new Table({
   updated_at: column.text
 });
 
+const pendingActions = new Table({
+  type: column.text,
+  payload: column.text,
+  timestamp: column.integer,
+  status: column.text,
+  retry_count: column.integer
+});
+
 export const AppSchema = new Schema({
   agent_feed_items: agentFeedItems,
-  omni_inbox_messages: omniInboxMessages
+  omni_inbox_messages: omniInboxMessages,
+  pending_actions: pendingActions
 });

--- a/src/ui/next/src/lib/powersync/PowerSyncProvider.tsx
+++ b/src/ui/next/src/lib/powersync/PowerSyncProvider.tsx
@@ -1,25 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { PowerSyncDatabase } from '@powersync/web';
 import { PowerSyncContext } from '@powersync/react';
-import { AppSchema } from './AppSchema';
-
-class BackendConnector {
-  async fetchCredentials() {
-    const res = await fetch('/api/v1/auth/powersync_token');
-    if (!res.ok) {
-      throw new Error(`Failed to get token: ${res.status}`);
-    }
-    const body = await res.json();
-    return {
-      endpoint: body.powersync_url,
-      token: body.token,
-      expiresAt: body.expires_at || new Date(Date.now() + 60 * 60 * 1000).toISOString()
-    };
-  }
-  async uploadData(database: any) {
-    // Offline mutations handle local changes queue directly
-  }
-}
+import { getSystemPowerSync, BackendConnector } from './db';
 
 export function isPowerSyncSupportedForLocation(isSecureContext: boolean, hostname: string) {
   return isSecureContext || hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
@@ -48,14 +30,7 @@ export const PowerSyncProvider = ({
     if (!supported) return;
     let _powerSync: PowerSyncDatabase;
     const init = async () => {
-      _powerSync = new PowerSyncDatabase({
-        database: {
-          dbFilename: 'ohc-offline.db'
-        },
-        schema: AppSchema,
-      });
-
-      await _powerSync.init();
+      _powerSync = await getSystemPowerSync();
 
       const connector = new BackendConnector();
       _powerSync.connect(connector);
@@ -72,7 +47,6 @@ export const PowerSyncProvider = ({
     return () => {
        if (_powerSync) {
          _powerSync.disconnect();
-         _powerSync.close();
        }
     };
   }, [supported]);

--- a/src/ui/next/src/lib/powersync/db.ts
+++ b/src/ui/next/src/lib/powersync/db.ts
@@ -1,0 +1,46 @@
+import { PowerSyncDatabase } from '@powersync/web';
+import { AppSchema } from './AppSchema';
+
+export class BackendConnector {
+  async fetchCredentials() {
+    const res = await fetch('/api/v1/auth/powersync_token');
+    if (!res.ok) {
+      throw new Error(`Failed to get token: ${res.status}`);
+    }
+    const body = await res.json();
+    return {
+      endpoint: body.powersync_url,
+      token: body.token,
+      expiresAt: body.expires_at || new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    };
+  }
+  async uploadData(database: any) {
+    // Offline mutations handle local changes queue directly
+  }
+}
+
+let systemPowerSync: PowerSyncDatabase | null = null;
+let initPromise: Promise<PowerSyncDatabase> | null = null;
+
+export function getSystemPowerSync(): Promise<PowerSyncDatabase> {
+  if (systemPowerSync) return Promise.resolve(systemPowerSync);
+  if (initPromise) return initPromise;
+
+  initPromise = new Promise(async (resolve, reject) => {
+    try {
+      const ps = new PowerSyncDatabase({
+        database: {
+          dbFilename: 'ohc-offline.db'
+        },
+        schema: AppSchema,
+      });
+      await ps.init();
+      systemPowerSync = ps;
+      resolve(ps);
+    } catch (e) {
+      reject(e);
+    }
+  });
+
+  return initPromise;
+}


### PR DESCRIPTION
This implements an offline-first CQRS sync queue for the frontend using `@powersync/web` and WA-SQLite to ensure mutations succeed immediately offline and sync gracefully in the background once online.

Resolves #29764

---
*PR created automatically by Jules for task [13524204515448101514](https://jules.google.com/task/13524204515448101514) started by @ql-owo-lp*