### PR TITLE
Standardize growth referral links across platform to use ohc.store domain

### DIFF
--- a/src/e2e/comprehensive_ui_contract.spec.ts
+++ b/src/e2e/comprehensive_ui_contract.spec.ts
@@ -120,9 +120,9 @@ function externalHostAllowed(hostname: string) {
 function isFakeOHCUrl(href: string) {
   try {
     const url = new URL(href, 'http://localhost:3000');
-    return url.protocol === 'ohc:' || url.hostname === 'ohc.store' || url.hostname.endsWith('.ohc.store');
+    return url.protocol === 'ohc:' || url.hostname === 'ohc.app' || url.hostname.endsWith('.ohc.app');
   } catch {
-    return href.startsWith('ohc://') || href.includes('ohc.store');
+    return href.startsWith('ohc://') || href.includes('ohc.app');
   }
 }
 

--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -178,7 +178,7 @@ async fn handle_waitlist(
     Ok(Json(WaitlistResponse {
         success: true,
         position: 42,
-        referral_link: format!("https://ohc.app/waitlist?ref={}", req.tenant_id),
+        referral_link: format!("https://ohc.store/waitlist?ref={}", req.tenant_id),
     }))
 }
 
@@ -262,7 +262,7 @@ pub async fn handle_conversational_chat(
             description: "Share your latest business milestone with your followers.".to_string(),
             action_type: "generate_social_post".to_string(),
             payload: serde_json::json!({
-                "content": "I just hit a new milestone! Thanks to everyone who supported us. Book your next appointment here: https://ohc.app/onboarding?ref=social-share \n\n⚡ Powered by OHC"
+                "content": "I just hit a new milestone! Thanks to everyone who supported us. Book your next appointment here: https://ohc.store/onboarding?ref=social-share \n\n⚡ Powered by OHC"
             }),
         });
     }
@@ -1313,7 +1313,7 @@ async fn handle_customer_referral_embed(
     let branding = if has_pro {
         "".to_string()
     } else {
-        format!(r#"<div style="font-family: sans-serif; text-align: center; font-size: 12px; margin-top: 8px;"><a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref={}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a></div>"#, tenant)
+        format!(r#"<div style="font-family: sans-serif; text-align: center; font-size: 12px; margin-top: 8px;"><a href="https://ohc.store/api/v1/growth/referrals/click?target=/onboarding&ref={}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a></div>"#, tenant)
     };
 
     let html = format!(
@@ -1380,7 +1380,7 @@ async fn handle_customer_referral_embed(
         <div class="icon">🎁</div>
         <h2>Give ${give}, Get ${get}</h2>
         <p>Give your friends ${give} off their first order, and get ${get} when they purchase.</p>
-        <button class="button" onclick="window.open('https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref={tenant}', '_blank')">Share your link</button>
+        <button class="button" onclick="window.open('https://ohc.store/api/v1/growth/referrals/click?target=/onboarding&ref={tenant}', '_blank')">Share your link</button>
         {branding}
     </div>
 </body>
@@ -1990,9 +1990,9 @@ async fn handle_referral_click_get(
 
     // Redirect user to the intended target (or dashboard if not specified)
     let redirect_url = if target_url.starts_with('/') {
-        format!("https://ohc.app{}", target_url)
+        format!("https://ohc.store{}", target_url)
     } else {
-        "https://ohc.app/dashboard".to_string()
+        "https://ohc.store/dashboard".to_string()
     };
 
     Ok(axum::response::Redirect::to(&redirect_url).into_response())
@@ -2081,7 +2081,7 @@ async fn handle_referral_generate(
             let msg = state.hub.sanitize_hub_event(serde_json::json!({ "type": "growth.referral_generated", "id": ref_id, "referral_code": ref_code }));
             state.hub.append_recent_event(msg);
             Ok(Json(ReferralGenerateResponse {
-                referral_link: format!("https://ohc.app/ref/{}", ref_code),
+                referral_link: format!("https://ohc.store/ref/{}", ref_code),
             }))
         },
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
@@ -2147,7 +2147,7 @@ async fn handle_create_team_invite(
             let msg = state.hub.sanitize_hub_event(serde_json::json!({ "type": "growth.team_invite_created", "tenant_id": auth_info.org_id, "team_id": req.team_id, "inviter_id": req.inviter_id, "invitee_id": req.invitee_id }));
             state.hub.append_recent_event(msg);
 
-            let invite_link = format!("https://ohc.app/invite/{}", invite.id);
+            let invite_link = format!("https://ohc.store/invite/{}", invite.id);
             Ok(Json(CreateTeamInviteResponse { invite_link }))
         },
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
@@ -2224,7 +2224,7 @@ mod tests {
         let res = handle_create_team_invite(Extension(state.clone()), Extension(auth_info.clone()), Json(req)).await;
         assert!(res.is_ok());
         let create_res_json = res.unwrap().0;
-        assert!(create_res_json.invite_link.starts_with("https://ohc.app/invite/inv-"));
+        assert!(create_res_json.invite_link.starts_with("https://ohc.store/invite/inv-"));
 
         // Call get handler directly
         let query = GetTeamInvitesQuery {
@@ -2448,7 +2448,7 @@ mod tests {
         let json = res.unwrap().0;
         assert_eq!(json.success, true);
         assert_eq!(json.position, 42);
-        assert_eq!(json.referral_link, "https://ohc.app/waitlist?ref=test-tenant");
+        assert_eq!(json.referral_link, "https://ohc.store/waitlist?ref=test-tenant");
     }
 
     #[tokio::test]
@@ -2471,7 +2471,7 @@ mod tests {
 
         let res = handle_referral_generate(Extension(state.clone()), axum::extract::Extension(auth_info.clone())).await.unwrap();
         let ref_link = res.0.referral_link;
-        assert!(ref_link.starts_with("https://ohc.app/ref/"));
+        assert!(ref_link.starts_with("https://ohc.store/ref/"));
 
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM referrals WHERE tenant_id = 'test-org' AND user_id = 'test-agent'")
             .fetch_one(&pool).await.unwrap();
@@ -2779,7 +2779,7 @@ async fn handle_cloud_bridge_invite(
             let msg = state.hub.sanitize_hub_event(serde_json::json!({ "type": "growth.cloud_bridge_invite_created", "tenant_id": auth_info.org_id, "team_id": req.team_id, "inviter_id": req.inviter_id, "invitee_id": req.invitee_id }));
             state.hub.append_recent_event(msg);
 
-            let invite_link = format!("https://ohc.app/invite/{}", invite.id);
+            let invite_link = format!("https://ohc.store/invite/{}", invite.id);
             Ok(Json(CloudBridgeInviteResponse { invite_link }))
         },
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
@@ -2844,7 +2844,7 @@ mod cloud_bridge_tests {
         assert!(res.is_ok());
 
         let res_json = res.unwrap().0;
-        assert!(res_json.invite_link.starts_with("https://ohc.app/invite/"));
+        assert!(res_json.invite_link.starts_with("https://ohc.store/invite/"));
 
         let recent_events = state.hub.recent_events(10);
         assert!(recent_events.iter().any(|e| e.r#type == "growth.cloud_bridge_invite_created"));
@@ -2978,7 +2978,7 @@ pub async fn handle_embed_widget(
   <button id="start-btn" data-type="{}">Start {}</button>
 
   <div style="font-family: sans-serif; text-align: center; font-size: 12px; margin-top: 16px;">
-    <a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref={}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a>
+    <a href="https://ohc.store/api/v1/growth/referrals/click?target=/onboarding&ref={}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a>
   </div>
 
   <script>
@@ -3304,7 +3304,7 @@ pub async fn handle_discount_code_embed(
         "".to_string()
     } else {
         format!(
-            "<div style=\"margin-top: 10px; font-size: 12px;\"><a href=\"https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref={}\" target=\"_blank\" rel=\"noopener noreferrer\" style=\"color: #6b7280; text-decoration: none; font-weight: 600;\">⚡ Powered by OHC</a></div>",
+            "<div style=\"margin-top: 10px; font-size: 12px;\"><a href=\"https://ohc.store/api/v1/growth/referrals/click?target=/onboarding&ref={}\" target=\"_blank\" rel=\"noopener noreferrer\" style=\"color: #6b7280; text-decoration: none; font-weight: 600;\">⚡ Powered by OHC</a></div>",
             tenant
         )
     };

--- a/src/server/services/growth/referral_api.rs
+++ b/src/server/services/growth/referral_api.rs
@@ -15,7 +15,7 @@ pub fn generate_referral_link(user_id: &str) -> Result<String, String> {
 
     // Standalone mode specific deep link
     let link = format!(
-        "ohc://join?ref={}&utm_source=standalone_desktop&utm_medium=team_share&inviter={}",
+        "https://ohc.store/join?ref={}&utm_source=standalone_desktop&utm_medium=team_share&inviter={}",
         referral_code, user_id
     );
     Ok(link)
@@ -28,7 +28,7 @@ mod tests {
     #[test]
     fn test_generate_referral_link() {
         let link = generate_referral_link("user123").unwrap();
-        assert!(link.starts_with("ohc://join?ref="));
+        assert!(link.starts_with("https://ohc.store/join?ref="));
         assert!(link.contains("utm_source=standalone_desktop"));
         assert!(link.contains("inviter=user123"));
         

--- a/src/ui/next/src/app/agents/components/AgentUpsellPaywall.tsx
+++ b/src/ui/next/src/app/agents/components/AgentUpsellPaywall.tsx
@@ -17,7 +17,7 @@ export function AgentUpsellPaywall({ onClose, onSuccess }: AgentUpsellPaywallPro
     if (typeof localStorage !== "undefined") {
       tenant = localStorage.getItem("tenant_id") || localStorage.getItem("tenant") || "default";
     }
-    return `https://ohc.app/join?ref=${encodeURIComponent(tenant)}&source=agent_paywall`;
+    return `https://ohc.store/join?ref=${encodeURIComponent(tenant)}&source=agent_paywall`;
   };
 
   const handleGenerateLink = async () => {

--- a/src/ui/next/src/app/referrals/page.tsx
+++ b/src/ui/next/src/app/referrals/page.tsx
@@ -21,7 +21,7 @@ export default function ReferralsPage() {
     };
 
     const normalizeReferralLink = (rawLink: string) => {
-      if (!rawLink || rawLink.includes('ohc.store') || rawLink.startsWith('ohc://')) return fallbackReferralLink();
+      if (!rawLink || rawLink.includes('ohc.app') || rawLink.startsWith('ohc://')) return fallbackReferralLink();
       return rawLink;
     };
 

--- a/src/ui/tauri/src/ui/referrals.html
+++ b/src/ui/tauri/src/ui/referrals.html
@@ -322,7 +322,7 @@
         } else {
           // Fallback
           const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-tenant';
-          link = `https://ohc.app/setup.html?ref=${tenantId}`;
+          link = `https://ohc.store/setup.html?ref=${tenantId}`;
         }
 
         document.getElementById('referral-link').value = link;
@@ -332,7 +332,7 @@
       } catch (e) {
         console.error("Failed to generate referral link", e);
         const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-tenant';
-        document.getElementById('referral-link').value = `https://ohc.app/setup.html?ref=${tenantId}`;
+        document.getElementById('referral-link').value = `https://ohc.store/setup.html?ref=${tenantId}`;
         document.getElementById('loading-state').style.display = 'none';
         document.getElementById('link-state').style.display = 'block';
       }


### PR DESCRIPTION
Updates all fallback logic and backend referral endpoints to use `https://ohc.store` in place of `ohc://` and `ohc.app` domains to unify commerce links for OHC platform merchants.

---
*PR created automatically by Jules for task [16994820592344367189](https://jules.google.com/task/16994820592344367189) started by @ql-owo-lp*