### PR TITLE
Add Clear Chat functionality to HelpChat and fix test suite config

### DIFF
--- a/src/ui/next/src/app/customer/subscriptions/[id]/page.test.tsx
+++ b/src/ui/next/src/app/customer/subscriptions/[id]/page.test.tsx
@@ -39,7 +39,7 @@ describe('CustomerSubscriptionPortal', () => {
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
+    if (vi.isFakeTimers && vi.isFakeTimers()) { vi.runOnlyPendingTimers(); }
     vi.useRealTimers();
     vi.restoreAllMocks();
   });

--- a/src/ui/next/src/app/smart-pricing/page.test.tsx
+++ b/src/ui/next/src/app/smart-pricing/page.test.tsx
@@ -26,7 +26,7 @@ describe('SmartPricingPage', () => {
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
+    if (vi.isFakeTimers && vi.isFakeTimers()) { vi.runOnlyPendingTimers(); }
     vi.useRealTimers();
     vi.restoreAllMocks();
   });

--- a/src/ui/next/src/components/HelpChat.test.tsx
+++ b/src/ui/next/src/components/HelpChat.test.tsx
@@ -124,6 +124,41 @@ describe('HelpChat Component', () => {
       expect(screen.getByText("Sorry, the connection timed out. Please try again later or check your network connection.")).toBeInTheDocument();
     });
   });
+
+  it('clears the chat when the clear button is clicked', async () => {
+    render(<HelpChat />);
+    const user = userEvent.setup({ delay: null });
+
+    // Open chat
+    fireEvent.click(screen.getByRole('button', { name: 'Open help chat' }));
+
+    // Send a message
+    const input = screen.getByPlaceholderText('Ask anything...');
+    const submitBtn = screen.getByRole('button', { name: 'Send message' });
+    await user.type(input, 'Test message');
+    act(() => {
+      fireEvent.click(submitBtn);
+    });
+
+    // Check message is displayed
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+
+    // Check clear button appears and click it
+    const clearBtn = screen.getByRole('button', { name: 'Clear chat' });
+    expect(clearBtn).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(clearBtn);
+    });
+
+    // Verify messages are cleared (back to initial)
+    expect(screen.queryByText('Test message')).not.toBeInTheDocument();
+    expect(screen.getByText("Hi! I'm your AI Help Agent. Need help setting up your store or understanding payments?")).toBeInTheDocument();
+
+    // Clear button should disappear
+    expect(screen.queryByRole('button', { name: 'Clear chat' })).not.toBeInTheDocument();
+  });
+
 });
 
 describe('HelpChat accessibility', () => {

--- a/src/ui/next/src/components/HelpChat.tsx
+++ b/src/ui/next/src/components/HelpChat.tsx
@@ -141,6 +141,16 @@ export function HelpChat() {
     }
   }, [inputValue, isLoading]);
 
+  const clearChat = () => {
+    setMessages([
+      {
+        id: "1",
+        sender: "agent",
+        text: "Hi! I'm your AI Help Agent. Need help setting up your store or understanding payments?",
+      },
+    ]);
+  };
+
   const isE2E = process.env.NEXT_PUBLIC_E2E === "true";
   const forceChat =
     typeof window !== "undefined" &&
@@ -189,7 +199,17 @@ export function HelpChat() {
                 </p>
               </div>
             </div>
-            <button
+            <div className="flex gap-2">
+              {messages.length > 1 && (
+                <button
+                  onClick={clearChat}
+                  className="text-blue-100 hover:text-white transition-colors bg-white/10 hover:bg-white/20 rounded-full p-1.5 min-h-[44px] px-3 flex items-center text-xs font-bold font-inter"
+                  aria-label="Clear chat"
+                >
+                  Clear
+                </button>
+              )}
+              <button
               onClick={() => setIsOpen(false)}
               className="text-blue-100 hover:text-white transition-colors bg-white/10 hover:bg-white/20 rounded-full p-1.5 min-h-[44px]"
               aria-label="Close help chat"
@@ -211,6 +231,7 @@ export function HelpChat() {
                 />
               </svg>
             </button>
+            </div>
           </div>
 
           {/* Messages */}

--- a/src/ui/next/src/e2e/help_components.spec.ts
+++ b/src/ui/next/src/e2e/help_components.spec.ts
@@ -77,6 +77,33 @@ test.describe('Help Components', () => {
     await expect(page.locator('text=Sorry, I\'m having trouble connecting right now.').first()).toBeVisible({ timeout: 15000 });
   });
 
+  test('Help Chat clears messages', async ({ page }) => {
+    await page.goto('/help?test_chat=true');
+
+    // Open chat
+    const chatButton = page.locator('button[aria-label="Open help chat"]');
+    await expect(chatButton).toBeVisible();
+    await chatButton.click();
+
+    // Fill message and send
+    const input = page.locator('input[placeholder="Ask anything..."]');
+    await input.fill('How do I clear this chat?');
+    await page.locator('button[aria-label="Send message"]').click();
+
+    // Verify user message
+    await expect(page.locator('text=How do I clear this chat?').first()).toBeVisible();
+
+    // Click clear
+    const clearButton = page.locator('button[aria-label="Clear chat"]');
+    await expect(clearButton).toBeVisible();
+    await clearButton.click();
+
+    // Verify messages are gone
+    await expect(page.locator('text=How do I clear this chat?')).not.toBeVisible();
+    await expect(page.locator('text=Hi! I\'m your AI Help Agent. Need help setting up your store or understanding payments?').first()).toBeVisible();
+    await expect(clearButton).not.toBeVisible();
+  });
+
   test('Interactive Walkthrough functions correctly on dashboard', async ({ page }) => {
     await page.goto('/dashboard?test_walkthrough=true');
 


### PR DESCRIPTION
Adds a "Clear Chat" button to the HelpChat component to allow users to reset their conversation history with the AI Support Agent. Additionally, this commit fixes a vitest configuration issue where `vi.runOnlyPendingTimers()` would throw an error if fake timers weren't initialized, which unblocks the test suite. Also adds unit and E2E test coverage for the new feature.

---
*PR created automatically by Jules for task [14046372640231569003](https://jules.google.com/task/14046372640231569003) started by @ql-owo-lp*