### PR TITLE
💰 Miser: [fix] Conditionally hide Manage Billing button for Free tier in Cost Dashboard

### DIFF
--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -200,14 +200,17 @@ export default function CostDashboardPage() {
                       </div>
                   )}
               </div>
-              <div className="mt-6 flex flex-col md:flex-row gap-4">
-                  <button
-                      onClick={handleManageBilling}
-                      className="px-6 py-2 bg-[#0f766e] hover:bg-[#0d645d] text-white rounded-xl font-medium transition-all shadow-sm flex items-center justify-center"
-                  >
-                      Manage Billing
-                  </button>
-              </div>
+              {data?.department_tier_usage?.current_plan !== 'Free' && (
+                  <div className="mt-6 flex flex-col md:flex-row gap-4">
+                      <button
+                          id="manage-billing-btn"
+                          onClick={handleManageBilling}
+                          className="px-6 py-2 bg-[#0f766e] hover:bg-[#0d645d] text-white rounded-xl font-medium transition-all shadow-sm flex items-center justify-center"
+                      >
+                          Manage Billing
+                      </button>
+                  </div>
+              )}
               {actionMessage && (
                   <div className="mt-4 rounded-xl border border-teal-100 bg-teal-50/20 p-4 text-sm font-medium text-[#0f766e] dark:text-[#6ac5bd] shadow-sm" role="status">
                       {actionMessage}


### PR DESCRIPTION
fix: conditionally render Manage Billing button in cost dashboard for non-Free tiers

The end-to-end tests expected the "Manage Billing" button in the cost dashboard to be hidden for the Free tier to avoid upselling/billing confusion where the tier is free and has no billing features available. 

This commit wraps the "Manage Billing" button with a conditional checking `data?.department_tier_usage?.current_plan !== 'Free'` and ensures it has the `id="manage-billing-btn"` for E2E tests.

---
*PR created automatically by Jules for task [3437041807150265298](https://jules.google.com/task/3437041807150265298) started by @ql-owo-lp*