### PR TITLE
Wizard: Remove domain step

### DIFF
--- a/src/e2e/onboarding_cuj.spec.ts
+++ b/src/e2e/onboarding_cuj.spec.ts
@@ -66,10 +66,9 @@ test.describe('Onboarding Wizard CUJ', () => {
     await page.locator('[data-testid="next-step-btn"][data-next="step-offer"]').click();
 
     await page.getByTestId('first-offer').fill('Chocolate Cake');
-    await page.locator('[data-testid="next-step-btn"][data-next="step-domain"]').click();
+    await page.locator('#step-offer [data-testid="next-step-btn"][data-next="step-template"]').click();
 
-    await page.getByTestId('domain-name').fill('my-bakery-shop');
-    await page.locator('[data-testid="next-step-btn"][data-next="step-template"]').click();
+
 
     await page.getByTestId('template-selection').selectOption('Modern');
 
@@ -118,7 +117,7 @@ test.describe('Onboarding Wizard CUJ', () => {
     await page.locator('[data-testid="next-step-btn"][data-next="step-offer"]').click();
 
     // Do not fill offer, try to proceed
-    await page.locator('[data-testid="next-step-btn"][data-next="step-domain"]').click();
+    await page.locator('#step-offer [data-testid="next-step-btn"][data-next="step-template"]').click();
 
     // Expect validation failure message
     await expect(page.getByText('Please enter an offer.')).toBeVisible();

--- a/src/e2e/setup.spec.ts
+++ b/src/e2e/setup.spec.ts
@@ -43,10 +43,7 @@ test.describe('OHC Setup Wizard Flow', () => {
     await page.locator('[data-testid="next-step-btn"][data-next="step-offer"]').click();
     // Offer step
     await page.getByTestId('first-offer').fill('Chocolate Cake');
-    await page.locator('[data-testid="next-step-btn"][data-next="step-domain"]').click();
-    // Domain step
-    await page.getByTestId('domain-name').fill('my-bakery-shop');
-    await page.locator('[data-testid="next-step-btn"][data-next="step-template"]').click();
+    await page.locator('#step-offer [data-testid="next-step-btn"][data-next="step-template"]').click();
     // Template step
     await page.getByTestId('template-selection').selectOption('Modern');
     // Make sure finish btn is visible before interacting
@@ -155,7 +152,7 @@ test.describe('OHC Setup Wizard Flow', () => {
     // Skip to template step (mock localStorage)
     await page.evaluate(() => {
         localStorage.setItem('onboardingState', JSON.stringify({
-            step: 8, // step-template
+            step: 7, // step-template
             businessName: 'Error Bakery',
             categories: 'Bakery',
             templateSelection: 'Modern'

--- a/src/e2e/tauri_onboarding.spec.ts
+++ b/src/e2e/tauri_onboarding.spec.ts
@@ -83,6 +83,7 @@ test.describe('Tauri Onboarding Wizard Flow', () => {
     // We mocked start btn but it relies on index.html script redirect, which might be intercepted or missing full context in playwright mock scheme.
     // Just explicitly go there since the button just does a simple location.href.
     await page.goto('http://mock/setup.html');
+    await page.getByRole('button', { name: 'Conversational Setup' }).click();
 
 
     // Initial Setup Step: Conversational Setup
@@ -183,12 +184,7 @@ test.describe('Tauri Onboarding Wizard Flow', () => {
     await page.locator('#step-offer').getByRole('button', { name: 'Next' }).click();
 
 
-    // Step 7: Domain
-    await expect(page.getByRole('heading', { name: "Where will your business live?" })).toBeVisible();
-    await page.getByPlaceholder("my-business").fill("test-business");
-    await page.locator('#step-domain').getByRole('button', { name: 'Next' }).click();
-
-    // Step 8: Template
+    // Step 7: Template
     await expect(page.getByRole('heading', { name: "Template Selection" })).toBeVisible();
 
     // Verify validation triggers
@@ -278,13 +274,7 @@ test.describe('Tauri Onboarding Wizard Flow', () => {
     await newPage.locator('#step-offer').getByRole('button', { name: 'Next' }).click();
 
 
-    // Step 7: Domain
-    await expect(newPage.getByRole('heading', { name: "Where will your business live?" })).toBeVisible();
-    await newPage.getByPlaceholder("my-business").fill("test-business");
-    await expect(newPage.getByPlaceholder("my-business")).toHaveValue("test-business");
-    await newPage.locator('#step-domain').getByRole('button', { name: 'Next' }).click();
-
-    // Step 8: Template
+    // Step 7: Template
     await expect(newPage.getByRole('heading', { name: "Template Selection" })).toBeVisible();
 
 

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1052,7 +1052,7 @@
         <div class="step-indicator" data-step="step-assistant"></div>
         <div class="step-indicator" data-step="step-admin"></div>
         <div class="step-indicator" data-step="step-offer"></div>
-        <div class="step-indicator" data-step="step-domain"></div>
+
         <div class="step-indicator" data-step="step-template"></div>
       </div>
       <div id="draft-saved-msg" style="display: none; color: #34C759; font-weight: bold; margin-bottom: 15px;">Draft Saved!</div>
@@ -1262,28 +1262,13 @@
         <input type="text" id="first-offer" data-testid="first-offer" class="glassmorphism" placeholder="e.g. I bake custom vegan cakes" inputmode="text" autocomplete="off" enterkeyhint="next" />
         <div id="offer-error" class="error-msg" aria-live="polite">Please enter an offer.</div>
         <div class="btn-group">
-          <button class="next-step-btn" aria-label="Next Step" title="Next Step" data-testid="next-step-btn" data-next="step-domain">Next</button> <!-- Replaced by script below -->
+          <button class="next-step-btn" aria-label="Next Step" title="Next Step" data-testid="next-step-btn" data-next="step-template">Next</button> <!-- Replaced by script below -->
           <button type="button" class="btn-secondary save-draft-btn" aria-label="Save Draft" title="Save Draft" data-testid="save-draft-btn">Save Draft</button>
           <button class="btn-secondary prev-step-btn" aria-label="Previous Step" title="Previous Step" data-testid="prev-step-btn" data-prev="step-admin">Back</button>
         </div>
       </div>
 
-      <!-- Step 7: Domain -->
-      <div class="step" id="step-domain">
-        <h1>Where will your business live?</h1>
-        <p>Choose a free subdomain for your store.</p>
-        <div style="display: flex; align-items: center; gap: 8px;">
-          <input type="text" id="domain-name" data-testid="domain-name" class="glassmorphism" placeholder="my-business" inputmode="url" autocapitalize="none" autocorrect="off" enterkeyhint="done" style="flex: 1; margin-bottom: 0;" />
-          <span style="font-size: 16px; color: #555;">.onehumancorp.com</span>
-        </div>
-        <div id="domain-error" class="error-msg" aria-live="polite" style="margin-top: 15px;">Please enter a valid domain name (alphanumeric and hyphens only).</div>
 
-        <div class="btn-group" style="margin-top: 20px;">
-          <button class="next-step-btn" aria-label="Next Step" title="Next Step" data-testid="next-step-btn" data-next="step-template">Next</button>
-          <button type="button" class="btn-secondary save-draft-btn" aria-label="Save Draft" title="Save Draft" data-testid="save-draft-btn">Save Draft</button>
-          <button class="btn-secondary prev-step-btn" aria-label="Previous Step" title="Previous Step" data-testid="prev-step-btn" data-prev="step-offer">Back</button>
-        </div>
-      </div>
 
       <!-- Step 8: Template -->
       <div class="step" id="step-template">
@@ -1301,7 +1286,7 @@
           <div id="submit-error" class="error-msg" aria-live="polite"></div>
           <button id="finish-btn" data-testid="finish-btn" aria-label="Launch Store" title="Launch Store">Launch Store</button>
           <button type="button" class="btn-secondary save-draft-btn" aria-label="Save Draft" title="Save Draft" data-testid="save-draft-btn">Save Draft</button>
-          <button class="btn-secondary prev-step-btn" aria-label="Previous Step" title="Previous Step" data-testid="prev-step-btn" data-prev="step-domain">Back</button>
+          <button class="btn-secondary prev-step-btn" aria-label="Previous Step" title="Previous Step" data-testid="prev-step-btn" data-prev="step-offer">Back</button>
         </div>
       </div>
 
@@ -1471,7 +1456,7 @@
       if (state.step === undefined || state.step === 0) {
          goToStep('step-initial');
       } else {
-         const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'];
+         const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template', 'step-instant', 'step-chat'];
          if (state.step < steps.length) {
             goToStep(steps[state.step]);
          }
@@ -1548,7 +1533,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           }
 
           if (state.step !== undefined && state.step > 0) {
-              const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'];
+              const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template', 'step-instant', 'step-chat'];
               if (state.step < steps.length) {
                   goToStep(steps[state.step]);
               }
@@ -1580,7 +1565,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           let stepNumber = 0;
           const activeStep = document.querySelector('.step.active');
           if (activeStep) {
-              stepNumber = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'].indexOf(activeStep.id);
+              stepNumber = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template', 'step-instant', 'step-chat'].indexOf(activeStep.id);
               if (stepNumber === -1) stepNumber = 0;
           }
           state.step = stepNumber;
@@ -1702,18 +1687,6 @@ if (state.capabilities && document.getElementById('cap-draft')) {
                   state.first_offer = inputs.firstOffer.value.trim();
               }
           }
-          else if (stepId === 'step-domain') {
-              const domainVal = inputs.domainName.value.trim();
-              if (domainVal === '' || !/^[a-zA-Z0-9-]+$/.test(domainVal)) {
-                  errors.domainName.style.display = 'block';
-                  if(inputs.domainName) inputs.domainName.style.borderColor = '#FF3B30';
-                  isValid = false;
-              } else {
-                  errors.domainName.style.display = 'none';
-                  if(inputs.domainName) inputs.domainName.style.borderColor = 'rgba(255, 255, 255, 0.5)';
-                  state.domain = domainVal;
-              }
-          }
           else if (stepId === 'step-template') {
               if (inputs.templateSelection.value === '') {
                   errors.templateSelection.style.display = 'block';
@@ -1752,7 +1725,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
               if (stepperIndicator) stepperIndicator.style.display = 'flex';
           }
 
-          const steps = ['step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template'];
+          const steps = ['step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template'];
           const currentIndex = steps.indexOf(stepId);
           if (stepperIndicator) stepperIndicator.setAttribute('aria-valuenow', currentIndex + 1);
 


### PR DESCRIPTION
Removed the domain setup step from the onboarding setup wizard to streamline the first-time setup experience.

- Deleted the `step-domain` HTML structure and its associated script validation logic from `src/ui/tauri/src/ui/setup.html`.
- Rewired the navigation attributes (`data-prev` and `data-next`) so the step flow proceeds directly from "Offer" (`step-offer`) to "Template Selection" (`step-template`).
- Cleaned up the JavaScript state array indexing logic to omit `step-domain`.
- Addressed Playwright end-to-end tests by updating the workflows in `onboarding_cuj.spec.ts`, `setup.spec.ts`, and `tauri_onboarding.spec.ts`.
- Removed stale and orphaned dead HTML chunks associated with the bypassed step.
- Adjusted strict mode locators inside test suites to target appropriate 'Next' buttons and guarantee safe resolution. All 18 tests run completely successfully.

---
*PR created automatically by Jules for task [15442113401926065296](https://jules.google.com/task/15442113401926065296) started by @ql-owo-lp*