### PR TITLE
Fix embeddable storefront growth loop E2E test

### DIFF
--- a/src/ui/next/src/app/api/v1/growth/storefront/embed/route.test.ts
+++ b/src/ui/next/src/app/api/v1/growth/storefront/embed/route.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from './route';
+
+describe('Storefront Embed Widget', () => {
+  it('returns 400 if tenant is missing', async () => {
+    const req = new Request('http://localhost/api/v1/growth/storefront/embed');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns HTML with correct tenant and default theme', async () => {
+    const req = new Request('http://localhost/api/v1/growth/storefront/embed?tenant=maya-cakes');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    expect(text).toContain('<!DOCTYPE html>');
+    expect(text).toContain('https://ohc.app?ref=maya-cakes');
+  });
+});

--- a/src/ui/next/src/app/api/v1/growth/storefront/embed/route.ts
+++ b/src/ui/next/src/app/api/v1/growth/storefront/embed/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+
+function escapeHtml(unsafe: string) {
+    return unsafe
+         .replace(/&/g, "&amp;")
+         .replace(/</g, "&lt;")
+         .replace(/>/g, "&gt;")
+         .replace(/"/g, "&quot;")
+         .replace(/'/g, "&#039;");
+}
+
+export async function GET(request: Request) {
+    const { searchParams } = new URL(request.url);
+    const tenant = searchParams.get('tenant');
+    const theme = searchParams.get('theme') || 'light';
+
+    if (!tenant) {
+        return new NextResponse('Missing tenant', { status: 400 });
+    }
+
+    const safeTenant = escapeHtml(encodeURIComponent(tenant));
+    const isDark = theme === 'dark';
+
+    const html = `<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Storefront</title>
+    <style>
+        body { font-family: sans-serif; margin: 0; padding: 16px; background: ${isDark ? '#1a1a1a' : '#fff'}; color: ${isDark ? '#fff' : '#000'}; }
+        .buy-button { background: #007bff; color: white; padding: 8px 16px; border: none; border-radius: 4px; cursor: pointer; }
+        .footer { margin-top: 24px; font-size: 12px; color: #666; text-align: center; }
+        .footer a { color: #007bff; text-decoration: none; }
+    </style>
+</head>
+<body>
+    <h2>Our Store</h2>
+    <p>Welcome to our online store.</p>
+    <button class="buy-button">Buy Now</button>
+
+    <div class="footer">
+        Powered by <a href="https://ohc.app?ref=${safeTenant}" target="_blank">OHC</a>
+    </div>
+</body>
+</html>`;
+
+    return new NextResponse(html, {
+        headers: {
+            'Content-Type': 'text/html',
+        },
+    });
+}

--- a/src/ui/next/src/e2e/embeddable-storefront.spec.ts
+++ b/src/ui/next/src/e2e/embeddable-storefront.spec.ts
@@ -11,8 +11,8 @@ test.describe('Embeddable Storefront Widget Growth Loop', () => {
         await widgetLink.click();
 
         // Should now be on the Storefront Widget page
-        const sectionHeader = page.getByRole('heading', { name: /Embed Your Store/ });
-        await expect(sectionHeader).toBeVisible();
+        const sectionHeader = page.locator('h1', { hasText: 'Embed Your Store' });
+        await expect(sectionHeader).toBeVisible({ timeout: 10000 });
 
         // Check for the "New Growth Loop" badge next to the header
         await expect(page.locator('text=New Growth Loop').first()).toBeVisible();
@@ -23,7 +23,7 @@ test.describe('Embeddable Storefront Widget Growth Loop', () => {
         await getWidgetBtn.click();
 
         // Modal should appear
-        const modalHeader = page.locator('h2:has-text("Embed Storefront")');
+        const modalHeader = page.getByRole('heading', { name: /Embed Storefront/i });
         await expect(modalHeader).toBeVisible();
 
         // The textarea should contain the iframe snippet


### PR DESCRIPTION
Fix embeddable storefront growth loop E2E test

This PR implements the missing `/api/v1/growth/storefront/embed` endpoint for the "Embeddable Storefront Widget" growth loop and fixes the related Playwright E2E test.
- Implemented the Next.js API route that serves the widget HTML and includes the viral "Powered by OHC" referral parameter.
- Properly sanitized and URL-encoded the `tenant` query parameter to prevent XSS vulnerabilities.
- Added Vitest unit tests for the endpoint.
- Corrected the Playwright locators in `src/ui/next/src/e2e/embeddable-storefront.spec.ts` from `"Embed Your Store"` to `"Embed Your Store 🌐"` (and subsequently adjusted it based on the exact DOM rendering, removing the emoji where necessary) to ensure tests pass.
- Ensured all tests (`bazel test //...` and local Playwright E2E) run and pass successfully.

---
*PR created automatically by Jules for task [9668423231710695566](https://jules.google.com/task/9668423231710695566) started by @ql-owo-lp*