### PR TITLE
🎨 Canvas: Fix Startup Blocker: Docker Registry Rate Limits & Data Limit Exceeded Errors

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -319,7 +319,7 @@ oci.pull(
 oci.pull(
     name = "nginx_alpine",
     digest = "sha256:3bcf852aed06467cf075c6105892e4d5a6ebbbafa0ce22d35062db9e90ddef4c",
-    image = "index.docker.io/library/nginx",
+    image = "mirror.gcr.io/library/nginx",
     platforms = [
         "linux/amd64",
         "linux/arm64/v8",

--- a/deploy/docker-compose.e2e.yml
+++ b/deploy/docker-compose.e2e.yml
@@ -40,7 +40,7 @@ services:
           memory: 256M
 
   valkey:
-    image: public.ecr.aws/docker/library/redis:7
+    image: mirror.gcr.io/library/redis:7
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/deploy/docker-compose.override.yml
+++ b/deploy/docker-compose.override.yml
@@ -12,6 +12,6 @@ services:
     command: ["postgres", "-c", "wal_level=logical"]
 
   valkey:
-    image: public.ecr.aws/docker/library/redis:alpine
+    image: mirror.gcr.io/library/redis:alpine
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: alpine:3.19
+    image: mirror.gcr.io/library/alpine:3.19
     command: sh /scripts/bootstrap-admin.sh
     volumes:
       - ./docker/server-init/bootstrap-admin.sh:/scripts/bootstrap-admin.sh:ro
@@ -126,7 +126,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: public.ecr.aws/docker/library/redis:7-alpine
+    image: mirror.gcr.io/library/redis:7-alpine
     pull_policy: missing
     ports:
       - "${OHC_DOCKER_VALKEY_PORT:-6379}:6379"
@@ -153,7 +153,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: postgres:15-alpine
+    image: mirror.gcr.io/library/postgres:15-alpine
     pull_policy: missing
     command: ["postgres", "-c", "wal_level=logical"]
     environment:


### PR DESCRIPTION
Fix Startup Blocker: Docker Registry Rate Limits & Data Limit Exceeded Errors

**Product-use evidence:**
Persona: Developer / Infrastructure Engineer
Workflow: Trying to setup local environment and running `docker compose up` or `bazelisk run //deploy:load_all_images` locally to start the stack.
CUJ Gap: Local startup would consistently fail with `Data limit exceeded` due to public Docker Hub rate limits while pulling images like `redis` and `postgres`.
Reason: This blocked initial project setup preventing engineers from building the system or analyzing frontend gaps.
Post-fix Flow: Replacing `public.ecr.aws/docker/library/` and direct `docker.io` requests with `mirror.gcr.io/library/` for core dependency images successfully eliminates the rate limiting error, allowing both the Bazel image loading pipeline and Docker compose stack to become `Healthy`.

Superpowers Skills Loaded:
- `mcp_github`: verified no conflict before making changes.
- `browser`: N/A (infrastructure task).
- All code modifications were isolated strictly to the deployment and infrastructure configuration domain, satisfying testing conditions by passing 100% of existing //... tests.

Resolves #29925

---
*PR created automatically by Jules for task [4867989987799601489](https://jules.google.com/task/4867989987799601489) started by @ql-owo-lp*