### PR TITLE
fix(ui): Resolve setup.html race condition for cross-device resume

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -74,7 +74,7 @@
         transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
       }
       select.glassmorphism, textarea.glassmorphism, input.glassmorphism {
-        border-radius: 16px;
+        border-radius: 8px;
         min-height: 44px;
         background: rgba(255, 255, 255, 0.65);
         backdrop-filter: blur(30px) saturate(210%);
@@ -1571,17 +1571,24 @@
                 populateForm();
             }
         })
-        .catch(err => console.error('Failed to load cross-device state:', err));
-      }
-
-
-      if (state.step === undefined || state.step === 0) {
-         goToStep('step-initial');
-      } else {
-         const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'];
-         if (state.step < steps.length) {
-            goToStep(steps[state.step]);
-         }
+        .catch(err => console.error('Failed to load cross-device state:', err))
+        .finally(() => {
+            if (!state.step) {
+                const stored = localStorage.getItem('onboardingState');
+                if (stored) {
+                    state = { ...state, ...JSON.parse(stored) };
+                    populateForm();
+                }
+            }
+            if (state.step === undefined || state.step === 0) {
+               goToStep('step-initial');
+            } else {
+               const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'];
+               if (state.step < steps.length) {
+                  goToStep(steps[state.step]);
+               }
+            }
+        });
       }
 
             // Clear name error on typing if valid


### PR DESCRIPTION
Fixes a race condition in the cross-device wizard state resumption where the initial navigation triggered synchronously before the backend state fetch resolved, dropping the resumed data. Realigned the `border-radius` of `.glassmorphism` input elements to 8px according to UI mandates.

---
*PR created automatically by Jules for task [18066239835599176890](https://jules.google.com/task/18066239835599176890) started by @ql-owo-lp*