### PR TITLE
fix(setup): correctly restore visual radio button selection using context-card class

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1541,8 +1541,8 @@ if (state.capabilities && document.getElementById('cap-draft')) {
               inputs.context.forEach(r => {
                   if (r.value === contextVal) {
                       r.checked = true;
-                      document.querySelectorAll('.radio-option').forEach(el => el.classList.remove('selected'));
-                      r.closest('.radio-option').classList.add('selected');
+                      document.querySelectorAll('.context-card').forEach(el => el.classList.remove('selected'));
+                      r.closest('.context-card').classList.add('selected');
                   }
               });
           }


### PR DESCRIPTION
This PR fixes a bug in the setup wizard UI (`src/ui/tauri/src/ui/setup.html`) where the work context radio cards visually failed to restore their `selected` styling state upon reloading the page. 

The Javascript logic iterating over `inputs.context` to determine the active context radio button checked against `.radio-option` class, which did not exist on the elements; the correct class is `.context-card`. We correctly update the selector to use `.context-card`.

E2E tests pass hermetically for these specific UI flows.

---
*PR created automatically by Jules for task [8952297699136919583](https://jules.google.com/task/8952297699136919583) started by @ql-owo-lp*