### PR TITLE
fix: set `updated_at` when pruning stuck agent missions

### DIFF
--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -443,7 +443,7 @@ impl HybridSyncDaemon {
 
     pub async fn prune_stuck_agent_missions(&self) -> Result<(), Box<dyn std::error::Error>> {
         // Find and fail stuck missions in sqlite pool
-        let res_sqlite = sqlx::query("UPDATE agent_missions SET status = 'FAILED', sync_error = '[bug] Mission became stuck', last_synced_at = CURRENT_TIMESTAMP WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hour') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hour')))")
+        let res_sqlite = sqlx::query("UPDATE agent_missions SET status = 'FAILED', sync_error = '[bug] Mission became stuck', last_synced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hour') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hour')))")
             .execute(&self.sqlite_pool)
             .await;
         if let Ok(res) = res_sqlite {
@@ -453,7 +453,7 @@ impl HybridSyncDaemon {
         }
 
         // Find and fail stuck missions in pg pool
-        let res_pg = sqlx::query("UPDATE agent_missions SET status = 'FAILED', sync_error = '[bug] Mission became stuck', last_synced_at = CURRENT_TIMESTAMP WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))")
+        let res_pg = sqlx::query("UPDATE agent_missions SET status = 'FAILED', sync_error = '[bug] Mission became stuck', last_synced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))")
             .execute(&self.pg_pool)
             .await;
         if let Ok(res) = res_pg {


### PR DESCRIPTION
### Description

This PR fixes a small bug in the orchestration layer's hybrid sync daemon where stagnant agent missions, when pruned and marked as `FAILED`, were not updating their `updated_at` timestamp in the database. Ensuring `updated_at` is accurate is essential for downstream systems, state tracking, and overall data hygiene.

**Changes:**
- Updated the SQL query for SQLite in `prune_stuck_agent_missions` to include `updated_at = CURRENT_TIMESTAMP`.
- Updated the SQL query for PostgreSQL in `prune_stuck_agent_missions` to include `updated_at = CURRENT_TIMESTAMP`.

### Verifications
- Validated via `bazelisk test //...` to ensure all functionality is correct. Unit tests explicitly test for logic paths impacted by these queries.
- Code review was requested and successfully passed.

### Superpowers Skills
- Used `test-driven-development` checking methodology by looking at existing e2e test behaviors to verify impact.
- Used `systematic-debugging` evaluating the code execution paths in the SQLite/PG sync behaviors.

---
*PR created automatically by Jules for task [9470951311619202552](https://jules.google.com/task/9470951311619202552) started by @ql-owo-lp*