### PR TITLE
fix(e2e): unskip and fix POS inventory sync tests

### DIFF
--- a/src/ui/next/src/e2e/pos-inventory-sync-optimistic.spec.ts
+++ b/src/ui/next/src/e2e/pos-inventory-sync-optimistic.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe.skip('POS Inventory Sync - Optimistic UI', () => {
+test.describe('POS Inventory Sync - Optimistic UI', () => {
   test('POS terminal immediately updates stock UI on charge before API returns', async ({ page }) => {
     // Navigate to POS terminal
     await page.goto('/pos/terminal');
@@ -15,7 +15,7 @@ test.describe.skip('POS Inventory Sync - Optimistic UI', () => {
     await page.getByRole('button', { name: '4', exact: true }).click();
 
     // Wait for the dashboard to load
-    await expect(page.getByRole('heading', { name: 'Manager' })).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('h1', { hasText: 'Manager' }).first()).toBeVisible({ timeout: 5000 });
 
     // Wait for the product catalog to be populated
     await expect(page.getByText('Vegan Celebration Cake')).toBeVisible();
@@ -53,7 +53,7 @@ test.describe.skip('POS Inventory Sync - Optimistic UI', () => {
     await page.getByRole('button', { name: '3', exact: true }).click();
     await page.getByRole('button', { name: '4', exact: true }).click();
 
-    await expect(page.getByRole('heading', { name: 'Manager' })).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('h1', { hasText: 'Manager' }).first()).toBeVisible({ timeout: 5000 });
 
     // Ensure product catalog is populated
     await expect(page.getByText('Vegan Celebration Cake')).toBeVisible({ timeout: 5000 });

--- a/src/ui/next/src/e2e/pos-inventory-sync.spec.ts
+++ b/src/ui/next/src/e2e/pos-inventory-sync.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe.skip('POS Inventory Sync - E2E Race Condition', () => {
+test.describe('POS Inventory Sync - E2E Race Condition', () => {
   test('POS terminal applies lock and prevents double booking online', async ({ page }) => {
     const tenantId = 'e2e-tenant-pos';
     const productId = 'e2e-product-cake-pos';
@@ -97,7 +97,7 @@ test.describe.skip('POS Inventory Sync - E2E Race Condition', () => {
     await page.getByRole('button', { name: 'Pay' }).click();
 
     // 4. Verify the "Item just sold out" message appears
-    await expect(page.getByText('Item just sold out.')).toBeVisible();
+    await expect(page.locator('h3', { hasText: 'Oops! Item just sold out.' })).toBeVisible();
 
     // Cleanup: Release lock so it doesn't affect other tests if they run concurrently
     // (Actually the lock will expire in 15 seconds, but let's release it cleanly)


### PR DESCRIPTION
This PR fixes and enables two skipped E2E tests related to POS inventory sync. The tests were failing due to outdated locators. The fixes ensure the locators match the current UI implementation, allowing the tests to pass successfully and preventing future regressions in these critical workflows.

---
*PR created automatically by Jules for task [7896048855506305342](https://jules.google.com/task/7896048855506305342) started by @wbbsuper*