### PR TITLE
feat(ui): optimize in-app help center and tooltip registry for 375px mobile screens

### DIFF
--- a/src/ui/tauri/src/ui/help-widget.mjs
+++ b/src/ui/tauri/src/ui/help-widget.mjs
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
             display: flex;
             align-items: center;
             justify-content: center;
-            transition: transform 0.2s;
+            transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
         }
         #ohc-floating-help-btn:hover {
             transform: scale(1.05);
@@ -76,10 +76,11 @@ document.addEventListener('DOMContentLoaded', () => {
             #ohc-floating-help-widget {
                 bottom: 0;
                 right: 0;
-                width: 100%;
+                width: 100vw;
                 height: 100%;
                 max-height: 100vh;
                 border-radius: 0;
+                box-sizing: border-box;
             }
         }
         #ohc-floating-help-header {

--- a/src/ui/tauri/src/ui/help.html
+++ b/src/ui/tauri/src/ui/help.html
@@ -97,12 +97,12 @@
       }
 
       @media (max-width: 480px) {
-        body { padding: 20px 10px; }
-        .header-card { padding: 24px 16px; margin-bottom: 24px; border-radius: 16px; }
-        h1 { font-size: 26px; margin-bottom: 16px; }
-        input[type="text"] { font-size: 15px; padding: 14px 16px; }
-        .grid { grid-template-columns: 1fr; gap: 16px; }
-        .section-title { font-size: 20px; margin-top: 30px; margin-bottom: 16px; }
+        body { padding: 16px 8px; }
+        .header-card { padding: 20px 12px; margin-bottom: 20px; border-radius: 16px; width: 100%; box-sizing: border-box; }
+        h1 { font-size: 24px; margin-bottom: 12px; }
+        input[type="text"] { font-size: 14px; padding: 12px 16px; min-height: 44px; }
+        .grid { grid-template-columns: 1fr; gap: 12px; }
+        .section-title { font-size: 20px; margin-top: 24px; margin-bottom: 12px; }
         .card { padding: 16px; min-height: auto; }
       }
       .card {
@@ -926,7 +926,7 @@ document.addEventListener('DOMContentLoaded', () => {
             display: flex;
             align-items: center;
             justify-content: center;
-            transition: transform 0.2s;
+            transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
         }
         #ohc-floating-help-btn:hover {
             transform: scale(1.05);
@@ -959,10 +959,11 @@ document.addEventListener('DOMContentLoaded', () => {
             #ohc-floating-help-widget {
                 bottom: 0;
                 right: 0;
-                width: 100%;
+                width: 100vw;
                 height: 100%;
                 max-height: 100vh;
                 border-radius: 0;
+                box-sizing: border-box;
             }
         }
         #ohc-floating-help-header {

--- a/src/ui/tauri/src/ui/tooltip-registry.html
+++ b/src/ui/tauri/src/ui/tooltip-registry.html
@@ -34,10 +34,11 @@
         p { color: #86868b; font-size: 15px; margin-bottom: 24px; line-height: 1.5; }
 
         @media (max-width: 480px) {
-            body { padding: 20px 10px; }
-            .container { padding: 20px; border-radius: 20px; }
-            th, td { padding: 10px 8px; font-size: 13px; }
+            body { padding: 16px 8px; }
+            .container { padding: 16px; border-radius: 16px; width: 100%; box-sizing: border-box; }
+            th, td { padding: 8px 4px; font-size: 12px; }
             h1 { font-size: 24px; }
+            input { font-size: 14px; padding: 12px; }
         }
     </style>
 </head>


### PR DESCRIPTION
**Problem:** The OHC In-App Help Center and Tooltip Registry needed mobile layout optimizations to perfectly fit 375px screens without horizontal scrollbars, ensuring that the touch targets are accessible and `.glassmorphism` padding adapts dynamically.

**Solution:**
- Reduced padding to `16px 8px` on the body and `.container` inside `tooltip-registry.html` and adjusted `th, td` sizing.
- Added `width: 100%; box-sizing: border-box;` in the media queries for 375px screens across `tooltip-registry.html` and `help.html`.
- Changed `width: 100%` to `width: 100vw; box-sizing: border-box;` for `#ohc-floating-help-widget` inside `help-widget.mjs` and `help.html` to eliminate overflow on mobile screens.
- Polished `#ohc-floating-help-btn` animation to use a smooth `cubic-bezier` transition curve.
- Verified fixes locally with `bazelisk test //...` and Playwright tests.

---
*PR created automatically by Jules for task [10625244577897324847](https://jules.google.com/task/10625244577897324847) started by @ql-owo-lp*