### PR TITLE
Optimize Setup Wizard UI and Hermetic Tests

### DIFF
--- a/src/e2e/setup.spec.ts
+++ b/src/e2e/setup.spec.ts
@@ -1,71 +1,56 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { test, expect } from '@playwright/test';
-
 test.describe('OHC Setup Wizard Flow', () => {
-
   test('should complete the interactive setup wizard flow smoothly on desktop', async ({ page }) => {
-
-    const tauriUiDir = require('path').join(process.cwd(), 'src/ui/tauri/src/ui');
+    const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
     await page.route('**/setup.html', async route => {
-        const htmlContent = require('fs').readFileSync(require('path').join(tauriUiDir, 'setup.html'), 'utf-8');
+        const htmlContent = fs.readFileSync(path.join(tauriUiDir, 'setup.html'), 'utf-8');
         await route.fulfill({ contentType: 'text/html', body: htmlContent });
     });
     // intercept tooltips
     await page.route('**/api/tooltips', async route => {
       await route.fulfill({ status: 200, body: JSON.stringify({}) });
     });
-
     await page.route('**/api/onboarding/draft', async route => {
        await route.fulfill({ status: 200, body: JSON.stringify({}) });
     });
-
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto('http://mock/setup.html');
-
     // Check initial UI loading
     await expect(page.locator('h1').first()).toBeVisible();
-
     // Click Start My Business (which goes to context)
     await page.locator('[data-testid="next-step-btn"][data-next="step-context"]').click();
-
     // Context step
     await page.locator('label', { hasText: 'Storefront or Cafe' }).click();
     await page.locator('[data-testid="next-step-btn"][data-next="step-categories"]').click();
-
     // Category step
     const categorySelect = page.getByTestId('business-categories');
     await expect(categorySelect).toBeVisible();
     await page.waitForTimeout(100);
     await categorySelect.selectOption('Bakery');
     await page.locator('[data-testid="next-step-btn"][data-next="step-name"]').click();
-
     // Name step
     await page.getByTestId('business-name').fill('Test Bakery');
     await page.locator('[data-testid="next-step-btn"][data-next="step-assistant"]').click();
-
     // Assistant step
     await page.getByTestId('assistant-name').fill('Buddy');
     await page.getByTestId('assistant-tone').selectOption('Friendly');
     await page.locator('[data-testid="next-step-btn"][data-next="step-admin"]').click();
-
     // Admin step
     await page.getByTestId('admin-email').fill('admin@testbakery.local');
     await page.getByTestId('admin-password').fill('SuperSecretPassword123');
     await page.locator('[data-testid="next-step-btn"][data-next="step-offer"]').click();
-
     // Offer step
     await page.getByTestId('first-offer').fill('Chocolate Cake');
     await page.locator('[data-testid="next-step-btn"][data-next="step-domain"]').click();
-
     // Domain step
     await page.getByTestId('domain-name').fill('my-bakery-shop');
     await page.locator('[data-testid="next-step-btn"][data-next="step-template"]').click();
-
     // Template step
     await page.getByTestId('template-selection').selectOption('Modern');
-
     // Make sure finish btn is visible before interacting
     await expect(page.getByTestId('finish-btn')).toBeVisible();
-
     // Intercept backend call
     await page.route('**/api/onboarding/start', async route => {
       await route.fulfill({
@@ -74,117 +59,91 @@ test.describe('OHC Setup Wizard Flow', () => {
         body: JSON.stringify({ organization_id: 'test-org-123' })
       });
     });
-
     await page.route('**/api/onboarding/state', async route => {
        await route.fulfill({ status: 200, body: JSON.stringify({}) });
     });
-
     // Click Save Draft
     const saveDraftBtn = page.getByTestId('save-draft-btn').last();
     await expect(saveDraftBtn).toBeVisible();
     await saveDraftBtn.click();
     await expect(saveDraftBtn).toHaveText('Saved!', { timeout: 3000 });
-
     await page.route('**/success.html', async route => {
       await route.fulfill({ status: 200, body: 'Success' });
     });
-
     // Submit setup
     await page.getByTestId('finish-btn').click();
-
   });
-
   test('should support 375px mobile view without horizontal scroll and minimum 44px touch targets', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     // intercept tooltips
     await page.route('**/api/tooltips', async route => {
       await route.fulfill({ status: 200, body: JSON.stringify({}) });
     });
-
-    const tauriUiDir = require('path').join(process.cwd(), 'src/ui/tauri/src/ui');
+    const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
     await page.route('**/setup.html', async route => {
-        const htmlContent = require('fs').readFileSync(require('path').join(tauriUiDir, 'setup.html'), 'utf-8');
+        const htmlContent = fs.readFileSync(path.join(tauriUiDir, 'setup.html'), 'utf-8');
         await route.fulfill({ contentType: 'text/html', body: htmlContent });
     });
-
     await page.goto('http://mock/setup.html');
-
     // Evaluate horizontal scroll
     const hasHorizontalScroll = await page.evaluate(() => {
         return document.documentElement.scrollWidth > window.innerWidth;
     });
     expect(hasHorizontalScroll).toBe(false);
-
     // Verify touch targets height
     const btnBox = await page.locator('.next-step-btn').first().boundingBox();
     expect(btnBox?.height).toBeGreaterThanOrEqual(44);
-
     await page.locator('[data-testid="next-step-btn"][data-next="step-context"]').click();
     const inputbox = await page.locator('label.context-card').first().boundingBox();
     expect(inputbox?.height).toBeGreaterThanOrEqual(44);
   });
 });
-
   test('should auto-save progress and clear it on success', async ({ page }) => {
-
-    const tauriUiDir = require('path').join(process.cwd(), 'src/ui/tauri/src/ui');
+    const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
     await page.route('**/setup.html', async route => {
-        const htmlContent = require('fs').readFileSync(require('path').join(tauriUiDir, 'setup.html'), 'utf-8');
+        const htmlContent = fs.readFileSync(path.join(tauriUiDir, 'setup.html'), 'utf-8');
         await route.fulfill({ contentType: 'text/html', body: htmlContent });
     });
     // intercept tooltips
     await page.route('**/api/tooltips', async route => {
       await route.fulfill({ status: 200, body: JSON.stringify({}) });
     });
-
     await page.route('**/api/onboarding/draft', async route => {
        await route.fulfill({ status: 200, body: JSON.stringify({}) });
     });
-
     await page.goto('http://mock/setup.html');
-
     // Check initial UI loading
     await expect(page.locator('h1').first()).toBeVisible();
     await page.locator('[data-testid="next-step-btn"][data-next="step-context"]').click();
-
     await page.locator('label', { hasText: 'Storefront or Cafe' }).click();
     await page.locator('[data-testid="next-step-btn"][data-next="step-categories"]').click();
-
     const categorySelect = page.getByTestId('business-categories');
     await expect(categorySelect).toBeVisible();
     await categorySelect.selectOption('Bakery');
     await page.locator('[data-testid="next-step-btn"][data-next="step-name"]').click();
-
     // Name step - Trigger auto-save
     await page.getByTestId('business-name').fill('AutoSave Bakery');
-
     // Wait for debounce and localstorage to be populated
     await page.waitForTimeout(600);
-
     // Reload page
     await page.reload();
-
     // Wait for the state to be reloaded (it jumps to step 3 since it was saved)
     await expect(page.getByTestId('business-name')).toHaveValue('AutoSave Bakery');
   });
-
   test('should show submit error if start fails', async ({ page }) => {
-    const tauriUiDir = require('path').join(process.cwd(), 'src/ui/tauri/src/ui');
+    const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
     await page.route('**/setup.html', async route => {
-        const htmlContent = require('fs').readFileSync(require('path').join(tauriUiDir, 'setup.html'), 'utf-8');
+        const htmlContent = fs.readFileSync(path.join(tauriUiDir, 'setup.html'), 'utf-8');
         await route.fulfill({ contentType: 'text/html', body: htmlContent });
     });
     // intercept tooltips
     await page.route('**/api/tooltips', async route => {
       await route.fulfill({ status: 200, body: JSON.stringify({}) });
     });
-
     await page.route('**/api/onboarding/draft', async route => {
        await route.fulfill({ status: 200, body: JSON.stringify({}) });
     });
-
     await page.goto('http://mock/setup.html');
-
     // Intercept backend call with failure
     await page.route('**/api/onboarding/start', async route => {
       await route.fulfill({
@@ -193,7 +152,6 @@ test.describe('OHC Setup Wizard Flow', () => {
         body: JSON.stringify({ error: 'Backend is broken' })
       });
     });
-
     // Skip to template step (mock localStorage)
     await page.evaluate(() => {
         localStorage.setItem('onboardingState', JSON.stringify({
@@ -204,80 +162,62 @@ test.describe('OHC Setup Wizard Flow', () => {
         }));
     });
     await page.reload();
-
     await page.getByTestId('template-selection').selectOption('Modern');
     await page.getByTestId('finish-btn').click();
-
     // Check error message
     const errorMsg = page.locator('#submit-error');
     await expect(errorMsg).toBeVisible();
     await expect(errorMsg).toHaveText('Backend is broken');
   });
-
-
 test.describe('OHC Setup Wizard Form Configuration', () => {
-
   test.beforeEach(async ({ page }) => {
-      const tauriUiDir = require('path').join(process.cwd(), 'src/ui/tauri/src/ui');
+      const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
       await page.route('**/setup.html', async route => {
-          const content = require('fs').readFileSync(require('path').join(tauriUiDir, 'setup.html'), 'utf-8');
+          const content = fs.readFileSync(path.join(tauriUiDir, 'setup.html'), 'utf-8');
           await route.fulfill({ contentType: 'text/html', body: content });
       });
   });
-
   test('should have appropriate HTML attributes for mobile input configuration', async ({ page }) => {
     await page.goto('http://mock/setup.html');
-
     // Name step
     const businessName = page.getByTestId('business-name');
     await expect(businessName).toHaveAttribute('autocomplete', 'organization');
-
     // Admin step
     const adminEmail = page.getByTestId('admin-email');
     await expect(adminEmail).toHaveAttribute('autocomplete', 'email');
     await expect(adminEmail).toHaveAttribute('inputmode', 'email');
-
     const adminPassword = page.getByTestId('admin-password');
     await expect(adminPassword).toHaveAttribute('autocomplete', 'new-password');
   });
-
   test('should have border-radius of 16px for .glassmorphism styling', async ({ page }) => {
     // This tests the CSS inline in setup.html and imported globals.css
     await page.goto('http://mock/setup.html');
-
     const container = page.locator('.container.glassmorphism').first();
     await expect(container).toHaveCSS('border-radius', '16px');
-
     const textInput = page.locator('#instant-bio');
     // Inputs also use glassmorphism but might be overridden to 8px.
     // However, the mandate specifies containers need 16px.
     await expect(textInput).toHaveCSS('border-radius', '8px');
   });
-
   test('should support 375px mobile view without horizontal scroll', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('http://mock/setup.html');
-
     // Evaluate horizontal scroll
     const hasHorizontalScroll = await page.evaluate(() => {
         return document.documentElement.scrollWidth > window.innerWidth;
     });
     expect(hasHorizontalScroll).toBe(false);
   });
-
   test('should have minimum 44px touch targets on buttons', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('http://mock/setup.html');
-
     // Verify touch targets height
     const btnBox = await page.locator('.next-step-btn').first().boundingBox();
     expect(btnBox?.height).toBeGreaterThanOrEqual(44);
   });
-
   test('should have minimum 44px touch targets on radio options', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('http://mock/setup.html');
-
     await page.locator('[data-testid="next-step-btn"][data-next="step-context"]').click();
     const inputbox = await page.locator('label.context-card').first().boundingBox();
     expect(inputbox?.height).toBeGreaterThanOrEqual(44);

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -31,6 +31,7 @@
         max-height: calc(100vh - 40px);
         overflow-y: auto;
       }
+                        /* OHC Premium Glassmorphism */
       .glassmorphism {
         border-radius: 16px;
         background: rgba(255, 255, 255, 0.65);
@@ -39,6 +40,8 @@
         border: 1px solid rgba(255, 255, 255, 0.4);
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
       }
+
+
       h1 {
         margin-top: 0;
         color: #1d1d1f;
@@ -82,7 +85,14 @@
         background: rgba(255, 255, 255, 0.65);
         box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.2);
       }
-      button { min-height: 44px; min-width: 44px;
+            button, input, select, textarea, .glassmorphism {
+        min-height: 44px;
+        box-sizing: border-box;
+      }
+      button, input, select, textarea {
+        border-radius: 8px !important;
+      }
+      button { min-width: 44px;
         background-color: #0066FF;
         color: white;
         border: none;
@@ -244,12 +254,8 @@
           box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
         }
         .glassmorphism {
-          border-radius: 16px;
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(30px) saturate(210%);
-          -webkit-backdrop-filter: blur(30px) saturate(210%);
-          border: 1px solid rgba(255, 255, 255, 0.1);
-          box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+          border-color: rgba(255, 255, 255, 0.1);
         }
         h1 {
           color: #F5F5F7;
@@ -788,24 +794,11 @@
         min-height: 44px;
         min-width: 44px;
       }
-      /* OHC Premium Glassmorphism Overrides */
-      .glassmorphism {
-        border-radius: 16px;
-        background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(210%);
-        -webkit-backdrop-filter: blur(30px) saturate(210%);
-        border: 1px solid rgba(255, 255, 255, 0.4);
-      }
-      button.glassmorphism,
-      input.glassmorphism,
-      select.glassmorphism,
-      textarea.glassmorphism,
-      .glassmorphism input,
-      .glassmorphism select,
-      .glassmorphism textarea,
-      .glassmorphism button { min-height: 44px; min-width: 44px;
-        border-radius: 8px;
-      }
+
+
+
+
+
 
       /* macOS-style scrollbar */
       .custom-scrollbar::-webkit-scrollbar {


### PR DESCRIPTION
The OneHumanCorp (OHC) setup wizard has been optimized according to the premium macOS translucent styling token rules, while ensuring 375px viewport dimensions remain responsive without overflow. The E2E tests (`src/e2e/setup.spec.ts`) have also been cleaned up and fixed, properly using `import * as fs` rather than inline `require()` calls and passing successfully across all test scenarios.

---
*PR created automatically by Jules for task [16082373446345143499](https://jules.google.com/task/16082373446345143499) started by @ql-owo-lp*