### PR TITLE
Remove localStorage mock data from Link-in-Bio feature

### DIFF
--- a/src/ui/next/src/app/link-in-bio-generator/page.tsx
+++ b/src/ui/next/src/app/link-in-bio-generator/page.tsx
@@ -88,15 +88,6 @@ export default function LinkInBioGeneratorPage() {
     }
   };
 
-  // Keep local storage write for backwards-compat during transition if needed,
-  // but main persistence is now the API via handlePublish.
-  useEffect(() => {
-    if (typeof localStorage !== 'undefined') {
-        const payload = { storeName, bio, links, theme };
-        localStorage.setItem(`ohc_bio_${tenant}`, JSON.stringify(payload));
-    }
-  }, [storeName, bio, links, theme, tenant]);
-
   const shareLink = `http://localhost:3000/bio/${tenant}`;
 
   const getThemeStyles = () => {

--- a/src/ui/tauri/src/ui/bio.html
+++ b/src/ui/tauri/src/ui/bio.html
@@ -278,25 +278,9 @@
             const response = await fetch(`/api/v1/growth/link-in-bio/${tenant}`);
             if (response.ok) {
                 data = await response.json();
-            } else {
-                // Try E2E test fallback
-                const saved = window.localStorage.getItem(`ohc_bio_${tenant}`);
-                if (saved) {
-                    const parsed = JSON.parse(saved);
-                    if (parsed.storeName) data.store_name = parsed.storeName;
-                    if (parsed.bio) data.bio = parsed.bio;
-                }
             }
         } catch(e) {
             console.error("Failed to load from API", e);
-            try {
-                const saved = window.localStorage.getItem(`ohc_bio_${tenant}`);
-                if (saved) {
-                    const parsed = JSON.parse(saved);
-                    if (parsed.storeName) data.store_name = parsed.storeName;
-                    if (parsed.bio) data.bio = parsed.bio;
-                }
-            } catch(e) {}
         }
 
         // Update UI

--- a/src/ui/tauri/src/ui/link-in-bio-generator.html
+++ b/src/ui/tauri/src/ui/link-in-bio-generator.html
@@ -404,16 +404,6 @@
             const response = await fetch(`/api/v1/growth/link-in-bio/${tenant}`);
             if (response.ok) {
                 currentState = await response.json();
-
-                // Keep compatibility with E2E tests that set this localStorage explicitly:
-                try {
-                    const saved = window.localStorage.getItem(`ohc_bio_${tenant}`);
-                    if (saved) {
-                        const parsed = JSON.parse(saved);
-                        if (parsed.storeName) currentState.store_name = parsed.storeName;
-                        if (parsed.bio) currentState.bio = parsed.bio;
-                    }
-                } catch(e) {}
             }
         } catch(e) {
             console.error("Failed to load bio config", e);
@@ -424,14 +414,6 @@
 
         let saveTimeout;
         function saveState() {
-            // Keep E2E tests happy by saving to localStorage too
-            window.localStorage.setItem(`ohc_bio_${tenant}`, JSON.stringify({
-                storeName: currentState.store_name,
-                bio: currentState.bio,
-                theme: currentState.theme,
-                links: currentState.links
-            }));
-
             // Debounce API call
             clearTimeout(saveTimeout);
             saveTimeout = setTimeout(async () => {


### PR DESCRIPTION
This PR removes all instances of `localStorage.getItem/setItem` referencing `ohc_bio_${tenant}` in the Next.js UI (`page.tsx`) and the Tauri UI (`bio.html`, `link-in-bio-generator.html`). This ensures the feature strictly relies on the backend API rather than a mock data / fallback logic, satisfying the "ZERO mock data" rule. All tests continue to pass via the live database.

---
*PR created automatically by Jules for task [3883944694224476964](https://jules.google.com/task/3883944694224476964) started by @ql-owo-lp*