### PR TITLE
✍️ Scribe: fix unused variable in unified inbox webhook

### DIFF
--- a/src/server/api/unified_inbox_webhook.rs
+++ b/src/server/api/unified_inbox_webhook.rs
@@ -190,7 +190,7 @@ pub async fn get_unified_feed(
 
     let mut feed_items: Vec<UnifiedFeedItem> = vec![];
 
-    let mut threads_res_mapped: Result<Vec<UnifiedThread>, sqlx::Error> = Ok(vec![]);
+    let threads_res_mapped: Result<Vec<UnifiedThread>, sqlx::Error>;
     match &state.db.store {
         crate::db::DbStore::Postgres => {
             let res = sqlx::query("SELECT id, tenant_id, customer_id, channel, status, CAST(created_at AS text) as created_at, CAST(updated_at AS text) as updated_at FROM unified_threads WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT 50")


### PR DESCRIPTION
This commit resolves a strict compiler failure in `//src/server:server_lib_core_unit_test`.

1. **Backend Compiler Fix**: Addressed a strict compiler warning (`#![warn(unused_variables)]`) regarding `let mut threads_res_mapped: Result<Vec<UnifiedThread>, sqlx::Error> = Ok(vec![]);` by removing the unused default assignment.
2. **Result**: `bazelisk test //...` is now fully green, passing hermetically and satisfying strict Rust CI requirements.

---
*PR created automatically by Jules for task [9982636528407088003](https://jules.google.com/task/9982636528407088003) started by @ql-owo-lp*