### PR TITLE
Fix budget health alert boolean type

### DIFF
--- a/src/ui/next/src/app/cost-dashboard/page.test.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.test.tsx
@@ -211,7 +211,7 @@ describe('CostDashboardPage', () => {
       period_end: "2023-10-31",
       trend: [],
       agent_costs: [],
-      budget_health_alert: "true" as any,
+      budget_health_alert: true,
       department_tier_usage: {
         departments: [
           {

--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -32,7 +32,7 @@ interface CostDashboardData {
   department_tier_usage?: DepartmentTierUsage;
   email_cost: number;
   api_cost: number;
-  budget_health_alert?: string;
+  budget_health_alert?: boolean;
 }
 
 interface DepartmentTierUsage {
@@ -251,7 +251,7 @@ export default function CostDashboardPage() {
         </section>
 
         {/* Budget Health Alert */}
-        {data && (data as any).budget_health_alert && (
+        {data && data.budget_health_alert && (
             <div id="budget-health-alert" className="p-4 bg-amber-50/70 border border-amber-200 backdrop-blur-2xl saturate-200 rounded-xl shadow-md hover:shadow-lg transition-all duration-300 flex items-start gap-3">
                 <svg className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />


### PR DESCRIPTION
Updated `budget_health_alert` in the frontend interfaces from a `string` to a `boolean` as returned from the backend, and updated tests.

---
*PR created automatically by Jules for task [10782574669050284928](https://jules.google.com/task/10782574669050284928) started by @ql-owo-lp*