### PR TITLE
fix: resolve xds+ dependency fetching issue

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -146,7 +146,7 @@ def go_repositories():
         name = "com_github_cncf_xds_go",
         build_file_generation = "on",
         importpath = "github.com/cncf/xds/go",
-        urls = ["https://api.github.com/repos/cncf/xds/tarball/e9ce68804cb4"],
+        urls = ["https://codeload.github.com/cncf/xds/legacy.tar.gz/e9ce68804cb4"],
         sum = "h1:Rjjh4E6iCUSW3n8E14lM6j1D0aRzDtdGk1iZ/g78A58=",
         version = "v0.0.0-20230607035331-e9ce68804cb4",
     )


### PR DESCRIPTION
Fixes the issue with Bazel fetch failure for `com_github_cncf_xds_go` by using `codeload.github.com` instead of `api.github.com/repos/` to avoid network fetching issues in sandbox environments.

This change avoids rate limit constraints from `api.github.com` and directly queries the CDN/archive. Tests have successfully verified the build passing.

---
*PR created automatically by Jules for task [8825064071609943064](https://jules.google.com/task/8825064071609943064) started by @ql-owo-lp*