### PR TITLE
🚀 Nova: [new growth feature] Add PoweredByOHC branding loop to Waitlist

### DIFF
--- a/src/ui/next/src/app/components/PoweredByOHC.test.tsx
+++ b/src/ui/next/src/app/components/PoweredByOHC.test.tsx
@@ -1,10 +1,16 @@
+/**
+ * @vitest-environment jsdom
+ */
+
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { PoweredByOHC } from './PoweredByOHC';
-import { describe, it, expect } from 'vitest';
-import '@testing-library/jest-dom';
+import { describe, it, expect, afterEach } from 'vitest';
 
 describe('PoweredByOHC Component', () => {
+  afterEach(() => {
+    cleanup();
+  });
   const testTenantId = 'test-org-123';
 
   it('renders the base button correctly', () => {
@@ -15,15 +21,15 @@ describe('PoweredByOHC Component', () => {
     // Find the one that has the text Powered by OHC
     const baseLink = linkElements.find(el => el.textContent?.includes('Powered by OHC'));
 
-    expect(baseLink).toBeInTheDocument();
-    expect(baseLink).toHaveAttribute('href', `/onboarding?ref=${testTenantId}&source=footer_widget`);
+    expect(baseLink).toBeDefined();
+    expect(baseLink?.getAttribute('href')).toBe(`/onboarding?ref=${testTenantId}&source=footer_widget`);
   });
 
   it('shows the popover when hovered', async () => {
     render(<PoweredByOHC tenantId={testTenantId} />);
 
     // The popover content shouldn't be there initially
-    expect(screen.queryByText(/Built with OneHumanCorp/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Built with OneHumanCorp/i)).toBeNull();
 
     // Find the container wrapper and trigger hover
     const wrapper = screen.getAllByRole('link')[0].parentElement;
@@ -32,17 +38,15 @@ describe('PoweredByOHC Component', () => {
     fireEvent.mouseEnter(wrapper);
 
     // Wait for the popover content to appear
-    await waitFor(() => {
-      expect(screen.getByText(/Built with OneHumanCorp/i)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/Built with OneHumanCorp/i)).toBeDefined();
 
     // There should now be two links to the onboarding URL (one in base, one in popover CTA)
     const links = screen.getAllByRole('link');
     expect(links.length).toBe(2);
-    expect(links[0]).toHaveAttribute('href', `/onboarding?ref=${testTenantId}&source=footer_widget`);
-    expect(links[1]).toHaveAttribute('href', `/onboarding?ref=${testTenantId}&source=footer_widget`);
+    expect(links[0].getAttribute('href')).toBe(`/onboarding?ref=${testTenantId}&source=footer_widget`);
+    expect(links[1].getAttribute('href')).toBe(`/onboarding?ref=${testTenantId}&source=footer_widget`);
 
     // CTA button text should be present
-    expect(screen.getByText(/Create Your Own/i)).toBeInTheDocument();
+    expect(screen.getByText(/Create Your Own/i)).toBeDefined();
   });
 });

--- a/src/ui/next/src/app/components/PoweredByOHC.tsx
+++ b/src/ui/next/src/app/components/PoweredByOHC.tsx
@@ -39,13 +39,13 @@ export function PoweredByOHC({ tenantId }: PoweredByOHCProps) {
   return (
     <div
       ref={containerRef}
-      className="powered-by-footer flex flex-col justify-center items-center mt-8 pb-4 relative z-50"
+      className="powered-by-footer flex flex-col justify-center items-center relative z-50"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
       {isHovered && (
         <div
-          className="absolute bottom-full mb-3 w-64 p-4 rounded-[20px] border border-white/50 bg-white/70 backdrop-blur-xl shadow-[0_20px_50px_rgba(0,0,0,0.15)] z-[9999] text-center animate-fade-in transition-all duration-300"
+          className="absolute bottom-full mb-3 w-64 p-4 rounded-[20px] border border-white/50 bg-white/70 backdrop-blur-xl shadow-[0_20px_50px_rgba(0,0,0,0.15)] z-[9999] text-center animate-fade-in transition-all duration-300 pointer-events-auto"
         >
           <div className="absolute -bottom-2 left-1/2 -translate-x-1/2 w-4 h-4 bg-white/70 border-b border-r border-white/50 transform rotate-45 backdrop-blur-xl z-[9998]"></div>
 

--- a/src/ui/next/src/app/waitlist/page.test.tsx
+++ b/src/ui/next/src/app/waitlist/page.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, act, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import WaitlistPage from './page';
+import * as navigation from 'next/navigation';
+
+// Mock navigation
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
+// Mock PoweredByOHC component
+vi.mock('../components/PoweredByOHC', () => ({
+  PoweredByOHC: () => <div data-testid="powered-by-ohc" />,
+}));
+
+describe('WaitlistPage', () => {
+  const mockPush = vi.fn();
+
+  beforeEach(() => {
+    (navigation.useRouter as any).mockReturnValue({ push: mockPush });
+    vi.clearAllMocks();
+
+    // Clear mock fetch
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the initial waitlist form', async () => {
+    await act(async () => {
+      render(<WaitlistPage />);
+    });
+
+    expect(screen.getByText('The AI platform for small business.')).toBeDefined();
+    expect(screen.getByPlaceholderText('Enter your email address')).toBeDefined();
+    expect(screen.getByText('Join the Waitlist')).toBeDefined();
+  });
+
+  it('handles successful form submission and shows success state with PoweredByOHC component', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        position: 42,
+        referral_link: 'https://example.com/ref/123'
+      })
+    };
+    (global.fetch as any).mockResolvedValue(mockResponse);
+
+    await act(async () => {
+      render(<WaitlistPage />);
+    });
+
+    const emailInput = screen.getByPlaceholderText('Enter your email address');
+    const submitButton = screen.getByText('Join the Waitlist');
+
+    await act(async () => {
+      fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+      fireEvent.click(submitButton);
+    });
+
+    // Check fetch arguments
+    expect(global.fetch).toHaveBeenCalledWith('/api/v1/growth/waitlist', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email: 'test@example.com' }),
+    });
+
+    // Verify success state content
+    expect(screen.getByText("You're #42 on the list!")).toBeDefined();
+    expect(screen.getByText('Move up the list!')).toBeDefined();
+
+    // Verify PoweredByOHC component is rendered in success state
+    expect(screen.getByTestId('powered-by-ohc')).toBeDefined();
+  });
+
+  it('handles submission errors', async () => {
+    const mockResponse = {
+      ok: false,
+      json: async () => ({})
+    };
+    (global.fetch as any).mockResolvedValue(mockResponse);
+
+    await act(async () => {
+      render(<WaitlistPage />);
+    });
+
+    const emailInput = screen.getByPlaceholderText('Enter your email address');
+    const submitButton = screen.getByText('Join the Waitlist');
+
+    await act(async () => {
+      fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+      fireEvent.click(submitButton);
+    });
+
+    // Verify error message
+    expect(screen.getByText('Failed to join waitlist. Please try again.')).toBeDefined();
+
+    // Verify we're still on the initial form
+    expect(screen.getByText('The AI platform for small business.')).toBeDefined();
+  });
+});

--- a/src/ui/next/src/app/waitlist/page.tsx
+++ b/src/ui/next/src/app/waitlist/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
+import { PoweredByOHC } from "../components/PoweredByOHC";
 
 export default function WaitlistPage() {
   const router = useRouter();
@@ -134,10 +135,8 @@ export default function WaitlistPage() {
             >
               Sign up another email
             </button>
-            <div className="mt-8 pt-6 border-t border-gray-200/60 w-full text-center">
-              <span className="text-xs font-semibold text-gray-400 flex items-center justify-center gap-1">
-                ⚡ Powered by OHC
-              </span>
+            <div className="mt-8 pt-6 border-t border-gray-200/60 w-full flex justify-center">
+              <PoweredByOHC tenantId="waitlist" />
             </div>
           </div>
         ) : (

--- a/src/ui/next/vitest.setup.ts
+++ b/src/ui/next/vitest.setup.ts
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom/vitest'
 import { vi } from 'vitest'
 
 // Mock next/navigation


### PR DESCRIPTION
🚀 Nova: [new growth feature] Waitlist branding loop

Added an interactive "Powered by OHC" footer loop to the waitlist onboarding flow to enable viral sharing out of the waitlist queue. Replaced the static span and updated the widget layout behavior. Fixes the vitest jsdom environment configurations and includes coverage.

---
*PR created automatically by Jules for task [9091194352998066833](https://jules.google.com/task/9091194352998066833) started by @ql-owo-lp*