### PR TITLE
🎨 Canvas: [ML Resilience] Verify DB retry attempts is set to 3

### DIFF
--- a/src/server/chaos.rs
+++ b/src/server/chaos.rs
@@ -389,7 +389,7 @@ mod tests {
             let p = pool_arc.clone();
             tasks.push(tokio::spawn(async move {
                 let mut attempt = 0;
-                let max_attempts = 3;
+                let max_attempts = crate::db::MAX_DB_RETRY_ATTEMPTS;
                 let mut backoff = Duration::from_millis(10);
                 loop {
                     let res = sqlx::query("INSERT INTO agent_missions (id, status, payload) VALUES (?, 'PENDING', 'data')")
@@ -432,7 +432,7 @@ mod tests {
     let _tracker = crate::telemetry::ChaosRecoveryTracker::new("Cloud");
         let mut success = false;
         let mut attempt = 0;
-        let max_attempts = 3;
+        let max_attempts = crate::db::MAX_DB_RETRY_ATTEMPTS;
         let mut backoff = Duration::from_millis(10);
 
         let simulated_acquire = || async {

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -12,6 +12,7 @@ use std::sync::OnceLock;
 static GLOBAL_POOL: OnceLock<PgPool> = OnceLock::new();
 const POSTGRES_MIGRATION_LOCK_KEY: i64 = 0x4f48_435f_4d49_4752;
 
+pub const MAX_DB_RETRY_ATTEMPTS: u32 = 3;
 
 pub fn secure_pg_pool_options() -> sqlx::postgres::PgPoolOptions {
     sqlx::postgres::PgPoolOptions::new()
@@ -629,7 +630,7 @@ impl DB {
         E: std::fmt::Debug + std::fmt::Display + From<String>,
     {
         let mut attempt = 0;
-        let max_attempts = 3;
+        let max_attempts = MAX_DB_RETRY_ATTEMPTS;
         #[cfg(not(test))]
         let mut backoff = std::time::Duration::from_millis(50);
         #[cfg(test)]

--- a/src/server/orchestration/chaos_test.rs
+++ b/src/server/orchestration/chaos_test.rs
@@ -176,7 +176,7 @@ impl ohc_builtin_agent::mesh::transport::MeshTransport for DroppingMockTransport
 
         let mut success = false;
         let mut attempts = 0;
-        let max_attempts = 3;
+        let max_attempts = crate::db::MAX_DB_RETRY_ATTEMPTS;
 
         while attempts < max_attempts {
             let should_drop = (rand::random::<f64>() * 100.0) < rate as f64;

--- a/src/server/orchestration/state/parity_test.rs
+++ b/src/server/orchestration/state/parity_test.rs
@@ -812,7 +812,7 @@ mod parity_tests {
         assert!(res.is_err());
         assert!(res.unwrap_err().contains("Database retry exhausted"));
         // execute_with_retry makes 1 initial attempt + 2 retries (max_attempts = 3)
-        assert_eq!(*attempts.lock().unwrap(), 3);
+        assert_eq!(*attempts.lock().unwrap(), crate::db::MAX_DB_RETRY_ATTEMPTS);
 
         let pg_db = setup_postgres_db().await;
         if let Some(db) = pg_db {
@@ -830,7 +830,7 @@ mod parity_tests {
 
             assert!(res.is_err());
             assert!(res.unwrap_err().contains("Database retry exhausted"));
-            assert_eq!(*attempts.lock().unwrap(), 3);
+            assert_eq!(*attempts.lock().unwrap(), crate::db::MAX_DB_RETRY_ATTEMPTS);
         }
     }
 
@@ -898,7 +898,7 @@ mod parity_tests {
 
         assert!(res.is_ok());
         assert_eq!(res.unwrap(), "success");
-        assert_eq!(*attempts.lock().unwrap(), 3);
+        assert_eq!(*attempts.lock().unwrap(), crate::db::MAX_DB_RETRY_ATTEMPTS);
 
         let pg_db = setup_postgres_db().await;
         if let Some(db) = pg_db {
@@ -920,7 +920,7 @@ mod parity_tests {
 
             assert!(res.is_ok());
             assert_eq!(res.unwrap(), "success");
-            assert_eq!(*attempts.lock().unwrap(), 3);
+            assert_eq!(*attempts.lock().unwrap(), crate::db::MAX_DB_RETRY_ATTEMPTS);
         }
     }
 }

--- a/src/server/orchestration/tasks.rs
+++ b/src/server/orchestration/tasks.rs
@@ -174,7 +174,7 @@ impl TaskDecompositionService {
 
     pub async fn claim_task(&self, agent_id: &str) -> Result<Option<SharedTask>, String> {
         let mut attempt = 0;
-        let max_attempts = 3;
+        let max_attempts = crate::db::MAX_DB_RETRY_ATTEMPTS;
         let timeout = task_claim_timeout();
 
         let start_time = std::time::Instant::now();

--- a/src/server/sip.rs
+++ b/src/server/sip.rs
@@ -59,7 +59,7 @@ impl SipDB {
 
     pub async fn handoff_mission(&self, mission_id: &str, blockers: &str) -> Result<(), sqlx::Error> {
         let mut attempt = 0;
-        let max_attempts = 3;
+        let max_attempts = crate::db::MAX_DB_RETRY_ATTEMPTS;
         let mut backoff = std::time::Duration::from_millis(50);
 
         loop {
@@ -118,7 +118,7 @@ impl SipDB {
         let threshold_time = Utc::now() - stagnant_threshold;
 
         let mut attempt = 0;
-        let max_attempts = 3;
+        let max_attempts = crate::db::MAX_DB_RETRY_ATTEMPTS;
         let mut backoff = std::time::Duration::from_millis(50);
 
         loop {
@@ -181,7 +181,7 @@ impl SipDB {
         let fail_threshold = Utc::now() - age_threshold;
         
         let mut attempt = 0;
-        let max_attempts = 3;
+        let max_attempts = crate::db::MAX_DB_RETRY_ATTEMPTS;
         let mut backoff = std::time::Duration::from_millis(50);
 
         loop {
@@ -279,7 +279,7 @@ impl SipDB {
 
     pub async fn drain_mission_queue(&self) -> Result<(), sqlx::Error> {
         let mut attempt = 0;
-        let max_attempts = 3;
+        let max_attempts = crate::db::MAX_DB_RETRY_ATTEMPTS;
         let mut backoff = std::time::Duration::from_millis(50);
 
         loop {
@@ -398,7 +398,7 @@ impl SipDB {
 
     pub async fn upsert_mission(&self, mission_id: &str, status: &str, payload: &str, force_local: bool) -> Result<(), sqlx::Error> {
         let mut attempt = 0;
-        let max_attempts = 3;
+        let max_attempts = crate::db::MAX_DB_RETRY_ATTEMPTS;
         let mut backoff = std::time::Duration::from_millis(50);
 
         let is_standalone = crate::is_standalone_runtime();


### PR DESCRIPTION
Extracted magic number '3' for max attempts into a global constant `MAX_DB_RETRY_ATTEMPTS` in `src/server/db.rs` and replaced hardcoded references across orchestration logic and tests (`chaos.rs`, `sip.rs`, `tasks.rs`, `parity_test.rs`).
Resolves #29969

---
*PR created automatically by Jules for task [9422125904483969061](https://jules.google.com/task/9422125904483969061) started by @ql-owo-lp*