### PR TITLE
Fix onboarding password validation

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2273,7 +2273,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
                    payment_pref: "online",
                    admin_email: state.adminEmail || "admin@mybusiness.com",
                    admin_name: state.assistantName || "Admin",
-                   admin_password: state.adminPassword || "password",
+                   admin_password: state.adminPassword || "password123",
                    website_template: state.templateSelection || "Modern",
                    first_product_name: state.firstOffer || "First Offer",
                    first_product_price: "0.00",


### PR DESCRIPTION
Fixes an issue where the Tauri setup onboarding flow would fail because the fallback password did not contain a number, which is required by the backend.

---
*PR created automatically by Jules for task [7692593119495669823](https://jules.google.com/task/7692593119495669823) started by @ql-owo-lp*