### PR TITLE
Fix compilation errors and lint warnings preventing build

### DIFF
--- a/src/agents/builtin/codex_runner.rs
+++ b/src/agents/builtin/codex_runner.rs
@@ -290,7 +290,7 @@ impl AppServer {
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
             let result = marketplace.download_agent(agent_id);
-            let _resp = match result {
+            let resp = match result {
                 Ok(agent) => JsonRpcResponse {
                     jsonrpc: "2.0".to_string(),
                     id: req.id.clone(),

--- a/src/server/chaos.rs
+++ b/src/server/chaos.rs
@@ -1419,7 +1419,7 @@ mod tests {
 
 #[cfg(test)]
 mod additional_chaos_tests {
-    use super::*;
+
 
     #[tokio::test]
     async fn test_chaos_simulate_sql_sync_lag() {

--- a/src/server/sip.rs
+++ b/src/server/sip.rs
@@ -513,14 +513,6 @@ mod tests {
     use std::env;
     use sqlx::Row;
 
-    // Helper to get a dummy pgpool for testing
-    async fn setup_dummy_pool() -> PgPool {
-        let db_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/dummy".to_string());
-        crate::db::secure_pg_pool_options()
-            .acquire_timeout(std::time::Duration::from_millis(50))
-            .connect_lazy(&db_url)
-            .unwrap()
-    }
 
     #[tokio::test]
     async fn test_delegate_mission_tc1_no_context_root() {


### PR DESCRIPTION
Fix compilation errors and lint warnings preventing build

- Fix `_resp` vs `resp` binding mismatch in `src/agents/builtin/codex_runner.rs`
- Remove unused `setup_dummy_pool` function in `src/server/sip.rs` to fix `dead_code` lint error
- Remove unused import `use super::*` in `src/server/chaos.rs` to fix `unused_imports` lint error

---
*PR created automatically by Jules for task [11852712570490596089](https://jules.google.com/task/11852712570490596089) started by @ql-owo-lp*