### PR TITLE
feat: Add 'My Plan' link to dashboard

### DIFF
--- a/src/ui/next/src/app/dashboard/page.test.tsx
+++ b/src/ui/next/src/app/dashboard/page.test.tsx
@@ -64,4 +64,6 @@ test('renders dashboard with actionable feed', async () => {
   expect(screen.getByRole("link", { name: /Campaign Orchestration/i })).toHaveAttribute("href", "/feed");
   expect(screen.getByText("Pro Plan ROI Calculator")).toBeDefined();
   expect(screen.getByText("Assistant Tasks")).toBeDefined();
+  expect(screen.getByText("My Plan")).toBeDefined();
+
 });

--- a/src/ui/next/src/app/dashboard/page.tsx
+++ b/src/ui/next/src/app/dashboard/page.tsx
@@ -1130,6 +1130,15 @@ export default function Dashboard() {
               <p className="text-sm text-gray-600 dark:text-gray-400">Offline-first mobile route management for field service workers.</p>
             </Link>
 
+
+            <Link href="/plan" className="block glassmorphism p-6 min-h-[44px] rounded-[16px] hover:shadow-lg transition-all hover:-translate-y-0.5 group border border-white/40 dark:border-white/10">
+              <div className="flex items-start justify-between mb-4">
+                <div className="w-12 h-12 rounded-full bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center text-2xl group-hover:scale-110 transition-transform">💳</div>
+                <div className="text-blue-600 dark:text-blue-400 font-semibold text-sm bg-blue-50 dark:bg-blue-900/30 px-3 py-1 rounded-full">Billing</div>
+              </div>
+              <h3 className="text-xl font-bold font-outfit text-[#1D1D1F] dark:text-[#F5F5F7] mb-2">My Plan</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">Manage your subscription, usage, and billing.</p>
+            </Link>
             <Link href="/settings" className="block glassmorphism p-6 min-h-[44px] rounded-[16px] hover:shadow-lg transition-all hover:-translate-y-0.5 group border border-white/40 dark:border-white/10">
               <div className="flex items-start justify-between mb-4">
                 <div className="w-12 h-12 rounded-full bg-gray-50 dark:bg-gray-900/30 flex items-center justify-center text-2xl group-hover:scale-110 transition-transform">⚙️</div>


### PR DESCRIPTION
This PR addresses a product request to make the `My Plan` feature more discoverable by adding a direct link from the dashboard's "Config" section.

Changes:
* Added a new card component linking to `/plan` in `src/ui/next/src/app/dashboard/page.tsx`.
* Updated the `Dashboard` component tests in `src/ui/next/src/app/dashboard/page.test.tsx` to assert that the "My Plan" text is present.

Testing:
* Verified locally that the UI renders the link.
* Playwright E2E tests and component unit tests pass.
* All `bazel` tests ran and passed.

---
*PR created automatically by Jules for task [13104190385649664020](https://jules.google.com/task/13104190385649664020) started by @ql-owo-lp*