### PR TITLE
🔧 Link: Fix unused imports, variables and verify ML-Resilience DB max_attempts

### DIFF
--- a/src/server/integrations/mcp_config_sync/tool.rs
+++ b/src/server/integrations/mcp_config_sync/tool.rs
@@ -260,7 +260,7 @@ mod mock_tests {
 #[cfg(test)]
 mod db_tests {
     use super::*;
-    use sqlx::postgres::PgPoolOptions;
+
 
     #[tokio::test]
     async fn test_sync_and_get_config() {

--- a/src/server/orchestration/departments/marketing_agent.rs
+++ b/src/server/orchestration/departments/marketing_agent.rs
@@ -497,7 +497,7 @@ use crate::orchestration::departments::marketing_seo::{SeoClient, RuntimeSeoClie
     struct MockSeoClient;
     #[async_trait::async_trait]
     impl SeoClient for MockSeoClient {
-        async fn generate_seo_metadata(&self, name: &str, description: &str, item_type: &str, price: f64) -> Result<(String, String, serde_json::Value), String> {
+        async fn generate_seo_metadata(&self, name: &str, description: &str, _item_type: &str, _price: f64) -> Result<(String, String, serde_json::Value), String> {
             Ok((
                 format!("Mock SEO Title for {}", name),
                 format!("Mock SEO Desc for {}", description),

--- a/src/server/orchestration/departments/marketing_seo.rs
+++ b/src/server/orchestration/departments/marketing_seo.rs
@@ -1,6 +1,3 @@
-use crate::orchestration::departments::orchestrator::{BaseAgent, AgentTriggerType, DepartmentOrchestrator, Department};
-use crate::orchestration::departments::types::{DepartmentType, DepartmentEvent, DepartmentConfig, ApprovalRequest, ActionRisk};
-use std::sync::Arc;
 use serde_json::json;
 
 #[async_trait::async_trait]


### PR DESCRIPTION
This PR satisfies Issue #29969 (which asked to ensure `execute_with_retry` max attempts is set to 3) by verifying that the limit is indeed already set to 3 in `src/server/db.rs` and its parity test. It also proactively cleans up a series of unused imports, compiler warnings, and un-prefixed unused variables discovered via `cargo clippy` and test builds during verification across `marketing_agent.rs`, `marketing_seo.rs`, and `mcp_config_sync`. All tests pass HERMETICALLY under Bazel across all packages.

Resolves #29969

---
*PR created automatically by Jules for task [10596061434373827805](https://jules.google.com/task/10596061434373827805) started by @ql-owo-lp*