### PR TITLE
Remove technical jargon from Dashboard UI

### DIFF
--- a/src/ui/next/src/app/dashboard/page.tsx
+++ b/src/ui/next/src/app/dashboard/page.tsx
@@ -340,13 +340,13 @@ export default function Dashboard() {
     {
       targetId: "sales-card-target",
       title: "Business Analytics",
-      content: "This panel reads sales and customer counts from the database-backed dashboard endpoint.",
+      content: "This panel shows your current sales and customer counts.",
       position: "bottom" as const,
     },
     {
       targetId: "operations-map-target",
       title: "Operations Map",
-      content: "Use this area to see the live state of orders, inbox, and inventory from your database.",
+      content: "Use this area to see the live state of your orders, messages, and inventory.",
       position: "bottom" as const,
     },
   ];
@@ -356,7 +356,7 @@ export default function Dashboard() {
     <AIPaywallWidget remainingActions={remainingActions} />
     <AppShell
       title="Dashboard"
-      subtitle="Network-style command center for database-backed store operations."
+      subtitle="Network-style command center for your store operations."
       statusItems={statusItems}
       actions={[
         { label: "Campaigns", href: "/dashboard/campaigns", icon: "campaigns" },
@@ -644,16 +644,16 @@ export default function Dashboard() {
           <div className="grid grid-cols-1 md:grid-cols-[1fr_300px] gap-6">
             <div className="app-grid metrics !grid-cols-2 lg:!grid-cols-4">
               <WalkthroughTarget id="sales-card-target" className="app-card">
-                <WithTooltip id="total-sales-tooltip" defaultText="Total revenue generated from database orders.">
+                <WithTooltip id="total-sales-tooltip" defaultText="Total revenue generated from your orders.">
                   <div className="app-metric-label">Total Sales</div>
                 </WithTooltip>
                 <div className="app-metric-value">{money(metrics.total_sales)}</div>
-                <div className="app-metric-note">{loading ? "Loading database rows" : "All recorded orders"}</div>
+                <div className="app-metric-note">{loading ? "Loading your data..." : "All recorded orders"}</div>
               </WalkthroughTarget>
               <div className="app-card">
                 <div className="app-metric-label">Customers</div>
                 <div className="app-metric-value">{metrics.active_customers}</div>
-                <div className="app-metric-note">Database customer records</div>
+                <div className="app-metric-note">Customer records</div>
               </div>
               <div className="app-card">
                 <div className="app-metric-label">Pending Orders</div>
@@ -676,7 +676,7 @@ export default function Dashboard() {
             <div className="app-panel-header">
               <div>
                 <div className="app-panel-title">Operations Map</div>
-                <div className="app-list-subtitle">Live database state across the store workflow.</div>
+                <div className="app-list-subtitle">Live overview of your store workflow.</div>
               </div>
               <Link href="/orders" className="app-button min-h-[44px]">Open Orders</Link>
             </div>
@@ -746,13 +746,13 @@ export default function Dashboard() {
                 <div className="app-list-item">
                   <div>
                     <div className="app-list-title">Inbox messages</div>
-                    <div className="app-list-subtitle">Open customer conversations are waiting in the database.</div>
+                    <div className="app-list-subtitle">You have open customer conversations waiting for your reply.</div>
                   </div>
                   <span className="app-badge">Inbox</span>
                 </div>
               )}
               {!loading && metrics.pending_orders === 0 && lowStockCount === 0 && messages.length === 0 && (dashboardData?.pendingReviews || []).filter((a: any) => a.payload?.feature_type === "ambassador_reply").length === 0 && (
-                <div className="app-empty">No database-backed actions are currently open.</div>
+                <div className="app-empty">No actions are currently required.</div>
               )}
             </div>
           </div>
@@ -766,7 +766,7 @@ export default function Dashboard() {
               <Link href="/orders" className="app-button min-h-[44px]">View All</Link>
             </div>
             {orders.length === 0 ? (
-              <div className="app-empty">{loading ? "Loading orders from the database..." : "No order rows found for this tenant."}</div>
+              <div className="app-empty">{loading ? "Loading your orders..." : "No orders found."}</div>
             ) : (
               <div className="app-table-wrap">
                 <table className="app-table">
@@ -800,7 +800,7 @@ export default function Dashboard() {
             </div>
             <div className="app-list">
               {messages.length === 0 ? (
-                <div className="app-empty">{loading ? "Loading inbox from the database..." : "No inbox message rows found for this tenant."}</div>
+                <div className="app-empty">{loading ? "Loading your messages..." : "No messages found."}</div>
               ) : messages.slice(0, 6).map((message) => (
                 <div key={message.id} className="app-list-item">
                   <div>


### PR DESCRIPTION
Replaced developer-centric jargon like "database", "rows", and "endpoint" with plain-language owner-friendly terms in the Dashboard UI to meet product design standards.

---
*PR created automatically by Jules for task [12306776642427808492](https://jules.google.com/task/12306776642427808492) started by @ql-owo-lp*