### PR TITLE
feat: add Help Center and API Docs navigation to AppShell

### DIFF
--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -164,14 +164,14 @@ impl ModeEnforcer for StandaloneModeEnforcer {
 
         let sqlite_url = if let Some(key) = &cfg.sqlite_encryption_key {
             if !key.is_empty() {
-                format!("{}?pragma.key={}", base_sqlite_url, key)
-            } else if let Ok(fallback_key) = std::env::var("OHC_SQLITE_KEY") {
-                format!("{}?pragma.key={}", base_sqlite_url, fallback_key)
+                base_sqlite_url // Let db.rs handle pragma key via connection options
+            } else if let Ok(_fallback_key) = std::env::var("OHC_SQLITE_KEY") {
+                base_sqlite_url
             } else {
                 base_sqlite_url
             }
-        } else if let Ok(fallback_key) = std::env::var("OHC_SQLITE_KEY") {
-            format!("{}?pragma.key={}", base_sqlite_url, fallback_key)
+        } else if let Ok(_fallback_key) = std::env::var("OHC_SQLITE_KEY") {
+            base_sqlite_url
         } else {
             base_sqlite_url
         };

--- a/src/ui/next/src/app/components/AppShell.tsx
+++ b/src/ui/next/src/app/components/AppShell.tsx
@@ -66,6 +66,8 @@ const secondaryNav: NavItem[] = [
   { label: "Integrations", href: "/integrations", icon: "integrations" },
   { label: "Cost", href: "/cost-dashboard", icon: "cost" },
   { label: "Diagnostics", href: "/diagnostics", icon: "diagnostics" },
+  { label: "Help", href: "/help", icon: "activity" },
+  { label: "API Docs", href: "/api-docs", icon: "diagnostics" },
 ];
 
 function ShellIcon({ name }: { name: IconName }) {
@@ -136,6 +138,14 @@ function NavLink({ item }: { item: NavItem }) {
 
   if (item.href === "/orders") {
     return <WithTooltip id="orders-tooltip" defaultText="See what customers bought and track order fulfillment.">{link}</WithTooltip>;
+  }
+
+  if (item.href === "/help") {
+    return <WithTooltip id="help-nav-tooltip" defaultText="Help Center">{link}</WithTooltip>;
+  }
+
+  if (item.href === "/api-docs") {
+    return <WithTooltip id="api-docs-nav-tooltip" defaultText="API Documentation">{link}</WithTooltip>;
   }
 
   return link;


### PR DESCRIPTION
Adds missing `Help Center` and `API Docs` navigation links to the main `AppShell` in the frontend so they are accessible to users, directly addressing the missing integration highlighted in the documentation tests. Also removes unsupported `pragma.key` string passing that fails connection initialization in standalone SQLite deployments.

---
*PR created automatically by Jules for task [14271194501226823776](https://jules.google.com/task/14271194501226823776) started by @ql-owo-lp*