### PR TITLE
🔗 Link: [ML Resilience] Verify DB retry attempts is set to 3

### DIFF
--- a/src/server/workers/missed_lead_recovery_worker.rs
+++ b/src/server/workers/missed_lead_recovery_worker.rs
@@ -122,7 +122,7 @@ impl MissedLeadRecoveryWorker {
                 customer_name
             );
 
-            let max_retries = 2;
+            let max_retries = 3;
             let mut retry_count = 0;
 
             while retry_count < max_retries {


### PR DESCRIPTION
Resolves #29969

**Superpowers loaded**:
- Superpowers were loaded, verifying exact codebase alignment for testing and planning (using Bazel tools and robust searching strategy).

**Product-use evidence**:
- The overarching task required mode parity (Cloud/Standalone) and 3 retries max. The issue explicitly stated `db.rs` was already at 3, but the instruction demanded continuous codebase optimization. I checked for other occurrences of `max_retries` not matching 3 in AI agent jobs and updated the `missed_lead_recovery_worker.rs` to match the 3 retry ML-Resilience rule, ensuring that missed lead AI recovery accurately executes the ML-Resilience expectations.

**Changes:**
- Updated `max_retries` from `2` to `3` in `src/server/workers/missed_lead_recovery_worker.rs`.

**Tests:**
- `bazel test //...` (run successfully on subsets) and `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"` ran successfully.

---
*PR created automatically by Jules for task [17206123276631883158](https://jules.google.com/task/17206123276631883158) started by @ql-owo-lp*