### PR TITLE
💰 Miser: [Add glassmorphism to pricing cards]

### DIFF
--- a/src/ui/tauri/src/ui/cost-dashboard.html
+++ b/src/ui/tauri/src/ui/cost-dashboard.html
@@ -236,7 +236,7 @@
       <div id="content" style="display: none;">
         <div class="grid">
           <!-- My Plan Widget -->
-          <div class="ohc-growth-card" id="my-plan-widget">
+          <div class="ohc-growth-card glassmorphism" id="my-plan-widget">
             <h2 style="margin-top: 0; font-size: 20px; border-bottom: 1px solid rgba(0,0,0,0.1); padding-bottom: 12px; margin-bottom: 20px;">Plan: <span id="my-plan-name" style="color: #0066FF;"></span></h2>
 
             <h2 class="app-panel-title text-xl font-bold font-outfit text-gray-900" style="margin-top: 0; margin-bottom: 20px;">Your Current Usage</h2>
@@ -271,7 +271,7 @@
           </div>
 
           <!-- Cost Dashboard Widget -->
-          <div class="ohc-growth-card" id="cost-dashboard-widget" style="display:none;">
+          <div class="ohc-growth-card glassmorphism" id="cost-dashboard-widget" style="display:none;">
             <h1 style="margin-top: 0; font-size: 20px; border-bottom: 1px solid rgba(0,0,0,0.1); padding-bottom: 12px; margin-bottom: 20px;">Cost Transparency Dashboard</h1><h2 style="margin: 0; font-size: 14px; font-weight: 500; color: #86868b; display:none;">Cost Transparency Dashboard</h2><button id="back-to-my-plan" class="btn-outline" style="margin-bottom: 12px;">Back to My Plan</button>
             <h2 style="display:none;">Business Advisory Dashboard</h2>
             <div style="display:none;">Advisory Summary</div>

--- a/src/ui/tauri/src/ui/pricing.html
+++ b/src/ui/tauri/src/ui/pricing.html
@@ -213,7 +213,7 @@
 
       <div class="pricing-grid">
         <!-- Free Plan -->
-        <div class="ohc-growth-card">
+        <div class="ohc-growth-card glassmorphism">
           <div class="plan-name">Free</div>
           <div class="plan-price">$0<span>/month</span></div>
           <ul class="features-list">
@@ -226,7 +226,7 @@
         </div>
 
         <!-- Starter Plan -->
-        <div class="ohc-growth-card recommended">
+        <div class="ohc-growth-card recommended glassmorphism">
           <div class="badge">Recommended</div>
           <div class="plan-name">Starter</div>
           <div class="plan-price">$29<span>/month</span></div>
@@ -241,7 +241,7 @@
         </div>
 
         <!-- Pro Plan -->
-        <div class="ohc-growth-card">
+        <div class="ohc-growth-card glassmorphism">
           <div class="plan-name">Pro</div>
           <div class="plan-price">$79<span>/month</span></div>
           <ul class="features-list">
@@ -254,7 +254,7 @@
         </div>
 
         <!-- Business Plan -->
-        <div class="ohc-growth-card">
+        <div class="ohc-growth-card glassmorphism">
           <div class="plan-name">Business</div>
           <div class="plan-price">$299<span>/month</span></div>
           <ul class="features-list">


### PR DESCRIPTION
This PR enforces the `glassmorphism` styling across `.ohc-growth-card` instances in `cost-dashboard.html` and `pricing.html`. The previous implementation had the `.glassmorphism` class defined in the CSS block, but did not apply it to the cards themselves. This satisfies the proactive optimization protocol's requirement to polish UX interfaces to macOS Translucent Glass standards.

Pre-commit execution has verified the stability of the build, and the `Miser` components' cost tracking functionality maintains expected behavior as outlined in the verified text files.

---
*PR created automatically by Jules for task [10253707373818666395](https://jules.google.com/task/10253707373818666395) started by @ql-owo-lp*