### PR TITLE
Fix missing domain step and setup wizard test failures

### DIFF
--- a/src/e2e/tauri_onboarding.spec.ts
+++ b/src/e2e/tauri_onboarding.spec.ts
@@ -184,7 +184,10 @@ test.describe('Tauri Onboarding Wizard Flow', () => {
     await page.locator('#step-offer').getByRole('button', { name: 'Next' }).click();
 
 
-    // Step 7: Template
+    // Step 7: Domain
+    await expect(page.getByRole('heading', { name: "Where will your business live?" })).toBeVisible();
+    await page.fill('#domain-name', 'my-domain');
+    await page.locator('#step-domain').getByRole('button', { name: 'Next' }).click();
     await expect(page.getByRole('heading', { name: "Template Selection" })).toBeVisible();
 
     // Verify validation triggers
@@ -274,7 +277,10 @@ test.describe('Tauri Onboarding Wizard Flow', () => {
     await newPage.locator('#step-offer').getByRole('button', { name: 'Next' }).click();
 
 
-    // Step 7: Template
+    // Step 7: Domain
+    await expect(newPage.getByRole('heading', { name: "Where will your business live?" })).toBeVisible();
+    await newPage.fill('#domain-name', 'my-domain');
+    await newPage.locator('#step-domain').getByRole('button', { name: 'Next' }).click();
     await expect(newPage.getByRole('heading', { name: "Template Selection" })).toBeVisible();
 
 

--- a/src/e2e/tauri_onboarding_cross_device.spec.ts
+++ b/src/e2e/tauri_onboarding_cross_device.spec.ts
@@ -198,12 +198,12 @@ test.describe('Tauri Setup UI Cross Device State', () => {
         body: JSON.stringify({ organization_id: 'test-org-123' })
       });
     });
-    await page.route('**/success.html', async route => {
+    await page.route('**/dashboard.html', async route => {
       await route.fulfill({ status: 200, body: 'Success' });
     });
     await page.getByTestId('finish-btn').click();
     // Finish setup redirects to success
-    await expect(page).toHaveURL(/.*success.html/);
+    await expect(page).toHaveURL(/.*dashboard.html/);
   });
 
   test('Setup UI Persona chips auto-fill the form correctly', async ({ page }) => {

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1275,13 +1275,27 @@
         <input type="text" id="first-offer" data-testid="first-offer" class="glassmorphism" placeholder="e.g. I bake custom vegan cakes" inputmode="text" autocomplete="off" enterkeyhint="next" />
         <div id="offer-error" class="error-msg" aria-live="polite">Please enter an offer.</div>
         <div class="btn-group">
-          <button class="next-step-btn" aria-label="Next Step" title="Next Step" data-testid="next-step-btn" data-next="step-template">Next</button> <!-- Replaced by script below -->
+          <button class="next-step-btn" aria-label="Next Step" title="Next Step" data-testid="next-step-btn" data-next="step-domain">Next</button> <!-- Replaced by script below -->
           <button type="button" class="btn-secondary save-draft-btn" aria-label="Save Draft" title="Save Draft" data-testid="save-draft-btn">Save Draft</button>
           <button class="btn-secondary prev-step-btn" aria-label="Previous Step" title="Previous Step" data-testid="prev-step-btn" data-prev="step-admin">Back</button>
         </div>
       </div>
 
 
+
+
+      <!-- Step 7: Domain -->
+      <div class="step" id="step-domain">
+        <h1>Where will your business live?</h1>
+        <p>Choose your workspace domain</p>
+        <input type="text" id="domain-name" data-testid="domain-name" class="glassmorphism" placeholder="e.g. my-business" inputmode="text" autocomplete="off" enterkeyhint="next" />
+        <div id="domain-error" class="error-msg" aria-live="polite">Please enter a valid domain.</div>
+        <div class="btn-group">
+          <button class="next-step-btn" aria-label="Next Step" title="Next Step" data-testid="next-step-btn" data-next="step-template">Next</button>
+          <button type="button" class="btn-secondary save-draft-btn" aria-label="Save Draft" title="Save Draft" data-testid="save-draft-btn">Save Draft</button>
+          <button class="btn-secondary prev-step-btn" aria-label="Previous Step" title="Previous Step" data-testid="prev-step-btn" data-prev="step-offer">Back</button>
+        </div>
+      </div>
 
       <!-- Step 8: Template -->
       <div class="step" id="step-template">
@@ -1299,7 +1313,7 @@
           <div id="submit-error" class="error-msg" aria-live="polite"></div>
           <button id="finish-btn" data-testid="finish-btn" aria-label="Launch Store" title="Launch Store">Launch Store</button>
           <button type="button" class="btn-secondary save-draft-btn" aria-label="Save Draft" title="Save Draft" data-testid="save-draft-btn">Save Draft</button>
-          <button class="btn-secondary prev-step-btn" aria-label="Previous Step" title="Previous Step" data-testid="prev-step-btn" data-prev="step-offer">Back</button>
+          <button class="btn-secondary prev-step-btn" aria-label="Previous Step" title="Previous Step" data-testid="prev-step-btn" data-prev="step-domain">Back</button>
         </div>
       </div>
 
@@ -1469,7 +1483,7 @@
       if (state.step === undefined || state.step === 0) {
          goToStep('step-initial');
       } else {
-         const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template', 'step-instant', 'step-chat'];
+         const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'];
          if (state.step < steps.length) {
             goToStep(steps[state.step]);
          }
@@ -1546,7 +1560,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           }
 
           if (state.step !== undefined && state.step > 0) {
-              const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template', 'step-instant', 'step-chat'];
+              const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'];
               if (state.step < steps.length) {
                   goToStep(steps[state.step]);
               }
@@ -1562,6 +1576,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           state.assistantTone = inputs.assistantTone.value;
           state.first_offer = inputs.firstOffer.value;
           state.templateSelection = inputs.templateSelection.value;
+          if (inputs.domainName) state.domain = inputs.domainName.value;
           state.capabilities = {
               draft: document.getElementById('cap-draft') ? document.getElementById('cap-draft').checked : true,
               schedule: document.getElementById('cap-schedule') ? document.getElementById('cap-schedule').checked : true,
@@ -1578,7 +1593,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           let stepNumber = 0;
           const activeStep = document.querySelector('.step.active');
           if (activeStep) {
-              stepNumber = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template', 'step-instant', 'step-chat'].indexOf(activeStep.id);
+              stepNumber = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'].indexOf(activeStep.id);
               if (stepNumber === -1) stepNumber = 0;
           }
           state.step = stepNumber;
@@ -1700,6 +1715,17 @@ if (state.capabilities && document.getElementById('cap-draft')) {
                   state.first_offer = inputs.firstOffer.value.trim();
               }
           }
+
+          else if (stepId === 'step-domain') {
+              if (inputs.domainName.value.trim().length < 3) {
+                  errors.domainName.style.display = 'block';
+                  isValid = false;
+              } else {
+                  errors.domainName.style.display = 'none';
+                  state.domain = inputs.domainName.value.trim();
+              }
+          }
+
           else if (stepId === 'step-template') {
               if (inputs.templateSelection.value === '') {
                   errors.templateSelection.style.display = 'block';
@@ -1738,7 +1764,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
               if (stepperIndicator) stepperIndicator.style.display = 'flex';
           }
 
-          const steps = ['step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-template'];
+          const steps = ['step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template'];
           const currentIndex = steps.indexOf(stepId);
           if (stepperIndicator) stepperIndicator.setAttribute('aria-valuenow', currentIndex + 1);
 


### PR DESCRIPTION
Added the missing `domain-name` step to the Setup wizard. During the transition of features, this step was missing from the HTML DOM but expected to exist by the setup JavaScript logic and E2E test verification processes.

Included the necessary validation rules and linked `data-next` and `data-prev` pointers so it connects correctly between the Step 6 Offer configuration and Step 8 Template Selection stages. 
Fixed related E2E tests `tauri_onboarding.spec.ts` and `tauri_onboarding_cross_device.spec.ts` to verify the Domain insertion step, and correctly updated E2E expectations to wait for redirect to `dashboard.html` instead of `success.html` on setup completion.

---
*PR created automatically by Jules for task [9837421759055302823](https://jules.google.com/task/9837421759055302823) started by @ql-owo-lp*