### PR TITLE
chore(tests): fix test hanging in builtin agents tests

### DIFF
--- a/src/agents/builtin/output_parser.rs
+++ b/src/agents/builtin/output_parser.rs
@@ -901,7 +901,7 @@ mod tests_clamped {
             retry_parser.parse_with_prompt(req, 10).await
         });
 
-        tokio::time::advance(std::time::Duration::from_millis(30000)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(30000)).await;
 
         let result = handle.await.unwrap();
 

--- a/src/agents/builtin/tool_executor_engine_tests.rs
+++ b/src/agents/builtin/tool_executor_engine_tests.rs
@@ -65,7 +65,7 @@ mod tests {
             ToolExecutionEngine::execute_tool_with_langgraph_mechanics(&tool, &tc, 2).await
         });
 
-        tokio::time::advance(std::time::Duration::from_millis(5000)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
 
         let res = handle.await.unwrap();
 
@@ -126,7 +126,7 @@ mod tests {
             ToolExecutionEngine::execute_tool_with_langgraph_mechanics(&tool, &tc, 2).await
         });
 
-        tokio::time::advance(std::time::Duration::from_millis(30000)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(30000)).await;
 
         let res = handle.await.unwrap();
 
@@ -159,7 +159,7 @@ mod tests {
             ToolExecutionEngine::execute_tool_with_langgraph_mechanics(&tool, &tc, 2).await
         });
 
-        tokio::time::advance(std::time::Duration::from_millis(30000)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(30000)).await;
 
         let res = handle.await.unwrap();
 
@@ -435,7 +435,7 @@ mod tests {
             ToolExecutionEngine::execute_tool_with_langgraph_mechanics(&tool, &tc, 5).await
         });
 
-        tokio::time::advance(std::time::Duration::from_millis(30000)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(30000)).await;
 
         let res = handle.await.unwrap();
 
@@ -499,7 +499,7 @@ mod additional_transient_tests {
             ToolExecutionEngine::execute_tool_with_langgraph_mechanics(&tool, &tc, 2).await
         });
 
-        tokio::time::advance(std::time::Duration::from_millis(5000)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
 
         let res = handle.await.unwrap();
 


### PR DESCRIPTION
### What does this PR do?
Replaces deprecated or incorrectly blocking calls to `tokio::time::advance` with `tokio::time::sleep` in the `output_parser.rs` and `tool_executor_engine_tests.rs` files within the `src/agents/builtin` directory. 

### Why is this needed?
The use of `tokio::time::advance` alongside `#[tokio::test(start_paused = true)]` inside the `ohc_builtin_agent_lib_unit_test` binary was causing indefinite hangs and timeouts when running `bazel test //...` across the repository. This change restores hermiticity and ensures tests execute reliably and pass.

### Product-use evidence
As a developer running the repository verification pipeline, attempting to run `bazel test //...` resulted in hanging tests specifically inside the `ohc_builtin_agent_lib_unit_test` binary. The tests now pass seamlessly without timing out.

### Superpowers loaded
- `rust`
- `testing`
- `bazel`

### Interaction audit
- Verified that all `tokio::time::advance` usages were swapped cleanly for `tokio::time::sleep`.
- Verified the global test suite (`bazel test //...`) passes fully without hanging processes.

---
*PR created automatically by Jules for task [7235457663117162406](https://jules.google.com/task/7235457663117162406) started by @ql-owo-lp*