### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix]

### DIFF
--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -180,6 +180,16 @@ impl Store {
                 let sqlite_key_opt = std::env::var("OHC_SQLITE_KEY").ok().or_else(|| {
                     let secret_path = ::server_config::get_safe_user_dir().join(".ohc_sqlite_key");
                     if secret_path.exists() {
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::PermissionsExt;
+                            if let Ok(mut perms) = std::fs::metadata(&secret_path).map(|m| m.permissions()) {
+                                if (perms.mode() & 0o777) != 0o600 {
+                                    perms.set_mode(0o600);
+                                    let _ = std::fs::set_permissions(&secret_path, perms);
+                                }
+                            }
+                        }
                         if let Ok(bytes) = std::fs::read_to_string(&secret_path) {
                             if !bytes.trim().is_empty() {
                                 return Some(bytes.trim().to_string());

--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -438,16 +438,28 @@ impl UserRepository for PgUserRepository {
 
     async fn is_revoked(&self, jti: &str, org_id: &str) -> Result<bool, String> {
         validate_org_id!(org_id);
+        let is_multitenant = is_multitenant_mode();
+        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
 
-        let row = sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $3 AND tenant_id = $2")
-            .bind(jti)
-            .bind(org_id)
-            .bind(chrono::Utc::now())
-            .fetch_one(&mut *tx)
-            .await
-            .map_err(|e| e.to_string())?;
+        let row = if should_bypass {
+            sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $2")
+                .bind(jti)
+                .bind(chrono::Utc::now())
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(|e| e.to_string())?
+        } else {
+            sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $3 AND tenant_id = $2")
+                .bind(jti)
+                .bind(org_id)
+                .bind(chrono::Utc::now())
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(|e| e.to_string())?
+        };
 
         let count: i64 = row.get(0);
         tx.rollback().await.map_err(|e| e.to_string())?;

--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -335,6 +335,8 @@ impl UserRepository for SqliteUserRepository {
         let is_multitenant = is_multitenant_mode();
         let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
 
+        let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
+
         sqlx::query(
             r#"
             INSERT INTO revoked_tokens (jti, expires_at, tenant_id) VALUES ($1, $2, $3)
@@ -344,30 +346,44 @@ impl UserRepository for SqliteUserRepository {
         .bind(jti)
         .bind(exp)
         .bind(org_id)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e: sqlx::Error| e.to_string())?;
 
 
         let now = chrono::Utc::now();
         if should_bypass {
-            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1").bind(now).execute(&self.pool).await.map_err(|e: sqlx::Error| e.to_string())?;
+            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1").bind(now).execute(&mut *tx).await.map_err(|e: sqlx::Error| e.to_string())?;
         } else {
-            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = $2").bind(now).bind(org_id).execute(&self.pool).await.map_err(|e: sqlx::Error| e.to_string())?;
+            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = $2").bind(now).bind(org_id).execute(&mut *tx).await.map_err(|e: sqlx::Error| e.to_string())?;
         }
+
+        tx.commit().await.map_err(|e| e.to_string())?;
 
         Ok(())
     }
 
     async fn is_revoked(&self, jti: &str, org_id: &str) -> Result<bool, String> {
         validate_org_id!(org_id);
-        let row = sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $3 AND tenant_id = $2")
-            .bind(jti)
-            .bind(org_id)
-            .bind(chrono::Utc::now())
-            .fetch_one(&self.pool)
-            .await
-            .map_err(|e: sqlx::Error| e.to_string())?;
+        let is_multitenant = is_multitenant_mode();
+        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+
+        let row = if should_bypass {
+            sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $2")
+                .bind(jti)
+                .bind(chrono::Utc::now())
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e: sqlx::Error| e.to_string())?
+        } else {
+            sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $3 AND tenant_id = $2")
+                .bind(jti)
+                .bind(org_id)
+                .bind(chrono::Utc::now())
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e: sqlx::Error| e.to_string())?
+        };
 
         let count: i32 = row.get(0);
         Ok(count > 0)


### PR DESCRIPTION
Implemented crucial security hardening and bugfixes in authentication stores (`sqlite_store.rs`, `postgres_store.rs`, `mod.rs`). Enforced `0600` permissions on the local SQLite encryption key (`.ohc_sqlite_key`) mirroring JWT secret protocols. Addressed a transaction safety issue inside `sqlite_store.rs`'s `revoke_token` logic to avoid race conditions. Repaired a logical bug inside `is_revoked` (for both SQLite and PostgreSQL stores) where the `should_bypass` parameter was previously ignored, causing system tenant checks to behave incorrectly. Tested successfully using Bazel and Playwright.

---
*PR created automatically by Jules for task [4286411192807535831](https://jules.google.com/task/4286411192807535831) started by @ql-owo-lp*