### PR TITLE
Fix/Remove obsolete business-setup redirect

### DIFF
--- a/src/agents/builtin/codex_runner.rs
+++ b/src/agents/builtin/codex_runner.rs
@@ -290,7 +290,7 @@ impl AppServer {
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
             let result = marketplace.download_agent(agent_id);
-            let _resp = match result {
+            let resp = match result {
                 Ok(agent) => JsonRpcResponse {
                     jsonrpc: "2.0".to_string(),
                     id: req.id.clone(),

--- a/src/ui/next/src/app/business-setup/page.tsx
+++ b/src/ui/next/src/app/business-setup/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function BusinessSetupCompatibilityPage() {
-  redirect('/onboarding');
-}

--- a/src/ui/next/src/app/components/ProductShellGuard.test.tsx
+++ b/src/ui/next/src/app/components/ProductShellGuard.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, expect, test, vi } from "vitest";
 import { ProductShellGuard } from "./ProductShellGuard";
 
 const navigationMock = vi.hoisted(() => ({
-  pathname: "/business-setup",
+  pathname: "/onboarding",
 }));
 
 vi.mock("next/navigation", () => ({
@@ -21,7 +21,7 @@ vi.mock("./AppShell", () => ({
 }));
 
 beforeEach(() => {
-  navigationMock.pathname = "/business-setup";
+  navigationMock.pathname = "/onboarding";
 });
 
 test("wraps dashboard workspace routes that do not own an app shell", () => {
@@ -32,7 +32,7 @@ test("wraps dashboard workspace routes that do not own an app shell", () => {
   );
 
   expect(screen.getByTestId("app-shell")).toBeDefined();
-  expect(screen.getByRole("heading", { name: "Business Setup" })).toBeDefined();
+  expect(screen.getByRole("heading", { name: "Setup" })).toBeDefined();
   expect(screen.getByText("Workspace content")).toBeDefined();
 });
 

--- a/src/ui/next/src/app/components/ProductShellGuard.tsx
+++ b/src/ui/next/src/app/components/ProductShellGuard.tsx
@@ -93,7 +93,7 @@ const titleOverrides: Record<string, string> = {
   "/booking": "Booking",
   "/brand-studio": "Brand Studio",
   "/builder": "Builder",
-  "/business-setup": "Business Setup",
+  "/onboarding": "Setup",
   "/cart-recovery": "Cart Recovery",
   "/changelog": "Changelog",
   "/chaos-report": "Chaos Report",

--- a/src/ui/next/src/app/dashboard/page.tsx
+++ b/src/ui/next/src/app/dashboard/page.tsx
@@ -401,7 +401,7 @@ export default function Dashboard() {
         >
           Start Tour
         </button>
-        <button type="button" onClick={() => router.push("/business-setup")} className="app-button min-h-[44px]">
+        <button type="button" onClick={() => router.push("/onboarding")} className="app-button min-h-[44px]">
           Launch Site
         </button>
         <button type="button" onClick={() => setShowMigration((open) => !open)} className="app-button min-h-[44px]">


### PR DESCRIPTION
This submission removes the deprecated `/business-setup` compatibility redirect, updates all frontend references (like the dashboard "Launch Site" button) to point directly to `/onboarding`, modifies `ProductShellGuard` so it associates `"/onboarding"` with the "Setup" shell, updates E2E specs, and fixes an unused `_resp` variable warning in `codex_runner.rs` to satisfy the `bazel` compilation strictness.

---
*PR created automatically by Jules for task [5415712874421671898](https://jules.google.com/task/5415712874421671898) started by @ql-owo-lp*