### PR TITLE
💰 Miser: Soft limit messages and telemetry for cost tracking

### DIFF
--- a/src/server/billing.rs
+++ b/src/server/billing.rs
@@ -239,16 +239,16 @@ impl Tracker {
     pub fn track_outbound_api_call(&self, tenant_id: &str, endpoint: &str) {
         // pii-safe
         tracing::info!("💰 Miser telemetry: Recording outbound API call for tenant: {}, endpoint: {}", tenant_id, endpoint);
-        if let Some(ref _auditor) = self.auditor {
-            // Future: auditor.record_api_call(tenant_id, endpoint);
+        if let Some(ref auditor) = self.auditor {
+            auditor.record_api_call(tenant_id, endpoint);
         }
     }
 
     pub fn track_email_send(&self, tenant_id: &str) {
         // pii-safe
         tracing::info!("💰 Miser telemetry: Recording communication metric for tenant: {}", tenant_id);
-        if let Some(ref _auditor) = self.auditor {
-            // Future: auditor.record_email_send(tenant_id);
+        if let Some(ref auditor) = self.auditor {
+            auditor.record_email_send(tenant_id);
         }
     }
 

--- a/src/server/pricing/rate_limit.rs
+++ b/src/server/pricing/rate_limit.rs
@@ -241,7 +241,7 @@ impl RedisRateLimiter {
                     is_allowed: true, // Soft limit per requirements
                     soft_limit_reached: true,
                     user_message: Some(format!(
-                        "You've hit your {} tier limit of {} AI actions this month. Keep your business growing with a plan upgrade!",
+                        "You've hit your {} tier soft limit of {} AI actions this month. Upgrade your plan to ensure seamless operations.",
                         match tier {
                             PlanTier::Free => "Free",
                             PlanTier::Starter => "Starter",
@@ -261,7 +261,7 @@ impl RedisRateLimiter {
                     is_allowed: true, // Soft limit per requirements
                     soft_limit_reached: true,
                     user_message: Some(format!(
-                        "This agent has hit its {} tier limit of {} actions this month. Upgrade to unlock more power for your business.",
+                        "This agent has hit its {} tier soft limit of {} actions this month. Upgrade to unlock more power for your business.",
                         match tier {
                             PlanTier::Free => "Free",
                             PlanTier::Starter => "Starter",
@@ -301,7 +301,7 @@ impl RedisRateLimiter {
                     is_allowed: true, // Soft limit per requirements
                     soft_limit_reached: true,
                     user_message: Some(format!(
-                        "You've reached your {} tier limit of {} products. Keep building your store with a plan upgrade!",
+                        "You've hit your {} tier soft limit of {} products. Upgrade your plan to ensure seamless operations and avoid interruptions.",
                         match tier {
                             PlanTier::Free => "Free",
                             PlanTier::Starter => "Starter",
@@ -348,7 +348,7 @@ impl RedisRateLimiter {
                     is_allowed: true, // Soft limit per requirements
                     soft_limit_reached: true,
                     user_message: Some(format!(
-                        "You've reached your {} tier limit of {} agent. Upgrade to unlock more power!",
+                        "You've reached your {} tier soft limit of {} agent(s). Upgrade to unlock more power!",
                         match tier {
                             PlanTier::Free => "Free",
                             PlanTier::Starter => "Starter",
@@ -413,7 +413,7 @@ impl RedisRateLimiter {
                     is_allowed: true, // Soft limit per requirements
                     soft_limit_reached: true,
                     user_message: Some(format!(
-                        "You've reached your {} tier limit of {}MB storage. Keep your business running smoothly with a plan upgrade!",
+                        "You've hit your {} tier soft limit of {}MB storage. Please upgrade to continue seamless operations.",
                         match tier {
                             PlanTier::Free => "Free",
                             PlanTier::Starter => "Starter",

--- a/src/server/services/billing/auditor.rs
+++ b/src/server/services/billing/auditor.rs
@@ -48,6 +48,8 @@ pub struct CostAuditor {
     storage_savings_counter: Counter<u64>,
     bandwidth_savings_counter: Counter<u64>,
     compute_cost_counter: Counter<u64>,
+    api_call_counter: Counter<u64>,
+    email_send_counter: Counter<u64>,
 }
 
 impl CostAuditor {
@@ -57,6 +59,8 @@ impl CostAuditor {
         let storage_savings_counter = meter.u64_counter("ohc_storage_savings_total_cents").build();
         let bandwidth_savings_counter = meter.u64_counter("ohc_bandwidth_savings_total_cents").build();
         let compute_cost_counter = meter.u64_counter("ohc_compute_cost_total_cents").build();
+        let api_call_counter = meter.u64_counter("ohc_api_calls_total").build();
+        let email_send_counter = meter.u64_counter("ohc_emails_sent_total").build();
 
         CostAuditor {
             config,
@@ -84,6 +88,8 @@ impl CostAuditor {
             storage_savings_counter,
             bandwidth_savings_counter,
             compute_cost_counter,
+            api_call_counter,
+            email_send_counter,
         }
     }
 
@@ -225,6 +231,19 @@ impl CostAuditor {
         let savings_cents = (savings * 100.0).round() as u64;
         self.bandwidth_savings_counter.add(savings_cents, &[KeyValue::new("tenant_id", tenant_id.to_string())]);
         savings
+    }
+
+    pub fn record_api_call(&self, tenant_id: &str, endpoint: &str) {
+        self.api_call_counter.add(1, &[
+            KeyValue::new("tenant_id", tenant_id.to_string()),
+            KeyValue::new("endpoint", endpoint.to_string()),
+        ]);
+    }
+
+    pub fn record_email_send(&self, tenant_id: &str) {
+        self.email_send_counter.add(1, &[
+            KeyValue::new("tenant_id", tenant_id.to_string()),
+        ]);
     }
 
     pub fn get_total_cost(&self) -> f64 {


### PR DESCRIPTION
Resolves the issue related to "Cost Engineer & Miser (L7)" by ensuring user-facing rate limits are explicitly labeled as "soft limits" with friendly upgrade prompts, rather than hard blocking errors. Also implements missing telemetry metrics (OpenTelemetry counters) for tracking outbound API calls and email sends, which were previously stubbed out, completing the infrastructure cost metering requirement.

All changes were verified using `bazel test //...` and `bazel test //src/e2e:playwright` which successfully passed.

---
*PR created automatically by Jules for task [16326206575228437546](https://jules.google.com/task/16326206575228437546) started by @ql-owo-lp*