### PR TITLE
Fix codex runner unused variable causing compile error

### DIFF
--- a/src/agents/builtin/codex_runner.rs
+++ b/src/agents/builtin/codex_runner.rs
@@ -290,7 +290,7 @@ impl AppServer {
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
             let result = marketplace.download_agent(agent_id);
-            let _resp = match result {
+            let resp = match result {
                 Ok(agent) => JsonRpcResponse {
                     jsonrpc: "2.0".to_string(),
                     id: req.id.clone(),


### PR DESCRIPTION
I checked `src/server/db.rs` and `src/server/orchestration/state/parity_test.rs` and verified that the ML-Resilience 60-Second Timeout rule is already implemented (`MAX_DB_RETRY_ATTEMPTS` is `3`).

As required by the Continuous Codebase Optimization rule, I searched for other bugs to fix. I found a compile error in `src/agents/builtin/codex_runner.rs` where the `resp` variable was defined as `_resp`, causing a "cannot find value `resp` in this scope" error. I fixed the error and verified the build succeeds.

---
*PR created automatically by Jules for task [8547676194097200529](https://jules.google.com/task/8547676194097200529) started by @ql-owo-lp*