### PR TITLE
🧹 Cleaner: Fix multi-tenant safety by adding RLS to task dependencies and epics

### DIFF
--- a/src/server/domain/repository/models.rs
+++ b/src/server/domain/repository/models.rs
@@ -33,6 +33,7 @@ pub struct ConversationalCheckoutSession {
 pub struct TaskDependency {
     pub task_id: String,
     pub depends_on_task_id: String,
+    pub organization_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]

--- a/src/server/domain/repository/task_repo.rs
+++ b/src/server/domain/repository/task_repo.rs
@@ -156,13 +156,14 @@ impl TaskRepository {
             DbStore::Postgres => {
                 sqlx::query(
                     r#"
-                    INSERT INTO task_dependencies (task_id, depends_on_task_id)
-                    VALUES ($1, $2)
+                    INSERT INTO task_dependencies (task_id, depends_on_task_id, organization_id)
+                    VALUES ($1, $2, $3)
                     ON CONFLICT DO NOTHING
                     "#
                 )
                 .bind(&dependency.task_id)
                 .bind(&dependency.depends_on_task_id)
+                .bind(&dependency.organization_id)
                 .execute(&self.db.pool)
                 .await
                 .map_err(|e| e.to_string())?;
@@ -170,13 +171,14 @@ impl TaskRepository {
             DbStore::Sqlite(sqlite_pool) => {
                 sqlx::query(
                     r#"
-                    INSERT INTO task_dependencies (task_id, depends_on_task_id)
-                    VALUES (?, ?)
+                    INSERT INTO task_dependencies (task_id, depends_on_task_id, organization_id)
+                    VALUES (?, ?, ?)
                     ON CONFLICT DO NOTHING
                     "#
                 )
                 .bind(&dependency.task_id)
                 .bind(&dependency.depends_on_task_id)
+                .bind(&dependency.organization_id)
                 .execute(sqlite_pool)
                 .await
                 .map_err(|e| e.to_string())?;
@@ -185,17 +187,18 @@ impl TaskRepository {
         Ok(())
     }
 
-    pub async fn get_task_dependencies(&self, task_id: &str) -> Result<Vec<TaskDependency>, String> {
+    pub async fn get_task_dependencies(&self, organization_id: &str, task_id: &str) -> Result<Vec<TaskDependency>, String> {
         let deps = match &self.db.store {
             DbStore::Postgres => {
                 sqlx::query_as::<_, TaskDependency>(
                     r#"
-                    SELECT task_id, depends_on_task_id
+                    SELECT task_id, depends_on_task_id, organization_id
                     FROM task_dependencies
-                    WHERE task_id = $1
+                    WHERE task_id = $1 AND organization_id = $2
                     "#
                 )
                 .bind(task_id)
+                .bind(organization_id)
                 .fetch_all(&self.db.pool)
                 .await
                 .map_err(|e| e.to_string())?
@@ -203,12 +206,13 @@ impl TaskRepository {
             DbStore::Sqlite(sqlite_pool) => {
                 sqlx::query_as::<_, TaskDependency>(
                     r#"
-                    SELECT task_id, depends_on_task_id
+                    SELECT task_id, depends_on_task_id, organization_id
                     FROM task_dependencies
-                    WHERE task_id = ?
+                    WHERE task_id = ? AND organization_id = ?
                     "#
                 )
                 .bind(task_id)
+                .bind(organization_id)
                 .fetch_all(sqlite_pool)
                 .await
                 .map_err(|e| e.to_string())?
@@ -404,6 +408,7 @@ mod tests {
             CREATE TABLE IF NOT EXISTS task_dependencies (
                 task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
                 depends_on_task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
+                organization_id TEXT NOT NULL,
                 PRIMARY KEY (task_id, depends_on_task_id)
             );
             "#
@@ -516,9 +521,10 @@ mod tests {
         repo.create_task_dependency(TaskDependency {
             task_id: "task_2".to_string(),
             depends_on_task_id: "task_1".to_string(),
+            organization_id: "tenant1".to_string(),
         }).await.unwrap();
 
-        let deps = repo.get_task_dependencies("task_2").await.unwrap();
+        let deps = repo.get_task_dependencies("tenant1", "task_2").await.unwrap();
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].depends_on_task_id, "task_1");
     }
@@ -559,6 +565,7 @@ mod tests {
         repo.create_task_dependency(TaskDependency {
             task_id: "task_2".to_string(),
             depends_on_task_id: "task_1".to_string(),
+            organization_id: "tenant1".to_string(),
         }).await.unwrap();
 
         // task_2 cannot be claimed because task_1 is not DONE

--- a/src/server/orchestration/kairos.rs
+++ b/src/server/orchestration/kairos.rs
@@ -722,6 +722,7 @@ mod tests {
             "CREATE TABLE IF NOT EXISTS task_dependencies (
                 task_id TEXT NOT NULL,
                 depends_on_task_id TEXT NOT NULL,
+                organization_id TEXT NOT NULL,
                 PRIMARY KEY (task_id, depends_on_task_id)
             )"
         )
@@ -872,6 +873,7 @@ mod tests {
             "CREATE TABLE IF NOT EXISTS shared_task_dependencies (
                 task_id TEXT NOT NULL,
                 depends_on_task_id TEXT NOT NULL,
+                organization_id TEXT NOT NULL,
                 PRIMARY KEY (task_id, depends_on_task_id)
             )"
         )
@@ -905,7 +907,7 @@ mod tests {
             .execute(&pool).await.unwrap();
         sqlx::query("INSERT INTO shared_tasks (id, organization_id, title, status, dependencies) VALUES ('2', 'tenant1', 'Task 2', 'PENDING', '[]')")
             .execute(&pool).await.unwrap();
-        sqlx::query("INSERT INTO shared_task_dependencies (task_id, depends_on_task_id) VALUES ('2', '1')")
+        sqlx::query("INSERT INTO shared_task_dependencies (task_id, depends_on_task_id, organization_id) VALUES ('2', '1', 'tenant1')")
             .execute(&pool).await.unwrap();
 
         // Try to claim, should get Task 1
@@ -988,6 +990,7 @@ mod tests {
             "CREATE TABLE IF NOT EXISTS task_dependencies (
                 task_id TEXT NOT NULL,
                 depends_on_task_id TEXT NOT NULL,
+                organization_id TEXT NOT NULL,
                 PRIMARY KEY (task_id, depends_on_task_id)
             )"
         )
@@ -1020,7 +1023,7 @@ mod tests {
         sqlx::query("INSERT INTO swarm_tasks (id, tenant_id, mission_id, title, status, dependencies) VALUES ('100', 'test-tenant', 'm100', 'Task A', 'PENDING', '[]')")
             .execute(&pool).await.unwrap();
         sqlx::query("INSERT INTO swarm_tasks (id, tenant_id, mission_id, title, status, dependencies) VALUES ('200', 'test-tenant', 'm100', 'Task B', 'PENDING', '[]')").execute(&pool).await.unwrap();
-        sqlx::query("INSERT INTO task_dependencies (task_id, depends_on_task_id) VALUES ('200', '100')")
+        sqlx::query("INSERT INTO task_dependencies (task_id, depends_on_task_id, organization_id) VALUES ('200', '100', 'test-tenant')")
             .execute(&pool).await.unwrap();
 
         // Task A is claimed

--- a/src/server/orchestration/state_machine.rs
+++ b/src/server/orchestration/state_machine.rs
@@ -83,10 +83,11 @@ impl StateMachine {
 
                 for dep in dependencies {
                     sqlx::query(
-                        "INSERT INTO shared_task_dependencies (task_id, depends_on_task_id) VALUES ($1, $2)"
+                        "INSERT INTO shared_task_dependencies (task_id, depends_on_task_id, organization_id) VALUES ($1, $2, $3)"
                     )
                     .bind(&tid)
                     .bind(&dep)
+                    .bind(organization_id)
                     .execute(&mut *tx)
                     .await
                     .map_err(|e| e.to_string())?;
@@ -113,10 +114,11 @@ impl StateMachine {
 
                 for dep in dependencies {
                     sqlx::query(
-                        "INSERT INTO shared_task_dependencies (task_id, depends_on_task_id) VALUES (?, ?)"
+                        "INSERT INTO shared_task_dependencies (task_id, depends_on_task_id, organization_id) VALUES (?, ?, ?)"
                     )
                     .bind(&tid)
                     .bind(&dep)
+                    .bind(organization_id)
                     .execute(&mut *tx)
                     .await
                     .map_err(|e| e.to_string())?;

--- a/src/server/orchestration/state_machine_test.rs
+++ b/src/server/orchestration/state_machine_test.rs
@@ -30,6 +30,7 @@ async fn test_state_machine_lifecycle_sqlite() {
         CREATE TABLE shared_task_dependencies (
             task_id TEXT NOT NULL,
             depends_on_task_id TEXT NOT NULL,
+            organization_id TEXT NOT NULL,
             PRIMARY KEY (task_id, depends_on_task_id)
         );
         "#
@@ -90,6 +91,7 @@ async fn test_state_machine_invalid_transitions_sqlite() {
         CREATE TABLE shared_task_dependencies (
             task_id TEXT NOT NULL,
             depends_on_task_id TEXT NOT NULL,
+            organization_id TEXT NOT NULL,
             PRIMARY KEY (task_id, depends_on_task_id)
         );
         "#


### PR DESCRIPTION
This PR ensures that tables storing tenant-sensitive data (such as epics, tasks, task_dependencies, and shared_task_dependencies) are protected by PostgreSQL Row Level Security (RLS). 

It implements the requested cleanup operation (Multi-Tenant Safety Check).

Changes:
1. `src/server/migrations/`: Added RLS policies and missing `organization_id` columns to `058_shared_tasks_decomposition_table.sql`, `021_epics_tasks.sql`, `051_task_dependencies.sql`, and `054_shared_task_dependencies.sql`.
2. `src/server/domain/repository/epic_task_repo.rs`: Updated data structures, tests, and query logic to insert and filter by `organization_id`.
3. `src/server/domain/repository/models.rs`: Updated `TaskDependency` to include `organization_id`.
4. `src/server/domain/repository/task_repo.rs`: Propagated `organization_id` into inserts and selects, updating all mock models in tests.
5. `src/server/orchestration/`: Updated raw SQL inserts in `kairos.rs`, `state_machine.rs`, and test files to propagate `organization_id`.

---
*PR created automatically by Jules for task [7694690519040009453](https://jules.google.com/task/7694690519040009453) started by @ql-owo-lp*