### PR TITLE
fix: mobile touch targets for inputs in setup.html

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -66,6 +66,7 @@
       }
       select.glassmorphism, textarea.glassmorphism, input.glassmorphism {
         border-radius: 8px;
+        min-height: 44px;
         background: rgba(255, 255, 255, 0.65);
         backdrop-filter: blur(30px) saturate(210%);
         -webkit-backdrop-filter: blur(30px) saturate(210%);


### PR DESCRIPTION
This PR ensures that all `select`, `textarea`, and `input` elements using the `.glassmorphism` class inside `setup.html` explicitly set a `min-height: 44px` to meet the mobile-first minimum touch target standards.

---
*PR created automatically by Jules for task [11174237587511197213](https://jules.google.com/task/11174237587511197213) started by @ql-owo-lp*