### PR TITLE
fix: register missing offline queue updated listener

### DIFF
--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -107,6 +107,8 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
     };
     updateOfflineCount();
 
+    window.addEventListener("ohc_queue_updated", updateOfflineCount);
+
     setIsOffline(!navigator.onLine);
 
     const handleOnline = async () => {
@@ -137,6 +139,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
     window.addEventListener("offline", handleOffline);
 
     return () => {
+      window.removeEventListener("ohc_queue_updated", updateOfflineCount);
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("offline", handleOffline);
     };


### PR DESCRIPTION
Added `window.addEventListener("ohc_queue_updated", updateOfflineCount);` to `UnifiedAgentFeed.tsx` so that it successfully monitors offline mutations saved to `SyncManager` offline queue.

Resolves #29807

**Product-use evidence:**
- Persona: Carlos the Handyman
- Real browser/Playwright UI flow: Navigated to dashboard, went offline, approved an action.
- Gap observed: The pending offline items queue count does not update.
- Expected behavior: Queue count updates automatically and syncing operates in the background.

**Tests:**
Ran `bazelisk test //src/ui/next:next_vitest` and confirmed all UI tests pass. Playwright E2E tests are skipping offline syncing specific assertions or are covered by the KDS spec.

---
*PR created automatically by Jules for task [12152996907320891160](https://jules.google.com/task/12152996907320891160) started by @ql-owo-lp*