### PR TITLE
feat(docs): expand tooltips and polish Help Center UI

### DIFF
--- a/src/ui/next/src/app/api/tooltips/route.ts
+++ b/src/ui/next/src/app/api/tooltips/route.ts
@@ -26,7 +26,8 @@ export async function GET(request: NextRequest) {
     "morning-briefing": "Your AI Decision Assistant's daily summary.",
     "checkout-cancel-tooltip": "Go back to the previous screen without subscribing.",
     "department-card-tooltip": "Click to view and manage pending approvals for this department.",
-    "my-plan-tooltip": "View and manage your subscription plan and usage."
+    "my-plan-tooltip": "View and manage your subscription plan and usage.",
+    "help-search-tooltip": "Search for specific topics or keywords in our help articles and videos."
   };
 
   const backendUrl = process.env.BACKEND_URL || 'http://127.0.0.1:18789';

--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -44,14 +44,18 @@ export default function HelpCenterPage() {
       <div className="max-w-4xl mx-auto">
         <h1 className="text-3xl sm:text-4xl font-extrabold font-outfit text-[#1D1D1F] mb-6 sm:mb-8 text-center tracking-tight">Help Center</h1>
 
-        <div className="mb-8 sm:mb-10 w-full sm:w-3/4 mx-auto">
-          <input
-            type="text"
-            placeholder="Search for help articles and videos..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full p-4 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-[0_8px_32px_rgba(0,0,0,0.05)] text-gray-900 bg-white/60 dark:bg-black/40 backdrop-blur-[30px] saturate-[210%] border border-white/80 dark:border-white/20 hover:bg-white/80 min-h-[50px] text-base placeholder:text-gray-500 transition-all rounded-2xl"
-          />
+        <div className="mb-8 sm:mb-10 w-full sm:w-3/4 mx-auto block">
+          <div className="w-full block">
+            <WithTooltip id="help-search-tooltip">
+              <input
+                type="text"
+                placeholder="Search for help articles and videos..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full p-4 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-[0_8px_32px_rgba(0,0,0,0.05)] text-gray-900 bg-white/60 dark:bg-black/40 backdrop-blur-[40px] saturate-[210%] border border-white/60 dark:border-white/20 hover:bg-white/80 min-h-[50px] text-base placeholder:text-gray-500 transition-all rounded-2xl"
+              />
+            </WithTooltip>
+          </div>
         </div>
 
         {filteredArticles.length === 0 && filteredVideos.length === 0 ? (

--- a/src/ui/next/src/components/HelpChat.tsx
+++ b/src/ui/next/src/components/HelpChat.tsx
@@ -172,11 +172,11 @@ export function HelpChat() {
 
       {/* Chat Interface */}
       {isOpen && (
-        <div id="ai-chat-interface" role="dialog" aria-labelledby="ai-chat-header-title" aria-modal="false" className="fixed bottom-24 right-6 z-[9999] w-[350px] max-w-[calc(100vw-32px)] pointer-events-auto bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.12)] flex flex-col overflow-hidden border border-white/40 dark:border-white/10 animate-slide-up-chat text-gray-800 dark:text-gray-100">
+        <div id="ai-chat-interface" role="dialog" aria-labelledby="ai-chat-header-title" aria-modal="false" className="fixed bottom-24 right-6 z-[9999] w-[350px] max-w-[calc(100vw-32px)] pointer-events-auto bg-white/60 dark:bg-[#16161a]/70 backdrop-blur-[40px] saturate-[210%] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.12)] flex flex-col overflow-hidden border border-white/60 dark:border-white/20 animate-slide-up-chat text-gray-800 dark:text-gray-100">
           {/* Header */}
           <div
             id="ai-chat-header"
-            className="bg-blue-600/95 text-white p-4 flex justify-between items-center backdrop-blur-[30px]"
+            className="bg-blue-600/90 text-white p-4 flex justify-between items-center backdrop-blur-[40px]"
           >
             <div className="flex items-center gap-2">
               <span className="text-xl drop-shadow-md">✨</span>


### PR DESCRIPTION
Expands contextual tooltips by adding "help-search-tooltip" to the API route and mapping it in the Help Center search bar (`src/ui/next/src/app/help/page.tsx`). Additionally, refines `HelpChat.tsx` and the Help Center search interface to strictly conform to macOS Translucent Glass UI standards (`backdrop-blur-[40px]`, `saturate-[210%]`, `bg-white/60`, `dark:bg-[#16161a]/70`). All local Vitest and Bazel e2e Playwright tests pass successfully.

---
*PR created automatically by Jules for task [10150455311182571433](https://jules.google.com/task/10150455311182571433) started by @ql-owo-lp*