### PR TITLE
🛡️ Sentry: [reliability fix] Fix ML-Resilience DB timeouts properly

### DIFF
--- a/src/server/chaos_db_test.rs
+++ b/src/server/chaos_db_test.rs
@@ -59,19 +59,34 @@ mod chaos_db_tests {
         assert_eq!(count, 50);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_sql_sync_lag() {
         // We simulate a long-running sync (lag) that times out.
-        // We enforce the 60-second ML-Resilience rule here by using tokio::time::timeout
-        // and expecting an error.
-        let timeout_duration = std::time::Duration::from_secs(60);
-        let result = tokio::time::timeout(timeout_duration, async {
-            // Simulate a query that takes longer than the timeout due to sync lag
-            tokio::time::sleep(std::time::Duration::from_secs(65)).await;
-            Ok::<(), String>(())
-        })
-        .await;
+        // We enforce the 60-second ML-Resilience rule here by simulating
+        // a database operation that hangs for 65 seconds using tokio's
+        // time pausing (so the test runs instantly).
+        let db_id = uuid::Uuid::new_v4().to_string();
+        let uri = format!("sqlite:file:{}?mode=memory&cache=shared", db_id);
 
-        assert!(result.is_err(), "Sync operation should time out to prevent cascading failures");
+        let sqlite_pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(&uri)
+            .await
+            .unwrap();
+
+        let db = Arc::new(DB {
+            pool: sqlx::postgres::PgPoolOptions::new().connect_lazy("postgres://dummy").unwrap(),
+            store: DbStore::Sqlite(sqlite_pool.clone()),
+        });
+
+        // Test the actual execute_with_retry timeout logic
+        let res: Result<(), String> = db.execute_with_retry("slow_query", || async {
+            // Simulate a query that takes longer than the timeout
+            tokio::time::sleep(std::time::Duration::from_secs(65)).await;
+            Ok(())
+        }).await;
+
+        assert!(res.is_err(), "Sync operation should time out to prevent cascading failures");
+        assert!(res.unwrap_err().contains("timed out after 60 seconds"), "Must be explicitly timed out by ML-Resilience rule");
     }
 }

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -637,10 +637,7 @@ impl DB {
 
         // Enforce the 60-second ML-Resilience rule for database operations
         let start_time = std::time::Instant::now();
-        #[cfg(not(test))]
         let timeout_duration = std::time::Duration::from_secs(60);
-        #[cfg(test)]
-        let timeout_duration = std::time::Duration::from_millis(2000);
 
         loop {
             if start_time.elapsed() > timeout_duration {


### PR DESCRIPTION
🛡️ Sentry: [reliability fix] Fix ML-Resilience DB timeouts properly

Loaded superpowers skills:
- https://github.com/obra/superpowers/

1. Updated `timeout_duration` in `db.execute_with_retry` to properly enforce the 60-second ML-Resilience rule for tests as well as production. This avoids masking timeout logic behind test-only compilation flags.
2. In `chaos_db_test.rs`, fixed `test_sql_sync_lag` to leverage `#[tokio::test(start_paused = true)]`. This allows the 65-second sleep to advance instantly while correctly testing the actual `db.execute_with_retry` timeout mechanism. This proves the 60-second limit is working without stalling Bazel or CI test suites.

All tests remain hermetic and cacheable without relaxing assertions or sacrificing test suite speed.

---
*PR created automatically by Jules for task [11863046643513814532](https://jules.google.com/task/11863046643513814532) started by @ql-owo-lp*