### PR TITLE
💰 Miser: Fix Cost Dashboard E2E Tests

### DIFF
--- a/src/e2e/cost_dashboard_ui.spec.ts
+++ b/src/e2e/cost_dashboard_ui.spec.ts
@@ -8,7 +8,7 @@ test.describe('Cost Dashboard & Plan Limits UI', () => {
     await page.goto('/cost-dashboard');
 
     // Wait for the main heading to be visible
-    await expect(page.locator('h2', { hasText: 'Cost Transparency Dashboard' }).first()).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' }).first()).toBeVisible({ timeout: 15000 });
 
     // Verify key sections are present
     await expect(page.locator('h2', { hasText: 'Cost Breakdown' })).toBeVisible();
@@ -20,7 +20,7 @@ test.describe('Cost Dashboard & Plan Limits UI', () => {
     await expect(page.locator('h3', { hasText: 'Department Usage' }).first()).toBeVisible();
 
     // Check if the plan navigation link is present
-    await expect(page.getByRole('link', { name: 'Back to My Plan' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Back to My Plan' })).toBeVisible();
   });
 
   test('should display my plan limits and route to pricing', async ({ page, adminUser, loginAs }) => {

--- a/src/e2e/miser_cost_features.spec.ts
+++ b/src/e2e/miser_cost_features.spec.ts
@@ -19,7 +19,7 @@ test.describe('Miser Cost Features E2E', () => {
     await expect(page.locator('text=Projected Monthly Cost')).toBeVisible();
 
     // Verify navigation back to My Plan works
-    const myPlanButton = page.getByRole('link', { name: 'Back to My Plan' });
+    const myPlanButton = page.getByRole('button', { name: 'Back to My Plan' });
     await expect(myPlanButton).toBeVisible();
 
     // Click the button and verify the plan widget is displayed

--- a/src/e2e/my_plan_dashboard.spec.ts
+++ b/src/e2e/my_plan_dashboard.spec.ts
@@ -33,7 +33,7 @@ test.describe('My Plan and Cost Dashboard Screens', () => {
     await page.goto('/cost-dashboard');
 
     // Check core metric elements visibility
-    await expect(page.locator('h2', { hasText: 'Cost Transparency Dashboard' })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' })).toBeVisible({ timeout: 10000 });
 
     // Verify elements by id or text mapped to their metrics
     await expect(page.locator('#cost-dashboard-revenue')).toBeVisible();


### PR DESCRIPTION
This PR updates the E2E test files (`miser_cost_features.spec.ts`, `cost_dashboard_ui.spec.ts`, and `my_plan_dashboard.spec.ts`) to fix broken locators on the Cost Dashboard. It ensures that the 'Cost Transparency Dashboard' text matches the visible `h1` element instead of a hidden `h2`, and changes the expected role of the 'Back to My Plan' element from a link to a button, restoring the tests to a passing state.

---
*PR created automatically by Jules for task [16265143692094913368](https://jules.google.com/task/16265143692094913368) started by @ql-owo-lp*