### PR TITLE
Fix Documentation E2E test paths

### DIFF
--- a/src/e2e/help_features_advanced.spec.ts
+++ b/src/e2e/help_features_advanced.spec.ts
@@ -19,7 +19,7 @@ test.describe('In-App Help & Documentation Features', () => {
   });
 
   test('views individual help article', async ({ page }) => {
-    await page.goto('/help_article.html?id=getting-started-1');
+    await page.goto('/help/getting-started-1');
 
     await expect(page.getByRole('heading', { name: 'Getting Started with Your Store' })).toBeVisible();
     await expect(page.getByText(/Tell us about your business/)).toBeVisible();

--- a/src/e2e/scribe-documentation-flows.spec.ts
+++ b/src/e2e/scribe-documentation-flows.spec.ts
@@ -12,7 +12,7 @@ test.describe('Documentation Features Flow', () => {
     await page.waitForLoadState('networkidle');
 
     // Click on the first article using a simpler selector that works regardless of exact visible state transitions
-    const articleLink = page.locator('a[href="/help_article.html?id=getting-started-1"]').first();
+    const articleLink = page.locator('a[href="/help/getting-started-1"]').first();
     await articleLink.click({ force: true });
 
     // Help Article Page


### PR DESCRIPTION
This PR fixes failing E2E tests related to documentation flows. The Help Center has been updated to use dynamic routing `/help/:articleId` in NextJS instead of the legacy `/help_article.html?id=:articleId` URL structure. 

This change updates the test navigations and locators in `src/e2e/scribe-documentation-flows.spec.ts` and `src/e2e/help_features_advanced.spec.ts` to expect the new route pattern, restoring E2E test correctness for the documentation suite.

---
*PR created automatically by Jules for task [7109389712496330105](https://jules.google.com/task/7109389712496330105) started by @ql-owo-lp*