### PR TITLE
fix(onboarding): handle instant build flow logic properly

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2097,6 +2097,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
               instantBioInputEl.style.borderColor = '';
               generateStorefrontBtn.disabled = true;
               generateStorefrontBtn.innerHTML = '<div class="spinner"></div>Building Your Business...';
+              goToStep('step-loading');
 
               try {
                   const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
@@ -2210,6 +2211,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
 
               } catch (err) {
                   console.error(err);
+                  goToStep('step-instant');
                   const errorMsg = err.message || "Network Error: Failed to fetch";
                   instantErrorEl.innerText = errorMsg;
                   instantErrorEl.style.display = 'block';


### PR DESCRIPTION
This commit fixes an issue with the "Instant Build" functionality during the onboarding process. Previously, the button would get disabled and show "Building Your Business..." but it wouldn't transition to the actual loading screen or restore the state correctly on failure. Now, `goToStep('step-loading')` is invoked when the build process initiates, displaying the proper UI loading state, and `goToStep('step-instant')` is called upon error so that the user can correct their input and try again.

---
*PR created automatically by Jules for task [15371947503034854738](https://jules.google.com/task/15371947503034854738) started by @ql-owo-lp*