### PR TITLE
Update registry sources for base images to mirror.gcr.io to fix startup blocker

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -319,7 +319,7 @@ oci.pull(
 oci.pull(
     name = "nginx_alpine",
     digest = "sha256:3bcf852aed06467cf075c6105892e4d5a6ebbbafa0ce22d35062db9e90ddef4c",
-    image = "index.docker.io/library/nginx",
+    image = "mirror.gcr.io/library/nginx",
     platforms = [
         "linux/amd64",
         "linux/arm64/v8",

--- a/deploy/docker-compose.e2e.yml
+++ b/deploy/docker-compose.e2e.yml
@@ -40,7 +40,7 @@ services:
           memory: 256M
 
   valkey:
-    image: public.ecr.aws/docker/library/redis:7
+    image: mirror.gcr.io/library/redis:7
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/deploy/docker-compose.override.yml
+++ b/deploy/docker-compose.override.yml
@@ -12,6 +12,6 @@ services:
     command: ["postgres", "-c", "wal_level=logical"]
 
   valkey:
-    image: public.ecr.aws/docker/library/redis:alpine
+    image: mirror.gcr.io/library/redis:alpine
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: alpine:3.19
+    image: mirror.gcr.io/library/alpine:3.19
     command: sh /scripts/bootstrap-admin.sh
     volumes:
       - ./docker/server-init/bootstrap-admin.sh:/scripts/bootstrap-admin.sh:ro
@@ -126,7 +126,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: public.ecr.aws/docker/library/redis:7-alpine
+    image: mirror.gcr.io/library/redis:7-alpine
     pull_policy: missing
     ports:
       - "${OHC_DOCKER_VALKEY_PORT:-6379}:6379"
@@ -153,7 +153,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: postgres:15-alpine
+    image: mirror.gcr.io/library/postgres:15-alpine
     pull_policy: missing
     command: ["postgres", "-c", "wal_level=logical"]
     environment:


### PR DESCRIPTION
Update registry sources for base images to mirror.gcr.io to fix startup blocker

Resolves #29925

Updated `deploy/docker-compose.yml`, `deploy/docker-compose.override.yml`, `deploy/docker-compose.e2e.yml` and `MODULE.bazel` to point to `mirror.gcr.io/library/*` for the alpine, postgres, redis, and nginx base images to fix the startup blocker caused by the Docker registry rate limits and data limit exceeded errors.

Superpowers loaded: `https://github.com/obra/superpowers/`.

Product-use evidence:
Persona: Developer / Infrastructure Engineer
Workflow: Attempting to start the application stack locally via `docker compose up --build` or `bazelisk run //deploy:load_all_images`.
Observed Result: The process was blocked by rate limits from public container registries such as `public.ecr.aws`.
Fix: Altering the image urls to point to `mirror.gcr.io` which bypasses these limits and reliably downloads base images.

Interaction Audit Table:
| Element/Action | Designed Purpose | Observed Result | Fix |
|---|---|---|---|
| Run `bazelisk run //deploy:load_all_images` | Load docker images | Rate limit error | Switched image sources to `mirror.gcr.io/library/*` |

---
*PR created automatically by Jules for task [14457686985739153222](https://jules.google.com/task/14457686985739153222) started by @ql-owo-lp*