### PR TITLE
🛡️ Sentinel: Fix OAuth token leakage in proxy redirect URL

### DIFF
--- a/src/agents/builtin/codex_runner.rs
+++ b/src/agents/builtin/codex_runner.rs
@@ -274,14 +274,14 @@ impl AppServer {
                     query.is_empty() || a.name.to_lowercase().contains(&query.to_lowercase())
                 })
                 .collect();
-            let resp = JsonRpcResponse {
+            let search_resp = JsonRpcResponse {
                 jsonrpc: "2.0".to_string(),
                 id: req.id.clone(),
                 result: serde_json::to_value(filtered).ok(),
                 error: None,
                 meta: None,
             };
-            return serde_json::to_string(&resp).unwrap_or_default();
+            return serde_json::to_string(&search_resp).unwrap_or_default();
         } else if req.method == "am_fetch_agent" {
             let marketplace = crate::marketplace::Marketplace::new();
             let agent_id = req
@@ -290,7 +290,7 @@ impl AppServer {
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
             let result = marketplace.download_agent(agent_id);
-            let _resp = match result {
+            let fetch_resp = match result {
                 Ok(agent) => JsonRpcResponse {
                     jsonrpc: "2.0".to_string(),
                     id: req.id.clone(),
@@ -309,7 +309,7 @@ impl AppServer {
                     meta: None,
                 },
             };
-            return serde_json::to_string(&resp).unwrap_or_default();
+            return serde_json::to_string(&fetch_resp).unwrap_or_default();
         } else if req.method == "am_publish_agent" {
             let marketplace = crate::marketplace::Marketplace::new();
             let agent: Result<crate::marketplace::AgentDefinition, _> = serde_json::from_value(req.params.clone());

--- a/src/server/api/oauth/proxy.rs
+++ b/src/server/api/oauth/proxy.rs
@@ -44,7 +44,7 @@ pub async fn handle_oauth_callback(
             let tunnel_base_url = std::env::var("OHC_TUNNEL_BASE_URL")
                 .unwrap_or_else(|_| "https://tunnel.ohc.network".to_string());
 
-            let mut redirect_url = format!("{}/{}/oauth/callback?code={}&state={}",
+            let mut redirect_url = format!("{}/{}/oauth/callback#code={}&state={}",
                 tunnel_base_url,
                 urlencoding::encode(&tunnel_id),
                 urlencoding::encode(&query.code),


### PR DESCRIPTION
This commit changes the URL fragment in `src/server/api/oauth/proxy.rs` from `?code=...` to `#code=...` to ensure that OAuth authorization codes and states are securely placed in the URL fragment. This prevents intermediate servers (like `tunnel.ohc.network`) or logging systems from capturing sensitive authorization tokens.

Additionally, this commit resolves a variable shadowing issue in `src/agents/builtin/codex_runner.rs` where the wrong response struct was being serialized and returned.

Superpowers skills loaded and applied: Security Code Review, Pre-Commit Code Review, Playwright Testing.

---
*PR created automatically by Jules for task [16219560218433675357](https://jules.google.com/task/16219560218433675357) started by @ql-owo-lp*