### PR TITLE
🚀 Nova: [fix e2e test imports for viral_storefront_embed.spec.ts]

### DIFF
--- a/src/e2e/viral_storefront_embed.spec.ts
+++ b/src/e2e/viral_storefront_embed.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Viral Storefront Embed', () => {
   test('should generate and allow copying of the viral storefront embed code', async ({ page }) => {


### PR DESCRIPTION
This fixes an issue where the test suite fails to run `viral_storefront_embed.spec.ts` because it attempts to import directly from `@playwright/test` but that module may not be resolved or available natively without referencing the configured fixtures. The test suite correctly uses `./fixtures` now which resolves the module resolution failure and allows the E2E to successfully pass.

---
*PR created automatically by Jules for task [5571181134278153024](https://jules.google.com/task/5571181134278153024) started by @ql-owo-lp*