### PR TITLE
🗺️ Guide: [Mobile-First Onboarding Constraints]

### DIFF
--- a/src/e2e/onboarding.spec.ts
+++ b/src/e2e/onboarding.spec.ts
@@ -326,6 +326,38 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     await page.waitForTimeout(500);
   });
 
+  test('Onboarding Flow respects mobile viewport constraints (375px) with valid touch targets using real stack', async ({ page, baseURL }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    // Go to the real local server root route which should present setup if unconfigured
+    await page.goto(baseURL || 'http://127.0.0.1:8080');
+
+    // Wait for the container to load
+    const container = page.locator('.container');
+    await expect(container).toBeVisible({ timeout: 15000 });
+
+    // Check .container has no horizontal overflow
+    const containerBox = await container.boundingBox();
+    expect(containerBox?.width).toBeLessThanOrEqual(375);
+
+    // Click step-by-step
+    const stepByStepButton = page.locator('button', { hasText: 'Step-by-step' }).first();
+    await stepByStepButton.click();
+
+    // Check .radio-option
+    const radioOption = page.locator('.radio-option').first();
+    const radioBox = await radioOption.boundingBox();
+    expect(Math.round(radioBox?.height || 0)).toBeGreaterThanOrEqual(44);
+
+    // Next step
+    await page.locator('#btn-next-type').click();
+
+    // Check .persona-chip
+    const personaChip = page.locator('.persona-chip').first();
+    const chipBox = await personaChip.boundingBox();
+    expect(Math.round(chipBox?.height || 0)).toBeGreaterThanOrEqual(44);
+  });
+
   // Test 5: Mobile responsiveness of the Instant Build component
   test('Instant Build respects mobile viewport constraints (375px) with valid touch targets for the conversational flow', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -25,7 +25,7 @@
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
         text-align: center;
         width: 100%;
-        max-width: min(480px, calc(100vw - 20px));
+        max-width: 480px;
         border: 1px solid rgba(255, 255, 255, 0.4);
         box-sizing: border-box;
         max-height: calc(100vh - 40px);
@@ -509,6 +509,9 @@
         text-align: left;
       }
       .radio-option {
+        min-height: 44px;
+        min-width: 44px;
+        box-sizing: border-box;
         display: flex;
         align-items: center;
         gap: 10px;
@@ -568,7 +571,10 @@
         justify-content: center;
         padding-bottom: 10px;
       }
-      .persona-chip { min-height: 44px;
+      .persona-chip {
+        min-height: 44px;
+        min-width: 44px;
+        box-sizing: border-box; min-height: 44px;
         flex: 0 0 auto;
         padding: 8px 16px;
         min-height: 44px !important;
@@ -706,6 +712,9 @@
           background: rgba(22, 22, 26, 0.7);
         }
         .radio-option {
+        min-height: 44px;
+        min-width: 44px;
+        box-sizing: border-box;
           background: rgba(22, 22, 26, 0.7);
           border-color: rgba(255, 255, 255, 0.2);
         }
@@ -741,13 +750,16 @@
           width: 100%;
           border: none;
         }
-        input, select, textarea, button, .radio-option, .persona-chip { min-height: 44px;
+        input, select, textarea, button, .radio-option, .persona-chip {
+        min-height: 44px;
+        min-width: 44px;
+        box-sizing: border-box; min-height: 44px;
           min-height: 44px !important;
         }
       }
 
             @media (max-width: 375px) {
-        .container { padding: 16px; margin: 10px; max-width: calc(100% - 20px); box-sizing: border-box; overflow-x: hidden; height: auto; max-height: calc(100vh - 40px); overflow-y: auto; }
+        .container { padding: 16px; margin: 0; max-width: 100%; box-sizing: border-box; overflow-x: hidden; height: auto; max-height: calc(100vh - 40px); overflow-y: auto; }
         .context-card { padding: 12px; min-height: 44px; }
         .work-context-cards { grid-template-columns: 1fr; }
         .radio-group { grid-template-columns: 1fr; } /* Added if it was a grid */
@@ -762,6 +774,9 @@
           transform: scale(1.2);
         }
         .radio-option {
+        min-height: 44px;
+        min-width: 44px;
+        box-sizing: border-box;
           padding: 8px 12px;
           font-size: 14px;
         }
@@ -772,6 +787,9 @@
           font-size: 13px;
         }
         .persona-chip {
+        min-height: 44px;
+        min-width: 44px;
+        box-sizing: border-box;
           padding: 6px 12px;
           font-size: 12px;
           min-height: 44px;


### PR DESCRIPTION
Ensure the onboarding setup screen perfectly complies with Mobile-First Layouts and Touch Targets design standards.

### Changes:
- **`setup.html`**: Enforced `min-height: 44px` and `min-width: 44px` with `box-sizing: border-box` to `.radio-option` and `.persona-chip` classes.
- **`setup.html`**: Updated `.container` element with `max-width: 480px` globally and removed `margin` strictly at the `<=375px` breakpoint so the container fits the 375px view perfectly without triggering horizontal scroll overflows.
- **`onboarding.spec.ts`**: Introduced a Playwright E2E test to verify viewport boundary behaviors, touch target box sizes, and interaction paths running strictly against the un-mocked application stack.

### Verification:
All tests successfully pass against `bazelisk test //...` and `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"`.

---
*PR created automatically by Jules for task [6771601794710658631](https://jules.google.com/task/6771601794710658631) started by @ql-owo-lp*