### PR TITLE
Fix Agent Feed Route in Dashboard UI

### DIFF
--- a/src/ui/next/src/app/api/dev/simulate-agent-feed-item/route.ts
+++ b/src/ui/next/src/app/api/dev/simulate-agent-feed-item/route.ts
@@ -1,0 +1,5 @@
+import { proxyBackendPost } from "../../ui/backendProxy";
+
+export async function POST(req: Request) {
+  return proxyBackendPost(req, "/api/dev/simulate-agent-feed-item");
+}

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -2016,7 +2016,7 @@
           let bodyPayload;
 
           if (isAgentFeed) {
-             url = `/api/v1/feed/${encodeURIComponent(id)}/state`;
+             url = `/api/agent-feed/${encodeURIComponent(id)}/state`;
              method = 'PUT';
              let finalState = 'APPROVED';
              if (typeof state === 'boolean') {


### PR DESCRIPTION
Fixed the `mock_agent_feed_end_to_end.spec.ts` failure by changing the frontend to use `/api/agent-feed/{id}/state` instead of `/api/v1/feed/{id}/state`. Also added the `/api/dev/simulate-agent-feed-item` endpoint proxy.

---
*PR created automatically by Jules for task [7611895069975965721](https://jules.google.com/task/7611895069975965721) started by @ql-owo-lp*