### PR TITLE
Fix: Add missing Translucent Glass styling on Cost Dashboard

### DIFF
--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -431,6 +431,20 @@ export default function CostDashboardPage() {
             )}
         </section>
       </div>
+
+      <style dangerouslySetInnerHTML={{__html: `
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@500;600;700;800&display=swap');
+        .font-inter { font-family: 'Inter', sans-serif; }
+        .font-outfit { font-family: 'Outfit', sans-serif; }
+        .ohc-growth-card {
+            backdrop-filter: blur(20px) saturate(200%);
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            font-family: 'Outfit', 'Inter', sans-serif;
+            border-radius: 12px;
+            padding: 24px;
+        }
+      `}} />
     </AppShell>
   );
 }


### PR DESCRIPTION
Added the missing translucent glass CSS styling to the Cost Dashboard page to ensure layout consistency across all growth cards.

---
*PR created automatically by Jules for task [14910745188848920703](https://jules.google.com/task/14910745188848920703) started by @ql-owo-lp*