### PR TITLE
fix: missing proxy endpoints and mobile E2E tests for unified agent feed

### DIFF
--- a/src/e2e/tests/unified_agent_feed_mobile.spec.ts
+++ b/src/e2e/tests/unified_agent_feed_mobile.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Mobile Unified Agent Feed @mobile', () => {
+  // Use a simulated mobile viewport
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test('should display Action Center and agent feed cards on mobile dashboard', async ({ page }) => {
+    // Navigate to dashboard
+    await page.goto('/dashboard');
+
+    // Check if the unified agent feed structure is present
+    await expect(page.locator('section[aria-label="Unified Agent Feed"]')).toBeVisible();
+
+    // Verify tabs are visible
+    await expect(page.getByRole('button', { name: /Proposals/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Activity Feed/i })).toBeVisible();
+
+    // The component might show "Loading Agent Proposals..." initially
+    const loadingMessage = page.getByText('Loading Agent Proposals...');
+    if (await loadingMessage.isVisible()) {
+      await expect(loadingMessage).toBeHidden({ timeout: 15000 });
+    }
+
+    // Either we see the "All caught up!" state or actual feed items
+    const allCaughtUp = page.getByText('All caught up!');
+    const agentCard = page.locator('.bg-\\[rgba\\(255\\,255\\,255\\,0\\.65\\)\\]').filter({ hasText: 'Approval' }).first();
+    const actionNeededCard = page.locator('.bg-\\[rgba\\(255\\,255\\,255\\,0\\.65\\)\\]').filter({ hasText: 'Action Needed' }).first();
+
+    const isAllCaughtUpVisible = await allCaughtUp.isVisible();
+    const isAgentCardVisible = await agentCard.isVisible();
+    const isActionNeededCardVisible = await actionNeededCard.isVisible();
+
+    // At least one of these states should be present
+    expect(isAllCaughtUpVisible || isAgentCardVisible || isActionNeededCardVisible).toBeTruthy();
+
+    // Check for standard dashboard widgets which should also be visible
+    await expect(page.getByText('Success Milestones')).toBeVisible();
+  });
+});

--- a/src/ui/next/src/app/api/agent-feed/[id]/route.ts
+++ b/src/ui/next/src/app/api/agent-feed/[id]/route.ts
@@ -1,0 +1,7 @@
+import { proxyBackendPut } from "../../ui/backendProxy";
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  // It seems the backend expects `{id}/state`
+  const { id } = params;
+  return proxyBackendPut(req, `/api/agent-feed/${id}/state`);
+}

--- a/src/ui/next/src/app/api/agent-feed/route.ts
+++ b/src/ui/next/src/app/api/agent-feed/route.ts
@@ -1,0 +1,9 @@
+import { proxyBackendGet, proxyBackendPost } from "../ui/backendProxy";
+
+export async function GET(req: Request) {
+  return proxyBackendGet(req, "/api/agent-feed");
+}
+
+export async function POST(req: Request) {
+  return proxyBackendPost(req, "/api/agent-feed");
+}

--- a/src/ui/next/src/app/api/triage/action/route.ts
+++ b/src/ui/next/src/app/api/triage/action/route.ts
@@ -1,0 +1,5 @@
+import { proxyBackendPost } from "../../ui/backendProxy";
+
+export async function POST(req: Request) {
+  return proxyBackendPost(req, "/api/triage/action");
+}

--- a/src/ui/next/src/app/api/triage/pending/route.ts
+++ b/src/ui/next/src/app/api/triage/pending/route.ts
@@ -1,0 +1,5 @@
+import { proxyBackendGet } from "../../ui/backendProxy";
+
+export async function GET(req: Request) {
+  return proxyBackendGet(req, "/api/triage/pending");
+}


### PR DESCRIPTION
This PR addresses the UI gaps in the Agent Feed component by ensuring its dependencies and automated verifications are in place.

- Implemented proxy endpoints for `/api/agent-feed`, `/api/agent-feed/[id]`, `/api/triage/pending`, and `/api/triage/action`.
- Created Playwright E2E tests specifically targeting the mobile viewport (`375x812`) to verify the "Action Center" feed, "Proposals", and "Activity Feed" tabs display correctly as requested in issue #30128.
- Validated all Next.js and Playwright test suites utilizing Bazelisk.

Note: The `UnifiedAgentFeed.tsx` URL fetching bug requested to be modified in the previous review was already found to be correctly handled in `main` as `fetch(\`/api/agent-feed/${id}\`)`, therefore no changes were strictly necessary on that file itself.

Resolves #30128

---
*PR created automatically by Jules for task [6662557201685380898](https://jules.google.com/task/6662557201685380898) started by @ql-owo-lp*