### PR TITLE
chore(queue): Clean up stagnant backlog items safely

### DIFF
--- a/src/server/queue.rs
+++ b/src/server/queue.rs
@@ -148,18 +148,22 @@ impl TaskQueue for MemoryTaskQueue {
 
     async fn cleanup_stale_jobs(&self) -> Result<u64, String> {
         let stale_threshold = Utc::now() - chrono::Duration::hours(1);
+        let stagnant_threshold = Utc::now() - chrono::Duration::hours(24);
         let mut count = 0;
         let mut to_update = Vec::new();
 
         for job in self.jobs.iter() {
             if job.status == "RUNNING" && job.updated_at < stale_threshold {
                 to_update.push(job.id.clone());
+            } else if job.status == "QUEUED" && job.created_at < stagnant_threshold {
+                to_update.push(job.id.clone());
             }
         }
 
         for id in to_update {
             if let Some(mut job) = self.jobs.get_mut(&id) {
-                if job.status == "RUNNING" && job.updated_at < stale_threshold {
+                if (job.status == "RUNNING" && job.updated_at < stale_threshold) ||
+                   (job.status == "QUEUED" && job.created_at < stagnant_threshold) {
                     job.status = "FAILED".to_string();
                     job.updated_at = Utc::now();
                     count += 1;
@@ -418,8 +422,28 @@ impl TaskQueue for PostgresTaskQueue {
         .await
         .map_err(|e| e.to_string())?;
 
+        // Clean up stagnant backlog items: QUEUED jobs stuck for > 24 hours
+        sqlx::query(
+            "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
+             SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload::text, '{}'), 'Stagnant backlog item stuck in QUEUED for > 24 hours'
+             FROM sub_agent_queue
+             WHERE status = 'QUEUED' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
+        )
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?;
+
+        let stagnant_result = sqlx::query(
+            "UPDATE sub_agent_queue
+             SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP
+             WHERE status = 'QUEUED' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
+        )
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?;
+
         tx.commit().await.map_err(|e| e.to_string())?;
-        Ok(result.rows_affected())
+        Ok(result.rows_affected() + stagnant_result.rows_affected())
     }
 }
 
@@ -1123,9 +1147,29 @@ impl TaskQueue for SqliteTaskQueue {
         .execute(&self.pool)
         .await;
 
-        match result {
-            Ok(r) => Ok(r.rows_affected()),
-            Err(_) => Ok(0), // Ignore errors if table doesn't exist or isn't used
+        // Clean up stagnant backlog items: QUEUED jobs stuck for > 24 hours
+        let _ = sqlx::query(
+            "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
+             SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload, '{}'), 'Stagnant backlog item stuck in QUEUED for > 24 hours'
+             FROM sub_agent_queue
+             WHERE status = 'QUEUED' AND created_at < datetime('now', '-24 hour')"
+        )
+        .execute(&self.pool)
+        .await;
+
+        let stagnant_result = sqlx::query(
+            "UPDATE sub_agent_queue
+             SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP
+             WHERE status = 'QUEUED' AND created_at < datetime('now', '-24 hour')"
+        )
+        .execute(&self.pool)
+        .await;
+
+        match (result, stagnant_result) {
+            (Ok(r), Ok(sr)) => Ok(r.rows_affected() + sr.rows_affected()),
+            (Ok(r), Err(_)) => Ok(r.rows_affected()),
+            (Err(_), Ok(sr)) => Ok(sr.rows_affected()),
+            (Err(_), Err(_)) => Ok(0), // Ignore errors if table doesn't exist or isn't used
         }
     }
 }
@@ -1340,6 +1384,27 @@ impl TaskQueue for RedisTaskQueue {
                         .await
                         .map_err(|e| e.to_string())?;
                     stale_count += 1;
+                }
+            }
+        }
+
+        // Clean up stagnant backlog items: QUEUED jobs stuck for > 24 hours
+        let list_len: isize = redis::cmd("LLEN").arg(&self.queue_name).query_async(&mut conn).await.map_err(|e| e.to_string())?;
+        if list_len > 0 {
+            let items: Vec<Vec<u8>> = redis::cmd("LRANGE").arg(&self.queue_name).arg(0).arg(list_len - 1).query_async(&mut conn).await.map_err(|e| e.to_string())?;
+            let stagnant_threshold_ms = (Utc::now() - chrono::Duration::hours(24)).timestamp_millis();
+
+            for item in items {
+                if let Ok(queue_job) = <::server_ohc::interop::QueueJob as prost::Message>::decode(&item[..]) {
+                    if queue_job.status == "QUEUED" && queue_job.created_at_ms < stagnant_threshold_ms {
+                        // Use LREM to safely remove just this specific stagnant item payload.
+                        // LREM key 1 value removes the first occurrence of the exact value.
+                        let mut pipe = redis::pipe();
+                        pipe.atomic();
+                        pipe.cmd("LREM").arg(&self.queue_name).arg(1).arg(&item);
+                        let _: () = pipe.query_async(&mut conn).await.map_err(|e| e.to_string())?;
+                        stale_count += 1;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Updates PostgresTaskQueue, SqliteTaskQueue, RedisTaskQueue and MemoryTaskQueue
to clean up stagnant jobs (QUEUED jobs older than 24 hours). Database queues
write the failures into department_dead_letters.

The RedisTaskQueue utilizes LREM to ensure safe, atomic deletion of stagnant elements without data-loss race conditions.

Resolves stagnant backlog queue hygiene requirement safely.

---
*PR created automatically by Jules for task [6787774458455333488](https://jules.google.com/task/6787774458455333488) started by @ql-owo-lp*