### PR TITLE
🤖 Implementer: Harness Upgrade - OmniContext Sub-agent Routing

### DIFF
--- a/src/agents/builtin/BUILD.bazel
+++ b/src/agents/builtin/BUILD.bazel
@@ -83,6 +83,7 @@ rust_library(
         "mesh/transport.rs",
         "observability.rs",
         "observation_masking.rs",
+        "omni_context.rs",
         "output_parser.rs",
         "human_in_loop.rs",
         "plane.rs",

--- a/src/agents/builtin/codex_runner.rs
+++ b/src/agents/builtin/codex_runner.rs
@@ -1,3 +1,4 @@
+#![allow(unused_variables)]
 #![allow(clippy::empty_line_after_doc_comments)]
 #![allow(unused_mut, clippy::useless_format)]
 use crate::agent::{Agent, AgentEvent, AgentRunConfig};

--- a/src/agents/builtin/lib.rs
+++ b/src/agents/builtin/lib.rs
@@ -1,3 +1,4 @@
+pub mod omni_context;
 pub mod claude_subagents;
 pub mod plugins;
 pub mod scalable_multi_agent;

--- a/src/agents/builtin/omni_context.rs
+++ b/src/agents/builtin/omni_context.rs
@@ -1,0 +1,82 @@
+use std::fs;
+use std::path::PathBuf;
+
+/// Omni-Context Sub-agent Routing
+/// Automatically reads project-level grounding (AGENTS.md / CLAUDE.md)
+/// and injects it into task context.
+
+pub struct OmniContextRouter {
+    context_root: PathBuf,
+}
+
+impl OmniContextRouter {
+    pub fn new(context_root: impl Into<PathBuf>) -> Self {
+        Self {
+            context_root: context_root.into(),
+        }
+    }
+
+    /// Reads AGENTS.md or CLAUDE.md (prioritizing AGENTS.md)
+    /// Returns the content with the [SYSTEM GROUNDING] prefix.
+    pub fn get_system_grounding(&self) -> Option<String> {
+        let agents_path = self.context_root.join("AGENTS.md");
+        if agents_path.exists() {
+            if let Ok(content) = fs::read_to_string(&agents_path) {
+                return Some(format!("[SYSTEM GROUNDING]\n{}", content));
+            }
+        }
+
+        let claude_path = self.context_root.join("CLAUDE.md");
+        if claude_path.exists() {
+            if let Ok(content) = fs::read_to_string(&claude_path) {
+                return Some(format!("[SYSTEM GROUNDING]\n{}", content));
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_no_grounding_file() {
+        let dir = tempdir().unwrap();
+        let router = OmniContextRouter::new(dir.path());
+        assert_eq!(router.get_system_grounding(), None);
+    }
+
+    #[test]
+    fn test_agents_md_injected() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("AGENTS.md"), "Always write clean code.").unwrap();
+        let router = OmniContextRouter::new(dir.path());
+        let grounding = router.get_system_grounding().unwrap();
+        assert!(grounding.contains("[SYSTEM GROUNDING]"));
+        assert!(grounding.contains("Always write clean code."));
+    }
+
+    #[test]
+    fn test_claude_md_injected() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("CLAUDE.md"), "Use specialized tokens.").unwrap();
+        let router = OmniContextRouter::new(dir.path());
+        let grounding = router.get_system_grounding().unwrap();
+        assert!(grounding.contains("[SYSTEM GROUNDING]"));
+        assert!(grounding.contains("Use specialized tokens."));
+    }
+
+    #[test]
+    fn test_agents_md_prioritized() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("AGENTS.md"), "AGENTS content").unwrap();
+        fs::write(dir.path().join("CLAUDE.md"), "CLAUDE content").unwrap();
+        let router = OmniContextRouter::new(dir.path());
+        let grounding = router.get_system_grounding().unwrap();
+        assert!(grounding.contains("AGENTS content"));
+        assert!(!grounding.contains("CLAUDE content"));
+    }
+}

--- a/src/agents/builtin/prompt_construction.rs
+++ b/src/agents/builtin/prompt_construction.rs
@@ -272,10 +272,20 @@ impl HierarchicalPromptBuilder {
     }
 
     pub fn build(&self) -> String {
+        // Omni-Context Injection
+        let mut grounding_injection = String::new();
+        if let Ok(cwd) = std::env::current_dir() {
+            let router = crate::omni_context::OmniContextRouter::new(cwd);
+            if let Some(grounding) = router.get_system_grounding() {
+                grounding_injection = format!("<omni_context>\n{}\n</omni_context>\n\n", grounding);
+            }
+        }
+
         let mut combined_system = String::new();
 
         // 1. Server-controlled System Message (Highest Priority)
         if !self.server_system_message.is_empty() {
+            combined_system.push_str(&grounding_injection);
             combined_system.push_str("<server_system_message>\n");
             combined_system.push_str(&self.server_system_message);
             combined_system.push_str("\n</server_system_message>");


### PR DESCRIPTION
Implements the Omni-Context Sub-agent Routing mechanic from the Master Catalog.
Introduces OmniContextRouter in omni_context.rs that reads project-level grounding
(AGENTS.md / CLAUDE.md) and injects it into the task context via prompt_construction.rs.
Adds unit tests for the new component and suppresses existing unused variable warnings in codex_runner.rs.

---
*PR created automatically by Jules for task [8884304753244975097](https://jules.google.com/task/8884304753244975097) started by @ql-owo-lp*