### PR TITLE
feat: optimize referral tracking GET proxy and apply premium widget styling

### DIFF
--- a/src/e2e/dashboard_viral_invite_widget.spec.ts
+++ b/src/e2e/dashboard_viral_invite_widget.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from './fixtures';
+
+test.describe('Dashboard Viral Invite Widget', () => {
+  test('should display the widget with loading state and invite link', async ({ page }) => {
+    // Navigate to dashboard
+    await page.goto('/dashboard');
+
+    // Wait for the widget to appear
+    const widget = page.locator('[data-testid="dashboard-viral-invite-widget"]');
+    await expect(widget).toBeVisible();
+
+    // Check initial state
+    const generateBtn = page.locator('#dashboard-invite-btn');
+    await expect(generateBtn).toBeVisible();
+    await expect(generateBtn).toContainText('Get My Invite Link');
+
+    // Click generate button
+    await generateBtn.click();
+
+    // It should briefly show loading
+    // Then show the input container
+    const inviteContainer = page.locator('#dashboard-invite-container');
+    await expect(inviteContainer).toBeVisible({ timeout: 10000 });
+
+    // Verify link structure
+    const inviteLinkInput = page.locator('#dashboard-invite-link');
+    await expect(inviteLinkInput).toBeVisible();
+    const linkValue = await inviteLinkInput.inputValue();
+    expect(linkValue).toMatch(/^https?:\/\//);
+
+    // Copy button
+    const copyBtn = page.locator('#dashboard-copy-btn');
+    await expect(copyBtn).toBeVisible();
+  });
+});

--- a/src/e2e/global-setup.ts
+++ b/src/e2e/global-setup.ts
@@ -2,6 +2,7 @@ import { chromium, type FullConfig } from '@playwright/test';
 
 
 export default async function globalSetup(config: FullConfig) {
+  process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://ohc:ohc@localhost:5432/ohc?sslmode=disable';
   const baseURL = config.projects[0]?.use?.baseURL as string | undefined;
   if (!baseURL) {
     throw new Error('Playwright baseURL is required for e2e global setup.');

--- a/src/e2e/growth_referral_widget_premium.spec.ts
+++ b/src/e2e/growth_referral_widget_premium.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from './fixtures';
+
+test.describe('Growth Referral Widget Premium Layout', () => {
+  test('should display correctly with premium glassmorphism classes', async ({ page }) => {
+    // Navigate to a page that uses the GrowthReferralWidget (e.g., team)
+    await page.goto('/team');
+
+    // Check for Sovereign-to-Cloud Bridge card
+    const cloudBridgeTitle = page.getByRole('heading', { name: 'Grow Your Team' });
+    await expect(cloudBridgeTitle).toBeVisible();
+
+    // Test copy embed code logic
+    const embedButton = page.getByRole('button', { name: 'Copy Embed Code' });
+    await expect(embedButton).toBeVisible();
+
+    // Give clipboard permissions
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    // Handle dialog
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toBe('Embed code copied to clipboard!');
+      await dialog.accept();
+    });
+
+    await embedButton.click();
+
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboardText).toContain('<iframe');
+    expect(clipboardText).toContain('⚡ Powered by OHC');
+  });
+});

--- a/src/e2e/referral_click_tracking.spec.ts
+++ b/src/e2e/referral_click_tracking.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from './fixtures';
+
+test.describe('Referral Click Tracking via GET', () => {
+  test('should successfully redirect and potentially log click', async ({ request }) => {
+    // Test the GET API endpoint manually
+    const response = await request.get('/api/v1/growth/referrals/click?target=/onboarding&ref=e2e-test-ref', {
+        maxRedirects: 0 // Prevent following so we can check the status code
+    });
+
+    // Next.js NextResponse.redirect uses 307
+    expect([307, 308, 302, 301]).toContain(response.status());
+    const redirectUrl = response.headers().location;
+    expect(redirectUrl).toContain('/onboarding?ref=e2e-test-ref');
+  });
+
+  test('should redirect correctly when accessing through browser', async ({ page }) => {
+     await page.goto('/api/v1/growth/referrals/click?target=/onboarding&ref=browser-test-ref');
+
+     // Should end up on onboarding
+     expect(page.url()).toContain('/onboarding');
+     expect(page.url()).toContain('ref=browser-test-ref');
+  });
+});

--- a/src/ui/next/src/app/api/v1/growth/referrals/click/route.ts
+++ b/src/ui/next/src/app/api/v1/growth/referrals/click/route.ts
@@ -58,11 +58,10 @@ export async function GET(request: Request) {
         const cookie = request.headers.get('cookie');
         if (cookie) headers.set('cookie', cookie);
 
-        // Best effort async fetch
-        fetch(`${backendUrl}/api/v1/growth/referrals/click`, {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({ id: ref })
+        // Best effort async fetch via GET proxy
+        fetch(`${backendUrl}/api/v1/growth/referrals/click?target=${encodeURIComponent(target)}&ref=${encodeURIComponent(ref)}`, {
+          method: 'GET',
+          headers
         }).catch(err => console.error("Error recording referral click on GET:", err));
     }
 

--- a/src/ui/next/src/app/components/GrowthReferralWidget.tsx
+++ b/src/ui/next/src/app/components/GrowthReferralWidget.tsx
@@ -66,7 +66,7 @@ export default function GrowthReferralWidget() {
 
   return (
     <div className="ohc-growth-card flex flex-col gap-8">
-      <div className="glass-card p-6 rounded-[16px] border border-white/40 dark:border-white/10 shadow-lg mb-6">
+      <div className="p-6 rounded-[16px] backdrop-blur-md bg-white/30 dark:bg-black/30 border border-white/20 dark:border-white/10 shadow-xl mb-6">
         <div className="flex flex-col md:flex-row gap-6 items-center">
         <div className="flex-1">
           <div className="inline-flex items-center gap-2 mb-2 px-3 py-1 rounded-full bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 text-sm font-semibold">
@@ -126,7 +126,7 @@ export default function GrowthReferralWidget() {
         </div>
       </div>
 
-      <div className="glass-card p-6 rounded-[16px] border border-white/40 dark:border-white/10 shadow-lg">
+      <div className="p-6 rounded-[16px] backdrop-blur-md bg-white/30 dark:bg-black/30 border border-white/20 dark:border-white/10 shadow-xl">
         <div className="flex flex-col md:flex-row gap-6 items-center">
           <div className="flex-1">
             <div className="inline-flex items-center gap-2 mb-2 px-3 py-1 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-sm font-semibold">

--- a/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.tsx
+++ b/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.tsx
@@ -57,7 +57,7 @@ export function DashboardViralInviteWidget() {
   const shareText = `Start your business on OHC! It's super easy. Use my link to get $50 off your first month: ${referralLink}`;
 
   return (
-    <div className="mb-6 p-6 rounded-[16px] glassmorphism border border-white/40 dark:border-white/10 bg-gradient-to-r from-indigo-50/50 to-purple-50/50 dark:from-indigo-900/20 dark:to-purple-900/20" data-testid="dashboard-viral-invite-widget">
+    <div className="mb-6 p-6 rounded-[16px] backdrop-blur-md bg-white/30 dark:bg-black/30 border border-white/20 dark:border-white/10 bg-gradient-to-r from-indigo-50/50 to-purple-50/50 dark:from-indigo-900/20 dark:to-purple-900/20 shadow-xl" data-testid="dashboard-viral-invite-widget">
       <div className="flex flex-col gap-4">
         <div>
           <h2 className="text-2xl font-bold font-outfit text-gray-900 dark:text-white mb-2">Invite & Earn</h2>
@@ -70,9 +70,17 @@ export function DashboardViralInviteWidget() {
             id="dashboard-invite-btn"
             onClick={handleGenerate}
             disabled={loading}
-            className="w-full min-h-[44px] min-w-[44px] bg-[#0f766e] hover:bg-[#0d645d] text-white font-semibold py-3 px-6 rounded-xl transition-colors"
+            className="w-full min-h-[44px] min-w-[44px] bg-[#0f766e] hover:bg-[#0d645d] text-white font-semibold py-3 px-6 rounded-xl transition-all shadow-md"
           >
-            {loading ? 'Generating...' : 'Get My Invite Link'}
+            {loading ? (
+              <span className="flex items-center justify-center gap-2">
+                <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                Generating...
+              </span>
+            ) : 'Get My Invite Link'}
           </button>
         ) : (
           <div id="dashboard-invite-container" className="flex flex-col gap-3">


### PR DESCRIPTION
This PR addresses improvements to the internal growth loops and referral tracking mechanisms, alongside a polished aesthetic update to the growth widgets.

Specifically, the Next.js `GET` handler for referral clicks was previously making a `POST` request to the backend. This patch corrects it to make a `GET` request, forwarding the query parameters (`ref` and `target`) so the backend correctly logs the interaction before redirecting the user. 

Furthermore, to adhere to the requested visual optimizations, the `DashboardViralInviteWidget` and `GrowthReferralWidget` were both upgraded to use a "macOS Translucent Glass" aesthetic, incorporating `backdrop-blur-md`, updated borders, and refined gradient backgrounds.

Three new end-to-end tests have been implemented to assert the visual presence of the widgets, interaction flow, and backend redirection routing respectively.

---
*PR created automatically by Jules for task [18383873308061683320](https://jules.google.com/task/18383873308061683320) started by @ql-owo-lp*