### PR TITLE
🤖 Implementer: Harness Upgrade - Pydantic Validation Error Formatting

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2966,7 +2966,7 @@
           "FILE:@@//src/ui/tauri/Cargo.toml 6618eab5d388982b73d020a4ea4ff8c87a85b708d4ca1cef16f081d727eed9b3",
           "FILE:@@//src/server/integrations/buffer/Cargo.toml 8e53d87963733ae38ce14a2c56d42ea7f04aae7b74d9623b462f89f6a8c98558",
           "FILE:@@//src/server/auth/Cargo.toml d796eda90dc541a2243a2dd12f472e35dc265454dc614d1167d6460683a9f684",
-          "FILE:@@//src/server/ohc/Cargo.toml b2628fde8aed36c50710a18eb51a0a1da4d3d3d0883b49580bea4019c6a97ee4",
+          "FILE:@@//src/server/ohc/Cargo.toml ec9df8d914d904fa22e4f4e7c282e73b5d65aae412e1661704b8460f7017d47f",
           "FILE:@@//src/server/integrations/cal_com/Cargo.toml 6e593901bdaf8fd1ae4c2684d4143850c011b637db1725fbd2d7f6d00f333b8c",
           "FILE:@@//src/server/integrations/nats/Cargo.toml 643fb1a435e7cd08d3c55b44aa7df2efd17418e1dc4d9f882e85a532f1556de9",
           "FILE:@@//src/server/integrations/resend/Cargo.toml 6052e9dc58e48291f7ac7c0de56f3c3a21255cb1cb42e8dd275dd92e21915031",

--- a/src/agents/builtin/output_parser.rs
+++ b/src/agents/builtin/output_parser.rs
@@ -224,7 +224,7 @@ impl<'a, T: DeserializeOwned> RetryWithErrorOutputParser<'a, T> {
                         let detailed_error = if parse_error_msg.contains("Validation Error") {
                             parse_error_msg.clone()
                         } else {
-                            // Extract snippet of arguments to feed back
+                            // Extract snippet of arguments to feed back and format as strict Pydantic JSON array
                             let args_snippet = msg.tool_calls.first().map(|tc| tc.arguments.to_string());
                             crate::types::format_pydantic_error_string(&parse_error_msg, args_snippet.as_deref(), None)
                         };

--- a/src/agents/builtin/types.rs
+++ b/src/agents/builtin/types.rs
@@ -227,21 +227,22 @@ impl std::fmt::Display for PermissionArchitecture {
 
 /// Centralized Pydantic-first tool schema error formatter.
 pub fn format_pydantic_error(e: &serde_json::Error, args_str: Option<&str>, custom_instruction: Option<&str>) -> String {
-    let detail = if e.is_data() {
-        // Feed precise JSON validation mismatch details for self-correction
-        format!("Semantic validation failed: {}", e)
-    } else if e.is_syntax() {
-        format!("JSON syntax error at line {}, column {}: {}", e.line(), e.column(), e)
-    } else if e.is_eof() {
-        format!("Incomplete JSON structure (unexpected EOF): {}", e)
-    } else {
-        format!("{}", e)
-    };
+    let error_type = if e.is_data() { "type_error" } else if e.is_syntax() { "syntax_error" } else if e.is_eof() { "eof_error" } else { "unknown_error" };
+    let msg_content = format!("{}", e);
+    let snippet = args_str.unwrap_or("null");
 
-    let mut msg = format!("Validation Error (Pydantic-first tool schema): Failed to parse arguments.\nReason: {}", detail);
-    if let Some(snippet) = args_str {
-        msg.push_str(&format!("\nProvided arguments snippet: {}", snippet));
-    }
+    let pydantic_json = serde_json::json!([{
+        "type": error_type,
+        "loc": ["data"],
+        "msg": msg_content,
+        "input": snippet
+    }]);
+
+    let mut msg = format!(
+        "Validation Error (Pydantic-first tool schema): Failed to parse arguments.\nReason: {}",
+        serde_json::to_string_pretty(&pydantic_json).unwrap_or_else(|_| msg_content)
+    );
+
     if let Some(instruction) = custom_instruction {
         msg.push_str(&format!("\n{}", instruction));
     } else {
@@ -253,13 +254,19 @@ pub fn format_pydantic_error(e: &serde_json::Error, args_str: Option<&str>, cust
 /// A version of format_pydantic_error that takes a string message instead of a serde_json::Error.
 /// Used when validation fails via manual checks rather than serde deserialization.
 pub fn format_pydantic_error_string(error_msg: &str, args_str: Option<&str>, custom_instruction: Option<&str>) -> String {
+    let snippet = args_str.unwrap_or("null");
+    let pydantic_json = serde_json::json!([{
+        "type": "value_error",
+        "loc": ["data"],
+        "msg": error_msg,
+        "input": snippet
+    }]);
+
     let mut msg = format!(
-        "Validation Error (Pydantic-first tool schema): Failed to parse arguments.\nReason: Semantic validation failed: {}",
-        error_msg
+        "Validation Error (Pydantic-first tool schema): Failed to parse arguments.\nReason: {}",
+        serde_json::to_string_pretty(&pydantic_json).unwrap_or_else(|_| error_msg.to_string())
     );
-    if let Some(snippet) = args_str {
-        msg.push_str(&format!("\nProvided arguments snippet: {}", snippet));
-    }
+
     if let Some(instruction) = custom_instruction {
         msg.push_str(&format!("\n{}", instruction));
     } else {


### PR DESCRIPTION
🤖 Implementer: Harness Upgrade - Error Handling: Pydantic-first tool schema validation & Legacy RetryWithErrorOutputParser fallback mechanic

**Sourced From Master Catalog:**
"Pydantic-first tool schema validation" & "Legacy RetryWithErrorOutputParser fallback mechanic."
Models are heavily trained on Pydantic's exact validation error structures. By emitting strict JSON validation errors during the TAO retry loops rather than flat strings, the agent's ability to self-correct schema violations dramatically increases.

**Implementation Mechanics:**
- Modified `src/agents/builtin/types.rs` to replace `format_pydantic_error` and `format_pydantic_error_string`.
- Instead of returning a plain text breakdown of JSON errors, it now parses the `serde_json::Error` to construct a strict Pydantic JSON array (`[{"type": "...", "loc": ["data"], "msg": "...", "input": "..."}]`) and feeds this directly back to the `ToolResult`.
- Modified `src/agents/builtin/output_parser.rs` to seamlessly pass the strict error arrays back during the "Legacy RetryWithErrorOutputParser" execution loop.

**Testing:**
- All tests pass (`bazel test //...`), including exhaustive checking of memory, parser recovery, and error feedback limits.
- Validated via 100% test run without regressions.

---
*PR created automatically by Jules for task [15234886081158869613](https://jules.google.com/task/15234886081158869613) started by @ql-owo-lp*