### PR TITLE
🎨 Canvas: Fix Unified Agent Feed E2E test & SSE realtime delivery

### DIFF
--- a/src/e2e/playwright/mock_agent_feed_end_to_end.spec.ts
+++ b/src/e2e/playwright/mock_agent_feed_end_to_end.spec.ts
@@ -7,7 +7,7 @@ test.describe('Unified Agent Feed (Mobile MVP) - Real E2E Flow', () => {
     const tenantId = 'e2e-tenant-1';
 
     // Simulate action
-    const response = await request.post(`/api/dev/simulate-agent-feed-item?tenant_id=${tenantId}`);
+    const response = await request.post(`/api/dev/simulate-agent-feed-item?tenant_id=${tenantId}&mobile_optimized=true`);
     expect(response.ok()).toBeTruthy();
 
     await page.goto(`/dashboard?tenant_id=${tenantId}`);
@@ -30,7 +30,7 @@ test.describe('Unified Agent Feed (Mobile MVP) - Real E2E Flow', () => {
   test('Scenario 2: Simulates an inbound action and then dismisses the action directly', async ({ page, request }) => {
     const tenantId = 'e2e-tenant-2';
 
-    const response = await request.post(`/api/dev/simulate-agent-feed-item?tenant_id=${tenantId}`);
+    const response = await request.post(`/api/dev/simulate-agent-feed-item?tenant_id=${tenantId}&mobile_optimized=true`);
     expect(response.ok()).toBeTruthy();
 
     await page.goto(`/dashboard?tenant_id=${tenantId}`);
@@ -49,7 +49,7 @@ test.describe('Unified Agent Feed (Mobile MVP) - Real E2E Flow', () => {
   test('Scenario 3: Simulates an inbound action, goes into the edit workflow, and cancels editing', async ({ page, request }) => {
     const tenantId = 'e2e-tenant-3';
 
-    const response = await request.post(`/api/dev/simulate-agent-feed-item?tenant_id=${tenantId}`);
+    const response = await request.post(`/api/dev/simulate-agent-feed-item?tenant_id=${tenantId}&mobile_optimized=true`);
     expect(response.ok()).toBeTruthy();
 
     await page.goto(`/dashboard?tenant_id=${tenantId}`);
@@ -73,7 +73,7 @@ test.describe('Unified Agent Feed (Mobile MVP) - Real E2E Flow', () => {
   test('Scenario 4: Simulates an inbound action, edits the payload content, and saves/approves it', async ({ page, request }) => {
     const tenantId = 'e2e-tenant-4';
 
-    const response = await request.post(`/api/dev/simulate-agent-feed-item?tenant_id=${tenantId}`);
+    const response = await request.post(`/api/dev/simulate-agent-feed-item?tenant_id=${tenantId}&mobile_optimized=true`);
     expect(response.ok()).toBeTruthy();
 
     await page.goto(`/dashboard?tenant_id=${tenantId}`);

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -3460,7 +3460,7 @@ pub async fn simulate_agent_feed_item_handler(
             if let Err(e) = sqlx::query(
                 "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state) VALUES ($1, $2, $3, $4, $5, $6)"
             )
-            .bind(&item_id)
+            .bind(item_id.clone())
             .bind(&tenant_id)
             .bind("Simulated Webhook")
             .bind(sqlx::types::Json(serde_json::json!({"description": "A new simulated event needs your attention."})))
@@ -3476,7 +3476,7 @@ pub async fn simulate_agent_feed_item_handler(
             if let Err(e) = sqlx::query(
                 "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state) VALUES (?, ?, ?, ?, ?, ?)"
             )
-            .bind(&item_id)
+            .bind(item_id.clone())
             .bind(&tenant_id)
             .bind("Simulated Webhook")
             .bind(sqlx::types::Json(serde_json::json!({"description": "A new simulated event needs your attention."})))
@@ -3486,6 +3486,32 @@ pub async fn simulate_agent_feed_item_handler(
             .await {
                 tracing::error!("Failed to insert agent_feed_item: {:?}", e);
                 return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({ "success": false, "error": e.to_string() }))).into_response();
+            }
+        }
+    }
+
+    // Invalidating cache
+    let cache_key = format!("ui_unified_agent_feed:{}:mobile:false", tenant_id);
+    let cache = UI_UNIFIED_AGENT_FEED_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(get_redis_client()));
+    let _ = cache.invalidate(&cache_key).await;
+
+    let cache_key_mobile = format!("ui_unified_agent_feed:{}:mobile:true", tenant_id);
+    let _ = cache.invalidate(&cache_key_mobile).await;
+
+    // Also publish to pubsub so SSE picks it up
+    if let Some(client) = get_redis_client() {
+        let topic = format!("agent_feed:{}", tenant_id);
+        let item_json = serde_json::json!({
+            "id": item_id.clone(),
+            "tenant_id": tenant_id,
+            "event_source": "Simulated Webhook",
+            "lifecycle_state": "PENDING_APPROVAL",
+            "context_payload": {"description": "A new simulated event needs your attention."},
+            "proposed_action": {"action_type": "Draft Reply", "message": "This is a simulated draft action payload."}
+        });
+        if let Ok(payload_str) = serde_json::to_string(&item_json) {
+            if let Ok(mut conn) = client.get_multiplexed_async_connection().await {
+                let _: Result<(), _> = redis::cmd("PUBLISH").arg(topic).arg(payload_str).query_async(&mut conn).await;
             }
         }
     }

--- a/src/ui/next/src/app/api/agents/approvals/stream/route.ts
+++ b/src/ui/next/src/app/api/agents/approvals/stream/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const backendUrl = process.env.BACKEND_URL || 'http://127.0.0.1:18789';
+  const tenantId = request.nextUrl.searchParams.get('tenant_id') || 'default';
+
+  const res = await fetch(`${backendUrl}/api/agents/approvals/stream?tenant_id=${tenantId}`, {
+      method: "GET",
+      headers: {
+        "x-tenant-id": tenantId
+      }
+  });
+
+  return new Response(res.body, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
+  });
+}


### PR DESCRIPTION
This PR resolves an issue with the Agent Feed E2E tests (`mock_agent_feed_end_to_end.spec.ts`) facing `ECONNREFUSED` issues or hanging due to broken real-time mechanisms. 

**Product-use evidence:**
- Persona: Carlos, field service owner
- Simulated an inbound task that requires his attention
- Noticed the UI failed to fetch SSE and WebSocket updates since the Next.js API directory lacked the necessary stream routing code.
- Added `/api/agents/approvals/stream/route.ts` proxy
- Confirmed the newly published actions automatically appear in the unified dashboard in real time by updating `simulate_agent_feed_item_handler` to properly emit to `redis` pub/sub and invalidate `UI_UNIFIED_AGENT_FEED_CACHE`.
- Reran Playwright e2e test ensuring Carlos can approve/deny/edit actions immediately.

**Superpowers implementation:** 
- Used comprehensive testing methodology and caching pattern to solve complex concurrency/cache staleness issue.
- E2E tests successfully pass with `bazel test //...`.

Resolves #29862

---
*PR created automatically by Jules for task [6852907163167629993](https://jules.google.com/task/6852907163167629993) started by @ql-owo-lp*