### PR TITLE
🤖 Implementer: Harness Upgrade - Error Handling (LLM-Recoverable ToolMessages)

### DIFF
--- a/src/agents/builtin/output_parser.rs
+++ b/src/agents/builtin/output_parser.rs
@@ -212,10 +212,19 @@ impl<'a, T: DeserializeOwned> RetryWithErrorOutputParser<'a, T> {
                 Ok(parsed) => return Ok(parsed),
                 Err(parse_error_msg) => {
                     if attempt >= max_retries {
-                        return Err(ToolError::Unexpected(format!(
-                            "Output parsing failed after {} retries. Last error: {}",
-                            max_retries, parse_error_msg
-                        )));
+                        if parse_error_msg.contains("Validation Error")
+                            || parse_error_msg.contains("Semantic validation failed")
+                            || parse_error_msg.contains("Expected native tool_calls")
+                            || parse_error_msg.contains("Missing required 'data' parameter")
+                            || parse_error_msg.contains("Failed to parse arguments")
+                        {
+                            return Err(ToolError::LlmRecoverable(parse_error_msg));
+                        } else {
+                            return Err(ToolError::Unexpected(format!(
+                                "Output parsing failed after {} retries. Last error: {}",
+                                max_retries, parse_error_msg
+                            )));
+                        }
                     }
 
                     // Feed the original prompt, the failed completion, and the parsing error back to the model as an LLM-recoverable ToolMessage


### PR DESCRIPTION
🤖 Implementer: Harness Upgrade - Error Handling (LLM-Recoverable ToolMessages)

Master Catalog B.8. Error Handling (Compounding Error Prevention) - LLM-recoverable (return the raw error as a ToolMessage directly to the model so it can self-correct).

Modified the output parser to accurately classify schema and semantic validation errors as `LlmRecoverable` even after retry exhaustion.

Testing instructions:
```bash
bazel test //src/agents/builtin/...
```

---
*PR created automatically by Jules for task [887027175317271751](https://jules.google.com/task/887027175317271751) started by @ql-owo-lp*