### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix]

### DIFF
--- a/src/server/api/oauth/proxy.rs
+++ b/src/server/api/oauth/proxy.rs
@@ -44,7 +44,7 @@ pub async fn handle_oauth_callback(
             let tunnel_base_url = std::env::var("OHC_TUNNEL_BASE_URL")
                 .unwrap_or_else(|_| "https://tunnel.ohc.network".to_string());
 
-            let mut redirect_url = format!("{}/{}/oauth/callback?code={}&state={}",
+            let mut redirect_url = format!("{}/{}/oauth/callback#code={}&state={}",
                 tunnel_base_url,
                 urlencoding::encode(&tunnel_id),
                 urlencoding::encode(&query.code),

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -164,14 +164,14 @@ impl ModeEnforcer for StandaloneModeEnforcer {
 
         let sqlite_url = if let Some(key) = &cfg.sqlite_encryption_key {
             if !key.is_empty() {
-                base_sqlite_url.clone()
-            } else if let Ok(_fallback_key) = std::env::var("OHC_SQLITE_KEY") {
-                base_sqlite_url.clone()
+                format!("{}?pragma.key={}", base_sqlite_url, key)
+            } else if let Ok(fallback_key) = std::env::var("OHC_SQLITE_KEY") {
+                format!("{}?pragma.key={}", base_sqlite_url, fallback_key)
             } else {
                 base_sqlite_url
             }
-        } else if let Ok(_fallback_key) = std::env::var("OHC_SQLITE_KEY") {
-            base_sqlite_url.clone()
+        } else if let Ok(fallback_key) = std::env::var("OHC_SQLITE_KEY") {
+            format!("{}?pragma.key={}", base_sqlite_url, fallback_key)
         } else {
             base_sqlite_url
         };


### PR DESCRIPTION
**Severity**: High
**Vulnerability**: 
1. `Local Data Exposure` via `SQLite` bypassing `PRAGMA key` enforcement.
2. `Token Leakage` via open redirects using query string in `OAuth Callback` rather than fragments.

**Impact**: 
- Attackers could potentially view SQLite databases locally in standalone mode since `sqlite_encryption_key` configurations were ignored and no `pragma.key` string substitution was occurring.
- Intermediate network proxies could log the user's `code` and `state` access token callbacks in the query params `?code=X&state=Y` during OAuth flows when operating via standalone OHC mode tunnel proxies.

**Fix Details**:
1. Added missing PRAGMA parameter to connection URL for `OHC_SQLITE_KEY` and configuration `sqlite_encryption_key` enforcing proper local storage encryptions (`src/server/config/mod.rs`).
2. Updated proxy router (`src/server/api/oauth/proxy.rs`) to utilize the URI fragment `#` instead of the URL query string `?` parameters when returning OAuth callback redirects, solving the Token Leakage in transit.
3. Verified the tenant leakage in DB revocation properly uses `tenant_id` on deletion (`src/server/auth/postgres_store.rs`), satisfying the Tenant Isolation Audit.

**Superpowers Skills Loaded**: None explicitly invoked, but standard OS hardening & secure development lifecycle practices followed.
**Product-use evidence**: Executing the test `test_valid_tunnel_id_secure_fragment_redirect` failed before the fix and succeeded afterward when resolving `?` to `#` in the `proxy.rs` router. Tested `test_revoke_token_tenant_isolation` logic.

---
*PR created automatically by Jules for task [9150455626572088821](https://jules.google.com/task/9150455626572088821) started by @ql-owo-lp*