### PR TITLE
💰 Miser: Cost dashboard and My Plan E2E & Unit Test Coverage and Fixes

### DIFF
--- a/src/e2e/cost_dashboard_ui.spec.ts
+++ b/src/e2e/cost_dashboard_ui.spec.ts
@@ -15,12 +15,15 @@ test.describe('Cost Dashboard & Plan Limits UI', () => {
     await expect(page.locator('span', { hasText: 'LLM Usage' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Storage' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Network & Storage Savings' }).first()).toBeVisible();
-    await expect(page.locator('span', { hasText: 'Trend:' }).first()).toBeVisible();
+    await expect(page.locator('h3', { hasText: '7-Day Trend' }).first()).toBeVisible();
     await expect(page.locator('h3', { hasText: 'Agent & Feature Costs' }).first()).toBeVisible();
-    await expect(page.locator('h3', { hasText: 'Department Usage' }).first()).toBeVisible();
+    await expect(page.locator('h2', { hasText: 'Department Tier Usage' }).first()).toBeVisible();
 
     // Check if the plan navigation link is present
-    await expect(page.getByRole('button', { name: 'Back to My Plan' })).toBeVisible();
+    const backButton = page.locator('a', { hasText: 'Back to My Plan' });
+    await expect(backButton).toBeVisible();
+    await backButton.click();
+    await expect(page.locator('h1', { hasText: 'My Plan' }).first()).toBeVisible({ timeout: 15000 });
   });
 
   test('should display my plan limits and route to pricing', async ({ page, adminUser, loginAs }) => {

--- a/src/ui/next/src/app/cost-dashboard/page.test.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.test.tsx
@@ -120,6 +120,7 @@ describe('CostDashboardPage', () => {
 
     // My Plan assertions
     expect(screen.getByText('My Plan')).toBeDefined();
+    expect(screen.getByText('Back to My Plan')).toBeDefined();
     expect(screen.getByText('Starter')).toBeDefined();
     // AI actions used this month: 150 / 1000. Text split.
     expect(screen.getAllByText(/150/)[0]).toBeDefined();

--- a/src/ui/next/src/app/plan/page.test.tsx
+++ b/src/ui/next/src/app/plan/page.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import MyPlanPage from './page';
+import { useRouter } from 'next/navigation';
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock('../../components/TooltipRegistry', () => ({
+  WithTooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../components/PoweredByOHC', () => ({
+  PoweredByOHC: () => <div data-testid="powered-by-ohc" />,
+}));
+
+describe('MyPlanPage', () => {
+  const mockPush = vi.fn();
+  let originalWindowLocation: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useRouter as any).mockReturnValue({ push: mockPush });
+    global.fetch = vi.fn();
+
+    (global.fetch as any).mockImplementation(async (url) => {
+      if (url === '/api/billing/my-plan') {
+        return {
+          ok: true,
+          json: async () => ({
+            current_plan: 'Starter',
+            ai_actions_used: 150,
+            ai_actions_limit: 1000,
+            storage_used_bytes: 2 * 1024 * 1024, // 2MB
+            storage_limit_bytes: 5 * 1024 * 1024 * 1024, // 5GB
+            next_bill_estimated: 2900,
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    originalWindowLocation = window.location;
+    delete (window as any).location;
+    window.location = { ...originalWindowLocation, href: '' } as any;
+  });
+
+  afterEach(() => {
+    window.location = originalWindowLocation;
+  });
+
+  it('renders the plan page', async () => {
+    await act(async () => {
+      render(<MyPlanPage />);
+    });
+
+    expect(screen.getByText('My Plan')).toBeDefined();
+    expect(screen.getByText('Starter')).toBeDefined();
+    expect(screen.getByText('$29.00')).toBeDefined();
+  });
+
+  it('navigates to pricing on upgrade click', async () => {
+    await act(async () => {
+      render(<MyPlanPage />);
+    });
+
+    const upgradeButton = screen.getByText('Upgrade');
+    await act(async () => {
+      fireEvent.click(upgradeButton);
+    });
+    expect(mockPush).toHaveBeenCalledWith('/pricing');
+  });
+
+  it('navigates to cost-dashboard on details click', async () => {
+    await act(async () => {
+      render(<MyPlanPage />);
+    });
+
+    const detailsButton = screen.getByText('View Detailed Costs');
+    await act(async () => {
+      fireEvent.click(detailsButton);
+    });
+    expect(mockPush).toHaveBeenCalledWith('/cost-dashboard');
+  });
+
+  it('initiates manage billing flow', async () => {
+    const mockPortalUrl = 'https://billing.stripe.com/p/session/test_123';
+    (global.fetch as any).mockImplementation(async (url, options) => {
+      if (url === '/api/billing/my-plan') {
+        return {
+          ok: true,
+          json: async () => ({ current_plan: 'Starter' }),
+        };
+      }
+      if (url === '/api/billing/create-billing-portal-session' && options?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({ url: mockPortalUrl }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    await act(async () => {
+      render(<MyPlanPage />);
+    });
+
+    const manageButton = screen.getByText('Manage Billing');
+    await act(async () => {
+      fireEvent.click(manageButton);
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/billing/create-billing-portal-session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      expect(window.location.href).toBe(mockPortalUrl);
+    });
+  });
+});


### PR DESCRIPTION
Cost dashboard optimizations and My Plan enhancements.

The task aimed to implement cost features but upon exploration, the main requested tasks and features (cost-dashboard and plan/pricing API and components) were already fully implemented. Instead, as per the guidelines, we improved existing systems and resolved failing test scenarios. 

This PR includes:
- Missing unit tests for My Plan page (`src/ui/next/src/app/plan/page.test.tsx`) are now implemented to ensure page interactions perform successfully including mocking network calls and window routing methods.
- Included assertions for the 'Back to My Plan' link on `src/ui/next/src/app/cost-dashboard/page.test.tsx` file for additional unit test coverage.
- Fixed broken Playwright locator identifiers on `src/e2e/cost_dashboard_ui.spec.ts` for elements such as 7-Day Trend, Department Tier Usage, and Back to My Plan link (which is an anchor tag, not a button role), enabling end-to-end tests for the cost dashboard and pricing interactions to pass cleanly.

---
*PR created automatically by Jules for task [5277328916965925063](https://jules.google.com/task/5277328916965925063) started by @wbbsuper*