### PR TITLE
Fix Miser cost alert threshold evaluation logic

### DIFF
--- a/src/e2e/miser_cost_features.spec.ts
+++ b/src/e2e/miser_cost_features.spec.ts
@@ -150,4 +150,24 @@ test.describe('Miser Cost Features E2E', () => {
     const managePlanButton = starterCard.locator('button', { hasText: 'Manage Plan' });
     await expect(managePlanButton).toBeVisible({ timeout: 15000 });
   });
+
+  test('Budget Alert triggers on projected cost threshold with real data', async ({ page, loginAs }) => {
+    const starterUser = { email: "starter@example.com", password: "password123", role: "ADMIN" };
+    await loginAs(page, starterUser as any);
+
+    // Let's create realistic data for cost threshold alert via actual API interactions
+    // by calling the endpoint that generates the cost payload. This mimics normal usage.
+    await page.request.post('/api/billing/report-cost', {
+        data: {
+            metric_name: 'ohc_llm_cost_total_cents',
+            value: 200000,
+            labels: { agent_id: 'agent_test_high_usage' }
+        }
+    });
+
+    await page.goto('/cost-dashboard');
+
+    // The threshold should trigger given a $2,000 spend on the Starter plan.
+    await expect(page.locator('text=Soft Limit Approaching')).toBeVisible({ timeout: 15000 });
+  });
 });

--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -464,8 +464,7 @@ pub async fn cost_dashboard_handler(
     let budget_limit = if budget_limit <= 0.0 { 10.0 } else { budget_limit };
 
     let budget_manager = ::server_pricing::budget::BudgetManager::new(budget_limit);
-    budget_manager.record_spend_cents(projected_cents).unwrap_or(false);
-    let budget_health_alert = budget_manager.check_alert_threshold();
+    let budget_health_alert = budget_manager.is_projected_cost_over_threshold(projected_cents);
 
 
     let department_tier_usage = department_res.unwrap_or_else(|_| empty_department_tier_usage_response());

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -1458,8 +1458,7 @@ impl HubService for MyHubService {
         let budget_limit = if budget_limit <= 0.0 { 10.0 } else { budget_limit };
 
         let budget_manager = ::server_pricing::budget::BudgetManager::new(budget_limit);
-        let _ = budget_manager.record_spend_cents(projected_cents);
-        let budget_health_alert = budget_manager.check_alert_threshold();
+        let budget_health_alert = budget_manager.is_projected_cost_over_threshold(projected_cents);
 
         let response = ::server_ohc::orchestration::CostDashboardResponse {
             total_revenue: (total_revenue_f64 * 100.0).round() as i64,

--- a/src/server/pricing/budget.rs
+++ b/src/server/pricing/budget.rs
@@ -103,6 +103,11 @@ impl BudgetManager {
         usage_percent >= self.alert_threshold_percent
     }
 
+    pub fn is_projected_cost_over_threshold(&self, projected_cost_cents: i64) -> bool {
+        let limit_threshold_cents = ((self.total_limit * 100.0) * (self.alert_threshold_percent / 100.0)).round() as i64;
+        projected_cost_cents >= limit_threshold_cents
+    }
+
     pub fn check_alert_threshold_cents(&self, total_limit_cents: i64) -> bool {
         if total_limit_cents <= 0 {
             return false;
@@ -239,6 +244,15 @@ mod tests {
         let exact_manager = BudgetManager::new(100.0).with_alert_threshold(80.0);
         exact_manager.record_spend_cents(8000).expect("failed to unwrap");
         assert!(exact_manager.check_alert_threshold_cents(10000));
+    }
+
+    #[test]
+    fn test_check_alert_threshold_with_projected_costs() {
+        let manager = BudgetManager::new(10.0);
+        // $10 limit, 80% threshold = $8 (800 cents)
+        assert!(!manager.is_projected_cost_over_threshold(700)); // $7
+        assert!(manager.is_projected_cost_over_threshold(800)); // $8
+        assert!(manager.is_projected_cost_over_threshold(1500)); // $15
     }
 
     #[test]


### PR DESCRIPTION
The `budget_manager` previously recorded the `projected_cents` using `record_spend_cents` to assess the alert status for budget thresholds. This incorrectly caused `projected_cents` to be registered as an *actual* spend instead of checking it implicitly, resulting in an inaccurate state since the variables were created and destroyed on each endpoint hit anyway. To solve this, a new `is_projected_cost_over_threshold` was added for `BudgetManager` and the dashboard API call sites in `lib.rs` and `billing_api.rs` were modified to use it. Additionally, E2E tests have been updated to check for this behavior dynamically via the real application stack.

---
*PR created automatically by Jules for task [3660664757315914823](https://jules.google.com/task/3660664757315914823) started by @ql-owo-lp*