### PR TITLE
Optimize Observation Masking and fix compiler warnings

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2966,7 +2966,7 @@
           "FILE:@@//src/ui/tauri/Cargo.toml 6618eab5d388982b73d020a4ea4ff8c87a85b708d4ca1cef16f081d727eed9b3",
           "FILE:@@//src/server/integrations/buffer/Cargo.toml 8e53d87963733ae38ce14a2c56d42ea7f04aae7b74d9623b462f89f6a8c98558",
           "FILE:@@//src/server/auth/Cargo.toml d796eda90dc541a2243a2dd12f472e35dc265454dc614d1167d6460683a9f684",
-          "FILE:@@//src/server/ohc/Cargo.toml b2628fde8aed36c50710a18eb51a0a1da4d3d3d0883b49580bea4019c6a97ee4",
+          "FILE:@@//src/server/ohc/Cargo.toml ec9df8d914d904fa22e4f4e7c282e73b5d65aae412e1661704b8460f7017d47f",
           "FILE:@@//src/server/integrations/cal_com/Cargo.toml 6e593901bdaf8fd1ae4c2684d4143850c011b637db1725fbd2d7f6d00f333b8c",
           "FILE:@@//src/server/integrations/nats/Cargo.toml 643fb1a435e7cd08d3c55b44aa7df2efd17418e1dc4d9f882e85a532f1556de9",
           "FILE:@@//src/server/integrations/resend/Cargo.toml 6052e9dc58e48291f7ac7c0de56f3c3a21255cb1cb42e8dd275dd92e21915031",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2966,7 +2966,7 @@
           "FILE:@@//src/ui/tauri/Cargo.toml 6618eab5d388982b73d020a4ea4ff8c87a85b708d4ca1cef16f081d727eed9b3",
           "FILE:@@//src/server/integrations/buffer/Cargo.toml 8e53d87963733ae38ce14a2c56d42ea7f04aae7b74d9623b462f89f6a8c98558",
           "FILE:@@//src/server/auth/Cargo.toml d796eda90dc541a2243a2dd12f472e35dc265454dc614d1167d6460683a9f684",
-          "FILE:@@//src/server/ohc/Cargo.toml ec9df8d914d904fa22e4f4e7c282e73b5d65aae412e1661704b8460f7017d47f",
+          "FILE:@@//src/server/ohc/Cargo.toml b2628fde8aed36c50710a18eb51a0a1da4d3d3d0883b49580bea4019c6a97ee4",
           "FILE:@@//src/server/integrations/cal_com/Cargo.toml 6e593901bdaf8fd1ae4c2684d4143850c011b637db1725fbd2d7f6d00f333b8c",
           "FILE:@@//src/server/integrations/nats/Cargo.toml 643fb1a435e7cd08d3c55b44aa7df2efd17418e1dc4d9f882e85a532f1556de9",
           "FILE:@@//src/server/integrations/resend/Cargo.toml 6052e9dc58e48291f7ac7c0de56f3c3a21255cb1cb42e8dd275dd92e21915031",

--- a/src/agents/builtin/.test_ralph_progress.json
+++ b/src/agents/builtin/.test_ralph_progress.json
@@ -1,0 +1,20 @@
+{
+  "task_description": "test task",
+  "features": [
+    {
+      "name": "Step 1",
+      "status": "completed"
+    },
+    {
+      "name": "Step 2",
+      "status": "completed"
+    }
+  ],
+  "current_feature_index": 2,
+  "notes": [
+    "Initialized task and broken down into features.",
+    "Completed feature Step 1: default output",
+    "Completed feature Step 2: default output"
+  ],
+  "is_complete": false
+}

--- a/src/agents/builtin/masking_tests.rs
+++ b/src/agents/builtin/masking_tests.rs
@@ -246,5 +246,5 @@ fn test_json_fallback_bug() {
     // If it falls back to raw string, it will be "[Observation Masked ...]" which is invalid JSON.
     assert!(serde_json::from_str::<Value>(result).is_ok(), "Fails to parse as JSON because it fell back to raw string masking");
     let parsed = serde_json::from_str::<Value>(result).unwrap();
-    assert!(parsed.get("error").is_some());
+    assert!(parsed.get("_masked_observation").is_some());
 }

--- a/src/agents/builtin/observation_masking.rs
+++ b/src/agents/builtin/observation_masking.rs
@@ -153,7 +153,9 @@ impl JetBrainsObservationMasker {
                     for tr in &mut messages[i].tool_results {
                         if tr.error.is_empty()
                             && (!tr.content.starts_with("{\"_masked_observation\"")
-                                && !tr.content.starts_with("{\"_masked_observation\": \"[Observation Masked"))
+                                && !tr
+                                    .content
+                                    .starts_with("{\"_masked_observation\": \"[Observation Masked"))
                         {
                             let bytes = tr.content.len();
                             if bytes > self.size_limit {
@@ -182,7 +184,8 @@ impl JetBrainsObservationMasker {
                                             bytes, tr.tool_call_id
                                         );
                                         tr.content =
-                                            serde_json::json!({ "_masked_observation": raw_msg }).to_string();
+                                            serde_json::json!({ "_masked_observation": raw_msg })
+                                                .to_string();
                                     }
                                     continue; // Treated as JSON, don't fall back to raw string masking
                                 }
@@ -205,9 +208,11 @@ impl JetBrainsObservationMasker {
                                     );
                                     let content_trimmed = tr.content.trim();
                                     if content_trimmed.starts_with('{') {
-                                        serde_json::json!({ "_masked_observation": raw_msg }).to_string()
+                                        serde_json::json!({ "_masked_observation": raw_msg })
+                                            .to_string()
                                     } else if content_trimmed.starts_with('[') {
-                                        serde_json::json!([{ "_masked_observation": raw_msg }]).to_string()
+                                        serde_json::json!([{ "_masked_observation": raw_msg }])
+                                            .to_string()
                                     } else {
                                         raw_msg
                                     }
@@ -218,9 +223,11 @@ impl JetBrainsObservationMasker {
                                     );
                                     let content_trimmed = tr.content.trim();
                                     if content_trimmed.starts_with('{') {
-                                        serde_json::json!({ "_masked_observation": raw_msg }).to_string()
+                                        serde_json::json!({ "_masked_observation": raw_msg })
+                                            .to_string()
                                     } else if content_trimmed.starts_with('[') {
-                                        serde_json::json!([{ "_masked_observation": raw_msg }]).to_string()
+                                        serde_json::json!([{ "_masked_observation": raw_msg }])
+                                            .to_string()
                                     } else {
                                         raw_msg
                                     }
@@ -438,6 +445,13 @@ mod additional_tests {
             tracing::debug!("MASKED CONTENT: {}", masked_content);
             assert!(last_element.contains("[Masked array:"));
             assert!(last_element.contains("elements truncated]"));
+        } else if let Some(s) = parsed
+            .as_array()
+            .and_then(|a| a[0].as_object())
+            .and_then(|o| o.get("_masked_observation"))
+            .and_then(|v| v.as_str())
+        {
+            assert!(s.contains("[Observation Masked"));
         } else if let Some(s) = parsed
             .as_object()
             .and_then(|o| o.get("_masked_observation"))

--- a/src/agents/builtin/observation_masking.rs
+++ b/src/agents/builtin/observation_masking.rs
@@ -153,7 +153,7 @@ impl JetBrainsObservationMasker {
                     for tr in &mut messages[i].tool_results {
                         if tr.error.is_empty()
                             && (!tr.content.starts_with("{\"_masked_observation\"")
-                                && !tr.content.starts_with("{\"error\": \"[Observation Masked"))
+                                && !tr.content.starts_with("{\"_masked_observation\": \"[Observation Masked"))
                         {
                             let bytes = tr.content.len();
                             if bytes > self.size_limit {
@@ -182,7 +182,7 @@ impl JetBrainsObservationMasker {
                                             bytes, tr.tool_call_id
                                         );
                                         tr.content =
-                                            serde_json::json!({ "error": raw_msg }).to_string();
+                                            serde_json::json!({ "_masked_observation": raw_msg }).to_string();
                                     }
                                     continue; // Treated as JSON, don't fall back to raw string masking
                                 }
@@ -205,9 +205,9 @@ impl JetBrainsObservationMasker {
                                     );
                                     let content_trimmed = tr.content.trim();
                                     if content_trimmed.starts_with('{') {
-                                        serde_json::json!({ "error": raw_msg }).to_string()
+                                        serde_json::json!({ "_masked_observation": raw_msg }).to_string()
                                     } else if content_trimmed.starts_with('[') {
-                                        serde_json::json!([{ "error": raw_msg }]).to_string()
+                                        serde_json::json!([{ "_masked_observation": raw_msg }]).to_string()
                                     } else {
                                         raw_msg
                                     }
@@ -218,9 +218,9 @@ impl JetBrainsObservationMasker {
                                     );
                                     let content_trimmed = tr.content.trim();
                                     if content_trimmed.starts_with('{') {
-                                        serde_json::json!({ "error": raw_msg }).to_string()
+                                        serde_json::json!({ "_masked_observation": raw_msg }).to_string()
                                     } else if content_trimmed.starts_with('[') {
-                                        serde_json::json!([{ "error": raw_msg }]).to_string()
+                                        serde_json::json!([{ "_masked_observation": raw_msg }]).to_string()
                                     } else {
                                         raw_msg
                                     }
@@ -359,9 +359,9 @@ mod tests {
 
         if let Ok(parsed) = serde_json::from_str::<Value>(masked_content) {
             if let Some(obj) = parsed.as_object() {
-                if obj.contains_key("error") {
+                if obj.contains_key("_masked_observation") {
                     // It fell back to complete masking. Let's make sure it contains Observation Masked.
-                    let err_str = obj.get("error").unwrap().as_str().unwrap();
+                    let err_str = obj.get("_masked_observation").unwrap().as_str().unwrap();
                     assert!(err_str.contains("[Observation Masked"));
                 } else {
                     assert_eq!(obj.get("small").unwrap().as_str().unwrap(), "abc");
@@ -440,7 +440,7 @@ mod additional_tests {
             assert!(last_element.contains("elements truncated]"));
         } else if let Some(s) = parsed
             .as_object()
-            .and_then(|o| o.get("error"))
+            .and_then(|o| o.get("_masked_observation"))
             .and_then(|v| v.as_str())
         {
             assert!(s.contains("[Observation Masked"));
@@ -490,8 +490,8 @@ mod additional_tests {
         let parsed: Value = serde_json::from_str(masked_content).expect("Should be valid JSON");
 
         if let Some(obj) = parsed.as_object() {
-            if obj.contains_key("error") {
-                let s = obj.get("error").unwrap().as_str().unwrap();
+            if obj.contains_key("_masked_observation") {
+                let s = obj.get("_masked_observation").unwrap().as_str().unwrap();
                 assert!(s.contains("[Observation Masked"));
             } else {
                 assert_eq!(obj.len(), 21); // 20 original keys + 1 masked keys summary

--- a/src/server/ohc/Cargo.toml
+++ b/src/server/ohc/Cargo.toml
@@ -14,3 +14,6 @@ tonic = { workspace = true }
 
 [build-dependencies]
 tonic-build = "0.12"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ohc_bazel)'] }


### PR DESCRIPTION
Optimize Observation Masking to emit \`_masked_observation\` instead of \`error\` which prevents hallucinations. Add \`check-cfg\` to Cargo.toml to suppress \`unexpected_cfgs\` compiler warning without breaking the Bazel build.

---
*PR created automatically by Jules for task [3771123973845565374](https://jules.google.com/task/3771123973845565374) started by @wbbsuper*