### PR TITLE
feat: Add `PoweredByOHC` footer to the checkout page

### DIFF
--- a/src/ui/next/src/app/checkout/page.tsx
+++ b/src/ui/next/src/app/checkout/page.tsx
@@ -185,9 +185,6 @@ function CheckoutContent() {
             </div>
 
             <PostPurchaseShareWidget tenantId={tenant || "default-store"} orderId={searchParams.get("orderId") || "success"} />
-            <div className="flex justify-center">
-              <PoweredByOHC tenantId={tenant} />
-            </div>
           </div>
         ) : tier ? (
             <div className="p-6 md:p-8 flex flex-col justify-between bg-white/60 backdrop-blur-2xl saturate-200 border border-white/40 shadow-lg rounded-[24px]">
@@ -220,7 +217,6 @@ function CheckoutContent() {
                   Cancel
                 </button>
               </WithTooltip>
-              <PoweredByOHC tenantId={tenant} />
             </div>
         ) : (
           <>
@@ -388,10 +384,14 @@ function CheckoutContent() {
               Cancel
             </button>
           </WithTooltip>
-          <PoweredByOHC tenantId={tenant} />
         </div>
         </>
         )}
+
+        {/* Powered By OHC Footer */}
+        <div className="flex justify-center mt-6 w-full relative z-[9999] pb-8">
+          <PoweredByOHC tenantId={tenant} />
+        </div>
       </main>
 
       {/* Post-Purchase Referral Modal */}

--- a/src/ui/next/src/app/components/PoweredByOHC.tsx
+++ b/src/ui/next/src/app/components/PoweredByOHC.tsx
@@ -39,17 +39,17 @@ export function PoweredByOHC({ tenantId }: PoweredByOHCProps) {
   return (
     <div
       ref={containerRef}
-      className="powered-by-footer flex flex-col justify-center items-center mt-8 pb-4 relative"
+      className="powered-by-footer flex flex-col justify-center items-center mt-8 pb-4 relative z-50"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
       {isHovered && (
         <div
-          className="absolute bottom-full mb-3 w-64 p-4 rounded-[20px] border border-white/50 bg-white/70 backdrop-blur-xl shadow-xl z-50 text-center animate-fade-in transition-all duration-300"
+          className="absolute bottom-full mb-3 w-64 p-4 rounded-[20px] border border-white/50 bg-white/70 backdrop-blur-xl shadow-[0_20px_50px_rgba(0,0,0,0.15)] z-[9999] text-center animate-fade-in transition-all duration-300"
         >
-          <div className="absolute -bottom-2 left-1/2 -translate-x-1/2 w-4 h-4 bg-white/70 border-b border-r border-white/50 transform rotate-45 backdrop-blur-xl z-40"></div>
+          <div className="absolute -bottom-2 left-1/2 -translate-x-1/2 w-4 h-4 bg-white/70 border-b border-r border-white/50 transform rotate-45 backdrop-blur-xl z-[9998]"></div>
 
-          <div className="relative z-50">
+          <div className="relative z-[9999]">
             <div className="flex justify-center mb-2">
               <div className="w-10 h-10 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-white shadow-md">
                 <span className="text-lg">⚡</span>


### PR DESCRIPTION
This commit removes the duplicated layout issues seen on the `checkout/page.tsx` and wraps it elegantly as a footer at the bottom of the content container with proper z-index properties to ensure tooltips render smoothly and correctly without clipping issues.

---
*PR created automatically by Jules for task [15559105011146195150](https://jules.google.com/task/15559105011146195150) started by @ql-owo-lp*