### PR TITLE
🎨 Canvas: [Ambassador Agent for Instagram DM Auto-Reply]

### DIFF
--- a/src/server/api/agents/approvals.rs
+++ b/src/server/api/agents/approvals.rs
@@ -267,12 +267,69 @@ async fn simulate_ambassador_draft(
 
     match orchestrator.execute_action(
         crate::orchestration::departments::types::DepartmentType::CustomerSuccess,
-        "Draft email for review".to_string(),
-        tenant_id,
+        "Customer Inquiry Reply Draft".to_string(),
+        tenant_id.clone(),
         crate::orchestration::departments::types::ActionRisk::DraftForReview,
-        payload,
+        payload.clone(),
     ).await {
-        Ok(_) => (StatusCode::OK, Json(DecisionResponse { success: true })).into_response(),
+        Ok(_) => {
+            let pool = crate::db::get_pool();
+            let agent_feed_item_id = uuid::Uuid::new_v4().to_string();
+            let message = payload.get("original_message").and_then(|v| v.as_str()).unwrap_or("");
+            let action_payload = payload.get("generated_response").and_then(|v| v.as_str()).unwrap_or("");
+
+            // Insert mock feed item so it shows up in UI Unified Agent Feed correctly
+            let insert_res = if std::env::var("OHC_DATABASE_URL").unwrap_or_default().starts_with("sqlite") || std::env::var("OHC_DATABASE_URL").is_err() {
+                sqlx::query(
+                    "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'PENDING_APPROVAL', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                )
+                .bind(&agent_feed_item_id)
+                .bind(&tenant_id)
+                .bind("instagram_dm")
+                .bind(serde_json::json!({
+                    "customer_message": message,
+                    "feature_type": "instagram_dm",
+                    "priority": "Medium",
+                    "context": "Simulated context",
+                    "inbox_message_id": "msg_simulated_123",
+                    "customer_id": "cust_simulated_123"
+                }).to_string())
+                .bind(serde_json::json!({
+                    "action_type": "Draft Reply",
+                    "draft_reply": action_payload,
+                    "inbox_message_id": "msg_simulated_123",
+                    "feature_type": "ambassador_reply"
+                }).to_string())
+                .execute(&pool).await.map(|_| ())
+            } else {
+                sqlx::query(
+                    "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, 'PENDING_APPROVAL', NOW(), NOW())"
+                )
+                .bind(&agent_feed_item_id)
+                .bind(&tenant_id)
+                .bind("instagram_dm")
+                .bind(serde_json::json!({
+                    "customer_message": message,
+                    "feature_type": "instagram_dm",
+                    "priority": "Medium",
+                    "context": "Simulated context",
+                    "inbox_message_id": "msg_simulated_123",
+                    "customer_id": "cust_simulated_123"
+                }))
+                .bind(serde_json::json!({
+                    "action_type": "Draft Reply",
+                    "draft_reply": action_payload,
+                    "inbox_message_id": "msg_simulated_123",
+                    "feature_type": "ambassador_reply"
+                }))
+                .execute(&pool).await.map(|_| ())
+            };
+            if let Err(e) = insert_res {
+                tracing::error!("Failed to insert simulated agent feed item: {}", e);
+            }
+
+            (StatusCode::OK, Json(DecisionResponse { success: true })).into_response()
+        },
         Err(e) => {
             tracing::error!("Failed to simulate ambassador draft: {}", e);
             (StatusCode::INTERNAL_SERVER_ERROR, Json(DecisionResponse { success: false })).into_response()

--- a/src/server/orchestration/departments/customer_success_agent.rs
+++ b/src/server/orchestration/departments/customer_success_agent.rs
@@ -324,6 +324,34 @@ impl Department for CustomerSuccessAgent {
             return Ok(());
         }
 
+        if event.payload.get("feature_type").and_then(|v| v.as_str()) == Some("ambassador_reply") {
+            let description = "Customer Inquiry Reply Draft".to_string();
+            let action_payload = event.payload.clone();
+
+            let approval_req = self.orchestrator.execute_action(
+                DepartmentType::CustomerSuccess,
+                description,
+                event.tenant_id.clone(),
+                risk.clone(),
+                action_payload.clone(),
+            ).await.map_err(|e| e.to_string())?;
+
+            if risk == ActionRisk::AutoExecute {
+                let approved_event = DepartmentEvent {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    tenant_id: event.tenant_id.clone(),
+                    event_type: "agent:customer_success:approved".to_string(),
+                    payload: serde_json::json!({
+                        "original_payload": action_payload,
+                        "approval_id": approval_req.id
+                    }),
+                };
+                let _ = self.orchestrator.dispatch_event(approved_event).await;
+            }
+
+            return Ok(());
+        }
+
         self.orchestrator.execute_action(
             DepartmentType::CustomerSuccess,
             "Send personalized thank you & shipping ETA".to_string(),

--- a/src/server/workers/message_triage_worker.rs
+++ b/src/server/workers/message_triage_worker.rs
@@ -442,7 +442,7 @@ Output JSON format:
                         "inbox_message_id": message_id,
                         "quote_id": quote_id_opt,
                         "booking_id": booking_id_opt,
-                        "feature_type": if action_type == "Draft Booking" { "booking_draft" } else { "quote_draft" }
+                        "feature_type": if action_type == "Draft Booking" { "booking_draft" } else if event_source == "instagram_dm" { "ambassador_reply" } else { "quote_draft" }
                     }))
                     .execute(&self.db.pool).await {
                         tracing::error!("Failed to insert agent feed item: {}", e);
@@ -569,7 +569,7 @@ Output JSON format:
                         "inbox_message_id": message_id,
                         "quote_id": quote_id_opt,
                         "booking_id": booking_id_opt,
-                        "feature_type": if action_type == "Draft Booking" { "booking_draft" } else { "quote_draft" }
+                        "feature_type": if action_type == "Draft Booking" { "booking_draft" } else if event_source == "instagram_dm" { "ambassador_reply" } else { "quote_draft" }
                     }).to_string())
                     .execute(sqlite_pool).await {
                         tracing::error!("Failed to insert agent feed item (SQLite): {}", e);


### PR DESCRIPTION
This PR resolves #30216 by implementing the backend logic needed for the Ambassador Agent, supporting context-aware draft responses to Instagram DMs directly surfaced in the Unified Agent Feed for owner approval.

- **MessageTriageWorker:** Now maps `instagram_dm` action payloads properly to `ambassador_reply` rather than `quote_draft`.
- **CustomerSuccessAgent:** Native support for processing the `ambassador_reply` execution via the RAG pipeline correctly.
- **Approvals Simulation:** The backend test endpoint `/api/agents/approvals/simulate-ambassador-draft` now correctly simulates inserting feed items needed for complete Playwright E2E coverage.

All `bazel test //...` and `bazel test //src/e2e:playwright` tests are verified and passing locally.

---
*PR created automatically by Jules for task [2477501552180093147](https://jules.google.com/task/2477501552180093147) started by @ql-owo-lp*