### PR TITLE
test(e2e): Fix E2E tests to rely on actual frontend application code

### DIFF
--- a/src/e2e/triage-feed-agent.spec.ts
+++ b/src/e2e/triage-feed-agent.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from './fixtures';
 
 test.describe('Agentic Work Triage Feed', () => {
-  test('Owner can review and approve AI-drafted replies', async ({ page, loginAs, defaultUser }) => {
+  test('Owner can review and approve AI-drafted replies', async ({ page, loginAs, adminUser }) => {
     // 1. Log in to the application
-    await loginAs(page, defaultUser);
+    await loginAs(page, adminUser);
 
     // 2. Simulate an incoming message by hitting the new test endpoint
     const response = await page.request.post(`/api/dev/simulate-triage-item?tenant_id=default`);
@@ -35,8 +35,8 @@ test.describe('Agentic Work Triage Feed', () => {
     await expect(card).not.toBeVisible({ timeout: 5000 });
   });
 
-  test('Owner can dismiss AI-drafted replies', async ({ page, loginAs, defaultUser }) => {
-    await loginAs(page, defaultUser);
+  test('Owner can dismiss AI-drafted replies', async ({ page, loginAs, adminUser }) => {
+    await loginAs(page, adminUser);
     const response = await page.request.post(`/api/dev/simulate-triage-item?tenant_id=default`);
     const json = await response.json();
     const triageItemId = json.id;
@@ -52,8 +52,8 @@ test.describe('Agentic Work Triage Feed', () => {
     await expect(card).not.toBeVisible({ timeout: 5000 });
   });
 
-  test('Triage feed handles empty state correctly', async ({ page, loginAs, defaultUser }) => {
-    await loginAs(page, defaultUser);
+  test('Triage feed handles empty state correctly', async ({ page, loginAs, adminUser }) => {
+    await loginAs(page, adminUser);
     await page.goto('/dashboard');
 
     // It should either show the empty state or an empty feed, but given we might have real data,
@@ -68,8 +68,8 @@ test.describe('Agentic Work Triage Feed', () => {
     ]);
   });
 
-  test('Triage feed item shows correct metadata', async ({ page, loginAs, defaultUser }) => {
-    await loginAs(page, defaultUser);
+  test('Triage feed item shows correct metadata', async ({ page, loginAs, adminUser }) => {
+    await loginAs(page, adminUser);
     const response = await page.request.post(`/api/dev/simulate-triage-item?tenant_id=default`);
     const json = await response.json();
     const triageItemId = json.id;
@@ -84,8 +84,8 @@ test.describe('Agentic Work Triage Feed', () => {
     await expect(card).toContainText('High');
   });
 
-  test('Triage feed layout is responsive', async ({ page, loginAs, defaultUser }) => {
-    await loginAs(page, defaultUser);
+  test('Triage feed layout is responsive', async ({ page, loginAs, adminUser }) => {
+    await loginAs(page, adminUser);
     await page.setViewportSize({ width: 375, height: 812 }); // Mobile
 
     const response = await page.request.post(`/api/dev/simulate-triage-item?tenant_id=default`);

--- a/src/e2e/wizard_cross_device.spec.ts
+++ b/src/e2e/wizard_cross_device.spec.ts
@@ -15,7 +15,16 @@ test.describe('Wizard Cross Device E2E', () => {
     // The first screen is "10-Minute Setup Wizard", clicking "Start My Business" moves to step 1
     await page.getByRole('button', { name: 'Back' }).click();
     await page.getByRole('button', { name: /Start My Business/ }).click();
-    await expect(page.getByRole('heading', { name: "What's the name of your business?" })).toBeVisible();
+    await expect(page.getByRole('heading', { name: "How do you work?" })).toBeVisible();
+
+    await page.getByText("I'm a Baker").click();
+    await page.locator('#step-context .next-step-btn').click();
+
+    await expect(page.getByRole('heading', { name: /What's your category?/ })).toBeVisible();
+    await page.locator('#business-categories').selectOption('Bakery');
+    await page.locator('#step-categories .next-step-btn').click();
+
+    await expect(page.getByRole('heading', { name: /What's the name of your business?/ })).toBeVisible();
 
     // 3. Move to step 2 and enter business name
     // It's already at the "What's the name of your business?" step. We fill the input.
@@ -38,8 +47,8 @@ test.describe('Wizard Cross Device E2E', () => {
     }).toBe('Cross Device Wizard');
 
     // Also trigger save to backend
-    await page.getByRole('button', { name: 'Next' }).click();
-    await expect(page.getByRole('heading', { name: "What do you sell?" })).toBeVisible();
+    await page.locator('#step-name .next-step-btn').click();
+    await expect(page.getByRole('heading', { name: "Set up your Assistant" })).toBeVisible();
     await page.waitForTimeout(1000);
 
     // 4. Simulate a cross-device session with a new browser context
@@ -63,8 +72,8 @@ test.describe('Wizard Cross Device E2E', () => {
     await newPage.waitForLoadState('networkidle');
 
     // 5. Verify the business name and step was properly restored
-    await expect(newPage.getByRole('heading', { name: 'What do you sell?' })).toBeVisible({ timeout: 10000 });
-    await newPage.locator('button:has-text("Back")').first().click();
+    await expect(newPage.getByRole('heading', { name: 'Set up your Assistant' })).toBeVisible({ timeout: 10000 });
+    await newPage.locator('#step-assistant .prev-step-btn').first().click();
     await expect(newPage.getByRole('heading', { name: "What's the name of your business?" })).toBeVisible();
     await expect(newPage.getByPlaceholder("e.g. Maya's Custom Cakes")).toHaveValue('Cross Device Wizard', { timeout: 10000 });
 

--- a/src/e2e/wizard_mobile_layout.spec.ts
+++ b/src/e2e/wizard_mobile_layout.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Wizard and Onboarding flows', () => {
 
@@ -28,18 +28,16 @@ test.describe('Wizard and Onboarding flows', () => {
 
     // Check click routing inside builder
     await page.locator('text="Start My Business"').click();
-    await expect(page.getByText("Let's build your store")).toBeVisible();
 
-    const nameInput = page.getByPlaceholder('e.g. Acme Corp');
-    await expect(nameInput).toBeVisible();
-    await nameInput.fill('Maya Cakes');
+    await expect(page.getByRole('heading', { name: 'How do you work?' })).toBeVisible();
+    await page.getByText("I'm a Baker").click();
+    await page.locator('#step-context .next-step-btn').click();
 
-    const descInput = page.getByPlaceholder('e.g. Retail, Consulting, Tech');
-    await expect(descInput).toBeVisible();
-    await descInput.fill('Bakery');
+    await expect(page.locator('#business-categories')).toBeVisible();
+    await page.locator('#business-categories').selectOption('Bakery');
+    await page.locator('#step-categories .next-step-btn').click();
 
-    await page.getByRole('button', { name: 'Next: Choose Vibe' }).click();
-    await expect(page.getByText('Select Your Vibe')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /What's the name of your business?/ })).toBeVisible();
   });
 
   test('Main Onboarding multi-step wizard mobile', async ({ page }) => {
@@ -49,19 +47,20 @@ test.describe('Wizard and Onboarding flows', () => {
     await expect(page.locator('text="10-Minute Setup Wizard"').first()).toBeVisible();
     await page.locator('text="Start My Business"').click();
 
-    await expect(page.locator('text="Which of these sounds most like your work?"')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'How do you work?' })).toBeVisible();
 
     // Check constraints are working inside inputs.
-    await page.locator('text="Online Creator"').first().click(); await page.locator('text="Next"').click(); await page.getByPlaceholder('e.g. Maya\'s Custom Cakes').fill('Cakes By Maya');
-    await page.getByPlaceholder('Tagline (optional)').fill('Baker');
+    await page.getByText("I'm a Baker").click();
+    await page.locator('#step-context .next-step-btn').click();
+    await expect(page.locator('#business-categories')).toBeVisible();
+    await page.locator('#business-categories').selectOption('Bakery');
+    await page.locator('#step-categories .next-step-btn').click();
 
-    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page.getByRole('heading', { name: /What's the name of your business?/ })).toBeVisible();
+    await page.getByPlaceholder('e.g. Maya\'s Custom Cakes').fill('Cakes By Maya');
+    await page.locator('#step-name .next-step-btn').click();
 
-    await expect(page.getByText('Select Your Vibe')).toBeVisible();
-    await page.getByText('Friendly').click();
-    await page.getByRole('button', { name: 'Next' }).click();
-
-    await expect(page.getByText('Final Details')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Set up your Assistant' })).toBeVisible();
   });
 
   test('Direct routing for business-setup compatibility page', async ({ page }) => {
@@ -76,15 +75,12 @@ test.describe('Wizard and Onboarding flows', () => {
     await page.goto('/setup.html');
 
     await expect(page.locator('text="10-Minute Setup Wizard"').first()).toBeVisible();
-    await page.getByText('Offering Services').click();
+    await page.locator('text="Start My Business"').click();
 
-    await expect(page.locator('text="Which of these sounds most like your work?"')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'How do you work?' })).toBeVisible();
+    await page.getByText("I'm a Baker").click();
+    await page.locator('#step-context .next-step-btn').click();
 
-    await page.getByPlaceholder('e.g. Acme Corp').fill('Auto Repair');
-    await page.getByPlaceholder('e.g. Retail, Consulting, Tech').fill('Mechanic');
-
-    await page.getByRole('button', { name: 'Next' }).click();
-
-    await expect(page.getByText('Select Your Vibe')).toBeVisible();
+    await expect(page.locator('#business-categories')).toBeVisible();
   });
 });

--- a/src/e2e/wizard_refinement.spec.ts
+++ b/src/e2e/wizard_refinement.spec.ts
@@ -8,14 +8,16 @@ test.describe('Wizard Refinement E2E', () => {
     await expect(page.getByRole('heading', { name: 'Tell us about your business' })).toBeVisible();
   });
 
-  test('exposes AI helper and prompt tuning areas', async ({ page }) => {
+  test('exposes AI helper and prompt tuning areas', async ({ page, loginAs, adminUser }) => {
+    await loginAs(page, adminUser);
     await page.goto('/dashboard');
     await page.getByRole('link', { name: 'AI Departments' }).click();
     await expect(page.getByRole('heading', { name: 'AI Departments' })).toBeVisible();
     await expect(page.getByText('The Promoter')).toBeVisible();
   });
 
-  test('settings remain accessible from dashboard quick actions', async ({ page }) => {
+  test('settings remain accessible from dashboard quick actions', async ({ page, loginAs, adminUser }) => {
+    await loginAs(page, adminUser);
     await page.goto('/dashboard');
     await page.getByRole('link', { name: 'Settings', exact: true }).click();
     await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();


### PR DESCRIPTION
This PR fixes failing E2E tests for the Setup Wizard by ensuring tests use the actual real frontend components from the `http://mock` domain and restoring local environment setups such as `adminUser` fixtures to prevent local timeout regressions where connections inside `Playwright` to external services are not feasible or timeout.

---
*PR created automatically by Jules for task [5810220520680196972](https://jules.google.com/task/5810220520680196972) started by @ql-owo-lp*