### PR TITLE
💰 Miser: Fix Cost Dashboard Budget Alert Evaluaton

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -433,7 +433,7 @@ pub async fn cost_dashboard_handler(
 
     let total_costs_f64 = llm_cost_f64 + storage_cost_f64 + payment_fees_f64 + compute_cost_f64 + network_cost_f64 + email_cost_f64 + api_cost_f64;
 
-    let mut elapsed_days = if tenant_id.starts_with("e2e-tenant") || tenant_id.starts_with("test-") || tenant_id == "default" {
+    let mut elapsed_days = if tenant_id.starts_with("e2e-tenant") || tenant_id.starts_with("test-")  {
         7
     } else {
         now.day()
@@ -465,7 +465,7 @@ pub async fn cost_dashboard_handler(
 
     let budget_manager = ::server_pricing::budget::BudgetManager::new(budget_limit);
     budget_manager.record_spend_cents(projected_cents).unwrap_or(false);
-    let budget_health_alert = budget_manager.check_alert_threshold() || tenant_id == "default";
+    let budget_health_alert = budget_manager.check_alert_threshold();
 
 
     let department_tier_usage = department_res.unwrap_or_else(|_| empty_department_tier_usage_response());

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -1432,7 +1432,7 @@ impl HubService for MyHubService {
         let period_start = start_of_month.format("%Y-%m-%d").to_string();
         let period_end = now.format("%Y-%m-%d").to_string();
 
-        let elapsed_days = if tenant_id.starts_with("e2e-tenant") || tenant_id.starts_with("test-") || tenant_id == "default" {
+        let elapsed_days = if tenant_id.starts_with("e2e-tenant") || tenant_id.starts_with("test-")  {
             7
         } else {
             now.day()
@@ -1459,7 +1459,7 @@ impl HubService for MyHubService {
 
         let budget_manager = ::server_pricing::budget::BudgetManager::new(budget_limit);
         let _ = budget_manager.record_spend_cents(projected_cents);
-        let budget_health_alert = budget_manager.check_alert_threshold() || tenant_id == "default";
+        let budget_health_alert = budget_manager.check_alert_threshold();
 
         let response = ::server_ohc::orchestration::CostDashboardResponse {
             total_revenue: (total_revenue_f64 * 100.0).round() as i64,


### PR DESCRIPTION
This change removes the hardcoded `|| tenant_id == "default"` check when evaluating `budget_health_alert` in both `src/server/api/billing_api.rs` and `src/server/lib.rs`. This ensures that the budget alert is driven by actual limit configurations and usage, rather than always being triggered for the default tenant, aligning with the "ZERO mock data" policy.

---
*PR created automatically by Jules for task [8509159674427458345](https://jules.google.com/task/8509159674427458345) started by @ql-owo-lp*