### PR TITLE
fix(tauri): synchronize setup state cross-device via backend APIs

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1522,10 +1522,37 @@
           clearTimeout(autoSaveTimer);
           autoSaveTimer = setTimeout(() => {
               saveCurrentState();
-              const msg = document.getElementById('draft-saved-msg');
-              if (msg) {
-                  msg.style.display = 'block';
-                  setTimeout(() => { msg.style.display = 'none'; }, 2000);
+
+              const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
+              const tenantId = localStorage.getItem("tenant_id") || "e2e-tenant";
+              const userId = localStorage.getItem("user_id") || "e2e-admin-user";
+
+              if (window.__TAURI__ && window.__TAURI__.core) {
+                  window.__TAURI__.core.invoke("save_onboarding_state", { state, tenantId, userId }).then(() => {
+                      const msg = document.getElementById('draft-saved-msg');
+                      if (msg) {
+                          msg.style.display = 'block';
+                          setTimeout(() => { msg.style.display = 'none'; }, 2000);
+                      }
+                  }).catch(console.error);
+              } else {
+                  fetch(`${backendUrl}/api/onboarding/draft`, {
+                      method: "POST",
+                      headers: {
+                          "Content-Type": "application/json",
+                          "X-Tenant-ID": tenantId,
+                          "X-User-ID": userId
+                      },
+                      body: JSON.stringify(state)
+                  }).then(res => {
+                      if (res.ok) {
+                          const msg = document.getElementById('draft-saved-msg');
+                          if (msg) {
+                              msg.style.display = 'block';
+                              setTimeout(() => { msg.style.display = 'none'; }, 2000);
+                          }
+                      }
+                  }).catch(console.error);
               }
           }, 500);
       }
@@ -1545,62 +1572,56 @@
       });
 
       // Load existing state
-      if (window.__TAURI__ && window.__TAURI__.core) {
+      async function loadState() {
         const tenantId = localStorage.getItem('tenant_id') || 'e2e-tenant';
         const userId = localStorage.getItem('user_id') || 'e2e-admin-user';
-        window.__TAURI__.core.invoke("get_onboarding_state", { tenantId, userId }).then((backendState) => {
-          if (backendState) {
-            state = { ...state, ...backendState };
-            populateForm();
-          }
-        }).catch(console.error);
 
-      } else {
-        const stored = localStorage.getItem('onboardingState');
-        if (stored) {
-          state = { ...state, ...JSON.parse(stored) };
-          populateForm();
+        let loadedState = null;
+        if (window.__TAURI__ && window.__TAURI__.core) {
+            try {
+                loadedState = await window.__TAURI__.core.invoke("get_onboarding_state", { tenantId, userId });
+            } catch (err) {
+                console.error('Tauri get_onboarding_state failed:', err);
+            }
+        } else {
+            const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
+            try {
+                const res = await fetch(`${backendUrl}/api/onboarding/draft`, {
+                    method: 'GET',
+                    headers: { 'X-Tenant-ID': tenantId, 'X-User-ID': userId }
+                });
+                if (res.ok) {
+                    loadedState = await res.json();
+                }
+            } catch (err) {
+                console.error('Web draft fetch failed:', err);
+            }
         }
 
-        // Fetch from API to support cross-device resume
-        const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
-        const tenantId = localStorage.getItem('tenant_id') || 'e2e-tenant';
-        const userId = localStorage.getItem('user_id') || 'e2e-admin-user';
+        // Merge from localStorage as fallback
+        const stored = localStorage.getItem('onboardingState');
+        if (stored) {
+            state = { ...state, ...JSON.parse(stored) };
+        }
 
-        fetch(`${backendUrl}/api/onboarding/draft`, {
-            method: 'GET',
-            headers: {
-                'X-Tenant-ID': tenantId,
-                'X-User-ID': userId
+        // Merge backend state, taking priority
+        if (loadedState && Object.keys(loadedState).length > 0) {
+            state = { ...state, ...loadedState };
+            localStorage.setItem('onboardingState', JSON.stringify(state));
+        }
+
+        populateForm();
+
+        if (state.step === undefined || state.step === 0) {
+            goToStep('step-initial');
+        } else {
+            const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'];
+            if (state.step < steps.length) {
+                goToStep(steps[state.step]);
             }
-        })
-        .then(res => res.json())
-        .then(apiState => {
-            if (apiState && Object.keys(apiState).length > 0) {
-                state = { ...state, ...(apiState) };
-                localStorage.setItem('onboardingState', JSON.stringify(state)); // Sync cross-device state down to local
-                populateForm();
-            }
-        })
-        .catch(err => console.error('Failed to load cross-device state:', err))
-        .finally(() => {
-            if (!state.step) {
-                const stored = localStorage.getItem('onboardingState');
-                if (stored) {
-                    state = { ...state, ...JSON.parse(stored) };
-                    populateForm();
-                }
-            }
-            if (state.step === undefined || state.step === 0) {
-               goToStep('step-initial');
-            } else {
-               const steps = ['step-initial', 'step-context', 'step-categories', 'step-name', 'step-assistant', 'step-admin', 'step-offer', 'step-domain', 'step-template', 'step-instant', 'step-chat'];
-               if (state.step < steps.length) {
-                  goToStep(steps[state.step]);
-               }
-            }
-        });
+        }
       }
+      loadState();
 
             // Clear name error on typing if valid
       inputs.name.addEventListener('input', () => {
@@ -1701,7 +1722,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           state.capabilities = {
               draft: document.getElementById('cap-draft') ? document.getElementById('cap-draft').checked : true,
               schedule: document.getElementById('cap-schedule') ? document.getElementById('cap-schedule').checked : true,
-              inventory: document.getElementById('cap-inventory') ? document.getElementById('cap-inventory').checked : false,
+              inventory: document.getElementById('cap-inventory') ? document.getElementById('cap-inventory').checked : false
           };
 
           let selectedContext = document.querySelector('input[name="work_context"]:checked');


### PR DESCRIPTION
- Unified the setup state loading logic into a robust `async loadState()` method that correctly handles fetching the existing draft state via Tauri IPC or standard web endpoints.
- Updated `debouncedAutoSave()` to invoke the `/api/onboarding/draft` or `save_onboarding_state` endpoints to ensure real-time persistence of state to the database rather than relying strictly on the "Save Draft" button.
- Cleaned up cross-device state resume logic to perfectly prioritize server state over stale local storage and successfully execute `goToStep` to resume user progress contextually.

---
*PR created automatically by Jules for task [11483586190672517716](https://jules.google.com/task/11483586190672517716) started by @ql-owo-lp*