### PR TITLE
fix: Correct probabilistic LFU eviction in HybridCache

### DIFF
--- a/src/server/utils/cache.rs
+++ b/src/server/utils/cache.rs
@@ -200,25 +200,21 @@ where
 
         if local.len() >= self.max_local_capacity && !local.contains_key(key) {
             let mut removed_keys = Vec::new();
-            let mut sampled_keys = Vec::new();
             let mut has_expired = false;
 
-            // Use random sampling instead of full scan for O(1) probabilistic LFU eviction
-            // taking 10 items is an industry standard approach for probabilistic eviction
-            let mut sample_count = 0;
+            let mut least_accessed_key = None;
+            let mut lowest_access_count = u64::MAX;
+
             for item in local.iter() {
                 if item.expiry <= now {
                     removed_keys.push(item.key().clone());
                     has_expired = true;
-                } else if sample_count < 10 {
-                    sampled_keys.push((item.key().clone(), item.access_count.load(Ordering::Relaxed)));
-                    sample_count += 1;
-                }
-
-                if sample_count >= 10 && has_expired {
-                    break;
-                } else if sample_count >= 10 {
-                    break;
+                } else {
+                    let count = item.access_count.load(Ordering::Relaxed);
+                    if count < lowest_access_count {
+                        lowest_access_count = count;
+                        least_accessed_key = Some(item.key().clone());
+                    }
                 }
             }
 
@@ -228,9 +224,9 @@ where
                 }
             } else {
                 if local.len() >= self.max_local_capacity {
-                    if let Some((least_accessed_key, _)) = sampled_keys.into_iter().min_by_key(|(_, count)| *count) {
-                        local.remove(&least_accessed_key);
-                        removed_keys.push(least_accessed_key);
+                    if let Some(key_to_remove) = least_accessed_key {
+                        local.remove(&key_to_remove);
+                        removed_keys.push(key_to_remove);
                     }
                 }
             }


### PR DESCRIPTION
Fixes the cache eviction logic in `src/server/utils/cache.rs`. The `HybridCache`'s `set_local` method was using an improperly constructed "random sampling" approach for probabilistic LFU eviction by taking the first 10 items from `DashMap::iter()`. Due to `DashMap`'s deterministic iteration order per shard, this repeatedly sampled the exact same items, completely breaking the LFU algorithm and leaving older cache entries trapped in other shards. Given the limited capacity (`max_local_capacity`), the eviction has been changed to a proper O(N) scan to find the actual lowest `access_count` across the entire map, which resolves the bug with virtually zero latency overhead.

---
*PR created automatically by Jules for task [6390490320737803389](https://jules.google.com/task/6390490320737803389) started by @ql-owo-lp*