### PR TITLE
refactor(agent_feed): remove unused variables and imports in AgentFeedService

### DIFF
--- a/src/server/api/agent_feed.rs
+++ b/src/server/api/agent_feed.rs
@@ -6,7 +6,6 @@ use axum::{
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 use chrono::{DateTime, Utc};
 use ::server_common::Claims;
 use crate::domain::repository::agent_feed_repo::{AgentFeedRepository, AgentFeedItem};

--- a/src/server/services/agent_feed/service.rs
+++ b/src/server/services/agent_feed/service.rs
@@ -5,15 +5,13 @@ use chrono::Utc;
 use serde_json::Value;
 
 pub struct AgentFeedService {
-    pool: PgPool,
     repo: AgentFeedRepository,
 }
 
 impl AgentFeedService {
     pub fn new(pool: PgPool) -> Self {
         Self {
-            repo: AgentFeedRepository::new(pool.clone()),
-            pool,
+            repo: AgentFeedRepository::new(pool),
         }
     }
 


### PR DESCRIPTION
**What changed**:
Removed unused `uuid::Uuid` import from `src/server/api/agent_feed.rs` and the unused `pool: PgPool` field from the `AgentFeedService` struct.

**Why it matters**:
To fulfill the requirement of "Continuous Codebase Optimization" when the primary requested features were already implemented, removing dead code reduces memory footprint and eliminates compiler warnings.

**How it was verified**:
Run `bazel test //...` and `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"` to ensure no functionality is affected.

---
*PR created automatically by Jules for task [11379509561967190725](https://jules.google.com/task/11379509561967190725) started by @ql-owo-lp*