### PR TITLE
fix(tests): resolve total_amount compilation error in unit tests

### DIFF
--- a/src/server/domain/unified_tenant_test.rs
+++ b/src/server/domain/unified_tenant_test.rs
@@ -178,7 +178,7 @@ mod tests {
             tenant_id: "t1".to_string(),
             customer_id: "c1".to_string(),
             status: None,
-            total_amount: None,
+            total_amount_cents: None,
             payment_source: None,
             created_at: None,
             updated_at: None,


### PR DESCRIPTION
This fixes a compilation error in `src/server/domain/unified_tenant_test.rs` where the test was using the outdated field `total_amount` instead of `total_amount_cents` for the `Order` struct.

This allows the full `bazelisk test //...` suite to pass.

---
*PR created automatically by Jules for task [10476838761668100384](https://jules.google.com/task/10476838761668100384) started by @ql-owo-lp*