### PR TITLE
fix(ui): refine onboarding wizard mobile layout and form validation

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -854,13 +854,14 @@
         }
       }
 
-            @media (max-width: 375px) {
+      @media (max-width: 375px) {
         .container { padding: 16px; margin: 0; width: 100vw; max-width: 100vw; box-sizing: border-box; overflow-x: hidden; height: auto; max-height: 100vh; border-radius: 16px; overflow-y: auto; border: none; }
-        .context-card { padding: 12px; min-height: 44px; }
+        .context-card { padding: 12px; min-height: 44px; border-radius: 16px; }
         .work-context-cards { grid-template-columns: 1fr; }
         .radio-group { grid-template-columns: 1fr; } /* Added if it was a grid */
         .stepper {
-          gap: 4px;
+          gap: 8px;
+          padding: 0 10px;
         }
         .step-indicator {
           width: 8px;
@@ -870,11 +871,18 @@
           transform: scale(1.2);
         }
         .radio-option {
-        min-height: 44px;
-        min-width: 44px;
-        box-sizing: border-box;
+          min-height: 44px;
+          min-width: 44px;
+          box-sizing: border-box;
           padding: 8px 12px;
           font-size: 14px;
+          border-radius: 16px;
+        }
+        button, input, select, textarea {
+          min-height: 44px;
+          min-width: 44px;
+          box-sizing: border-box;
+          border-radius: 8px;
         }
         h1 {
           font-size: 20px;
@@ -883,12 +891,12 @@
           font-size: 13px;
         }
         .persona-chip {
-        min-height: 44px;
-        min-width: 44px;
-        box-sizing: border-box;
+          min-height: 44px;
+          min-width: 44px;
+          box-sizing: border-box;
           padding: 6px 12px;
           font-size: 12px;
-          min-height: 44px;
+          border-radius: 16px;
         }
       }
 
@@ -1301,9 +1309,9 @@
         <input type="email" id="admin-email" data-testid="admin-email" class="glassmorphism" placeholder="admin@mybusiness.com" inputmode="email" autocomplete="email" enterkeyhint="next" />
         <div id="email-error" class="error-msg" aria-live="polite">Please enter a valid email address.</div>
 
-        <div style="position: relative; width: 100%;">
-          <input type="password" id="admin-password" data-testid="admin-password" class="glassmorphism" placeholder="Password (min 8 chars)" autocomplete="new-password" enterkeyhint="next" style="padding-right: 40px;" />
-          <button type="button" id="toggle-password-visibility" aria-label="Toggle password visibility" title="Toggle password visibility" style="position: absolute; right: 10px; top: 50%; transform: translateY(-50%); background: none; border: none; cursor: pointer; padding: 4px; display: flex; align-items: center; justify-content: center; color: #555;">
+        <div style="position: relative; width: 100%; margin-bottom: 20px; display: flex; align-items: center;">
+          <input type="password" id="admin-password" data-testid="admin-password" class="glassmorphism" placeholder="Password (min 8 chars)" autocomplete="new-password" enterkeyhint="next" style="padding-right: 44px !important; margin-bottom: 0; flex: 1;" />
+          <button type="button" id="toggle-password-visibility" aria-label="Toggle password visibility" title="Toggle password visibility" style="position: absolute; right: 0; height: 100%; width: 44px; background: none; border: none; cursor: pointer; padding: 0; display: flex; align-items: center; justify-content: center; color: #555; box-shadow: none; min-width: auto !important; min-height: auto !important; z-index: 10;">
             <svg id="eye-icon-show" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
               <circle cx="12" cy="12" r="3"></circle>
@@ -1745,9 +1753,11 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           else if (stepId === 'step-categories') {
               if (inputs.categories.value.trim() === '') {
                   errors.categories.style.display = 'block';
+                  inputs.categories.style.borderColor = '#FF3B30';
                   isValid = false;
               } else {
                   errors.categories.style.display = 'none';
+                  inputs.categories.style.borderColor = '';
                   state.categories = inputs.categories.value.trim();
               }
           }
@@ -1758,25 +1768,29 @@ if (state.capabilities && document.getElementById('cap-draft')) {
                   isValid = false;
               } else {
                   errors.name.style.display = 'none';
-                  inputs.name.style.borderColor = 'rgba(255, 255, 255, 0.5)';
+                  inputs.name.style.borderColor = '';
                   state.businessName = inputs.name.value.trim();
                   state.tagline = inputs.tagline.value.trim();
               }
           }
           else if (stepId === 'step-assistant') {
               if (inputs.assistantName.value.trim() === '') {
-                  errors.assistantName.style.display = 'block'; inputs.assistantName.style.borderColor = '#FF3B30';
+                  errors.assistantName.style.display = 'block';
+                  inputs.assistantName.style.borderColor = '#FF3B30';
                   isValid = false;
               } else {
-                  errors.assistantName.style.display = 'none'; inputs.assistantName.style.borderColor = 'rgba(255, 255, 255, 0.5)';
+                  errors.assistantName.style.display = 'none';
+                  inputs.assistantName.style.borderColor = '';
                   state.assistantName = inputs.assistantName.value.trim();
               }
 
               if (!inputs.assistantTone.value) {
                   errors.assistantTone.style.display = 'block';
+                  inputs.assistantTone.style.borderColor = '#FF3B30';
                   isValid = false;
               } else {
                   errors.assistantTone.style.display = 'none';
+                  inputs.assistantTone.style.borderColor = '';
                   state.assistantTone = inputs.assistantTone.value;
               }
           }
@@ -1792,7 +1806,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
                   stepValid = false;
               } else {
                   errors.adminEmail.style.display = 'none';
-                  inputs.adminEmail.style.borderColor = 'rgba(255, 255, 255, 0.5)';
+                  inputs.adminEmail.style.borderColor = '';
               }
 
               if (passVal === '' || passVal.length < 8 || !/\d/.test(passVal)) {
@@ -1802,7 +1816,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
                   stepValid = false;
               } else {
                   errors.adminPassword.style.display = 'none';
-                  inputs.adminPassword.style.borderColor = 'rgba(255, 255, 255, 0.5)';
+                  inputs.adminPassword.style.borderColor = '';
               }
 
               if (stepValid) {
@@ -1815,9 +1829,11 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           else if (stepId === 'step-offer') {
               if (inputs.firstOffer.value.trim() === '') {
                   errors.firstOffer.style.display = 'block';
+                  inputs.firstOffer.style.borderColor = '#FF3B30';
                   isValid = false;
               } else {
                   errors.firstOffer.style.display = 'none';
+                  inputs.firstOffer.style.borderColor = '';
                   state.first_offer = inputs.firstOffer.value.trim();
               }
           }
@@ -1825,9 +1841,11 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           else if (stepId === 'step-domain') {
               if (inputs.domainName.value.trim().length < 3) {
                   errors.domainName.style.display = 'block';
+                  inputs.domainName.style.borderColor = '#FF3B30';
                   isValid = false;
               } else {
                   errors.domainName.style.display = 'none';
+                  inputs.domainName.style.borderColor = '';
                   state.domain = inputs.domainName.value.trim();
               }
           }
@@ -1835,9 +1853,11 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           else if (stepId === 'step-template') {
               if (inputs.templateSelection.value === '') {
                   errors.templateSelection.style.display = 'block';
+                  inputs.templateSelection.style.borderColor = '#FF3B30';
                   isValid = false;
               } else {
                   errors.templateSelection.style.display = 'none';
+                  inputs.templateSelection.style.borderColor = '';
                   state.templateSelection = inputs.templateSelection.value;
               }
           }


### PR DESCRIPTION
This PR refines the onboarding stepper wizard by improving the visual layout on 375px mobile screens, standardizing validation input feedback, and fixing a layout bug on the admin password visibility toggle.

*   **Responsive Styling:** Added mobile media queries to enforce `min-height: 44px` and `min-width: 44px` for touch targets. Added `border-radius: 16px` consistent with OHC Apple/Ubiquiti-style layout standards.
*   **Form Validation Polish:** Fixed `validateStep` in `setup.html` to remove inline `border-color` completely instead of replacing it with a hardcoded `rgba` value when validation succeeds.
*   **Password Toggle Fix:** Adjusted the admin password container layout using flexbox to properly align the visibility toggle icon and prevent overlapping.

---
*PR created automatically by Jules for task [10591337075574914560](https://jules.google.com/task/10591337075574914560) started by @ql-owo-lp*