### PR TITLE
💰 Miser: correct payment routing implementation path

### DIFF
--- a/docs/technical/features/cost_optimization_miser.md
+++ b/docs/technical/features/cost_optimization_miser.md
@@ -3,7 +3,7 @@
 ## Implemented Features
 1. **Prompt Caching**: `src/server/pricing/prompt_caching.rs` implements a TTL-based cache to bypass LLM generation costs for repeated requests.
 2. **Storage Compression**: `src/server/pricing/compression.rs` provides `optimize_image` (WebP conversion) and string compression techniques to reduce storage and CDN transit costs. A `bandwidth_savings` calculator in `src/server/pricing/calculator.rs` measures the savings.
-3. **Transaction Fee Routing**: `src/server/pricing/payment_routing.rs` routes payments strategically to minimize Stripe transfer fees (e.g. batching small payouts, using ACH for large amounts).
+3. **Transaction Fee Routing**: `src/server/integrations/stripe/routing.rs` routes payments strategically to minimize Stripe transfer fees (e.g. batching small payouts, using ACH for large amounts).
 4. **Rate Limiting & Quotas**: `src/server/pricing/rate_limit.rs` and `src/server/pricing/budget.rs` provide Redis-backed soft rate limits and storage quotas per tenant plan tier.
 5. **Cost Transparency Dashboard**: `src/server/api/billing_api.rs` and frontend implementations provide detailed, accurate cost tracking, including `Network Cost` and `Bandwidth Savings`.
 

--- a/src/server/pricing/prompt_caching.rs
+++ b/src/server/pricing/prompt_caching.rs
@@ -160,7 +160,7 @@ impl PromptCache {
             return String::new();
         }
 
-        let max_chars = max_tokens * 4;
+        let max_chars = max_tokens * 4; // Fast heuristic assuming 4 chars per token
 
         let mut char_count = 0;
         let mut byte_index = context.len();


### PR DESCRIPTION
This updates the documentation to correctly point to the Stripe payment routing implementation, which was originally noted as missing but was fully implemented in `src/server/integrations/stripe/routing.rs`. Tests pass natively.

---
*PR created automatically by Jules for task [12791068391115139889](https://jules.google.com/task/12791068391115139889) started by @ql-owo-lp*