### PR TITLE
fix(ui): pass initial triage data to WorkTriageFeed to fix blank state

### DIFF
--- a/src/e2e/ui/triage_action_feed.spec.ts
+++ b/src/e2e/ui/triage_action_feed.spec.ts
@@ -14,7 +14,7 @@ test.describe('Triage Action Feed UI', () => {
     };
 
     // Attempt to seed data
-    const res = await page.request.post(`/api/triage/create?tenant_id=${tenantId}`, {
+    const res = await page.request.post(`/api/ui/triage/create?tenant_id=${tenantId}`, {
         data: {
           customer_id: 'cust_test',
           ...seedData

--- a/src/ui/next/src/app/api/agent-feed/[id]/route.ts
+++ b/src/ui/next/src/app/api/agent-feed/[id]/route.ts
@@ -1,6 +1,7 @@
 import { proxyBackendPut } from "../../ui/backendProxy";
+import { NextRequest } from "next/server";
 
-export async function PUT(req: Request, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
   // It seems the backend expects `{id}/state`
   const { id } = params;
   return proxyBackendPut(req, `/api/agent-feed/${id}/state`);

--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -190,7 +190,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
 
           unifiedData = await unifiedRes.json();
         } else {
-          fetchTriage();
+          if (!unifiedData?.triage || unifiedData.triage.length === 0) fetchTriage(); else setTriageItems(unifiedData.triage);
         }
 
         if (mounted) {

--- a/src/ui/next/src/app/dashboard/page.tsx
+++ b/src/ui/next/src/app/dashboard/page.tsx
@@ -294,6 +294,9 @@ export default function Dashboard() {
           bom_items: Array.isArray(supplyData?.bom_items) ? supplyData.bom_items : [],
         });
         setApprovals(Array.isArray(approvalsData?.approvals) ? approvalsData.approvals : (Array.isArray(approvalsData) ? approvalsData : []));
+        if (unifiedData.triage) {
+          setInitialTriage(unifiedData.triage);
+        }
       } catch (e: any) {
         setError(e?.message || "Failed to load dashboard data");
       } finally {


### PR DESCRIPTION
fix(ui): pass initial triage data to WorkTriageFeed to fix blank state

Resolves #30224

Loaded superpowers: none.

- The `initialTriage` variable was defined but not set when loading the dashboard data. Now it properly receives the `unifiedData.triage` value.
- Modified `UnifiedAgentFeed` to rely on the initial data if present instead of re-fetching.
- Updated the `triage_action_feed` E2E test to use the proper UI proxy endpoint (`/api/ui/triage/create`).
- All tests pass (including `triage-feed-agent` and `triage_action_feed`).

Interaction Audit:
- Tested `Approve & Execute` button in triage feed -> Successfully marks action as approved and updates status badge.
- Tested `Dismiss` button in triage feed -> Successfully marks action as dismissed.

---
*PR created automatically by Jules for task [6636051391433640464](https://jules.google.com/task/6636051391433640464) started by @ql-owo-lp*