### PR TITLE
test: fix pii leakage check regex and false positives

### DIFF
--- a/src/server/pii_leakage_check.sh
+++ b/src/server/pii_leakage_check.sh
@@ -25,7 +25,7 @@ for FILE in $FILES; do
 
     # We grep all matches first. The issue reviewer mentioned ".*? with grep -E is not supported",
     # so we should use a simpler pattern for the {}
-    MATCHES=$(grep -iE "tracing::(info|debug|warn|error)!\(.*\{[^\}]*\}[^;]*(^|[^a-zA-Z0-9_])($PII_KEYWORDS)([^a-zA-Z0-9_]|$)|tracing::(info|debug|warn|error)!\((.*[^a-zA-Z0-9_])?($PII_KEYWORDS)([^a-zA-Z0-9_]|$)[^;]*\{[^\}]*\}" "$FILE" || true)
+    MATCHES=$(grep -nE "tracing::(info|debug|warn|error)!\(.*\{.*\}.*\)" "$FILE" | grep -iE "($PII_KEYWORDS)" || true)
 
     if [ -n "$MATCHES" ]; then
         # Check if the matched line has an explicit opt-out // pii-safe

--- a/src/server/services/sync/offline_pos.rs
+++ b/src/server/services/sync/offline_pos.rs
@@ -77,7 +77,7 @@ impl CRDTOfflineSynchronizer {
                     }
                 }
                 Ok(None) => {
-                    tracing::warn!("Product {} not found or unauthorized for tenant {}", mutation.product_id, tenant_id);
+                    tracing::warn!("Product {} not found or unauthorized for tenant {}", mutation.product_id, tenant_id); // pii-safe
                 }
                 Err(e) => {
                     tracing::error!("Failed to deduct inventory for product {}: {}", mutation.product_id, e);


### PR DESCRIPTION
Fixes the `pii_leakage_check.sh` script to correctly identify PII keywords in `tracing::` logs, and adds a `// pii-safe` flag to an `offline_pos.rs` log to resolve a false positive.

---
*PR created automatically by Jules for task [8189168095634968570](https://jules.google.com/task/8189168095634968570) started by @ql-owo-lp*