### PR TITLE
🔗 Link: Fix Startup Blocker by replacing public image registries with mirror.gcr.io

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -319,7 +319,7 @@ oci.pull(
 oci.pull(
     name = "nginx_alpine",
     digest = "sha256:3bcf852aed06467cf075c6105892e4d5a6ebbbafa0ce22d35062db9e90ddef4c",
-    image = "index.docker.io/library/nginx",
+    image = "mirror.gcr.io/library/nginx",
     platforms = [
         "linux/amd64",
         "linux/arm64/v8",

--- a/deploy/docker-compose.override.yml
+++ b/deploy/docker-compose.override.yml
@@ -8,10 +8,10 @@ services:
     image: onehumancorp/server:latest
 
   postgres:
-    image: ankane/pgvector:v0.5.1
+    image: mirror.gcr.io/ankane/pgvector:v0.5.1
     command: ["postgres", "-c", "wal_level=logical"]
 
   valkey:
-    image: public.ecr.aws/docker/library/redis:alpine
+    image: mirror.gcr.io/library/redis:alpine
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       LOG_LEVEL: "info"
       LISTEN_ADDR: "0.0.0.0:18789"
       DATABASE_URL: postgres://ohc:ohc@postgres:5432/ohc?sslmode=disable
-      REDIS_URL: redis://localhost:6379
+      REDIS_URL: redis://valkey:6379
     depends_on:
       postgres:
         condition: service_healthy
@@ -60,8 +60,8 @@ services:
       LOG_LEVEL: "info"
       PORT: "8080"
       OHC_PORT: "8080"
-      REDIS_ADDR: localhost:6379
-      REDIS_URL: redis://localhost:6379
+      REDIS_ADDR: valkey:6379
+      REDIS_URL: redis://valkey:6379
       DATABASE_URL: postgres://ohc:ohc@postgres:5432/ohc?sslmode=disable
       CHATWOOT_URL: http://chatwoot:3000
       CHATWOOT_ADMIN_EMAIL: admin@ohc.local
@@ -101,7 +101,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: alpine:3.19
+    image: mirror.gcr.io/library/alpine:3.19
     command: sh /scripts/bootstrap-admin.sh
     volumes:
       - ./docker/server-init/bootstrap-admin.sh:/scripts/bootstrap-admin.sh:ro
@@ -126,7 +126,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: public.ecr.aws/docker/library/redis:7-alpine
+    image: mirror.gcr.io/library/redis:7-alpine
     pull_policy: missing
     ports:
       - "${OHC_DOCKER_VALKEY_PORT:-6379}:6379"
@@ -153,7 +153,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: postgres:15-alpine
+    image: mirror.gcr.io/library/postgres:15-alpine
     pull_policy: missing
     command: ["postgres", "-c", "wal_level=logical"]
     environment:
@@ -215,7 +215,7 @@ services:
       LOG_LEVEL: "info"
       SECRET_KEY_BASE: changeme_secret_key_base_at_least_64_chars_long_for_production
       DATABASE_URL: postgres://ohc:ohc@postgres:5432/chatwoot?sslmode=disable
-      REDIS_URL: redis://localhost:6379
+      REDIS_URL: redis://valkey:6379
       RAILS_ENV: production
       INSTALLATION_ENV: docker
       DEFAULT_LOCALE: en
@@ -239,7 +239,7 @@ services:
       LOG_LEVEL: "info"
       SECRET_KEY_BASE: changeme_secret_key_base_at_least_64_chars_long_for_production
       DATABASE_URL: postgres://ohc:ohc@postgres:5432/chatwoot?sslmode=disable
-      REDIS_URL: redis://localhost:6379
+      REDIS_URL: redis://valkey:6379
       RAILS_ENV: production
       INSTALLATION_ENV: docker
       DEFAULT_LOCALE: en
@@ -267,7 +267,7 @@ services:
       LOG_LEVEL: "info"
       SECRET_KEY_BASE: changeme_secret_key_base_at_least_64_chars_long_for_production
       DATABASE_URL: postgres://ohc:ohc@postgres:5432/chatwoot?sslmode=disable
-      REDIS_URL: redis://localhost:6379
+      REDIS_URL: redis://valkey:6379
       RAILS_ENV: production
       INSTALLATION_ENV: docker
       DEFAULT_LOCALE: en


### PR DESCRIPTION
🔗 Link: Fix Startup Blocker: Docker Registry Rate Limits & Data Limit Exceeded Errors

Resolves #29925

**Product-use evidence:**
- **Persona**: Developer / Infrastructure Engineer
- **Journey**: Initially observed that spinning up the environment via `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.override.yml up -d` would halt and fail downloading base container images from public registries with a rate limit error, entirely blocking the initialization of the application and testing suite.
- **Gap**: The current application used heavily restricted and rate-limited public docker registries such as `ankane`, `public.ecr.aws`, and `index.docker.io`. Furthermore, `REDIS_URL` was erroneously pointed to `localhost` causing issues inside Docker's bridged networks where `valkey` should have been used.
- **Resolution**: Updated `deploy/docker-compose.yml`, `deploy/docker-compose.override.yml`, and `MODULE.bazel` to point directly to `mirror.gcr.io`. Changed `localhost:6379` to `valkey:6379` in Docker networking environments so the server properly links with the `valkey` redis deployment instance. Re-ran `docker compose up -d` and confirmed the stack fully initializes gracefully. Ran `npx @bazel/bazelisk test //...` and verified 100% of all checks complete securely and fully.

**Superpowers used:**
None explicitly loaded, but applied strict test pass requirements, ensuring all unit + e2e functionality remained unaffected during infrastructural config swaps.

---
*PR created automatically by Jules for task [5574612352437170182](https://jules.google.com/task/5574612352437170182) started by @ql-owo-lp*