### PR TITLE
🚀 Nova: Link-in-Bio Growth Loop

### DIFF
--- a/src/e2e/link-in-bio.spec.ts
+++ b/src/e2e/link-in-bio.spec.ts
@@ -56,6 +56,8 @@ test.describe('Link-in-Bio Generator E2E', () => {
         // Wait for preview to render the badge
         const previewPoweredBy = memberPage.locator('#powered-by-link');
         await expect(previewPoweredBy).toBeVisible();
+        await expect(previewPoweredBy).toHaveAttribute('href', /\/api\/v1\/growth\/referrals\/click/);
+        await expect(previewPoweredBy).toHaveAttribute('href', /source=bio_page/);
 
         // Click the toggle to remove branding
         await memberPage.locator('label', { has: memberPage.locator('#remove-branding-toggle') }).click();

--- a/src/ui/tauri/src/ui/link-in-bio-generator.html
+++ b/src/ui/tauri/src/ui/link-in-bio-generator.html
@@ -382,7 +382,7 @@
                 </div>
 
                 <div class="footer">
-                    <a id="powered-by-link" href="https://ohc.store/join?ref=my-store">⚡ Powered by OHC</a>
+                    <a id="powered-by-link" href="/api/v1/growth/referrals/click?target=/setup.html&ref=my-store&source=bio_page">⚡ Powered by OHC</a>
                 </div>
             </div>
         </div>
@@ -467,7 +467,7 @@
         function updatePreview() {
             previewTitle.textContent = currentState.store_name;
             previewBio.textContent = currentState.bio;
-            poweredByLink.href = `https://ohc.store/join?ref=${tenant}`;
+            poweredByLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenant)}&source=bio_page`;
             poweredByLink.style.display = currentState.remove_branding ? 'none' : 'block';
 
             if (currentState.remove_branding) {


### PR DESCRIPTION
🚀 Nova: Link-in-Bio Growth Loop

- Replaced direct setup link with referral tracking API click endpoint in Link-in-Bio generator to enable viral growth.
- Updated Playwright E2E tests to assert the correct tracking link generation.

---
*PR created automatically by Jules for task [17724152866123780346](https://jules.google.com/task/17724152866123780346) started by @ql-owo-lp*