### PR TITLE
feat: implement edge-cached storefronts with SWR

### DIFF
--- a/src/e2e/global_edge_storefront.spec.ts
+++ b/src/e2e/global_edge_storefront.spec.ts
@@ -7,18 +7,18 @@ test.describe('Global Edge-Cached Dynamic Storefronts E2E', () => {
     const tenantId = '11111111-1111-1111-1111-111111111111';
     const productId = '22222222-2222-2222-2222-222222222222';
 
-    let res = await request.get(`/api/v1/storefront/${tenantId}/${productId}`);
+    let res = await request.get(`http://127.0.0.1:18789/api/v1/storefront/${tenantId}/${productId}`);
     expect(res.status()).toBe(200);
 
     // Perform an inventory invalidation trigger via webhook (simulating backend ops)
-    const invalidateRes = await request.post('/api/v1/storefront/webhook/invalidate', {
+    const invalidateRes = await request.post('http://127.0.0.1:18789/api/v1/storefront/webhook/invalidate', {
       data: { tags: [`entity:product:${productId}`] }
     });
     expect(invalidateRes.status()).toBe(200);
 
     // Hit cache again and verify regeneration logic is invoked
     // In a real e2e environment this hits the backend properly. We verify the API endpoint contract.
-    let refreshed = await request.get(`/api/v1/storefront/${tenantId}/${productId}`);
+    let refreshed = await request.get(`http://127.0.0.1:18789/api/v1/storefront/${tenantId}/${productId}`);
     expect(refreshed.status()).toBe(200);
   });
 
@@ -26,7 +26,7 @@ test.describe('Global Edge-Cached Dynamic Storefronts E2E', () => {
     const tenantId = '11111111-1111-1111-1111-111111111111';
     const productId = '22222222-2222-2222-2222-222222222222';
 
-    let res = await request.get(`/api/v1/storefront/${tenantId}/${productId}`);
+    let res = await request.get(`http://127.0.0.1:18789/api/v1/storefront/${tenantId}/${productId}`);
     let text = await res.text();
     // Validating fallback SEO or html tags
     expect(text).toContain('<!DOCTYPE html>');
@@ -36,7 +36,7 @@ test.describe('Global Edge-Cached Dynamic Storefronts E2E', () => {
     const tenantId = 'invalid-tenant-id';
     const productId = 'invalid-product-id';
 
-    let res = await request.get(`/api/v1/storefront/${tenantId}/${productId}`);
+    let res = await request.get(`http://127.0.0.1:18789/api/v1/storefront/${tenantId}/${productId}`);
     expect(res.status()).toBe(400); // Bad Request from Uuid parse fail
   });
 
@@ -44,7 +44,7 @@ test.describe('Global Edge-Cached Dynamic Storefronts E2E', () => {
     const tenantId = '00000000-0000-0000-0000-000000000000';
     const productId = '00000000-0000-0000-0000-000000000000';
 
-    let res = await request.get(`/api/v1/storefront/${tenantId}/${productId}`);
+    let res = await request.get(`http://127.0.0.1:18789/api/v1/storefront/${tenantId}/${productId}`);
     expect(res.status()).toBe(200);
     // Should display simple fallback logic
     expect(await res.text()).toContain('Product 00000000-0000-0000-0000-000000000000 not found');
@@ -52,7 +52,7 @@ test.describe('Global Edge-Cached Dynamic Storefronts E2E', () => {
 
   test('validates cache regeneration after offline POS sync deduction', async ({ request, page }) => {
     // Analogous to updating POS orders invalidation endpoint
-    const invalidateRes = await request.post('/api/v1/storefront/webhook/invalidate', {
+    const invalidateRes = await request.post('http://127.0.0.1:18789/api/v1/storefront/webhook/invalidate', {
       data: { tags: [`tenant-id:00000000-0000-0000-0000-000000000000`] }
     });
     expect(invalidateRes.status()).toBe(200);

--- a/src/server/api/storefront_delivery.rs
+++ b/src/server/api/storefront_delivery.rs
@@ -8,7 +8,7 @@ use axum::http::StatusCode;
 use serde::Deserialize;
 use sqlx::PgPool;
 use uuid::Uuid;
-use crate::builder::edge::{get_edge_cache, regenerate_cache};
+use crate::builder::edge::{get_edge_cache, regenerate_cache, get_ongoing_generation, inject_dynamic_inventory};
 
 #[derive(Clone)]
 pub struct DeliveryState {
@@ -48,8 +48,57 @@ async fn get_storefront_product(
     let cache_key = format!("storefront:product:{}:{}", tenant_id, product_id);
 
     if let Some((cached_html, is_stale)) = cache.get_with_swr(&cache_key).await {
+        let html = inject_dynamic_inventory(cached_html, tenant_id, &state.pool, cache.clone()).await;
+        let mut response = Html(html).into_response();
+        let cache_tag = format!("tenant-id:{}", tenant_id);
+        if let Ok(val) = cache_tag.parse() {
+            response.headers_mut().insert("Cache-Tag", val);
+        }
+        response.headers_mut().insert(
+            axum::http::header::CACHE_CONTROL,
+            "public, s-maxage=60, stale-while-revalidate=86400".parse().unwrap(),
+        );
+
         if !is_stale {
-            let mut response = Html(cached_html).into_response();
+            return Ok(response);
+        } else {
+            let ongoing = get_ongoing_generation();
+            let mut guard = ongoing.lock().await;
+            if !guard.contains(&cache_key) {
+                guard.insert(cache_key.clone());
+                let pool_clone = state.pool.clone();
+                let cache_key_clone = cache_key.clone();
+                let cache_clone = cache.clone();
+                tokio::spawn(async move {
+                    let _ = regenerate_storefront_product(pool_clone, tenant_id, product_id, cache_key_clone.clone(), cache_clone).await;
+                    let ongoing = get_ongoing_generation();
+                    ongoing.lock().await.remove(&cache_key_clone);
+                });
+            }
+            return Ok(response);
+        }
+    }
+
+    let ongoing = get_ongoing_generation();
+    let is_generating = {
+        let mut guard = ongoing.lock().await;
+        if guard.contains(&cache_key) {
+            true
+        } else {
+            guard.insert(cache_key.clone());
+            false
+        }
+    };
+
+    if is_generating {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        if let Some((cached_html, _)) = cache.get_with_swr(&cache_key).await {
+            let html = inject_dynamic_inventory(cached_html, tenant_id, &state.pool, cache.clone()).await;
+            let mut response = Html(html).into_response();
+            let cache_tag = format!("tenant-id:{}", tenant_id);
+            if let Ok(val) = cache_tag.parse() {
+                response.headers_mut().insert("Cache-Tag", val);
+            }
             response.headers_mut().insert(
                 axum::http::header::CACHE_CONTROL,
                 "public, s-maxage=60, stale-while-revalidate=86400".parse().unwrap(),
@@ -58,19 +107,54 @@ async fn get_storefront_product(
         }
     }
 
-    // In a real scenario we might render directly here if it's missing,
-    // but the builder edge regenerate_cache logic expects a site_id.
-    // Let's find the primary site for this tenant.
+    let result = regenerate_storefront_product(state.pool.clone(), tenant_id, product_id, cache_key.clone(), cache.clone()).await;
+
+    {
+        let ongoing = get_ongoing_generation();
+        ongoing.lock().await.remove(&cache_key);
+    }
+
+    if let Ok((html, tags)) = result {
+        let final_html = inject_dynamic_inventory(html, tenant_id, &state.pool, cache.clone()).await;
+        let mut response = Html(final_html).into_response();
+        if !tags.is_empty() {
+            if let Ok(cache_tag) = tags.join(", ").parse() {
+                response.headers_mut().insert("Cache-Tag", cache_tag);
+            }
+        }
+        response.headers_mut().insert(
+            axum::http::header::CACHE_CONTROL,
+            "public, s-maxage=60, stale-while-revalidate=86400".parse().unwrap(),
+        );
+        return Ok(response);
+    }
+
+    // Fallback simple HTML
+    let mut response = Html(format!("<!DOCTYPE html><html><body>Product {} not found</body></html>", product_id)).into_response();
+    response.headers_mut().insert(
+        axum::http::header::CACHE_CONTROL,
+        "public, max-age=10".parse().unwrap(),
+    );
+    Ok(response)
+}
+
+async fn regenerate_storefront_product(
+    pool: PgPool,
+    tenant_id: Uuid,
+    product_id: Uuid,
+    cache_key: String,
+    cache: std::sync::Arc<crate::utils::cache::HybridCache<String>>,
+) -> Result<(String, Vec<String>), StatusCode> {
     let site_id_res = sqlx::query_scalar::<_, Uuid>(
         "SELECT id FROM builder_sites WHERE tenant_id = $1 ORDER BY created_at ASC LIMIT 1"
     )
     .bind(tenant_id)
-    .fetch_one(&state.pool)
+    .fetch_one(&pool)
     .await;
 
     if let Ok(site_id) = site_id_res {
         // Just call regenerate_cache from builder edge
-        if let Ok((mut html, tags)) = regenerate_cache(state.pool.clone(), tenant_id, site_id, cache_key.clone(), cache.clone()).await {
+        if let Ok((mut html, tags)) = regenerate_cache(pool.clone(), tenant_id, site_id, cache_key.clone(), cache.clone()).await {
             #[derive(sqlx::FromRow)]
             struct ProductSeoRow {
                 seo_title: Option<String>,
@@ -84,7 +168,7 @@ async fn get_storefront_product(
             )
             .bind(product_id.to_string())
             .bind(tenant_id.to_string())
-            .fetch_optional(&state.pool)
+            .fetch_optional(&pool)
             .await;
 
             if let Ok(Some(row)) = seo_res {
@@ -120,25 +204,11 @@ async fn get_storefront_product(
                 }
             }
 
-            let mut response = Html(html).into_response();
-            if !tags.is_empty() {
-                if let Ok(cache_tag) = tags.join(", ").parse() {
-                    response.headers_mut().insert("Cache-Tag", cache_tag);
-                }
-            }
-            response.headers_mut().insert(
-                axum::http::header::CACHE_CONTROL,
-                "public, s-maxage=60, stale-while-revalidate=86400".parse().unwrap(),
-            );
-            return Ok(response);
+            // Pre-warm the cache since SWR or cache miss just resolved
+            cache.set_with_tags(&cache_key, html.clone(), tags.clone(), std::time::Duration::from_secs(3600)).await;
+
+            return Ok((html, tags));
         }
     }
-
-    // Fallback simple HTML
-    let mut response = Html(format!("<!DOCTYPE html><html><body>Product {} not found</body></html>", product_id)).into_response();
-    response.headers_mut().insert(
-        axum::http::header::CACHE_CONTROL,
-        "public, max-age=10".parse().unwrap(),
-    );
-    Ok(response)
+    Err(StatusCode::NOT_FOUND)
 }


### PR DESCRIPTION
This PR addresses issue #30499 which identifies that OHC currently serves customer-facing catalog/booking pages directly from the central database, resulting in high latency, particularly for media-heavy catalogs. It relies on the new `SWR` (Stale-While-Revalidate) edge logic and injects dynamic content accurately.

Changes:
1. Implements proper HTTP Cache-Control utilizing `s-maxage` and `stale-while-revalidate` for `src/server/api/storefront_delivery.rs`.
2. Employs `get_ongoing_generation` background locking mechanism preventing thundering herd cache misses while regenerating cache correctly asynchronously.
3. Automatically maps UUID queries toward storefront and verifies metadata via `inject_dynamic_inventory` injection inside generated HTML payloads.
4. Validates edge caching flow internally via `storefront_edge_seo.spec.ts`.

---
*PR created automatically by Jules for task [1803223773917288953](https://jules.google.com/task/1803223773917288953) started by @ql-owo-lp*