### PR TITLE
UI: Enforce macOS Translucent Glass visual standards

### DIFF
--- a/src/ui/next/src/app/checkout/page.tsx
+++ b/src/ui/next/src/app/checkout/page.tsx
@@ -9,7 +9,6 @@ import { OneTapReferral } from "../components/OneTapReferral";
 import { PostPurchaseShareWidget } from "../components/PostPurchaseShareWidget";
 import { ShareAndSaveWidget } from "../components/ShareAndSaveWidget";
 
-
 function CheckoutContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -26,18 +25,21 @@ function CheckoutContent() {
   const [shareDiscountApplied, setShareDiscountApplied] = useState(false);
   const [isSoldOut, setIsSoldOut] = useState(false);
   const { lastMessage } = useSyncGateway({
-    topics: ['inventory'],
+    topics: ["inventory"],
     enabled: !!tenant && !!productId,
   });
 
   useEffect(() => {
-    if (lastMessage && lastMessage.product_id === productId && lastMessage.action === 'reserve') {
+    if (
+      lastMessage &&
+      lastMessage.product_id === productId &&
+      lastMessage.action === "reserve"
+    ) {
       setIsSoldOut(true);
-      setCheckoutStatus('Item just sold out.');
+      setCheckoutStatus("Item just sold out.");
       setIsSoldOut(true);
     }
   }, [lastMessage, productId]);
-
 
   useEffect(() => {
     if (typeof localStorage !== "undefined") {
@@ -58,14 +60,16 @@ function CheckoutContent() {
     if (typeof localStorage !== "undefined") {
       const customerId = localStorage.getItem("customer_id") || "guest";
       const currentTenant = localStorage.getItem("tenant") || "my-store";
-      fetch(`/api/v1/growth/loyalty?tenant_id=${currentTenant}&customer_id=${customerId}`)
-        .then(res => {
+      fetch(
+        `/api/v1/growth/loyalty?tenant_id=${currentTenant}&customer_id=${customerId}`,
+      )
+        .then((res) => {
           if (res.ok) {
             return res.json();
           }
           return { points_balance: 50 }; // Fallback to 50 for guests/failures
         })
-        .then(data => {
+        .then((data) => {
           setAvailablePoints(data.points_balance || 50);
           if ((data.points_balance || 50) >= 50) {
             setLoyaltyDiscount(0.1); // 10%
@@ -78,7 +82,7 @@ function CheckoutContent() {
           setIsLoyaltyReady(true);
         });
     } else {
-        setIsLoyaltyReady(true);
+      setIsLoyaltyReady(true);
     }
   }, []);
 
@@ -96,11 +100,12 @@ function CheckoutContent() {
       if (data.success && data.fee !== undefined) {
         setDeliveryFee(data.fee);
       } else {
-        setDeliveryError(data.message || "Delivery not available for this address.");
+        setDeliveryError(
+          data.message || "Delivery not available for this address.",
+        );
         setDeliveryFee(null);
       }
     } catch (e) {
-
       setDeliveryError("Error checking delivery.");
     } finally {
       setIsCheckingDelivery(false);
@@ -109,7 +114,6 @@ function CheckoutContent() {
 
   const [isSubscription, setIsSubscription] = useState(false);
   const isSuccess = searchParams.get("success") === "true";
-
 
   const handlePayment = async (isSub = false) => {
     setIsProcessing(true);
@@ -121,13 +125,16 @@ function CheckoutContent() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          ...(typeof localStorage !== "undefined" && localStorage.getItem('token') ? { "Authorization": `Bearer ${localStorage.getItem('token')}` } : {})
+          ...(typeof localStorage !== "undefined" &&
+          localStorage.getItem("token")
+            ? { Authorization: `Bearer ${localStorage.getItem("token")}` }
+            : {}),
         },
         body: JSON.stringify({
           tier,
           is_subscription: tier ? true : isSub,
           product_id: tier ? undefined : productId,
-          quantity: tier ? undefined : quantity
+          quantity: tier ? undefined : quantity,
         }),
       });
       if (response.status === 409) {
@@ -138,13 +145,14 @@ function CheckoutContent() {
 
       const data = await response.json();
       if (!response.ok || !data.checkout_url) {
-        throw new Error(data.message || data.error || "Failed to create checkout session");
+        throw new Error(
+          data.message || data.error || "Failed to create checkout session",
+        );
       }
 
       setCheckoutStatus("Redirecting to checkout...");
       window.location.assign(data.checkout_url);
     } catch (e: any) {
-
       setCheckoutStatus("Checkout is temporarily unavailable.");
       setIsProcessing(false);
     }
@@ -158,7 +166,11 @@ function CheckoutContent() {
           defaultText="Review your order or plan details before securely completing your purchase."
         >
           <h1 className="text-2xl font-bold font-outfit text-center md:text-left text-gray-900 tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-gray-900 to-gray-600">
-            {isSuccess ? "Order Successful" : (tier ? "Plan Upgrade" : "Secure Checkout")}
+            {isSuccess
+              ? "Order Successful"
+              : tier
+                ? "Plan Upgrade"
+                : "Secure Checkout"}
           </h1>
         </WithTooltip>
       </header>
@@ -169,223 +181,343 @@ function CheckoutContent() {
       >
         {isSuccess ? (
           <div className="flex flex-col gap-6">
-            <div className="p-8 flex flex-col justify-center items-center bg-white/60 backdrop-blur-2xl saturate-200 border border-white/40 shadow-lg rounded-[24px] text-center">
+            <div className="p-8 flex flex-col justify-center items-center bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-lg rounded-[24px] text-center">
               <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mb-4">
-                <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                <svg
+                  className="w-8 h-8 text-green-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
               </div>
-              <h2 className="text-2xl font-bold font-outfit text-gray-900 mb-2">Thank you for your order!</h2>
-              <p className="text-gray-600 mb-6">Your payment was successful and your order is being processed.</p>
+              <h2 className="text-2xl font-bold font-outfit text-gray-900 mb-2">
+                Thank you for your order!
+              </h2>
+              <p className="text-gray-600 mb-6">
+                Your payment was successful and your order is being processed.
+              </p>
 
               <button
-                onClick={() => router.push('/')}
+                onClick={() => router.push("/")}
                 className="w-full px-4 py-3 bg-gray-100 text-gray-800 rounded-lg font-medium hover:bg-gray-200 transition-colors"
               >
                 Return to Store
               </button>
             </div>
 
-            <PostPurchaseShareWidget tenantId={tenant || "default-store"} orderId={searchParams.get("orderId") || "success"} />
+            <PostPurchaseShareWidget
+              tenantId={tenant || "default-store"}
+              orderId={searchParams.get("orderId") || "success"}
+            />
           </div>
         ) : tier ? (
-            <div className="p-6 md:p-8 flex flex-col justify-between bg-white/60 backdrop-blur-2xl saturate-200 border border-white/40 shadow-lg rounded-[24px]">
-              <div className="mb-6">
-                <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">OHC {tier} Plan</h3>
-                <p className="text-gray-600 text-sm">You are upgrading to the {tier} tier. Your card will be charged based on your region's pricing.</p>
+          <div className="p-6 md:p-8 flex flex-col justify-between bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-lg rounded-[24px]">
+            <div className="mb-6">
+              <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">
+                OHC {tier} Plan
+              </h3>
+              <p className="text-gray-600 text-sm">
+                You are upgrading to the {tier} tier. Your card will be charged
+                based on your region's pricing.
+              </p>
+            </div>
+
+            {checkoutStatus && (
+              <p
+                className="text-sm font-medium text-indigo-700 mb-4"
+                role="status"
+              >
+                {checkoutStatus}
+              </p>
+            )}
+
+            <WithTooltip
+              id="checkout-plan-upgrade-tooltip"
+              defaultText={
+                "Click here to securely subscribe to the " + tier + " plan."
+              }
+            >
+              <button
+                onClick={() => handlePayment(true)}
+                disabled={isProcessing || isSoldOut}
+                className={
+                  "w-full mb-3 px-4 py-3 text-white rounded-lg font-medium transition-colors shadow-sm " +
+                  (isProcessing
+                    ? "bg-indigo-400 cursor-not-allowed"
+                    : "bg-indigo-600 hover:bg-indigo-700")
+                }
+              >
+                {isProcessing ? "Processing..." : "Upgrade"}
+              </button>
+            </WithTooltip>
+
+            <WithTooltip
+              id="checkout-cancel-tooltip"
+              defaultText="Go back to the previous screen without subscribing."
+            >
+              <button
+                onClick={() => router.push("/pricing")}
+                className="w-full px-4 py-3 bg-gray-200 text-gray-800 rounded-lg font-medium hover:bg-gray-300 transition-colors"
+              >
+                Cancel
+              </button>
+            </WithTooltip>
+          </div>
+        ) : (
+          <>
+            <div
+              className="p-6 shadow-sm flex flex-col gap-4 mb-4"
+              style={{
+                background: "rgba(255, 255, 255, 0.65)",
+                backdropFilter: "blur(30px) saturate(210%)",
+                borderRadius: "24px",
+                border: "1px solid rgba(255, 255, 255, 0.4)",
+              }}
+            >
+              <div className="flex justify-between items-center pb-4 border-b border-gray-100">
+                <span className="font-semibold text-gray-700">
+                  Service Deposit
+                </span>
+                <span className="text-xl font-bold font-outfit text-gray-900">
+                  $45.00
+                </span>
               </div>
 
-              {checkoutStatus && (
-                <p className="text-sm font-medium text-indigo-700 mb-4" role="status">
-                  {checkoutStatus}
+              <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4 my-2">
+                <p className="text-indigo-800 text-xs font-medium">
+                  A 20% discount (
+                  {discountParam && !isNaN(Number(discountParam))
+                    ? discountParam
+                    : "20"}
+                  %) has been applied to this order automatically.
                 </p>
+              </div>
+
+              {true && (
+                <div
+                  className="bg-indigo-50/50 border border-indigo-100/50 rounded-xl p-4 my-2 backdrop-blur-md cursor-pointer hover:bg-indigo-50/80 transition-colors"
+                  onClick={() => setUseLoyaltyPoints(!useLoyaltyPoints)}
+                >
+                  <div className="flex justify-between items-center">
+                    <div>
+                      <p className="text-indigo-900 text-sm font-bold font-outfit">
+                        Neighborhood Collective Points
+                      </p>
+                      <p className="text-indigo-800 text-xs font-medium">
+                        You have {availablePoints} points available
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="text-indigo-600 text-sm font-bold">
+                        {loyaltyDiscount
+                          ? `-${loyaltyDiscount * 100}% off`
+                          : "0% off"}
+                      </span>
+                      <div
+                        className={`w-10 h-6 rounded-full flex items-center p-1 transition-colors ${useLoyaltyPoints ? "bg-indigo-600" : "bg-gray-300"}`}
+                      >
+                        <div
+                          className={`bg-white w-4 h-4 rounded-full shadow-sm transform transition-transform ${useLoyaltyPoints ? "translate-x-4" : "translate-x-0"}`}
+                        ></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               )}
 
-              <WithTooltip id="checkout-plan-upgrade-tooltip" defaultText={"Click here to securely subscribe to the " + tier + " plan."}>
-                <button
-                  onClick={() => handlePayment(true)}
-                  disabled={isProcessing || isSoldOut}
-                  className={"w-full mb-3 px-4 py-3 text-white rounded-lg font-medium transition-colors shadow-sm " + (isProcessing ? 'bg-indigo-400 cursor-not-allowed' : 'bg-indigo-600 hover:bg-indigo-700')}
+              <div className="flex flex-col gap-2">
+                <label className="text-sm font-semibold text-gray-700">
+                  Delivery Address (Optional)
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={deliveryAddress}
+                    onChange={(e) => setDeliveryAddress(e.target.value)}
+                    placeholder="Enter address for delivery quote"
+                    className="flex-1 px-3 py-2 bg-white border border-gray-200 rounded-lg text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                  <button
+                    onClick={checkDeliveryEligibility}
+                    disabled={!deliveryAddress || isCheckingDelivery}
+                    className="px-3 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-200 disabled:opacity-50 transition-colors"
+                  >
+                    {isCheckingDelivery ? "Checking..." : "Check"}
+                  </button>
+                </div>
+                {deliveryError && (
+                  <p className="text-xs text-red-500 mt-1">{deliveryError}</p>
+                )}
+                {deliveryFee !== null && (
+                  <p className="text-xs text-green-600 mt-1 font-medium">
+                    Delivery available: +${deliveryFee.toFixed(2)}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex items-center mb-4">
+                <label
+                  htmlFor="subscribe"
+                  className="flex items-center cursor-pointer group"
                 >
-                  {isProcessing ? 'Processing...' : 'Upgrade'}
+                  <div className="relative">
+                    <input
+                      type="checkbox"
+                      id="subscribe"
+                      className="sr-only"
+                      checked={isSubscription}
+                      onChange={(e) => setIsSubscription(e.target.checked)}
+                    />
+                    <div
+                      className={`block w-10 h-6 rounded-full transition-colors duration-300 ease-in-out ${isSubscription ? "bg-indigo-500 shadow-[0_0_10px_rgba(99,102,241,0.5)]" : "bg-gray-300"}`}
+                    ></div>
+                    <div
+                      className={`dot absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition-transform duration-300 ease-in-out shadow-sm ${isSubscription ? "transform translate-x-4" : ""}`}
+                    ></div>
+                  </div>
+                  <div className="ml-3 text-sm font-medium text-gray-700 group-hover:text-gray-900 transition-colors">
+                    Subscribe & Save 10%
+                  </div>
+                </label>
+              </div>
+
+              <div className="bg-green-50 border border-green-100 rounded-xl p-4 my-2 mb-4">
+                <div className="flex justify-between items-center">
+                  <span className="text-green-800 text-sm font-bold">
+                    Available Rewards
+                  </span>
+                  <span className="text-green-800 text-sm font-bold">
+                    1 Reward Available
+                  </span>
+                </div>
+                <p className="text-green-700 text-xs font-medium mt-1">
+                  You have earned a free coffee! Tap 'Pay' to automatically
+                  apply your reward at checkout.
+                </p>
+              </div>
+
+              <ShareAndSaveWidget
+                tenantId={tenant}
+                discountPercentage={10}
+                onShareComplete={() => setShareDiscountApplied(true)}
+              />
+
+              {deliveryFee !== null && (
+                <div className="flex justify-between items-center pt-2 border-t border-gray-100">
+                  <span className="font-semibold text-gray-700">
+                    Total with Delivery
+                  </span>
+                  <span className="text-xl font-bold font-outfit text-gray-900">
+                    $
+                    {(
+                      (45.0 + deliveryFee) *
+                      (useLoyaltyPoints && loyaltyDiscount
+                        ? 1 - loyaltyDiscount
+                        : 1) *
+                      (shareDiscountApplied ? 0.9 : 1)
+                    ).toFixed(2)}
+                  </span>
+                </div>
+              )}
+              {deliveryFee === null && (
+                <div className="flex justify-between items-center pt-2 border-t border-gray-100">
+                  <span className="font-semibold text-gray-700">Total</span>
+                  <span className="text-xl font-bold font-outfit text-gray-900">
+                    $
+                    {(
+                      45.0 *
+                      (useLoyaltyPoints && loyaltyDiscount
+                        ? 1 - loyaltyDiscount
+                        : 1) *
+                      (shareDiscountApplied ? 0.9 : 1)
+                    ).toFixed(2)}
+                  </span>
+                </div>
+              )}
+
+              <WithTooltip
+                id="checkout-pay-tooltip"
+                defaultText="Tap to quickly and securely pay for your order."
+              >
+                <button
+                  onClick={() => handlePayment(isSubscription)}
+                  disabled={isProcessing}
+                  className="w-full px-4 py-3 bg-black text-white rounded-lg font-medium hover:bg-gray-900 transition-colors shadow-sm flex items-center justify-center gap-2"
+                >
+                  {isSoldOut
+                    ? "Sold Out"
+                    : isProcessing
+                      ? "Processing..."
+                      : "Pay"}
                 </button>
               </WithTooltip>
 
-              <WithTooltip id="checkout-cancel-tooltip" defaultText="Go back to the previous screen without subscribing.">
+              {checkoutStatus && checkoutStatus !== "Item just sold out." && (
+                <p
+                  className="text-sm font-medium text-indigo-700"
+                  role="status"
+                >
+                  {checkoutStatus}
+                </p>
+              )}
+              {checkoutStatus === "Item just sold out." && (
+                <div className="fixed bottom-0 left-0 right-0 p-6 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] z-[100] shadow-2xl rounded-t-[24px]">
+                  <div className="flex items-start gap-4 max-w-lg mx-auto">
+                    <div className="w-12 h-12 bg-red-100 rounded-full flex-shrink-0 flex items-center justify-center text-xl text-red-600">
+                      <svg
+                        className="w-6 h-6"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                        />
+                      </svg>
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-bold text-gray-900 mb-1 font-outfit">
+                        Oops! Item just sold out.
+                      </h3>
+                      <p className="text-gray-600 text-sm leading-relaxed mb-4">
+                        Someone at our physical store is buying the last one
+                        right now. Check back in 15 minutes or browse similar
+                        items.
+                      </p>
+                      <button
+                        onClick={() => setCheckoutStatus("")}
+                        className="px-4 py-2 bg-gray-900 text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-colors"
+                      >
+                        Got it
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              <WithTooltip
+                id="checkout-cancel-tooltip"
+                defaultText="Go back to the previous screen without buying anything."
+              >
                 <button
-                  onClick={() => router.push('/pricing')}
+                  onClick={() => router.push("/pricing")}
                   className="w-full px-4 py-3 bg-gray-200 text-gray-800 rounded-lg font-medium hover:bg-gray-300 transition-colors"
                 >
                   Cancel
                 </button>
               </WithTooltip>
             </div>
-        ) : (
-          <>
-        <div
-          className="p-6 shadow-sm flex flex-col gap-4 mb-4"
-          style={{
-            background: "rgba(255, 255, 255, 0.65)",
-            backdropFilter: "blur(30px) saturate(210%)",
-            borderRadius: "24px",
-            border: "1px solid rgba(255, 255, 255, 0.4)",
-          }}
-        >
-          <div className="flex justify-between items-center pb-4 border-b border-gray-100">
-            <span className="font-semibold text-gray-700">Service Deposit</span>
-            <span className="text-xl font-bold font-outfit text-gray-900">
-              $45.00
-            </span>
-          </div>
-
-          <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4 my-2">
-            <p className="text-indigo-800 text-xs font-medium">
-              A 20% discount ({(discountParam && !isNaN(Number(discountParam))) ? discountParam : "20"}%) has been applied to this order automatically.
-            </p>
-          </div>
-
-          {true && (
-            <div className="bg-indigo-50/50 border border-indigo-100/50 rounded-xl p-4 my-2 backdrop-blur-md cursor-pointer hover:bg-indigo-50/80 transition-colors" onClick={() => setUseLoyaltyPoints(!useLoyaltyPoints)}>
-              <div className="flex justify-between items-center">
-                <div>
-                  <p className="text-indigo-900 text-sm font-bold font-outfit">Neighborhood Collective Points</p>
-                  <p className="text-indigo-800 text-xs font-medium">You have {availablePoints} points available</p>
-                </div>
-                <div className="flex items-center gap-3">
-                  <span className="text-indigo-600 text-sm font-bold">{loyaltyDiscount ? `-${loyaltyDiscount * 100}% off` : '0% off'}</span>
-                  <div className={`w-10 h-6 rounded-full flex items-center p-1 transition-colors ${useLoyaltyPoints ? 'bg-indigo-600' : 'bg-gray-300'}`}>
-                    <div className={`bg-white w-4 h-4 rounded-full shadow-sm transform transition-transform ${useLoyaltyPoints ? 'translate-x-4' : 'translate-x-0'}`}></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          <div className="flex flex-col gap-2">
-            <label className="text-sm font-semibold text-gray-700">Delivery Address (Optional)</label>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={deliveryAddress}
-                onChange={(e) => setDeliveryAddress(e.target.value)}
-                placeholder="Enter address for delivery quote"
-                className="flex-1 px-3 py-2 bg-white border border-gray-200 rounded-lg text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-              />
-              <button
-                onClick={checkDeliveryEligibility}
-                disabled={!deliveryAddress || isCheckingDelivery}
-                className="px-3 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-200 disabled:opacity-50 transition-colors"
-              >
-                {isCheckingDelivery ? "Checking..." : "Check"}
-              </button>
-            </div>
-            {deliveryError && <p className="text-xs text-red-500 mt-1">{deliveryError}</p>}
-            {deliveryFee !== null && <p className="text-xs text-green-600 mt-1 font-medium">Delivery available: +${deliveryFee.toFixed(2)}</p>}
-          </div>
-
-          <div className="flex items-center mb-4">
-            <label htmlFor="subscribe" className="flex items-center cursor-pointer group">
-              <div className="relative">
-                <input
-                  type="checkbox"
-                  id="subscribe"
-                  className="sr-only"
-                  checked={isSubscription}
-                  onChange={(e) => setIsSubscription(e.target.checked)}
-                />
-                <div className={`block w-10 h-6 rounded-full transition-colors duration-300 ease-in-out ${isSubscription ? 'bg-indigo-500 shadow-[0_0_10px_rgba(99,102,241,0.5)]' : 'bg-gray-300'}`}></div>
-                <div className={`dot absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition-transform duration-300 ease-in-out shadow-sm ${isSubscription ? 'transform translate-x-4' : ''}`}></div>
-              </div>
-              <div className="ml-3 text-sm font-medium text-gray-700 group-hover:text-gray-900 transition-colors">
-                Subscribe & Save 10%
-              </div>
-            </label>
-          </div>
-
-          <div className="bg-green-50 border border-green-100 rounded-xl p-4 my-2 mb-4">
-            <div className="flex justify-between items-center">
-              <span className="text-green-800 text-sm font-bold">Available Rewards</span>
-              <span className="text-green-800 text-sm font-bold">1 Reward Available</span>
-            </div>
-            <p className="text-green-700 text-xs font-medium mt-1">
-              You have earned a free coffee! Tap 'Pay' to automatically apply your reward at checkout.
-            </p>
-          </div>
-
-          <ShareAndSaveWidget
-            tenantId={tenant}
-            discountPercentage={10}
-            onShareComplete={() => setShareDiscountApplied(true)}
-          />
-
-          {deliveryFee !== null && (
-             <div className="flex justify-between items-center pt-2 border-t border-gray-100">
-               <span className="font-semibold text-gray-700">Total with Delivery</span>
-               <span className="text-xl font-bold font-outfit text-gray-900">
-                 ${(((45.00 + deliveryFee) * (useLoyaltyPoints && loyaltyDiscount ? (1 - loyaltyDiscount) : 1)) * (shareDiscountApplied ? 0.9 : 1)).toFixed(2)}
-               </span>
-             </div>
-          )}
-          {deliveryFee === null && (
-             <div className="flex justify-between items-center pt-2 border-t border-gray-100">
-               <span className="font-semibold text-gray-700">Total</span>
-               <span className="text-xl font-bold font-outfit text-gray-900">
-                 ${((45.00 * (useLoyaltyPoints && loyaltyDiscount ? (1 - loyaltyDiscount) : 1)) * (shareDiscountApplied ? 0.9 : 1)).toFixed(2)}
-               </span>
-             </div>
-          )}
-
-          <WithTooltip
-            id="checkout-pay-tooltip"
-            defaultText="Tap to quickly and securely pay for your order."
-          >
-            <button
-              onClick={() => handlePayment(isSubscription)}
-              disabled={isProcessing}
-              className="w-full px-4 py-3 bg-black text-white rounded-lg font-medium hover:bg-gray-900 transition-colors shadow-sm flex items-center justify-center gap-2"
-            >
-              {isSoldOut ? "Sold Out" : isProcessing ? "Processing..." : "Pay"}
-            </button>
-          </WithTooltip>
-
-          {checkoutStatus && checkoutStatus !== "Item just sold out." && (
-            <p className="text-sm font-medium text-indigo-700" role="status">
-              {checkoutStatus}
-            </p>
-          )}
-          {checkoutStatus === "Item just sold out." && (
-            <div className="fixed bottom-0 left-0 right-0 p-6 bg-white/80 backdrop-blur-xl border-t border-gray-200 z-[100] shadow-2xl rounded-t-[24px]">
-              <div className="flex items-start gap-4 max-w-lg mx-auto">
-                <div className="w-12 h-12 bg-red-100 rounded-full flex-shrink-0 flex items-center justify-center text-xl text-red-600">
-                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-                </div>
-                <div>
-                  <h3 className="text-lg font-bold text-gray-900 mb-1 font-outfit">Oops! Item just sold out.</h3>
-                  <p className="text-gray-600 text-sm leading-relaxed mb-4">
-                    Someone at our physical store is buying the last one right now. Check back in 15 minutes or browse similar items.
-                  </p>
-                  <button
-                    onClick={() => setCheckoutStatus("")}
-                    className="px-4 py-2 bg-gray-900 text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-colors"
-                  >
-                    Got it
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-
-          <WithTooltip
-            id="checkout-cancel-tooltip"
-            defaultText="Go back to the previous screen without buying anything."
-          >
-            <button
-              onClick={() => router.push("/pricing")}
-              className="w-full px-4 py-3 bg-gray-200 text-gray-800 rounded-lg font-medium hover:bg-gray-300 transition-colors"
-            >
-              Cancel
-            </button>
-          </WithTooltip>
-        </div>
-        </>
+          </>
         )}
 
         {/* Powered By OHC Footer */}
@@ -433,14 +565,27 @@ function CheckoutContent() {
                 </h3>
               </div>
               <p className="text-indigo-800 text-xs font-medium">
-                Give a 20% discount to friends and get a 10% commission when they
-                make their first purchase! <a href={`/onboarding?ref=${tenant}&source=checkout_affiliate`} target="_blank" className="font-bold hover:underline" onClick={(e) => {
-                  fetch('/api/v1/growth/referrals/click', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ referrer_id: tenant, source: 'checkout_affiliate' })
-                  }).catch(() => { /* ignore */ });
-                }}>⚡ Powered by OHC</a>
+                Give a 20% discount to friends and get a 10% commission when
+                they make their first purchase!{" "}
+                <a
+                  href={`/onboarding?ref=${tenant}&source=checkout_affiliate`}
+                  target="_blank"
+                  className="font-bold hover:underline"
+                  onClick={(e) => {
+                    fetch("/api/v1/growth/referrals/click", {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({
+                        referrer_id: tenant,
+                        source: "checkout_affiliate",
+                      }),
+                    }).catch(() => {
+                      /* ignore */
+                    });
+                  }}
+                >
+                  ⚡ Powered by OHC
+                </a>
               </p>
             </div>
 
@@ -475,7 +620,13 @@ function CheckoutContent() {
 
 export default function CheckoutPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen flex items-center justify-center font-inter text-gray-500">Loading Checkout...</div>}>
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center font-inter text-gray-500">
+          Loading Checkout...
+        </div>
+      }
+    >
       <CheckoutContent />
     </Suspense>
   );

--- a/src/ui/next/src/app/smart-pricing/page.tsx
+++ b/src/ui/next/src/app/smart-pricing/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import React, { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function SmartPricingPage() {
   const router = useRouter();
@@ -13,37 +13,46 @@ export default function SmartPricingPage() {
 
   useEffect(() => {
     // Only fetch on client
-    if (typeof window !== 'undefined') {
-      const savedEnabled = localStorage.getItem('smartPricingEnabled');
+    if (typeof window !== "undefined") {
+      const savedEnabled = localStorage.getItem("smartPricingEnabled");
       if (savedEnabled !== null) setEnabled(JSON.parse(savedEnabled));
 
-      const savedPerishables = localStorage.getItem('smartPricingPerishables');
-      if (savedPerishables !== null) setDiscountPerishables(JSON.parse(savedPerishables));
+      const savedPerishables = localStorage.getItem("smartPricingPerishables");
+      if (savedPerishables !== null)
+        setDiscountPerishables(JSON.parse(savedPerishables));
 
-      const savedSurge = localStorage.getItem('smartPricingSurge');
+      const savedSurge = localStorage.getItem("smartPricingSurge");
       if (savedSurge !== null) setSurgePricing(JSON.parse(savedSurge));
 
-      const savedMax = localStorage.getItem('smartPricingMaxAdjustment');
+      const savedMax = localStorage.getItem("smartPricingMaxAdjustment");
       if (savedMax !== null) setMaxAdjustment(parseInt(savedMax, 10));
     }
   }, []);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('smartPricingEnabled', JSON.stringify(enabled));
-      localStorage.setItem('smartPricingPerishables', JSON.stringify(discountPerishables));
-      localStorage.setItem('smartPricingSurge', JSON.stringify(surgePricing));
-      localStorage.setItem('smartPricingMaxAdjustment', maxAdjustment.toString());
+    if (typeof window !== "undefined") {
+      localStorage.setItem("smartPricingEnabled", JSON.stringify(enabled));
+      localStorage.setItem(
+        "smartPricingPerishables",
+        JSON.stringify(discountPerishables),
+      );
+      localStorage.setItem("smartPricingSurge", JSON.stringify(surgePricing));
+      localStorage.setItem(
+        "smartPricingMaxAdjustment",
+        maxAdjustment.toString(),
+      );
 
       // Simulate real backend mutation loop silently if enabled
       if (enabled) {
-         fetch('/api/agents/approvals/simulate-smart-pricing', {
-            method: 'POST',
-            headers: {
-              'Authorization': `Bearer ${localStorage.getItem('token') || ''}`,
-              'Content-Type': 'application/json'
-            }
-         }).catch(() => { /* silent fail in local mode */ });
+        fetch("/api/agents/approvals/simulate-smart-pricing", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("token") || ""}`,
+            "Content-Type": "application/json",
+          },
+        }).catch(() => {
+          /* silent fail in local mode */
+        });
       }
     }
   }, [enabled, discountPerishables, surgePricing, maxAdjustment]);
@@ -51,9 +60,14 @@ export default function SmartPricingPage() {
   return (
     <div className="flex flex-col min-h-screen font-inter bg-[#F5F5F7]">
       <header className="px-6 py-4 flex items-center justify-between border-b border-white/40 dark:border-white/10 sticky top-0 z-50 bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] backdrop-saturate-[2.1]">
-        <h1 className="text-2xl font-bold font-outfit text-[#1D1D1F] tracking-[-0.02em]">Smart Pricing</h1>
+        <h1 className="text-2xl font-bold font-outfit text-[#1D1D1F] tracking-[-0.02em]">
+          Smart Pricing
+        </h1>
         <div className="flex items-center min-h-[44px]">
-          <button onClick={() => router.push('/dashboard')} className="px-4 py-2 bg-gray-200 rounded-[16px] text-sm font-medium hover:bg-gray-300 transition-colors">
+          <button
+            onClick={() => router.push("/dashboard")}
+            className="px-4 py-2 bg-gray-200 rounded-[16px] text-sm font-medium hover:bg-gray-300 transition-colors"
+          >
             Back to Dashboard
           </button>
         </div>
@@ -61,13 +75,20 @@ export default function SmartPricingPage() {
 
       <main className="p-6 md:p-8 flex-1 max-w-3xl mx-auto w-full flex flex-col gap-6">
         <div className="text-center mb-4">
-          <p className="text-lg text-[#86868B]">Let AI automatically adjust your prices to maximize revenue and clear inventory, while staying within your safe limits.</p>
+          <p className="text-lg text-[#86868B]">
+            Let AI automatically adjust your prices to maximize revenue and
+            clear inventory, while staying within your safe limits.
+          </p>
         </div>
 
-        <div className="p-6 shadow-sm rounded-[16px] flex items-center justify-between bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] backdrop-saturate-[2.1] border border-white/40 dark:border-white/10">
+        <div className="p-6 shadow-sm rounded-[16px] flex items-center justify-between bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)]">
           <div>
-            <h3 className="text-lg font-semibold font-outfit text-[#1D1D1F]">Enable Smart Pricing</h3>
-            <p className="text-sm text-gray-500 mt-1">Turn on autonomous hyper-local dynamic pricing.</p>
+            <h3 className="text-lg font-semibold font-outfit text-[#1D1D1F]">
+              Enable Smart Pricing
+            </h3>
+            <p className="text-sm text-gray-500 mt-1">
+              Turn on autonomous hyper-local dynamic pricing.
+            </p>
           </div>
           <div className="flex items-center min-h-[44px]">
             <button
@@ -75,21 +96,29 @@ export default function SmartPricingPage() {
               aria-pressed={enabled}
               data-testid="enable-smart-pricing-toggle"
               onClick={() => setEnabled(!enabled)}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${enabled ? 'bg-[#34C759]' : 'bg-gray-300'}`}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${enabled ? "bg-[#34C759]" : "bg-gray-300"}`}
             >
-              <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${enabled ? 'translate-x-6' : 'translate-x-1'}`} />
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${enabled ? "translate-x-6" : "translate-x-1"}`}
+              />
             </button>
           </div>
         </div>
 
         {enabled && (
-          <div className="p-6 shadow-sm rounded-[16px] flex flex-col gap-6 bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] backdrop-saturate-[2.1] border border-white/40 dark:border-white/10">
-            <h3 className="text-lg font-semibold font-outfit border-b pb-2 text-[#1D1D1F] border-black/10">Configuration</h3>
+          <div className="p-6 shadow-sm rounded-[16px] flex flex-col gap-6 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)]">
+            <h3 className="text-lg font-semibold font-outfit border-b pb-2 text-[#1D1D1F] border-black/10">
+              Configuration
+            </h3>
 
             <div className="flex items-center justify-between gap-4">
               <div className="flex-1">
-                <p className="font-medium text-[#1D1D1F]">Auto-discount perishables 2 hours before closing</p>
-                <p className="text-xs text-gray-500 mt-1">Clear out remaining inventory today.</p>
+                <p className="font-medium text-[#1D1D1F]">
+                  Auto-discount perishables 2 hours before closing
+                </p>
+                <p className="text-xs text-gray-500 mt-1">
+                  Clear out remaining inventory today.
+                </p>
               </div>
               <div className="flex items-center min-h-[44px]">
                 <button
@@ -97,17 +126,23 @@ export default function SmartPricingPage() {
                   aria-pressed={discountPerishables}
                   data-testid="discount-perishables-toggle"
                   onClick={() => setDiscountPerishables(!discountPerishables)}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${discountPerishables ? 'bg-[#0066FF]' : 'bg-gray-300'}`}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${discountPerishables ? "bg-[#0066FF]" : "bg-gray-300"}`}
                 >
-                  <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${discountPerishables ? 'translate-x-6' : 'translate-x-1'}`} />
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${discountPerishables ? "translate-x-6" : "translate-x-1"}`}
+                  />
                 </button>
               </div>
             </div>
 
             <div className="flex items-center justify-between gap-4">
               <div className="flex-1">
-                <p className="font-medium text-[#1D1D1F]">Surge pricing during high demand</p>
-                <p className="text-xs text-gray-500 mt-1">Charge a premium during peak rush hours.</p>
+                <p className="font-medium text-[#1D1D1F]">
+                  Surge pricing during high demand
+                </p>
+                <p className="text-xs text-gray-500 mt-1">
+                  Charge a premium during peak rush hours.
+                </p>
               </div>
               <div className="flex items-center min-h-[44px]">
                 <button
@@ -115,17 +150,23 @@ export default function SmartPricingPage() {
                   aria-pressed={surgePricing}
                   data-testid="surge-pricing-toggle"
                   onClick={() => setSurgePricing(!surgePricing)}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${surgePricing ? 'bg-[#0066FF]' : 'bg-gray-300'}`}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${surgePricing ? "bg-[#0066FF]" : "bg-gray-300"}`}
                 >
-                  <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${surgePricing ? 'translate-x-6' : 'translate-x-1'}`} />
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${surgePricing ? "translate-x-6" : "translate-x-1"}`}
+                  />
                 </button>
               </div>
             </div>
 
             <div className="mt-4">
               <div className="flex justify-between items-center mb-2">
-                <label className="font-medium text-[#1D1D1F]">Maximum price adjustment bounds (+/-)</label>
-                <span className="font-bold text-blue-600">{maxAdjustment}%</span>
+                <label className="font-medium text-[#1D1D1F]">
+                  Maximum price adjustment bounds (+/-)
+                </label>
+                <span className="font-bold text-blue-600">
+                  {maxAdjustment}%
+                </span>
               </div>
               <div className="flex items-center min-h-[44px]">
                 <input
@@ -145,11 +186,15 @@ export default function SmartPricingPage() {
         )}
       </main>
 
-      <style dangerouslySetInnerHTML={{__html: `
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@500;600;700;800&display=swap');
         .font-inter { font-family: 'Inter', sans-serif; }
         .font-outfit { font-family: 'Outfit', sans-serif; }
-      `}} />
+      `,
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
This commit enhances the UI by implementing the "Translucent Glass standards" detailed in the system instructions. Specifically, the hardcoded Tailwind arbitrary values for standard iOS/macOS-like translucent and blur backgrounds have been systematically added.

Files touched:
- `src/ui/next/src/app/checkout/page.tsx`
- `src/ui/next/src/app/smart-pricing/page.tsx`

Tests pass successfully locally.

---
*PR created automatically by Jules for task [17602128934498252444](https://jules.google.com/task/17602128934498252444) started by @ql-owo-lp*