### PR TITLE
💰 Miser: Cost Metering and Telemetry for APIs and Emails

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2966,7 +2966,7 @@
           "FILE:@@//src/ui/tauri/Cargo.toml 6618eab5d388982b73d020a4ea4ff8c87a85b708d4ca1cef16f081d727eed9b3",
           "FILE:@@//src/server/integrations/buffer/Cargo.toml 8e53d87963733ae38ce14a2c56d42ea7f04aae7b74d9623b462f89f6a8c98558",
           "FILE:@@//src/server/auth/Cargo.toml d796eda90dc541a2243a2dd12f472e35dc265454dc614d1167d6460683a9f684",
-          "FILE:@@//src/server/ohc/Cargo.toml b2628fde8aed36c50710a18eb51a0a1da4d3d3d0883b49580bea4019c6a97ee4",
+          "FILE:@@//src/server/ohc/Cargo.toml ec9df8d914d904fa22e4f4e7c282e73b5d65aae412e1661704b8460f7017d47f",
           "FILE:@@//src/server/integrations/cal_com/Cargo.toml 6e593901bdaf8fd1ae4c2684d4143850c011b637db1725fbd2d7f6d00f333b8c",
           "FILE:@@//src/server/integrations/nats/Cargo.toml 643fb1a435e7cd08d3c55b44aa7df2efd17418e1dc4d9f882e85a532f1556de9",
           "FILE:@@//src/server/integrations/resend/Cargo.toml 6052e9dc58e48291f7ac7c0de56f3c3a21255cb1cb42e8dd275dd92e21915031",

--- a/src/server/billing.rs
+++ b/src/server/billing.rs
@@ -239,16 +239,16 @@ impl Tracker {
     pub fn track_outbound_api_call(&self, tenant_id: &str, endpoint: &str) {
         // pii-safe
         tracing::info!("💰 Miser telemetry: Recording outbound API call for tenant: {}, endpoint: {}", tenant_id, endpoint);
-        if let Some(ref _auditor) = self.auditor {
-            // Future: auditor.record_api_call(tenant_id, endpoint);
+        if let Some(ref auditor) = self.auditor {
+            auditor.record_api_call(tenant_id, endpoint);
         }
     }
 
     pub fn track_email_send(&self, tenant_id: &str) {
         // pii-safe
         tracing::info!("💰 Miser telemetry: Recording communication metric for tenant: {}", tenant_id);
-        if let Some(ref _auditor) = self.auditor {
-            // Future: auditor.record_email_send(tenant_id);
+        if let Some(ref auditor) = self.auditor {
+            auditor.record_email_send(tenant_id);
         }
     }
 

--- a/src/server/services/billing/auditor.rs
+++ b/src/server/services/billing/auditor.rs
@@ -43,7 +43,11 @@ pub struct CostAuditor {
     tenant_tokens: Mutex<HashMap<String, i64>>,
     tenant_cached_tokens: Mutex<HashMap<String, i64>>,
     agent_storage_bytes: Mutex<HashMap<String, i64>>,
+    pub tenant_api_calls: Mutex<HashMap<String, u64>>,
+    pub tenant_email_sends: Mutex<HashMap<String, u64>>,
     telemetry_tx: Option<tokio::sync::mpsc::UnboundedSender<AuditEvent>>,
+    api_calls_counter: opentelemetry::metrics::Counter<u64>,
+    email_sends_counter: opentelemetry::metrics::Counter<u64>,
     llm_cost_counter: Counter<u64>,
     storage_savings_counter: Counter<u64>,
     bandwidth_savings_counter: Counter<u64>,
@@ -57,6 +61,8 @@ impl CostAuditor {
         let storage_savings_counter = meter.u64_counter("ohc_storage_savings_total_cents").build();
         let bandwidth_savings_counter = meter.u64_counter("ohc_bandwidth_savings_total_cents").build();
         let compute_cost_counter = meter.u64_counter("ohc_compute_cost_total_cents").build();
+        let api_calls_counter = meter.u64_counter("ohc_api_calls_total").build();
+        let email_sends_counter = meter.u64_counter("ohc_email_sends_total").build();
 
         CostAuditor {
             config,
@@ -79,7 +85,11 @@ impl CostAuditor {
             tenant_tokens: Mutex::new(HashMap::new()),
             tenant_cached_tokens: Mutex::new(HashMap::new()),
             agent_storage_bytes: Mutex::new(HashMap::new()),
+            tenant_api_calls: Mutex::new(HashMap::new()),
+            tenant_email_sends: Mutex::new(HashMap::new()),
             telemetry_tx: None,
+            api_calls_counter,
+            email_sends_counter,
             llm_cost_counter,
             storage_savings_counter,
             bandwidth_savings_counter,
@@ -269,6 +279,27 @@ impl CostAuditor {
     pub fn get_total_cached_tokens(&self) -> i64 {
         let tenant_cached_tokens = self.tenant_cached_tokens.lock().unwrap();
         tenant_cached_tokens.values().sum()
+    }
+
+    pub fn record_api_call(&self, tenant_id: &str, endpoint: &str) {
+        let mut calls = self.tenant_api_calls.lock().unwrap();
+        let counter = calls.entry(tenant_id.to_string()).or_insert(0);
+        *counter += 1;
+
+        self.api_calls_counter.add(1, &[
+            opentelemetry::KeyValue::new("tenant_id", tenant_id.to_string()),
+            opentelemetry::KeyValue::new("endpoint", endpoint.to_string()),
+        ]);
+    }
+
+    pub fn record_email_send(&self, tenant_id: &str) {
+        let mut sends = self.tenant_email_sends.lock().unwrap();
+        let counter = sends.entry(tenant_id.to_string()).or_insert(0);
+        *counter += 1;
+
+        self.email_sends_counter.add(1, &[
+            opentelemetry::KeyValue::new("tenant_id", tenant_id.to_string()),
+        ]);
     }
 
     pub fn get_tenant_tokens(&self, tenant_id: &str) -> i64 {
@@ -562,6 +593,32 @@ mod tests {
         };
         let savings = auditor.record_cache_hit(event);
         assert!(savings > 0.0);
+    }
+
+    #[test]
+    fn test_record_api_call_and_email_send() {
+        let config = CostConfig::default();
+        let auditor = CostAuditor::new(config);
+
+        auditor.record_api_call("tenant1", "/api/test");
+        auditor.record_api_call("tenant1", "/api/test");
+        auditor.record_api_call("tenant2", "/api/other");
+
+        {
+            let calls = auditor.tenant_api_calls.lock().unwrap();
+            assert_eq!(calls.get("tenant1"), Some(&2));
+            assert_eq!(calls.get("tenant2"), Some(&1));
+        }
+
+        auditor.record_email_send("tenant1");
+        auditor.record_email_send("tenant3");
+        auditor.record_email_send("tenant3");
+
+        {
+            let sends = auditor.tenant_email_sends.lock().unwrap();
+            assert_eq!(sends.get("tenant1"), Some(&1));
+            assert_eq!(sends.get("tenant3"), Some(&2));
+        }
     }
 
     #[test]


### PR DESCRIPTION
This PR implements the missing infrastructure cost metering features from the "Miser" role goals, specifically adding telemetry tracking for outbound API calls and email sends to the OpenTelemetry integration within the `CostAuditor`. It updates `src/server/billing.rs` to call the new methods instead of just leaving comments, and adds comprehensive tests for these metrics.

---
*PR created automatically by Jules for task [6016947584336532724](https://jules.google.com/task/6016947584336532724) started by @ql-owo-lp*