### PR TITLE
🔗 Link: Fix simulated agent feed items to publish to redis and invalidate cache correctly

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -3494,6 +3494,38 @@ pub async fn simulate_agent_feed_item_handler(
         cache.invalidate(&format!("ui_triage:{}:mobile:false", tenant_id)).await;
         cache.invalidate(&format!("ui_triage:{}:mobile:true", tenant_id)).await;
     }
+    if let Some(cache) = UI_UNIFIED_AGENT_FEED_CACHE.get() {
+        cache.invalidate(&format!("ui_unified_agent_feed:{}:mobile:false", tenant_id)).await;
+        cache.invalidate(&format!("ui_unified_agent_feed:{}:mobile:true", tenant_id)).await;
+    }
+    if let Some(cache) = UI_UNIFIED_FEED_CACHE.get() {
+        cache.invalidate(&format!("ui_unified_feed:{}:mobile:false", tenant_id)).await;
+        cache.invalidate(&format!("ui_unified_feed:{}:mobile:true", tenant_id)).await;
+    }
+
+    let cache = crate::api::agent_feed::get_agent_feed_cache();
+    cache.invalidate_by_tag(&format!("agent_feed_tenant:{}", tenant_id)).await;
+
+    // Publish to Redis Pub/Sub for WebSockets
+    if let Some(client) = get_redis_client() {
+        let topic = format!("agent_feed:{}", tenant_id);
+        let payload_json = serde_json::json!({
+            "id": item_id,
+            "tenant_id": tenant_id,
+            "event_source": "Simulated Webhook",
+            "context_payload": {"description": "A new simulated event needs your attention."},
+            "proposed_action": {"action_type": "Draft Reply", "message": "This is a simulated draft action payload."},
+            "lifecycle_state": "PENDING_APPROVAL",
+            "created_at": chrono::Utc::now().to_rfc3339(),
+            "updated_at": chrono::Utc::now().to_rfc3339()
+        }).to_string();
+
+        tokio::spawn(async move {
+            if let Ok(mut conn) = client.get_multiplexed_async_connection().await {
+                let _: Result<(), _> = redis::cmd("PUBLISH").arg(topic).arg(payload_json).query_async(&mut conn).await;
+            }
+        });
+    }
 
     (axum::http::StatusCode::OK, axum::Json(serde_json::json!({ "success": true, "id": item_id }))).into_response()
 }

--- a/test_powersync_local.ts
+++ b/test_powersync_local.ts
@@ -1,2 +1,0 @@
-import { AppSchema } from './src/ui/next/src/lib/powersync/AppSchema';
-console.log(AppSchema);


### PR DESCRIPTION
Fix simulated agent feed items to publish to redis and invalidate cache correctly

Resolves #29862

Superpowers loaded: Next.js styling standards, Tailwind CSS conventions, and Playwright DOM traversal.
Product-use evidence:
- Persona: Retail business operator.
- UI Flow attempted: Trigger mock event -> Dashboard.
- CUJ gap observed: Real-time UI updates (via WebSockets) were missing because the simulation endpoint failed to publish to the Redis Pub/Sub topic and to invalidate the specific cache tags used by the frontend feed.
- Post-fix UI: Submitting the simulated event instantly displays the event on the UI. The `bazel test //...` suite is fully green.

---
*PR created automatically by Jules for task [7811078232162631502](https://jules.google.com/task/7811078232162631502) started by @ql-owo-lp*