### PR TITLE
Fix Next.js build compilation errors

### DIFF
--- a/src/ui/next/next-env.d.ts
+++ b/src/ui/next/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/ui/next/src/app/proposals/customer-view/page.tsx
+++ b/src/ui/next/src/app/proposals/customer-view/page.tsx
@@ -3,10 +3,11 @@
 import React, { useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 
-export default function CustomerProposalView() {
+function CustomerProposalView() {
     const searchParams = useSearchParams();
     const proposalId = searchParams.get('id');
     const [isLoading, setIsLoading] = useState(false);
+
 
     const handlePayDeposit = async () => {
         setIsLoading(true);
@@ -59,3 +60,4 @@ export default function CustomerProposalView() {
         </div>
     );
 }
+export default function CustomerProposalViewPage() { return <React.Suspense><CustomerProposalView /></React.Suspense>; }

--- a/src/ui/next/src/components/feed/ProposalDraftCard.tsx
+++ b/src/ui/next/src/components/feed/ProposalDraftCard.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 
-export function ProposalDraftCard() {
+export function ProposalDraftCard({ item }: { item: any }) {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isApproved, setIsApproved] = useState(false);
 

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
This PR resolves two frontend build errors in the `src/ui/next` Next.js application that caused compilation failure.

1. Added the missing `item` prop parameter to `ProposalDraftCard` component to align with how it is called in the `FeedPage`.
2. Wrapped the `CustomerProposalView` component in `<React.Suspense>` to resolve an error relating to the usage of `useSearchParams` hook inside the Next App Router.

Both fixes are verified to allow `next build` to complete, and the Playwright tests have passed.

---
*PR created automatically by Jules for task [5560849665600505484](https://jules.google.com/task/5560849665600505484) started by @ql-owo-lp*