### PR TITLE
Fix NetworkStatusIndicator styling to match OHC Translucent Glass standard

### DIFF
--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -634,7 +634,7 @@
 
 
       <div id="network-status-indicator" class="hidden fixed top-2 left-1/2 transform -translate-x-1/2 z-50 flex items-center justify-center pointer-events-none" style="display: none;">
-        <div class="bg-white/80 backdrop-blur-md px-4 py-1.5 rounded-full shadow border border-gray-200/50 flex items-center gap-2 pointer-events-auto">
+        <div class="bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] px-4 py-1.5 rounded-full shadow border border-white/40 dark:border-white/10 flex items-center gap-2 pointer-events-auto">
           <div id="network-status-dot" class="w-2 h-2 rounded-full bg-orange-500"></div>
           <span id="network-status-text" class="text-sm font-semibold text-gray-800">Working Offline</span>
         </div>

--- a/src/ui/tauri/src/ui/pos.html
+++ b/src/ui/tauri/src/ui/pos.html
@@ -348,7 +348,7 @@
       <div id="pos-view" style="display: flex; flex-direction: column; height: 100%;">
 
       <div id="network-status-indicator" class="hidden fixed top-2 left-1/2 transform -translate-x-1/2 z-50 flex items-center justify-center pointer-events-none" style="display: none;">
-        <div class="bg-white/80 backdrop-blur-md px-4 py-1.5 rounded-full shadow border border-gray-200/50 flex items-center gap-2 pointer-events-auto">
+        <div class="bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] px-4 py-1.5 rounded-full shadow border border-white/40 dark:border-white/10 flex items-center gap-2 pointer-events-auto">
           <div id="network-status-dot" class="w-2 h-2 rounded-full bg-yellow-400"></div>
           <span id="network-status-text" class="text-sm font-semibold text-gray-800">Offline - Changes will sync later</span>
         </div>


### PR DESCRIPTION
Fix NetworkStatusIndicator styling to match OHC Translucent Glass standard

Updated `network-status-indicator` in `dashboard.html` and `pos.html` to align with the new Translucent Glass standard specified in the `NetworkStatusIndicator.tsx` file (`bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] px-4 py-1.5 rounded-full shadow border border-white/40 dark:border-white/10...`).

---
*PR created automatically by Jules for task [14346284644700418800](https://jules.google.com/task/14346284644700418800) started by @ql-owo-lp*