### PR TITLE
🤖 Implementer: Harness Upgrade - Pydantic-first tool schema validation

### DIFF
--- a/src/agents/builtin/output_parser.rs
+++ b/src/agents/builtin/output_parser.rs
@@ -223,6 +223,8 @@ impl<'a, T: DeserializeOwned> RetryWithErrorOutputParser<'a, T> {
                         current_req.messages.push(msg.clone());
                         let detailed_error = if parse_error_msg.contains("Validation Error") {
                             parse_error_msg.clone()
+                        } else if parse_error_msg.contains("Semantic validation failed") {
+                            parse_error_msg.clone()
                         } else {
                             // Extract snippet of arguments to feed back and format as strict Pydantic JSON array
                             let args_snippet = msg.tool_calls.first().map(|tc| tc.arguments.to_string());

--- a/src/agents/builtin/types.rs
+++ b/src/agents/builtin/types.rs
@@ -231,12 +231,29 @@ pub fn format_pydantic_error(e: &serde_json::Error, args_str: Option<&str>, cust
     let msg_content = format!("{}", e);
     let snippet = args_str.unwrap_or("null");
 
-    let pydantic_json = serde_json::json!([{
+    let extended_msg_content = if e.is_data() {
+        format!("Semantic validation failed: {}", msg_content)
+    } else if e.is_syntax() {
+        format!("JSON syntax error: {}", msg_content)
+    } else if e.is_eof() {
+        format!("Incomplete JSON structure (unexpected EOF): {}", msg_content)
+    } else {
+        msg_content.clone()
+    };
+
+    let mut pydantic_json_obj = serde_json::json!({
         "type": error_type,
         "loc": ["data"],
-        "msg": msg_content,
-        "input": snippet
-    }]);
+        "msg": extended_msg_content,
+    });
+
+    if args_str.is_some() {
+        pydantic_json_obj.as_object_mut().unwrap().insert("input".to_string(), serde_json::Value::String(snippet.to_string()));
+    } else {
+        pydantic_json_obj.as_object_mut().unwrap().insert("input".to_string(), serde_json::Value::String("null".to_string()));
+    }
+
+    let pydantic_json = serde_json::json!([pydantic_json_obj]);
 
     let mut msg = format!(
         "Validation Error (Pydantic-first tool schema): Failed to parse arguments.\nReason: {}",


### PR DESCRIPTION
🤖 Implementer: Harness Upgrade - Pydantic-first tool schema validation

This PR introduces an architectural upgrade from the "Master Catalog" of industry standards: Pydantic-first tool schema validation. 

Mechanic details: 
We leverage `serde_json::Error` characteristics (`is_data()`, `is_syntax()`, `is_eof()`) to classify output parsing failures precisely and formulate clear textual feedback for the LLM. 
For example, if it's a semantic data error, we prepend `"Semantic validation failed: "` to the returned parsing error. This detailed, strongly-typed error is then fed back into the `RetryWithErrorOutputParser` (our fallback loop mechanic) allowing the model to quickly self-correct schema validation failures instead of generic errors.

This ensures better self-correction and prevents the context from rotting with obscure syntax errors. 

Testing instructions:
Run the builtin agent tests to verify that semantic and structural error formatting tests pass:
`bazel test //src/agents/builtin/...`

---
*PR created automatically by Jules for task [5329948627303136001](https://jules.google.com/task/5329948627303136001) started by @ql-owo-lp*