### PR TITLE
feat(growth): wire up viral referral loop in exit-intent builder popup

### DIFF
--- a/src/e2e/viral_exit_intent.spec.ts
+++ b/src/e2e/viral_exit_intent.spec.ts
@@ -24,9 +24,15 @@ test.describe('Viral Exit-Intent Loop', () => {
     await expect(page.locator('.preview-popup').filter({ hasText: 'Special Limited Time Offer!' })).toBeVisible();
     await expect(page.locator('.preview-popup').filter({ hasText: 'Get 10% off your first order when you sign up for our newsletter.' })).toBeVisible();
 
-    // 5. Test Copy Embed Code logic
-    await page.getByRole('button', { name: 'Copy to Clipboard' }).click();
+    // 5. Test Copy Embed Code logic and Viral Referral Link
+    const copyButton = page.getByRole('button', { name: 'Copy to Clipboard' });
+    await copyButton.click();
     await expect(page.getByRole('button', { name: 'Copied!' })).toBeVisible();
+
+    // Check the embed code text area content directly since we don't have a reliable way to check clipboard in all CI environments
+    const embedCode = await page.locator('#code-output').textContent();
+    expect(embedCode).toContain('/api/v1/growth/referrals/click?target=/setup.html&ref=');
+    expect(embedCode).toContain('⚡ Powered by OHC');
 
     // 6. Test Paywall logic
     const brandingToggle = page.locator('#branding-toggle');

--- a/src/ui/tauri/src/ui/exit-intent-builder.html
+++ b/src/ui/tauri/src/ui/exit-intent-builder.html
@@ -379,6 +379,7 @@
     }
 
     function updateCode() {
+      const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'e2e-tenant';
       const code = `
 <!-- OHC Exit-Intent Pop-up -->
 <script>
@@ -395,7 +396,7 @@
               <h2 style="margin-top: 0; color: #1d1d1f;">${inputHeadline.value}</h2>
               <p style="color: #4b5563; margin-bottom: 1.5rem;">${inputDesc.value}</p>
               <button style="background: ${inputColor.value}; color: white; border: none; padding: 0.75rem 1.5rem; border-radius: 4px; font-weight: bold; cursor: pointer; width: 100%;">${inputButton.value}</button>
-              ${!brandingToggle.checked ? `<div style="margin-top: 1rem; font-size: 0.75rem; color: #9ca3af;"><a href="https://onehumancorp.com" style="color: #9ca3af; text-decoration: none;">⚡ Powered by OHC</a></div>` : ''}
+              ${!brandingToggle.checked ? `<div style="margin-top: 1rem; font-size: 0.75rem; color: #9ca3af;"><a href="https://ohc.app/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenantId)}" style="color: #9ca3af; text-decoration: none;">⚡ Powered by OHC</a></div>` : ''}
             </div>
           </div>
         \`;


### PR DESCRIPTION
Updates the generated code from the exit-intent popup builder to use a proper tracking referral link (`/api/v1/growth/referrals/click?target=/setup.html&ref=${tenant_id}`) instead of a static generic link. This ensures the "Powered by OHC" watermark acts as an active viral loop. Includes corresponding updates to the Playwright E2E test.

---
*PR created automatically by Jules for task [13999165129379208114](https://jules.google.com/task/13999165129379208114) started by @ql-owo-lp*