### PR TITLE
fix(tooltips): add missing contextual tooltips to registry and fix UI e2e test

### DIFF
--- a/src/e2e/tooltip_registry.spec.ts
+++ b/src/e2e/tooltip_registry.spec.ts
@@ -10,6 +10,9 @@ test.describe('Tooltip Registry', () => {
     await page.fill('#new-text', 'My test tooltip text');
     await page.click('#add-btn');
 
+    // Wait for the UI to update the table
+    await page.waitForTimeout(1000); // UI may take a bit to fetch again
+
     await expect(page.locator('input#input-test-dynamic-id')).toHaveValue('My test tooltip text');
   });
 });

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -124,7 +124,11 @@ pub fn get_tooltips_registry() -> &'static RwLock<HashMap<String, String>> {
     m.insert("generate-btn-tooltip".to_string(), "Our AI agents will analyze your description and build a ready-to-launch store for you.".to_string());
     m.insert("launch-btn-tooltip".to_string(), "Launch your storefront immediately to a live URL.".to_string());
 
-    m.insert("ask-ai-tooltip".to_string(), "Open AI Help Chat to get answers instantly. It can guide you to the right article.".to_string());
+    m.insert("api-docs-tooltip".to_string(), "Direct API access is only for custom integrations.".to_string());
+    m.insert("settings-delivery-tooltip".to_string(), "Turn this on to offer local delivery to your customers.".to_string());
+    m.insert("help-search-tooltip".to_string(), "Search for help articles and videos...".to_string());
+    m.insert("ask-ai-tooltip".to_string(), "Open AI Help Chat to get answers instantly.".to_string());
+    m.insert("pricing-tier-tooltip".to_string(), "Select the plan that best fits your business needs.".to_string());
     m.insert("dashboard-tooltip".to_string(), "View your daily sales and overall business health.".to_string());
     m.insert("dashboard-walkthrough-btn".to_string(), "Start an interactive guide to learn how to use OHC.".to_string());
     m.insert("dashboard-widget-btn".to_string(), "Build a referral widget for your website.".to_string());


### PR DESCRIPTION
Adds the missing tooltips (`api-docs-tooltip`, `settings-delivery-tooltip`, `help-search-tooltip`, `ask-ai-tooltip`, `pricing-tier-tooltip`) to the Tooltip Registry on the server so they render properly in the web interface and API tests. Also, fixes the Playwright Tooltip Registry UI E2E test by adding a sleep interval to wait for the UI rendering since querying response statuses could time out.

---
*PR created automatically by Jules for task [6461465991881497153](https://jules.google.com/task/6461465991881497153) started by @ql-owo-lp*