### PR TITLE
Fix border radius for app cards and app panels

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -1034,3 +1034,11 @@ select {
 
 
 .rounded-full { border-radius: 9999px !important; }.ohc-growth-card { backdrop-filter: blur(20px) saturate(200%); background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1); font-family: 'Outfit', 'Inter', sans-serif; border-radius: 12px; padding: 24px; }
+
+.app-card {
+  border-radius: 16px;
+}
+
+.app-panel {
+  border-radius: 16px;
+}


### PR DESCRIPTION
Fixed border-radius values for UI containers to match OHC Premium standards. Added `border-radius: 16px;` to `.app-card` and `.app-panel` inside the Next.js prototype's `globals.css` so that the `test_glassmorphism_ui.spec.ts` E2E test assertions pass.

---
*PR created automatically by Jules for task [4410505060433329432](https://jules.google.com/task/4410505060433329432) started by @ql-owo-lp*