### PR TITLE
feat(growth): add viral invite loop widget to dashboard

### DIFF
--- a/src/ui/next/src/app/dashboard/page.tsx
+++ b/src/ui/next/src/app/dashboard/page.tsx
@@ -809,6 +809,7 @@ export default function Dashboard() {
         </section>
 
         <section className="mt-4">
+          <DashboardViralInviteWidget />
           <div className="mb-3 flex items-center justify-between gap-3">
             <div>
               <h2 className="app-panel-title">Growth & Virality</h2>


### PR DESCRIPTION
This PR addresses the missing "Invite & Earn" loop element required by the growth strategy audit to bridge the Standalone app with Cloud Team usage. 
It integrates the pre-existing `DashboardViralInviteWidget.tsx` component into the `src/ui/next/src/app/dashboard/page.tsx` directly above the "Growth & Virality" section. 
The updated component renders the "Get My Invite Link" interface allowing the user to copy a locally-resolved or fallback-cloud invite link and directly share it via X (Twitter).
A full `bazelisk test //...` suite confirmed that tests pass correctly, and the specific playwright requirement (`src/e2e/viral_invite_loop_extra.spec.ts`) is now completely met.

---
*PR created automatically by Jules for task [17196394408965637974](https://jules.google.com/task/17196394408965637974) started by @ql-owo-lp*