### PR TITLE
fix: unused assignment in unified_inbox_webhook

### DIFF
--- a/src/server/api/unified_inbox_webhook.rs
+++ b/src/server/api/unified_inbox_webhook.rs
@@ -190,7 +190,7 @@ pub async fn get_unified_feed(
 
     let mut feed_items: Vec<UnifiedFeedItem> = vec![];
 
-    let mut threads_res_mapped: Result<Vec<UnifiedThread>, sqlx::Error> = Ok(vec![]);
+    let threads_res_mapped: Result<Vec<UnifiedThread>, sqlx::Error>;
     match &state.db.store {
         crate::db::DbStore::Postgres => {
             let res = sqlx::query("SELECT id, tenant_id, customer_id, channel, status, CAST(created_at AS text) as created_at, CAST(updated_at AS text) as updated_at FROM unified_threads WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT 50")


### PR DESCRIPTION
This commit removes the unused `mut` and initial assignment in `unified_inbox_webhook.rs` which was causing a compiler warning (`#[warn(unused_mut)]` and `#[warn(unused_assignments)]`). No other bugs were found regarding `prune_stuck_agent_missions` nor `prune_stuck_sub_agent_queue` since they were already executing on the correct DB pools. All tests and playwright checks pass perfectly.

---
*PR created automatically by Jules for task [14485756453197537973](https://jules.google.com/task/14485756453197537973) started by @ql-owo-lp*