### PR TITLE
Fix `search_workspace` parity for SQLite and Postgres

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -512,8 +512,9 @@ impl DB {
                 }
 
                 // Search Orders
-                let order_rows = sqlx::query("SELECT id, status, CAST(total_cost AS REAL) as total_cost FROM purchase_orders WHERE tenant_id = ? AND (id LIKE ? OR status LIKE ?) ORDER BY id ASC LIMIT 10")
+                let order_rows = sqlx::query("SELECT id, status, CAST(total_cost AS REAL) as total_cost FROM purchase_orders WHERE tenant_id = ? AND (id LIKE ? OR status LIKE ? OR CAST(total_cost AS TEXT) LIKE ?) ORDER BY id ASC LIMIT 10")
                     .bind(tenant_id)
+                    .bind(&query_lower)
                     .bind(&query_lower)
                     .bind(&query_lower)
                     .fetch_all(sqlite_pool)
@@ -589,7 +590,7 @@ impl DB {
                 }
 
                 // Search Orders
-                let order_rows = sqlx::query("SELECT id, status, CAST(total_cost AS DOUBLE PRECISION) as total_cost FROM purchase_orders WHERE tenant_id = $1 AND (id ILIKE $2 OR status ILIKE $2) ORDER BY id ASC LIMIT 10")
+                let order_rows = sqlx::query("SELECT id, status, CAST(total_cost AS DOUBLE PRECISION) as total_cost FROM purchase_orders WHERE tenant_id = $1 AND (id ILIKE $2 OR status ILIKE $2 OR CAST(total_cost AS TEXT) ILIKE $2) ORDER BY id ASC LIMIT 10")
                     .bind(tenant_id)
                     .bind(&query_lower)
                     .fetch_all(&mut *tx)


### PR DESCRIPTION
Fix `search_workspace` parity for SQLite and Postgres

Updates `search_workspace` to also search by `total_cost` in purchase orders, both for SQLite and Postgres to maintain parity. Fixes the failing test `test_sqlite_pg_parity_search_workspace`.

---
*PR created automatically by Jules for task [185247233556707911](https://jules.google.com/task/185247233556707911) started by @ql-owo-lp*