### PR TITLE
🔨 Forge: [ML Resilience] Add DB retry jitter in execute_with_retry

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -679,7 +679,10 @@ impl DB {
                             )
                             .await;
                         }
-                        tokio::time::sleep(backoff).await;
+                        // Add jitter to avoid thundering herd on retries
+                        let jitter_factor = 1.0 + (rand::random::<f64>() * 0.5); // Up to 50% extra
+                        let jittered_backoff = std::time::Duration::from_secs_f64(backoff.as_secs_f64() * jitter_factor);
+                        tokio::time::sleep(jittered_backoff).await;
                         backoff *= 2;
                     } else {
                         return Err(err);


### PR DESCRIPTION
- Added jitter (up to 50% extra backoff duration) to `src/server/db.rs:execute_with_retry`.
- This proactively optimizes database locking resilience by avoiding thundering herd when jobs run concurrently.
- No tests broken; `cargo test parity` succeeded.

Resolves #29969

---
*PR created automatically by Jules for task [1984128794401676029](https://jules.google.com/task/1984128794401676029) started by @ql-owo-lp*