### PR TITLE
Fix `com_github_cncf_xds_go` network fetch failure

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -146,7 +146,7 @@ def go_repositories():
         name = "com_github_cncf_xds_go",
         build_file_generation = "on",
         importpath = "github.com/cncf/xds/go",
-        urls = ["https://codeload.github.com/cncf/xds/legacy.tar.gz/e9ce68804cb4"],
+        urls = ["https://github.com/cncf/xds/archive/e9ce68804cb4.tar.gz"],
         sum = "h1:Rjjh4E6iCUSW3n8E14lM6j1D0aRzDtdGk1iZ/g78A58=",
         version = "v0.0.0-20230607035331-e9ce68804cb4",
     )


### PR DESCRIPTION
Fixes the issue where `com_github_cncf_xds_go` failed to download due to GitHub deprecating `codeload.github.com/.../legacy.tar.gz`. Replaced the URL with the standard `archive` URL `https://github.com/cncf/xds/archive/e9ce68804cb4.tar.gz`.

---
*PR created automatically by Jules for task [4428632001918516322](https://jules.google.com/task/4428632001918516322) started by @ql-owo-lp*