### PR TITLE
🧹 Cleaner: Enforce Row Level Security on assistant tables

### DIFF
--- a/src/server/migrations/147_assistant_rls.sql
+++ b/src/server/migrations/147_assistant_rls.sql
@@ -1,0 +1,68 @@
+-- +goose Up
+-- Migration 147: Enforce RLS on assistant tables
+DO $$
+DECLARE
+    t_name text;
+    pol_name text;
+BEGIN
+    FOR t_name IN
+        SELECT unnest(ARRAY[
+            'assistant_workspaces',
+            'assistant_tasks',
+            'assistant_messages',
+            'assistant_artifacts',
+            'assistant_file_changes',
+            'assistant_memory_records',
+            'assistant_skills',
+            'assistant_connectors'
+        ])
+    LOOP
+        IF to_regclass(t_name) IS NOT NULL THEN
+            EXECUTE format('ALTER TABLE IF EXISTS %I ENABLE ROW LEVEL SECURITY', t_name);
+            EXECUTE format('ALTER TABLE IF EXISTS %I FORCE ROW LEVEL SECURITY', t_name);
+            pol_name := format('tenant_isolation_%s', t_name);
+
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_policies
+                WHERE schemaname = current_schema()
+                  AND tablename = t_name
+                  AND policyname = pol_name
+            ) THEN
+                EXECUTE format(
+                    'CREATE POLICY %I ON %I USING (tenant_id::text = current_setting(''app.current_tenant'', true)) WITH CHECK (tenant_id::text = current_setting(''app.current_tenant'', true))',
+                    pol_name,
+                    t_name
+                );
+            END IF;
+        END IF;
+    END LOOP;
+END
+$$;
+
+-- +goose Down
+DO $$
+DECLARE
+    t_name text;
+    pol_name text;
+BEGIN
+    FOR t_name IN
+        SELECT unnest(ARRAY[
+            'assistant_workspaces',
+            'assistant_tasks',
+            'assistant_messages',
+            'assistant_artifacts',
+            'assistant_file_changes',
+            'assistant_memory_records',
+            'assistant_skills',
+            'assistant_connectors'
+        ])
+    LOOP
+        IF to_regclass(t_name) IS NOT NULL THEN
+            pol_name := format('tenant_isolation_%s', t_name);
+            EXECUTE format('DROP POLICY IF EXISTS %I ON %I', pol_name, t_name);
+            EXECUTE format('ALTER TABLE IF EXISTS %I DISABLE ROW LEVEL SECURITY', t_name);
+        END IF;
+    END LOOP;
+END
+$$;


### PR DESCRIPTION
As a Maintainer agent, I discovered that several tables introduced for the Assistant features (`assistant_workspaces`, `assistant_tasks`, `assistant_messages`, `assistant_artifacts`, and `assistant_file_changes`) were missing Row Level Security (RLS) enforcement. 

This PR adds a new migration file (`147_assistant_rls.sql`) that correctly applies `ENABLE ROW LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY` to these tables, along with generating the appropriate `tenant_isolation_` pg_policies tying data access to `app.current_tenant` to eliminate potential multi-tenant data leakage risks.

All checks (backend `bazelisk test //...` and Playwright E2E UI `bazelisk test //src/e2e:playwright`) have passed successfully locally.

---
*PR created automatically by Jules for task [15746457234837041047](https://jules.google.com/task/15746457234837041047) started by @ql-owo-lp*