### PR TITLE
Fix telemetry value fetching panic by using f64 for DOUBLE PRECISION

### DIFF
--- a/src/agents/builtin/codex_runner.rs
+++ b/src/agents/builtin/codex_runner.rs
@@ -290,7 +290,7 @@ impl AppServer {
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
             let result = marketplace.download_agent(agent_id);
-            let _resp = match result {
+            let resp = match result {
                 Ok(agent) => JsonRpcResponse {
                     jsonrpc: "2.0".to_string(),
                     id: req.id.clone(),

--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -99,7 +99,7 @@ impl HybridSyncDaemon {
         for row in &rows {
             let metric_name: String = row.get("metric_name");
             let metric_type: String = row.get("metric_type");
-            let value: f32 = row.get("value");
+            let value: f64 = row.get("value");
             let labels_json: String = row.get("labels_json");
             let timestamp: chrono::NaiveDateTime = row.get("timestamp");
 

--- a/src/server/services/sync/telemetry_sync.rs
+++ b/src/server/services/sync/telemetry_sync.rs
@@ -65,11 +65,11 @@ impl TelemetrySyncDaemon {
 
             // Extract the data from rows since `Row` might not be Send/Sync
             // or easily parallelizable directly. We consume it into an iterator.
-            let extracted_data: Vec<(i32, String, String, f32, String, DateTime<Utc>)> = rows.into_iter().map(|row| {
+            let extracted_data: Vec<(i32, String, String, f64, String, DateTime<Utc>)> = rows.into_iter().map(|row| {
                 let id: i32 = row.get("id");
                 let metric_name: String = row.get("metric_name");
                 let metric_type: String = row.get("metric_type");
-                let value: f32 = row.get("value");
+                let value: f64 = row.get("value");
                 let labels_json: String = row.get("labels_json");
                 let timestamp: DateTime<Utc> = row.get("timestamp");
                 (id, metric_name, metric_type, value, labels_json, timestamp)
@@ -120,7 +120,7 @@ impl TelemetrySyncDaemon {
                 let id: i32 = row.get("id");
                 let metric_name: String = row.get("metric_name");
                 let metric_type: String = row.get("metric_type");
-                let value: f32 = row.get("value");
+                let value: f64 = row.get("value");
                 let labels_json: String = row.get("labels_json");
                 let timestamp: DateTime<Utc> = row.get("timestamp");
 

--- a/src/server/telemetry/forecaster.rs
+++ b/src/server/telemetry/forecaster.rs
@@ -60,7 +60,7 @@ impl Forecaster {
         let mut recent_usage = HashMap::new();
         for row in rows {
             use sqlx::Row;
-            let val: f32 = row.get("value");
+            let val: f64 = row.get("value");
             let labels_json: String = row.get("labels_json");
 
             if let Ok(parsed) = serde_json::from_str::<Value>(&labels_json) {
@@ -169,7 +169,7 @@ mod tests {
         forecaster.run_forecast_cycle().await.unwrap();
 
         // Check if predicted_24h is recorded
-        let row: (f32,) = sqlx::query_as("SELECT value FROM telemetry_buffer WHERE metric_name = 'ohc_token_burn_rate_predicted_24h' AND labels_json LIKE $1 ORDER BY timestamp DESC LIMIT 1")
+        let row: (f64,) = sqlx::query_as("SELECT value FROM telemetry_buffer WHERE metric_name = 'ohc_token_burn_rate_predicted_24h' AND labels_json LIKE $1 ORDER BY timestamp DESC LIMIT 1")
             .bind(format!("%{}%", org_id))
             .fetch_one(&pool).await.unwrap();
 
@@ -178,7 +178,7 @@ mod tests {
 
         // Cycle 2: No new tokens, should decay
         forecaster.run_forecast_cycle().await.unwrap();
-        let row2: (f32,) = sqlx::query_as("SELECT value FROM telemetry_buffer WHERE metric_name = 'ohc_token_burn_rate_predicted_24h' AND labels_json LIKE $1 ORDER BY timestamp DESC LIMIT 1")
+        let row2: (f64,) = sqlx::query_as("SELECT value FROM telemetry_buffer WHERE metric_name = 'ohc_token_burn_rate_predicted_24h' AND labels_json LIKE $1 ORDER BY timestamp DESC LIMIT 1")
             .bind(format!("%{}%", org_id))
             .fetch_one(&pool).await.unwrap();
 

--- a/src/server/telemetry/mcp_sync_worker.rs
+++ b/src/server/telemetry/mcp_sync_worker.rs
@@ -42,7 +42,7 @@ impl McpSyncWorker {
         for row in &rows {
             let metric_name: String = row.get("metric_name");
             let metric_type: String = row.get("metric_type");
-            let value: f32 = row.get("value");
+            let value: f64 = row.get("value");
             let labels_json: String = row.get("labels_json");
             let timestamp: chrono::NaiveDateTime = row.get("timestamp");
 

--- a/src/server/telemetry_test.rs
+++ b/src/server/telemetry_test.rs
@@ -159,7 +159,7 @@ mod tests {
 
         use sqlx::Row;
         let _ = pool;
-        let value: f32 = row.get("value");
+        let value: f64 = row.get("value");
         assert_eq!(value, 15000.0);
 
         let labels_json: String = row.get("labels_json");
@@ -185,7 +185,7 @@ mod tests {
 
         use sqlx::Row;
         let _ = pool;
-        let value: f32 = row.get("value");
+        let value: f64 = row.get("value");
         assert_eq!(value, 1.5);
 
         let labels_json: String = row.get("labels_json");
@@ -213,7 +213,7 @@ mod tests {
 
         use sqlx::Row;
         let _ = pool;
-        let value: f32 = row.get("value");
+        let value: f64 = row.get("value");
         assert_eq!(value, 0.5);
 
         let labels_json: String = row.get("labels_json");
@@ -240,7 +240,7 @@ mod tests {
 
         use sqlx::Row;
         let _ = pool;
-        let value: f32 = row.get("value");
+        let value: f64 = row.get("value");
         assert_eq!(value, 125.0);
 
         let labels_json: String = row.get("labels_json");


### PR DESCRIPTION
The telemetry_buffer table's value column was upgraded to DOUBLE PRECISION in a recent database migration. The Rust code was still querying this as an `f32`, causing sqlx runtime panics because it expects `f64` for DOUBLE PRECISION. This updates the corresponding struct mappings, tuple bounds, and `row.get` extractions to use `f64`.

It also fixes an unused unused variable issue (`_resp` to `resp`) in the codex agent.

---
*PR created automatically by Jules for task [6129828383924506561](https://jules.google.com/task/6129828383924506561) started by @ql-owo-lp*