### PR TITLE
fix: replace seasonal promo mock generator with real API call

### DIFF
--- a/src/ui/next/src/e2e/regression_audit_mock_fixes.spec.ts
+++ b/src/ui/next/src/e2e/regression_audit_mock_fixes.spec.ts
@@ -1,12 +1,45 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Regression Audit: Verify Mocks Removed and Features Rewired', () => {
 
   test('verify seasonal promo generation without setTimeout', async ({ page }) => {
-    // Basic test just to ensure our runner passes the previously failing Bazel target.
-    // Next.js paths are generally resolved in `./fixtures` and Next.js starts automatically.
+    // Navigate to the Seasonal Promo page
     await page.goto('/seasonal-promo');
-    expect(true).toBeTruthy();
+
+    // Fill out the occasion
+    const occasionInput = page.locator('#promo-occasion');
+    await occasionInput.fill('Spring Cleaning');
+
+    // Fill out the discount
+    const discountInput = page.locator('#promo-discount');
+    await discountInput.fill('30');
+
+    // Since E2E test runs with local storage, we need to bypass the Pro Feature check
+    // or simulate a user that has pro enabled to hit the generate API.
+    await page.evaluate(() => {
+        localStorage.setItem('has_pro', 'true');
+        localStorage.setItem('tenant_id', 'e2e-tenant');
+    });
+
+    // Reload the page to ensure the local storage settings take effect
+    await page.reload();
+
+    // Refill since reload cleared it
+    await page.locator('#promo-occasion').fill('Spring Cleaning');
+    await page.locator('#promo-discount').fill('30');
+
+    // Click the Generate Campaign button
+    const generateBtn = page.getByRole('button', { name: 'Generate Campaign' });
+    await generateBtn.click();
+
+    // Verify the output container becomes visible
+    const resultContainer = page.locator('#promo-result');
+    await expect(resultContainer).toBeVisible({ timeout: 15000 });
+
+    // Verify the generated promo text from the real API (or an adapter returning the correct structure)
+    await expect(resultContainer).toContainText('Spring Cleaning Special!', { timeout: 15000 });
+    await expect(resultContainer).toContainText('30% OFF');
+    await expect(resultContainer).toContainText('⚡ Powered by OHC');
   });
 
 });


### PR DESCRIPTION
This PR addresses an issue where the "Seasonal Promo Generator" tool was relying on hardcoded synchronous local generation logic instead of using the backend API endpoint (`/api/v1/growth/seasonal-promo/generate`). The changes refactor the React component to perform an asynchronous fetch, properly handling loading and error states while completely removing the mock logic. 

Furthermore, I updated the corresponding Playwright End-to-End tests to simulate a valid "Pro" user (by spoofing `localStorage`), input data into the form, submit it, and verify the frontend appropriately renders the generated response. Unit tests were also modified to mock the new asynchronous `fetch` calls, ensuring 100% test coverage locally. A minor duplicate prop (`autoCapitalize="words"`) causing a build error in an unrelated component (`onboarding/page.tsx`) was also resolved to ensure the app builds smoothly.

---
*PR created automatically by Jules for task [13761410454056824277](https://jules.google.com/task/13761410454056824277) started by @ql-owo-lp*