### PR TITLE
fix: update Next.js Help Center page title to match tests

### DIFF
--- a/src/e2e/docs.spec.ts
+++ b/src/e2e/docs.spec.ts
@@ -22,7 +22,7 @@ test.describe('Documentation & Help Features', () => {
     await helpBtn.click();
 
     // Verify widget opened by checking if "Help Center" title inside the widget is visible
-    const helpCenterTitle = page.getByRole('heading', { name: 'Help Center', exact: true });
+    const helpCenterTitle = page.getByRole('heading', { name: 'In-App Help Center', exact: true });
     await expect(helpCenterTitle).toBeVisible();
 
     // Check for article (since backend might be returning it slowly, add retries or let playwright handle it)

--- a/src/e2e/documentation.spec.ts
+++ b/src/e2e/documentation.spec.ts
@@ -8,7 +8,7 @@ test.describe('Documentation full suite', () => {
     // Title should be present
     const title = page.locator('h1');
     await expect(title).toBeVisible();
-    await expect(title).toContainText('Help Center');
+    await expect(title).toContainText('In-App Help Center');
 
     // Make sure search bar exists
     const searchInput = page.getByPlaceholder('Search for help articles and videos...');

--- a/src/e2e/documentation_full.spec.ts
+++ b/src/e2e/documentation_full.spec.ts
@@ -8,7 +8,7 @@ test.describe('Documentation full suite', () => {
     // Title should be present
     const title = page.locator('h1');
     await expect(title).toBeVisible();
-    await expect(title).toContainText('Help Center');
+    await expect(title).toContainText('In-App Help Center');
 
     // Make sure search bar exists
     const searchInput = page.locator('input[placeholder="Search for help articles and videos..."]');

--- a/src/e2e/help_features_advanced.spec.ts
+++ b/src/e2e/help_features_advanced.spec.ts
@@ -5,7 +5,7 @@ test.describe('In-App Help & Documentation Features', () => {
     await page.goto('/api/ui/help.html');
 
     // Help Center title is visible
-    await expect(page.getByRole('heading', { name: /Help Center/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /In-App Help Center/i })).toBeVisible();
 
     // Verify some articles are loaded
     await expect(page.getByText('Getting Started').first()).toBeVisible();

--- a/src/e2e/playwright/documentation_features.spec.ts
+++ b/src/e2e/playwright/documentation_features.spec.ts
@@ -4,7 +4,7 @@ test.describe('Documentation Features CUJ', () => {
   test('User can access help center, use chat, run walkthroughs, view changelog, and API docs', async ({ page }) => {
     // 1. Visit Help Center
     await page.goto('/help');
-    await expect(page.locator('h1')).toContainText('Help Center');
+    await expect(page.locator('h1')).toContainText('In-App Help Center');
 
     // 2. Open AI Help Chat
     const helpChatButton = page.locator('button[aria-label="Open help chat"]');

--- a/src/e2e/tauri_help.spec.ts
+++ b/src/e2e/tauri_help.spec.ts
@@ -26,7 +26,7 @@ test.describe('Help Center and Contextual Help (Tauri UI)', () => {
 
     // Go to /help
     await page.goto('/api/ui/help.html');
-    await expect(page.locator('text=Help Center').first()).toBeVisible();
+    await expect(page.locator('text=In-App Help Center').first()).toBeVisible();
     await expect(page.locator('text=Getting Started').first()).toBeVisible();
 
     await page.fill('input[placeholder="Search for help articles and videos..."]', 'paid');

--- a/src/e2e/ui/help_center.spec.ts
+++ b/src/e2e/ui/help_center.spec.ts
@@ -8,7 +8,7 @@ test.describe('Help Center & Documentation Features', () => {
     await page.goto('/api/ui/help.html');
 
     // 2. Help Center Page is loaded
-    await expect(page.locator('h1:has-text("Help Center")')).toBeVisible();
+    await expect(page.locator('h1:has-text("In-App Help Center")')).toBeVisible();
 
     // 3. Search for a specific topic
     const searchInput = page.locator('input[placeholder="Search for help articles and videos..."]');

--- a/src/ui/next/src/app/help/page.test.tsx
+++ b/src/ui/next/src/app/help/page.test.tsx
@@ -54,7 +54,7 @@ describe('HelpCenterPage', () => {
   it('renders articles loaded from API', async () => {
     render(<TooltipProvider><HelpCenterPage /></TooltipProvider>);
 
-    expect(screen.getByText('Help Center')).toBeInTheDocument();
+    expect(screen.getByText('In-App Help Center')).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByText('Getting Started')).toBeInTheDocument();

--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -42,7 +42,7 @@ export default function HelpCenterPage() {
   return (
     <div className="min-h-screen bg-[#F5F5F7] py-6 sm:py-12 px-4 sm:px-6 lg:px-8 font-inter">
       <div className="max-w-4xl mx-auto">
-        <h1 className="text-3xl sm:text-4xl font-extrabold font-outfit text-[#1D1D1F] mb-6 sm:mb-8 text-center tracking-tight">Help Center</h1>
+        <h1 className="text-3xl sm:text-4xl font-extrabold font-outfit text-[#1D1D1F] mb-6 sm:mb-8 text-center tracking-tight">In-App Help Center</h1>
 
         <div className="mb-8 sm:mb-10 w-full sm:w-3/4 mx-auto block">
           <div className="w-full block">

--- a/src/ui/next/src/e2e/documentation_cuj.spec.ts
+++ b/src/ui/next/src/e2e/documentation_cuj.spec.ts
@@ -92,7 +92,7 @@ test.describe("Documentation User Journey", () => {
     await page.goto("/help");
 
     // Verify Help Center is loaded
-    await expect(page.locator("h1", { hasText: "Help Center" })).toBeVisible();
+    await expect(page.locator("h1", { hasText: "In-App Help Center" })).toBeVisible();
 
     // Verify Categories from the mock we added
     await expect(

--- a/src/ui/next/src/e2e/help.spec.ts
+++ b/src/ui/next/src/e2e/help.spec.ts
@@ -64,7 +64,7 @@ test.describe("Help Center", () => {
     await page.goto("/help");
 
     // Verify Help Center title
-    await expect(page.locator("h1", { hasText: "Help Center" })).toBeVisible();
+    await expect(page.locator("h1", { hasText: "In-App Help Center" })).toBeVisible();
 
     // Verify that categories are rendered (Getting Started, My Store, Payments)
     await expect(
@@ -97,14 +97,14 @@ test.describe("Help Center", () => {
     await page.waitForURL("/help/getting-started-1");
 
     await page.goto("/help");
-    await expect(page.locator("h1", { hasText: "Help Center" })).toBeVisible();
+    await expect(page.locator("h1", { hasText: "In-App Help Center" })).toBeVisible();
   });
 
   test("should use backend search for filtering articles", async ({ page }) => {
     await page.goto("/help");
 
     // Verify Help Center title
-    await expect(page.locator("h1", { hasText: "Help Center" })).toBeVisible();
+    await expect(page.locator("h1", { hasText: "In-App Help Center" })).toBeVisible();
 
     // Wait for hydration to complete by checking for initial content
     await expect(

--- a/src/ui/next/src/e2e/help_components.spec.ts
+++ b/src/ui/next/src/e2e/help_components.spec.ts
@@ -36,7 +36,7 @@ test.describe('Help Components', () => {
     await page.goto('/help');
 
     // Wait for at least one article title to appear
-    await expect(page.locator('h1:has-text("Help Center")')).toBeVisible();
+    await expect(page.locator('h1:has-text("In-App Help Center")')).toBeVisible();
     await expect(page.locator('h2:has-text("Getting Started")')).toBeVisible();
     await expect(page.locator('h3:has-text("Getting Started with Your Store")')).toBeVisible();
 


### PR DESCRIPTION
Fixing failing tests related to the Help Center page title.
The expectation was "In-App Help Center", but the component title was just "Help Center". Updated the title in the page component to match the requirement, and updated the other test files expecting "Help Center" to expect "In-App Help Center".

Changes made:
- Changed `<h1>Help Center</h1>` to `<h1>In-App Help Center</h1>` in `src/ui/next/src/app/help/page.tsx`
- Changed test expectations in `src/ui/next/src/app/help/page.test.tsx`
- Changed test expectations in `src/ui/next/src/e2e/documentation_cuj.spec.ts`
- Changed test expectations in `src/ui/next/src/e2e/help.spec.ts`
- Changed test expectations in `src/ui/next/src/e2e/help_components.spec.ts`
- Changed test expectations in `src/e2e/docs.spec.ts`, `src/e2e/documentation.spec.ts`, `src/e2e/documentation_full.spec.ts`, `src/e2e/help_features_advanced.spec.ts`, `src/e2e/playwright/documentation_features.spec.ts`, `src/e2e/tauri_help.spec.ts`, and `src/e2e/ui/help_center.spec.ts`.

---
*PR created automatically by Jules for task [17851711713534641729](https://jules.google.com/task/17851711713534641729) started by @ql-owo-lp*