### PR TITLE
🔗 Link: fix missing agent_feed_items migration for Agent Feed [research]

### DIFF
--- a/src/server/migrations/143_agent_feed_items.sql
+++ b/src/server/migrations/143_agent_feed_items.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS agent_feed_items (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    event_source TEXT NOT NULL,
+    context_payload JSONB,
+    proposed_action JSONB,
+    lifecycle_state TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+DO $$
+BEGIN
+    IF to_regclass('agent_feed_items') IS NOT NULL THEN
+        ALTER TABLE agent_feed_items ENABLE ROW LEVEL SECURITY;
+        DROP POLICY IF EXISTS tenant_isolation_agent_feed_items ON agent_feed_items;
+        CREATE POLICY tenant_isolation_agent_feed_items ON agent_feed_items USING (tenant_id::text = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+    END IF;
+END
+$$;


### PR DESCRIPTION
This PR resolves missing `agent_feed_items` DB schema errors by adding the table correctly to `src/server/migrations` instead of only inside `db/migrations`. It aligns with the existing architecture and resolves Playwright E2E feed tests and internal rust agent_feed unit test.

Resolves #29862

### Product-use evidence
- **Persona:** Business Owner
- **Attempted Flow:** Accessing the `/feed` page via Next.js
- **Observed Bug:** Backend failed to respond successfully or the DB encountered relation `agent_feed_items` missing error due to unexecuted migrations during tests.
- **Why a real owner needs it:** Owners rely on the agent feed to get their actionable intelligence; without the DB, it throws internal errors and missing relations on triage insertions.
- **Action Taken:** Duplicated `agent_feed_items` into main `migrations` folder so `bazel` rust tests run migrations effectively, meaning DB creates the table correctly and E2E can fulfill backend properly.

---
*PR created automatically by Jules for task [9689314469732922815](https://jules.google.com/task/9689314469732922815) started by @ql-owo-lp*