### PR TITLE
feat(billing): display dynamic storage limits on Cost Transparency Dashboard

### DIFF
--- a/src/ui/next/src/app/cost-dashboard/page.test.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.test.tsx
@@ -126,7 +126,7 @@ describe('CostDashboardPage', () => {
     expect(screen.getAllByText(/150/)[0]).toBeDefined();
     expect(screen.getAllByText(/\/ 1000/)[0]).toBeDefined();
     // Storage used
-    expect(screen.getByText(/2 MB/)).toBeDefined();
+    expect(screen.getAllByText(/2 MB/)[0]).toBeDefined();
     // Next bill estimated
     expect(screen.getByText('$29.00')).toBeDefined(); // Since Next bill estimated uses formatCurrency which divides by 100
 

--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -184,6 +184,21 @@ export default function CostDashboardPage() {
                       <h3 className="text-sm font-medium text-gray-500">Estimated Next Bill</h3>
                       <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">{formatCurrency(myPlanData?.next_bill_estimated || 0)}</p>
                   </div>
+                  {myPlanData?.storage_limit_bytes && myPlanData?.storage_used_bytes != null && (
+                      <div className="p-4 app-card ohc-growth-card glass-card md:col-span-2 lg:col-span-4">
+                          <div className="flex justify-between text-sm text-gray-600 mb-1">
+                              <span>{myPlanData.storage_limit_bytes > 0 ? `${formatStorage(myPlanData.storage_limit_bytes).replace('.0 MB', ' MB').replace('.0 GB', ' GB')} Storage Quota` : 'Unlimited Storage Quota'}</span>
+                              <span>
+                                  {myPlanData.storage_limit_bytes > 0 ? (
+                                      myPlanData.storage_used_bytes >= myPlanData.storage_limit_bytes ? 'Limit reached' : `${formatStorage(myPlanData.storage_used_bytes)} used (${Math.round((myPlanData.storage_used_bytes / myPlanData.storage_limit_bytes) * 100)}%)`
+                                  ) : `${formatStorage(myPlanData.storage_used_bytes)} used`}
+                              </span>
+                          </div>
+                          <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+                              <div className={`h-2.5 rounded-full ${myPlanData.storage_used_bytes >= myPlanData.storage_limit_bytes ? 'bg-red-600' : 'bg-blue-600'}`} style={{ width: `${Math.min(100, Math.max(0, (myPlanData.storage_used_bytes / myPlanData.storage_limit_bytes) * 100))}%` }}></div>
+                          </div>
+                      </div>
+                  )}
               </div>
               <div className="mt-6 flex flex-col md:flex-row gap-4">
                   <button


### PR DESCRIPTION
feat(billing): display dynamic storage limits on Cost Transparency Dashboard

* Refactored storage quota logic to dynamically render available and used quota limits correctly on the UI.
* Fixed formatting error for 0 MB scenarios where fallback limits were missing UI states.

---
*PR created automatically by Jules for task [18072000883087841617](https://jules.google.com/task/18072000883087841617) started by @ql-owo-lp*