### PR TITLE
⚡ Bolt: [performance improvement] Async Cache Writes for Unified Feed

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -5168,7 +5168,11 @@ async fn ui_dashboard_unified_feed_handler(
         "priority_tasks": priority_tasks,
     });
 
-    let _ = cache.set(&cache_key, cacheable_result.clone(), std::time::Duration::from_secs(10)).await;
+    if let Some(c) = UI_UNIFIED_FEED_CACHE.get() {
+        let cache_key_set = cache_key.clone();
+        let cacheable_result_set = cacheable_result.clone();
+        let _ = tokio::spawn(async move { c.set(&cache_key_set, cacheable_result_set, std::time::Duration::from_secs(10)).await; });
+    }
 
     // Add supply to the final result
     let mut final_result = cacheable_result;


### PR DESCRIPTION
**Problem**
The `ui_dashboard_unified_feed_handler` was experiencing higher latency during cache misses. The backend was waiting for the `cache.set` operation (which inserts the newly fetched unified feed into Redis) to complete before returning the HTTP response.

**Solution**
Moved the cache write operation into an asynchronous background task using `tokio::spawn(async move { ... })`. Cloned the `cache_key` and `cacheable_result` explicitly to satisfy the `'static` lifetime requirements of the background task.

**Testing**
- Executed `bazel test //...` successfully without errors.
- Checked UI E2E Playwright tests which all passed.

---
*PR created automatically by Jules for task [10474978287915996679](https://jules.google.com/task/10474978287915996679) started by @ql-owo-lp*