### PR TITLE
fix: update mobile attributes for setup wizard inputs

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1078,7 +1078,7 @@
         <h1>Tell us about your business</h1>
         <p>Our AI will handle the rest in 30 seconds.</p>
 
-        <textarea id="instant-bio" data-testid="instant-bio" class="glassmorphism" placeholder="e.g. I run a local bakery that sells custom vegan cakes..." rows="6" style="resize: none; padding: 14px;" enterkeyhint="done"></textarea>
+        <textarea id="instant-bio" data-testid="instant-bio" class="glassmorphism" placeholder="e.g. I run a local bakery that sells custom vegan cakes..." rows="6" style="resize: none; padding: 14px;" enterkeyhint="next"></textarea>
         <input type="url" id="instant-image-url" data-testid="instant-image-url" class="glassmorphism" placeholder="Image URL (Optional)" inputmode="url" autocomplete="url" enterkeyhint="next" style="margin-bottom: 20px; width: 100%; min-height: 44px; border-radius: 16px;">
         <div id="instant-error" class="error-msg" aria-live="polite" style="margin-bottom: 20px;"></div>
 
@@ -1383,7 +1383,7 @@
         <h1>Where will your business live?</h1>
         <p>Choose your workspace domain</p>
         <div style="display: flex; align-items: center; justify-content: center; gap: 8px;">
-          <input type="text" id="domain-name" data-testid="domain-name" class="glassmorphism" placeholder="e.g. my-business" inputmode="text" autocomplete="off" enterkeyhint="next" style="margin-bottom: 0; text-align: right; padding-right: 4px;" />
+          <input type="text" id="domain-name" data-testid="domain-name" class="glassmorphism" placeholder="e.g. my-business" inputmode="url" autocomplete="off" autocapitalize="none" autocorrect="off" enterkeyhint="done" style="margin-bottom: 0; text-align: right; padding-right: 4px;" />
           <span style="font-size: 18px; font-weight: 500; color: #1D1D1F; opacity: 0.8;">.ohc.app</span>
         </div>
         <div id="domain-error" class="error-msg" aria-live="polite" style="margin-top: 10px;">Please enter a valid domain.</div>


### PR DESCRIPTION
Fixes Playwright E2E test failures by updating mobile-friendly HTML input attributes on `#instant-bio` and `#domain-name` in `src/ui/tauri/src/ui/setup.html`.

Specifically:
- Changed `enterkeyhint` on `#instant-bio` from `done` to `next`
- Updated `#domain-name` to use `inputmode="url"`, `autocapitalize="none"`, `autocorrect="off"`, and `enterkeyhint="done"`.

This ensures a frictionless mobile experience for users setting up their onboarding context.

---
*PR created automatically by Jules for task [12983817828805691356](https://jules.google.com/task/12983817828805691356) started by @ql-owo-lp*