### PR TITLE
Add Interactive Walkthroughs

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -43,10 +43,12 @@ pub async fn get_walkthrough(axum::extract::Path(page): axum::extract::Path<Stri
             WalkthroughStep { selector: "#wrapped-summary".to_string(), title: "AI Savings".to_string(), text: "Here you can see the time and effort your agents have saved you.".to_string() }
         ],
         "pos" => vec![
-            WalkthroughStep { selector: "#charge-btn".to_string(), title: "Accept your first payment".to_string(), text: "Enter an amount and tap here to charge your first customer. It's that easy!".to_string() }
+            WalkthroughStep { selector: "#pos-keypad".to_string(), title: "Enter Amount".to_string(), text: "Type in the total sale amount using the keypad.".to_string() },
+            WalkthroughStep { selector: "#charge-btn".to_string(), title: "Charge Customer".to_string(), text: "Tap here to process the payment. It's that easy!".to_string() }
         ],
         "assistant" => vec![
-            WalkthroughStep { selector: "#ohc-help-input-area".to_string(), title: "Activate your AI Support Agent".to_string(), text: "Chat here to activate your AI agent. They can handle support tickets while you sleep.".to_string() }
+            WalkthroughStep { selector: "#ai-chat-trigger".to_string(), title: "Open Assistant".to_string(), text: "Click here to open your AI Support Agent.".to_string() },
+            WalkthroughStep { selector: "#ohc-help-input-area".to_string(), title: "Ask Anything".to_string(), text: "Type your request here and the agent will handle it while you sleep.".to_string() }
         ],
         _ => vec![],
     };

--- a/src/ui/next/src/app/components/AppShell.tsx
+++ b/src/ui/next/src/app/components/AppShell.tsx
@@ -179,7 +179,7 @@ export function AppShell({
         <header className="app-topbar">
           <div className="min-w-0">
             <div className="app-breadcrumb">Site: default</div>
-            <h1 className="app-title">{title}</h1>
+            <h1 id="dashboard-title" className="app-title">{title}</h1>
             {subtitle && <p className="app-subtitle">{subtitle}</p>}
           </div>
           <div className="app-topbar-right">

--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -290,7 +290,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
   };
 
   return (
-    <div className="p-6 rounded-3xl shadow-2xl mt-6 relative overflow-hidden bg-white/65 backdrop-blur-[30px] saturate-[210%] border border-white/40">
+    <div id="pos-keypad" className="p-6 rounded-3xl shadow-2xl mt-6 relative overflow-hidden bg-white/65 backdrop-blur-[30px] saturate-[210%] border border-white/40">
       <h2 className="text-lg font-bold font-outfit text-gray-900 mb-2">Tap to Pay via Terminal</h2>
       <p className={`text-sm mb-6 font-medium p-3 rounded-xl border ${status?.toLowerCase()?.includes('fail') || status?.toLowerCase()?.includes('error') || status?.toLowerCase()?.includes('sold out') ? 'bg-red-50/80 backdrop-blur-md text-red-800 border-red-200' : 'text-gray-600 border-transparent'}`}>Status: {status}</p>
 
@@ -342,7 +342,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
 
       {connectedReader && (
         <div>
-          <button onClick={processPayment} disabled={reserving} className={`w-full bg-gradient-to-b from-[#0066FF] to-[#0052CC] text-white px-6 py-4 min-h-[56px] rounded-2xl font-bold text-lg shadow-xl shadow-blue-500/30 transition-all charge-btn ${reserving ? 'opacity-50' : 'hover:shadow-blue-500/40 hover:scale-[1.02] active:scale-[0.98]'}`}>
+          <button id="charge-btn" onClick={processPayment} disabled={reserving} className={`w-full bg-gradient-to-b from-[#0066FF] to-[#0052CC] text-white px-6 py-4 min-h-[56px] rounded-2xl font-bold text-lg shadow-xl shadow-blue-500/30 transition-all charge-btn ${reserving ? 'opacity-50' : 'hover:shadow-blue-500/40 hover:scale-[1.02] active:scale-[0.98]'}`}>
             {reserving ? 'Processing...' : `Charge $${(amount / 100).toFixed(2)}`}
           </button>
         </div>

--- a/src/ui/next/src/components/HelpChat.tsx
+++ b/src/ui/next/src/components/HelpChat.tsx
@@ -172,6 +172,7 @@ export function HelpChat() {
       <div className="fixed bottom-24 right-6 z-[9999] pointer-events-auto">
         {!isOpen && (
           <button
+            id="ai-chat-trigger"
             onClick={() => setIsOpen(true)}
             className="bg-blue-600/95 text-white p-4 min-h-[44px] rounded-full shadow-2xl hover:shadow-xl hover:scale-105 transition-all flex items-center justify-center gap-2 group backdrop-blur-[30px] saturate-[210%]"
             aria-label="Open help chat"
@@ -294,6 +295,7 @@ export function HelpChat() {
             className="p-3 bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] border-t border-white/40 dark:border-white/10 flex gap-2 items-center"
           >
             <input
+              id="ohc-help-input-area"
               type="text"
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}


### PR DESCRIPTION
Implemented the "Interactive Walkthroughs" feature required by the user by connecting the walkthrough target IDs (`id="dashboard-title"`, `id="pos-keypad"`, `id="charge-btn"`, `id="ai-chat-trigger"`, `id="ohc-help-input-area"`) to the correct UI components, and updating the backend API in `docs.rs` to serve a step-by-step tour. Verified the flows utilizing Playwright. All tests passed.

---
*PR created automatically by Jules for task [2695487798388718091](https://jules.google.com/task/2695487798388718091) started by @ql-owo-lp*