### PR TITLE
🔗 Link: [Fix Startup Blocker] Fix Docker Registry Rate Limits Errors

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -319,7 +319,7 @@ oci.pull(
 oci.pull(
     name = "nginx_alpine",
     digest = "sha256:3bcf852aed06467cf075c6105892e4d5a6ebbbafa0ce22d35062db9e90ddef4c",
-    image = "index.docker.io/library/nginx",
+    image = "mirror.gcr.io/library/nginx",
     platforms = [
         "linux/amd64",
         "linux/arm64/v8",

--- a/deploy/docker-compose.e2e.yml
+++ b/deploy/docker-compose.e2e.yml
@@ -40,7 +40,7 @@ services:
           memory: 256M
 
   valkey:
-    image: public.ecr.aws/docker/library/redis:7
+    image: mirror.gcr.io/library/redis:7
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/deploy/docker-compose.override.yml
+++ b/deploy/docker-compose.override.yml
@@ -12,6 +12,6 @@ services:
     command: ["postgres", "-c", "wal_level=logical"]
 
   valkey:
-    image: public.ecr.aws/docker/library/redis:alpine
+    image: mirror.gcr.io/library/redis:alpine
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: alpine:3.19
+    image: mirror.gcr.io/library/alpine:3.19
     command: sh /scripts/bootstrap-admin.sh
     volumes:
       - ./docker/server-init/bootstrap-admin.sh:/scripts/bootstrap-admin.sh:ro
@@ -126,7 +126,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: public.ecr.aws/docker/library/redis:7-alpine
+    image: mirror.gcr.io/library/redis:7-alpine
     pull_policy: missing
     ports:
       - "${OHC_DOCKER_VALKEY_PORT:-6379}:6379"
@@ -153,7 +153,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: postgres:15-alpine
+    image: mirror.gcr.io/library/postgres:15-alpine
     pull_policy: missing
     command: ["postgres", "-c", "wal_level=logical"]
     environment:


### PR DESCRIPTION
Resolves #29925.

When new developers or automated environments attempt to launch the OneHumanCorp stack locally using `docker compose -f deploy/docker-compose.yml up -d` or `bazelisk run //deploy:load_all_images`, the startup process was being blocked by external container registry failures (e.g. `error from registry: Data limit exceeded`) due to rate limiting issues from the default public container registries (e.g. AWS ECR, Docker Hub).

This patch mirrors the required base images (Redis, Postgres, Alpine, Nginx) to the high-limit private registry Google Artifact Registry (`mirror.gcr.io`) for both Docker Compose configurations and the Bazel `WORKSPACE`/`MODULE.bazel` files.

Superpowers used:
* Loaded "Google Engineering Excellence" rules: Ensure fixes address the root cause and update all environments.
* Completed manual verification via `docker compose -f deploy/docker-compose.yml up -d` and `bazelisk run //deploy:load_all_images` locally.

Tests run:
* `bazelisk test //...`
* `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"`

---
*PR created automatically by Jules for task [10046821639271859024](https://jules.google.com/task/10046821639271859024) started by @ql-owo-lp*