### PR TITLE
fix(e2e): update local storage keys and values in tests to match actual state

### DIFF
--- a/src/e2e/business_setup_1.spec.ts
+++ b/src/e2e/business_setup_1.spec.ts
@@ -7,7 +7,7 @@ test.describe('Business Setup Wizard', () => {
       localStorage.setItem('tenant_id', tenantId);
       localStorage.setItem('user_id', tenantId);
       localStorage.removeItem('ohc_wizard_state');
-      localStorage.removeItem('onboarding-storage-v3');
+      localStorage.removeItem('onboardingState');
     }, id);
     await page.goto('/website-builder');
     await page.waitForLoadState('networkidle');

--- a/src/e2e/wizard_cross_device.spec.ts
+++ b/src/e2e/wizard_cross_device.spec.ts
@@ -6,7 +6,7 @@ test.describe('Wizard Cross Device E2E', () => {
     await page.addInitScript((tenantId) => {
       localStorage.setItem('tenant_id', tenantId);
       localStorage.setItem('user_id', tenantId);
-      localStorage.removeItem('onboarding-storage-v3');
+      localStorage.removeItem('onboardingState');
     }, 'storefront');
     await page.goto('/setup.html');
     await page.waitForLoadState('networkidle');
@@ -24,11 +24,11 @@ test.describe('Wizard Cross Device E2E', () => {
 
     // Wait until local storage is updated with the business name
     await expect.poll(async () => {
-      const stateStr = await page.evaluate(() => localStorage.getItem('onboarding-storage-v3'));
+      const stateStr = await page.evaluate(() => localStorage.getItem('onboardingState'));
       if (!stateStr) return '';
       try {
         const state = JSON.parse(stateStr);
-        return state.state.businessName;
+        return state.businessName;
       } catch (e) {
         return '';
       }
@@ -49,11 +49,11 @@ test.describe('Wizard Cross Device E2E', () => {
     // Inject the exact same local storage state to the new context to test restoration
     // We navigate to dashboard first to have the right origin
     await newPage.goto('/dashboard');
-    const wizardState = await page.evaluate(() => localStorage.getItem('onboarding-storage-v3'));
+    const wizardState = await page.evaluate(() => localStorage.getItem('onboardingState'));
 
     await newPage.evaluate((state) => {
         if(state) {
-            localStorage.setItem('onboarding-storage-v3', state);
+            localStorage.setItem('onboardingState', state);
         }
         localStorage.setItem('tenant_id', 'storefront');
         localStorage.setItem('user_id', 'storefront');


### PR DESCRIPTION
- `onboarding-storage-v3` has been renamed to `onboardingState`.
- `state.state.businessName` has been flattened to `state.businessName`.

The tests have been updated to reflect these changes to fix test failures.

---
*PR created automatically by Jules for task [7368404427941742561](https://jules.google.com/task/7368404427941742561) started by @ql-owo-lp*