### PR TITLE
👂 Echo: Mobile-first 'Zero-Click Generation' storefront onboarding flow

### DIFF
--- a/src/ui/next/src/app/zero-click-builder/page.test.tsx
+++ b/src/ui/next/src/app/zero-click-builder/page.test.tsx
@@ -25,14 +25,14 @@ describe('ZeroClickBuilderPage', () => {
     render(<ZeroClickBuilderPage />);
     expect(screen.getByText('Zero-Click Business Generator')).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/I am a home baker/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Generate My Business/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Generate Store/i })).toBeDisabled();
   });
 
   it('enables the button when prompt is entered', () => {
     render(<ZeroClickBuilderPage />);
     const textarea = screen.getByPlaceholderText(/I am a home baker/i);
     fireEvent.change(textarea, { target: { value: 'I sell custom sneakers' } });
-    expect(screen.getByRole('button', { name: /Generate My Business/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /Generate Store/i })).toBeEnabled();
   });
 
   it('submits the form and displays the result', async () => {
@@ -53,7 +53,7 @@ describe('ZeroClickBuilderPage', () => {
     const textarea = screen.getByPlaceholderText(/I am a home baker/i);
     fireEvent.change(textarea, { target: { value: 'I sell custom sneakers' } });
 
-    const button = screen.getByRole('button', { name: /Generate My Business/i });
+    const button = screen.getByRole('button', { name: /Generate Store/i });
     fireEvent.click(button);
 
     // Should show loading state
@@ -81,7 +81,7 @@ describe('ZeroClickBuilderPage', () => {
     render(<ZeroClickBuilderPage />);
     const textarea = screen.getByPlaceholderText(/I am a home baker/i);
     fireEvent.change(textarea, { target: { value: 'I sell custom sneakers' } });
-    fireEvent.click(screen.getByRole('button', { name: /Generate My Business/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Generate Store/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Your business is live!')).toBeInTheDocument();
@@ -106,7 +106,7 @@ describe('ZeroClickBuilderPage', () => {
     render(<ZeroClickBuilderPage />);
     const textarea = screen.getByPlaceholderText(/I am a home baker/i);
     fireEvent.change(textarea, { target: { value: 'I sell custom sneakers' } });
-    fireEvent.click(screen.getByRole('button', { name: /Generate My Business/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Generate Store/i }));
     await waitFor(() => expect(screen.getByText('Your business is live!')).toBeInTheDocument(), { timeout: 3000 });
     fireEvent.click(screen.getByRole('button', { name: /Share on X/i }));
     expect(mockOpen).toHaveBeenCalled();

--- a/src/ui/next/src/app/zero-click-builder/page.tsx
+++ b/src/ui/next/src/app/zero-click-builder/page.tsx
@@ -119,9 +119,9 @@ export default function ZeroClickBuilderPage() {
               <button
                 type="submit"
                 disabled={isGenerating || !prompt.trim()}
-                className="w-full flex items-center justify-center gap-2 bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-4 rounded-xl font-semibold text-lg transition-all active:scale-[0.98] disabled:opacity-50 disabled:pointer-events-none shadow-sm hover:shadow-md"
+                className="w-full min-h-[44px] flex items-center justify-center gap-2 bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-4 rounded-xl font-semibold text-lg transition-all active:scale-[0.98] disabled:opacity-50 disabled:pointer-events-none shadow-sm hover:shadow-md"
               >
-                <span>🚀</span> Generate My Business
+                <span>🚀</span> Generate Store
               </button>
             </form>
           </div>

--- a/src/ui/next/src/e2e/zero-click-builder.spec.ts
+++ b/src/ui/next/src/e2e/zero-click-builder.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Zero Click Builder Mobile Onboarding', () => {
+  test.use({ viewport: { width: 375, height: 812 } }); // Mobile-first constraint
+
+  test('User can generate a store with a single prompt', async ({ page, context }) => {
+    // Navigate to the zero-click-builder page
+    await page.goto('/zero-click-builder');
+
+    // 1. Verify premium tokens & text
+    await expect(page.getByText('Zero-Click Business Generator')).toBeVisible();
+
+    // The single text area where the prompt is typed
+    const promptInput = page.locator('#prompt');
+    await expect(promptInput).toBeVisible();
+
+    // 2. Type natural language prompt
+    await promptInput.fill('I am a home baker in Austin selling custom vegan cakes and cupcakes.');
+
+    // 3. Find "Generate Store" button
+    const generateBtn = page.getByRole('button', { name: /Generate Store/i });
+    await expect(generateBtn).toBeEnabled();
+
+    // Mock API response
+    await context.route('**/api/v1/growth/zero-click-builder/generate', async route => {
+      await new Promise(r => setTimeout(r, 2000));
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          organization_id: 'test-org-123',
+          user_id: 'test-user-123',
+          name: 'Austin Vegan Cakes',
+          url: 'https://austin-vegan-cakes.ohc.app'
+        })
+      });
+    });
+
+    // 4. Tap Generate Button
+    await generateBtn.click();
+
+    // 5. Verify visually engaging loading state
+    await expect(page.getByText('Analyzing your business...')).toBeVisible();
+
+    // 6. Verify completion & transition to live preview
+    await expect(page.getByText('Your business is live!')).toBeVisible({ timeout: 15000 });
+
+    // Check if iframe for preview rendered
+    await expect(page.locator('iframe[title="Live Storefront Preview"]')).toBeVisible();
+
+    // Verify auth/redirect handoff button
+    const launchBtn = page.getByRole('button', { name: /Launch My Store/i });
+    await expect(launchBtn).toBeVisible();
+
+    // Test the button navigates to dashboard
+    await launchBtn.click();
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+});


### PR DESCRIPTION
- Added the Playwright E2E tests for the Zero-Click Generation onboarding feature.
- Made UX adjustments on the page to fit 375px requirements by adjusting button touch target sizing.
- Added `min-h-[44px]` touch target sizing.
- Changed button text to "Generate Store" to match the description.
- Verified interactions manually.

---
*PR created automatically by Jules for task [5728896214291254261](https://jules.google.com/task/5728896214291254261) started by @ql-owo-lp*

Resolves #30363