### PR TITLE
fix: Align schema and references for tier to plan_tier

### DIFF
--- a/src/server/chaos.rs
+++ b/src/server/chaos.rs
@@ -1250,7 +1250,7 @@ mod tests {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS tenants (
                 id TEXT PRIMARY KEY,
-                tier TEXT NOT NULL
+                plan_tier TEXT NOT NULL
             );"
         ).execute(&pool).await.unwrap();
 
@@ -1271,9 +1271,9 @@ mod tests {
 
         let throttler = crate::orchestration::departments::throttling::ThrottlingManager::new(db);
 
-        // Explicitly setup tenant tier = "starter" (which has a hard limit of 500)
+        // Explicitly setup tenant plan_tier = "starter" (which has a hard limit of 500)
         let tenant_id = "tenant_starter_test";
-        sqlx::query("INSERT INTO tenants (id, tier) VALUES (?, 'starter')")
+        sqlx::query("INSERT INTO tenants (id, plan_tier) VALUES (?, 'starter')")
             .bind(tenant_id)
             .execute(&pool).await.unwrap();
 

--- a/src/server/orchestration/departments/operations_agent.rs
+++ b/src/server/orchestration/departments/operations_agent.rs
@@ -280,7 +280,7 @@ mod tests {
             "CREATE TABLE tenants (
                 id TEXT PRIMARY KEY,
                 business_name TEXT,
-                tier TEXT
+                plan_tier TEXT
             )",
         )
         .execute(&sqlite_pool)
@@ -314,7 +314,7 @@ mod tests {
         .execute(&sqlite_pool)
         .await
         .unwrap();
-        sqlx::query("INSERT INTO tenants (id, business_name, tier) VALUES ('tenant-ops', 'Ops Test', 'starter')")
+        sqlx::query("INSERT INTO tenants (id, business_name, plan_tier) VALUES ('tenant-ops', 'Ops Test', 'starter')")
             .execute(&sqlite_pool)
             .await
             .unwrap();

--- a/src/server/orchestration/departments/throttling.rs
+++ b/src/server/orchestration/departments/throttling.rs
@@ -15,9 +15,9 @@ impl ThrottlingManager {
         let now = Utc::now();
         let year_month = now.format("%Y-%m").to_string();
 
-        let tier: String = match &self.db.store {
+        let plan_tier: String = match &self.db.store {
             DbStore::Postgres => {
-                let row: Option<(String,)> = sqlx::query_as("SELECT tier FROM tenants WHERE id = $1")
+                let row: Option<(String,)> = sqlx::query_as("SELECT plan_tier FROM tenants WHERE id = $1")
                     .bind(tenant_id)
                     .fetch_optional(&self.db.pool)
                     .await
@@ -25,7 +25,7 @@ impl ThrottlingManager {
                 row.map(|(t,)| t).unwrap_or_else(|| "free".to_string())
             }
             DbStore::Sqlite(pool) => {
-                let row: Option<(String,)> = sqlx::query_as("SELECT tier FROM tenants WHERE id = ?")
+                let row: Option<(String,)> = sqlx::query_as("SELECT plan_tier FROM tenants WHERE id = ?")
                     .bind(tenant_id)
                     .fetch_optional(pool)
                     .await
@@ -34,7 +34,7 @@ impl ThrottlingManager {
             }
         };
 
-        let limit = match tier.to_lowercase().as_str() {
+        let limit = match plan_tier.to_lowercase().as_str() {
             "starter" => 500,
             "pro" => 2000,
             _ => 1000, // free (increased for e2e tests)
@@ -48,7 +48,7 @@ impl ThrottlingManager {
                     .map_err(|e| e.to_string())?;
 
                 let _ = sqlx::query(
-                    "INSERT INTO tenants (id, name, tier)
+                    "INSERT INTO tenants (id, name, plan_tier)
                      VALUES ($1, $2, 'free')
                      ON CONFLICT (id) DO NOTHING"
                 )


### PR DESCRIPTION
- Fixed test `test_token_budget_server_side_enforcement` failing due to `tier` missing in the simulated db schema (`plan_tier` is the current naming format).
- Fixed `OperationsAgent` test `operations_agent_consumes_subscription_fulfillment_batch_events` failing due to similar `tier` mismatches causing out of budget conditions during the test due to defaulting to 1000 instead of 500 when falling back.
- Made `ThrottlingManager` use `plan_tier` correctly instead of `tier` so token consumption behaves predictably depending on the user's tier.

---
*PR created automatically by Jules for task [1169599104372862989](https://jules.google.com/task/1169599104372862989) started by @ql-owo-lp*