### PR TITLE
chore: fix Docker registry rate limits by using mirror.gcr.io

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -319,7 +319,7 @@ oci.pull(
 oci.pull(
     name = "nginx_alpine",
     digest = "sha256:3bcf852aed06467cf075c6105892e4d5a6ebbbafa0ce22d35062db9e90ddef4c",
-    image = "index.docker.io/library/nginx",
+    image = "mirror.gcr.io/library/nginx",
     platforms = [
         "linux/amd64",
         "linux/arm64/v8",

--- a/deploy/docker-compose.e2e.yml
+++ b/deploy/docker-compose.e2e.yml
@@ -40,7 +40,7 @@ services:
           memory: 256M
 
   valkey:
-    image: public.ecr.aws/docker/library/redis:7
+    image: mirror.gcr.io/library/redis:7
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/deploy/docker-compose.override.yml
+++ b/deploy/docker-compose.override.yml
@@ -12,6 +12,6 @@ services:
     command: ["postgres", "-c", "wal_level=logical"]
 
   valkey:
-    image: public.ecr.aws/docker/library/redis:alpine
+    image: mirror.gcr.io/library/redis:alpine
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: alpine:3.19
+    image: mirror.gcr.io/library/alpine:3.19
     command: sh /scripts/bootstrap-admin.sh
     volumes:
       - ./docker/server-init/bootstrap-admin.sh:/scripts/bootstrap-admin.sh:ro
@@ -126,7 +126,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: public.ecr.aws/docker/library/redis:7-alpine
+    image: mirror.gcr.io/library/redis:7-alpine
     pull_policy: missing
     ports:
       - "${OHC_DOCKER_VALKEY_PORT:-6379}:6379"
@@ -153,7 +153,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: postgres:15-alpine
+    image: mirror.gcr.io/library/postgres:15-alpine
     pull_policy: missing
     command: ["postgres", "-c", "wal_level=logical"]
     environment:


### PR DESCRIPTION
Resolves #29925

The user was encountering "Data limit exceeded" errors during local startup and testing because essential base images (Redis, Postgres, Alpine, Nginx) were being pulled directly from `public.ecr.aws` and Docker Hub, which have strict rate limits.

This PR updates the relevant `docker-compose.yml`, `docker-compose.e2e.yml`, `docker-compose.override.yml`, and `MODULE.bazel` files to use `mirror.gcr.io/library/...` instead. Google Artifact Registry provides a high-limit cache for these common official images, resolving the startup blockers.

Superpowers loaded:
- Basic coding workflow and best practices.

Product-use evidence:
- **Persona:** Developer / Infrastructure Engineer
- **UI Flow:** `docker compose up` / Bazel test local environment setup.
- **Gap Observed:** Local startup fails on image pulls, blocking the entire development environment.
- **Why it matters:** If the core containers don't start, the system cannot be run, tested, or modified.
- **Post-fix result:** Running `docker compose up` and `bazelisk run //deploy:load_all_images` successfully pulls the necessary cache layers without exceeding rate limits, allowing containers to start properly.

---
*PR created automatically by Jules for task [2904934349874725786](https://jules.google.com/task/2904934349874725786) started by @ql-owo-lp*