### PR TITLE
Fix Agent Timeout and Server-side Token Budgets

### DIFF
--- a/src/agents/builtin/agent.rs
+++ b/src/agents/builtin/agent.rs
@@ -16,12 +16,7 @@ use ohc_builtin_agent_core::types::{
 use ohc_builtin_agent_llm::LlmClient;
 
 pub fn agent_task_timeout() -> std::time::Duration {
-    let secs = std::env::var("OHC_AGENT_TASK_TIMEOUT_SECS")
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(60);
-    std::time::Duration::from_secs(secs)
+    std::time::Duration::from_secs(60)
 }
 
 /// Default computational guide using bash commands

--- a/src/agents/builtin/codex_runner.rs
+++ b/src/agents/builtin/codex_runner.rs
@@ -309,6 +309,7 @@ impl AppServer {
                     meta: None,
                 },
             };
+            return serde_json::to_string(&resp).unwrap_or_default();
         } else if req.method == "am_publish_agent" {
             let marketplace = crate::marketplace::Marketplace::new();
             let agent: Result<crate::marketplace::AgentDefinition, _> = serde_json::from_value(req.params.clone());
@@ -1231,7 +1232,7 @@ mod tests {
 
         // Test Agent Marketplace am_fetch_agent method
         let req_json_am_fetch = r#"{"jsonrpc": "2.0", "id": "14", "method": "am_fetch_agent", "params": {"agent_id": "Senior Rust Developer"}}"#;
-        let resp_json_am_fetch = app_server.handle_request(req_json_am_fetch).await;
+        let _resp_json_am_fetch = app_server.handle_request(req_json_am_fetch).await;
         // Test Agent Marketplace am_publish_agent method
         let req_json_am_publish = r#"{"jsonrpc": "2.0", "id": "15", "method": "am_publish_agent", "params": {"name": "New Agent", "description": "New", "role": "Tester", "system_prompt": "Test"}}"#;
         let resp_json_am_publish = app_server.handle_request(req_json_am_publish).await;

--- a/src/server/orchestration/departments/throttling.rs
+++ b/src/server/orchestration/departments/throttling.rs
@@ -40,6 +40,10 @@ impl ThrottlingManager {
             _ => 1000, // free (increased for e2e tests)
         };
 
+        if points > limit {
+            return Ok(false);
+        }
+
         match &self.db.store {
             DbStore::Postgres => {
                 let mut tx = self.db.pool.begin().await.map_err(|e| e.to_string())?;
@@ -57,59 +61,76 @@ impl ThrottlingManager {
                 .execute(&mut *tx)
                 .await;
 
-                let res: Option<(i32,)> = sqlx::query_as(
+                // First, check existing points to handle the initial insertion exceeding limit safely.
+                let current_usage: Option<i32> = sqlx::query_scalar(
+                    "SELECT actions_used FROM tenant_ai_budgets WHERE tenant_id = $1 AND year_month = $2 FOR UPDATE"
+                )
+                .bind(tenant_id)
+                .bind(&year_month)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| e.to_string())?;
+
+                let current = current_usage.unwrap_or(0);
+                if current + points > limit {
+                    tx.rollback().await.ok();
+                    return Ok(false);
+                }
+
+                let _ = sqlx::query(
                     "INSERT INTO tenant_ai_budgets (tenant_id, year_month, actions_used)
                      VALUES ($1, $2, $3)
                      ON CONFLICT (tenant_id, year_month) DO UPDATE
                      SET actions_used = tenant_ai_budgets.actions_used + $3,
-                         updated_at = CURRENT_TIMESTAMP
-                     WHERE tenant_ai_budgets.actions_used + $3 <= $4
-                     RETURNING actions_used"
+                         updated_at = CURRENT_TIMESTAMP"
                 )
                 .bind(tenant_id)
                 .bind(&year_month)
                 .bind(points)
-                .bind(limit)
-                .fetch_optional(&mut *tx)
+                .execute(&mut *tx)
                 .await
                 .map_err(|e| e.to_string())?;
 
                 tx.commit().await.map_err(|e| e.to_string())?;
 
-                if let Some((actions_used,)) = res {
-                    Ok(actions_used <= limit)
-                } else {
-                    Ok(false)
-                }
+                Ok(true)
             }
             DbStore::Sqlite(pool) => {
                 let mut tx = pool.begin().await.map_err(|e| e.to_string())?;
-                let res: Option<(i32,)> = sqlx::query_as(
+
+                let current_usage: Option<i32> = sqlx::query_scalar(
+                    "SELECT actions_used FROM tenant_ai_budgets WHERE tenant_id = ? AND year_month = ?"
+                )
+                .bind(tenant_id)
+                .bind(&year_month)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| e.to_string())?;
+
+                let current = current_usage.unwrap_or(0);
+                if current + points > limit {
+                    tx.rollback().await.ok();
+                    return Ok(false);
+                }
+
+                let _ = sqlx::query(
                     "INSERT INTO tenant_ai_budgets (tenant_id, year_month, actions_used)
                      VALUES (?, ?, ?)
                      ON CONFLICT (tenant_id, year_month) DO UPDATE
                      SET actions_used = tenant_ai_budgets.actions_used + ?,
-                         updated_at = CURRENT_TIMESTAMP
-                     WHERE tenant_ai_budgets.actions_used + ? <= ?
-                     RETURNING actions_used"
+                         updated_at = CURRENT_TIMESTAMP"
                 )
                 .bind(tenant_id)
                 .bind(&year_month)
                 .bind(points)
                 .bind(points)
-                .bind(points)
-                .bind(limit)
-                .fetch_optional(&mut *tx)
+                .execute(&mut *tx)
                 .await
                 .map_err(|e| e.to_string())?;
 
                 tx.commit().await.map_err(|e| e.to_string())?;
 
-                if let Some((actions_used,)) = res {
-                    Ok(actions_used <= limit)
-                } else {
-                    Ok(false)
-                }
+                Ok(true)
             }
         }
     }


### PR DESCRIPTION
Fix agent timeout and token budget server-side enforcement

Enforce a strictly 60-second task timeout for agents to satisfy ML Resilience Rules.
Enforce server-side AI token budgets accurately handling limit overflows on initial points consumption.
Revert SQLite N+1 parity issue for cleaning up sessions.

---
*PR created automatically by Jules for task [7747660388560512947](https://jules.google.com/task/7747660388560512947) started by @ql-owo-lp*