### PR TITLE
docs: fix api-docs horizontal scroll and help modal close button

### DIFF
--- a/src/ui/tauri/src/ui/api-docs.html
+++ b/src/ui/tauri/src/ui/api-docs.html
@@ -28,6 +28,7 @@
       .swagger-ui .markdown p { word-break: break-word; }
       body {
         max-width: 100vw;
+        overflow-x: hidden;
         font-family: "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
         background-color: #f5f5f7;
         margin: 0;
@@ -138,7 +139,7 @@
       }
 
       @media (prefers-color-scheme: dark) {
-        body { background-color: #16161a; }
+        body { background-color: #16161a; overflow-x: hidden; }
         .docs-card {
           background: rgba(22, 22, 26, 0.7);
           border-color: rgba(255, 255, 255, 0.1);

--- a/src/ui/tauri/src/ui/help.html
+++ b/src/ui/tauri/src/ui/help.html
@@ -392,7 +392,7 @@
     <!-- Video Modal -->
     <div id="video-modal">
       <div class="modal-content">
-        <button class="modal-close" id="close-video">Close video</button>
+        <button class="modal-close" id="close-video" aria-label="Close video">Close video</button>
         <video id="video-player" controls>
           Your browser does not support the video tag.
         </video>


### PR DESCRIPTION
docs: fix api-docs horizontal scroll and help modal close button

Added overflow-x: hidden to api-docs to prevent horizontal scrolling on mobile viewports.
Added aria-label to close-video button in help.html to satisfy the Playwright e2e test requirements.

---
*PR created automatically by Jules for task [18257043821055391193](https://jules.google.com/task/18257043821055391193) started by @ql-owo-lp*