### PR TITLE
🛡️ Sentry: Server-side enforcement of token budget under chaos testing

### DIFF
--- a/src/server/orchestration/departments/throttling.rs
+++ b/src/server/orchestration/departments/throttling.rs
@@ -63,11 +63,13 @@ impl ThrottlingManager {
                      ON CONFLICT (tenant_id, year_month) DO UPDATE
                      SET actions_used = tenant_ai_budgets.actions_used + $3,
                          updated_at = CURRENT_TIMESTAMP
+                     WHERE tenant_ai_budgets.actions_used + $3 <= $4
                      RETURNING actions_used"
                 )
                 .bind(tenant_id)
                 .bind(&year_month)
                 .bind(points)
+                .bind(limit)
                 .fetch_optional(&mut *tx)
                 .await
                 .map_err(|e| e.to_string())?;
@@ -81,21 +83,27 @@ impl ThrottlingManager {
                 }
             }
             DbStore::Sqlite(pool) => {
+                let mut tx = pool.begin().await.map_err(|e| e.to_string())?;
                 let res: Option<(i32,)> = sqlx::query_as(
                     "INSERT INTO tenant_ai_budgets (tenant_id, year_month, actions_used)
                      VALUES (?, ?, ?)
                      ON CONFLICT (tenant_id, year_month) DO UPDATE
                      SET actions_used = tenant_ai_budgets.actions_used + ?,
                          updated_at = CURRENT_TIMESTAMP
+                     WHERE tenant_ai_budgets.actions_used + ? <= ?
                      RETURNING actions_used"
                 )
                 .bind(tenant_id)
                 .bind(&year_month)
                 .bind(points)
                 .bind(points)
-                .fetch_optional(pool)
+                .bind(points)
+                .bind(limit)
+                .fetch_optional(&mut *tx)
                 .await
                 .map_err(|e| e.to_string())?;
+
+                tx.commit().await.map_err(|e| e.to_string())?;
 
                 if let Some((actions_used,)) = res {
                     Ok(actions_used <= limit)


### PR DESCRIPTION
This PR fixes a Time-of-Check to Time-of-Use (TOCTOU) vulnerability that allowed concurrent requests to exceed the AI agent token budget. The issue was observed during chaos testing (`test_token_budget_server_side_enforcement`).

**Root Cause:**
The budget enforcement in `ThrottlingManager::check_and_consume_budget` was reading the budget state and then issuing an unconditional `ON CONFLICT DO UPDATE` to consume the points, which failed to prevent concurrent execution from violating the budget limit.

**Fix:**
Implemented atomic condition validation using `WHERE tenant_ai_budgets.actions_used + points <= limit` within the UPSERT query for both PostgreSQL and SQLite. This guarantees that operations exceeding the budget are inherently rejected at the database transaction layer. Furthermore, wrapped the SQLite implementation in an atomic transaction to guarantee execution consistency matching the PostgreSQL version.

**Verification:**
- Ran `bazelisk test //...` - all 83 backend tests passed successfully under load.
- Simulated concurrency directly using `test_token_budget_server_side_enforcement` showing proper denial of concurrent budget overuse.
- Front-end Playwright tests run fully.

---
*PR created automatically by Jules for task [11581800214787964823](https://jules.google.com/task/11581800214787964823) started by @ql-owo-lp*