### PR TITLE
fix: Update documentation E2E routes to point to backend mappings

### DIFF
--- a/src/e2e/api-docs.spec.ts
+++ b/src/e2e/api-docs.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures';
 test.describe('API Documentation', () => {
   test('should display interactive Swagger UI layout', async ({ page }) => {
     // Navigate to API Docs page
-    await page.goto('/api-docs');
+    await page.goto('/api/ui/api-docs.html');
 
     // Ensure the advanced warning is visible
     await expect(page.locator('text=Advanced:')).toBeVisible();
@@ -22,7 +22,7 @@ test.describe('API Documentation', () => {
   test('should not have horizontal scroll issues on mobile viewport', async ({ page }) => {
     // Set viewport to mobile (375px)
     await page.setViewportSize({ width: 375, height: 812 });
-    await page.goto('/api-docs');
+    await page.goto('/api/ui/api-docs.html');
 
     // Wait for the swagger UI to load
     await expect(page.locator('.swagger-ui')).toBeVisible({ timeout: 15000 });

--- a/src/e2e/documentation_extended.spec.ts
+++ b/src/e2e/documentation_extended.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures';
 test.describe('Extended Documentation & Help Features', () => {
 
   test('should display empty state when Help Center search yields no results', async ({ page }) => {
-    await page.goto('/help.html');
+    await page.goto('/api/ui/help.html');
 
     const searchInput = page.getByPlaceholder('Search for help articles and videos...');
     await searchInput.fill('XYZNonExistent123');
@@ -30,7 +30,7 @@ test.describe('Extended Documentation & Help Features', () => {
   });
 
   test('should display duration badges on video tutorials', async ({ page }) => {
-    await page.goto('/help.html');
+    await page.goto('/api/ui/help.html');
 
     // Wait for the video list to load
     await expect(page.getByRole('heading', { name: 'Video Guides', exact: true })).toBeVisible();
@@ -40,7 +40,7 @@ test.describe('Extended Documentation & Help Features', () => {
   });
 
   test('should display external link to full technical changelog in release notes', async ({ page }) => {
-    await page.goto('/changelog.html');
+    await page.goto('/api/ui/changelog.html');
 
     await expect(page.getByRole('heading', { name: 'Release Notes & Changelog' })).toBeVisible();
 
@@ -50,7 +50,7 @@ test.describe('Extended Documentation & Help Features', () => {
   });
 
   test('should load Swagger UI in API Documentation page', async ({ page }) => {
-    await page.goto('/api-docs.html');
+    await page.goto('/api/ui/api-docs.html');
 
     // Check for advanced badge
     await expect(page.getByText('Advanced:')).toBeVisible();

--- a/src/e2e/documentation_full.spec.ts
+++ b/src/e2e/documentation_full.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test.describe('Documentation full suite', () => {
   test('Help portal loads properly and search works', async ({ page }) => {
     // Visit help page
-    await page.goto('/help.html');
+    await page.goto('/api/ui/help.html');
 
     // Title should be present
     const title = page.locator('h1');
@@ -27,7 +27,7 @@ test.describe('Documentation full suite', () => {
 
   test('Changelog pulls data dynamically', async ({ page }) => {
     // Visit changelog page
-    await page.goto('/changelog.html');
+    await page.goto('/api/ui/changelog.html');
 
     // Title should be present
     const title = page.locator('h1');
@@ -42,7 +42,7 @@ test.describe('Documentation full suite', () => {
 
   test('API Docs loads Swagger UI', async ({ page }) => {
     // Visit api docs page
-    await page.goto('/api-docs.html');
+    await page.goto('/api/ui/api-docs.html');
 
     // Check for Swagger UI wrapper
     const swaggerUI = page.locator('.swagger-ui');

--- a/src/e2e/help_features_advanced.spec.ts
+++ b/src/e2e/help_features_advanced.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './fixtures';
 
 test.describe('In-App Help & Documentation Features', () => {
   test('navigates to Help Center and searches for an article', async ({ page }) => {
-    await page.goto('/help.html');
+    await page.goto('/api/ui/help.html');
 
     // Help Center title is visible
     await expect(page.getByRole('heading', { name: /Help Center/i })).toBeVisible();
@@ -51,12 +51,12 @@ test.describe('In-App Help & Documentation Features', () => {
   });
 
   test('api docs page', async ({ page }) => {
-    await page.goto('/api-docs.html');
+    await page.goto('/api/ui/api-docs.html');
     await expect(page.getByText('API Reference for advanced users')).toBeVisible();
   });
 
   test('changelog page', async ({ page }) => {
-    await page.goto('/changelog.html');
+    await page.goto('/api/ui/changelog.html');
     await expect(page.getByText('Release Notes & Changelog')).toBeVisible();
     await expect(page.getByText('New Features')).toBeVisible();
   });

--- a/src/e2e/walkthrough_tooltips.spec.ts
+++ b/src/e2e/walkthrough_tooltips.spec.ts
@@ -86,7 +86,7 @@ test.describe('Walkthrough and Tooltips features', () => {
   });
 
   test('Help Center elements are visible', async ({ page }) => {
-    await page.goto('/help.html');
+    await page.goto('/api/ui/help.html');
 
     // Verify title
     await expect(page.locator('h1')).toHaveText('In-App Help Center');

--- a/src/ui/next/src/e2e/api-docs.spec.ts
+++ b/src/ui/next/src/e2e/api-docs.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test.describe('API Documentation', () => {
   test('should load the Swagger UI on the api-docs page', async ({ page }) => {
     // Navigate to the API Docs page
-    await page.goto('/api-docs');
+    await page.goto('/api/ui/api-docs.html');
 
     // Check for the "Advanced" warning banner
     await expect(page.getByText('This section is for developers directly integrating')).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
The E2E tests for the documentation, changelog, and API Docs were
failing because they were trying to navigate to the files directly
(e.g., `/api-docs.html`) instead of the actual paths mapped by the
backend (e.g., `/api/ui/api-docs.html`).

This commit updates all relevant E2E tests to point to the correct
routes, resolving the test failures.

---
*PR created automatically by Jules for task [12374690638832844053](https://jules.google.com/task/12374690638832844053) started by @ql-owo-lp*