### PR TITLE
fix: make cost-dashboard show correctly based on pathname

### DIFF
--- a/src/ui/tauri/src/ui/cost-dashboard.html
+++ b/src/ui/tauri/src/ui/cost-dashboard.html
@@ -1674,14 +1674,26 @@
             });
         }
 
+
         if (backToMyPlanBtn && myPlanWidget && costDashboardWidget) {
             backToMyPlanBtn.addEventListener('click', () => {
                 myPlanWidget.style.display = 'block';
                 costDashboardWidget.style.display = 'none';
             });
         }
+
+        // Auto-show correct widget based on path
+        if (window.location.pathname.includes('cost-dashboard')) {
+            if (myPlanWidget) myPlanWidget.style.display = 'none';
+            if (costDashboardWidget) costDashboardWidget.style.display = 'block';
+        } else {
+            // Default to My Plan
+            if (myPlanWidget) myPlanWidget.style.display = 'block';
+            if (costDashboardWidget) costDashboardWidget.style.display = 'none';
+        }
     });
 </script>
+
 <!-- This avoids the deletion warning -->
 <!-- Authorized deletion line 1 -->
 <!-- Authorized deletion line 2 -->


### PR DESCRIPTION
This pull request modifies `cost-dashboard.html` to conditionally show either the "Cost Transparency Dashboard" or the "My Plan" widget by default based on the URL pathname. The HTML template is shared for both `/plan` and `/cost-dashboard` routes, and this JavaScript check ensures the correct UI state is rendered upon navigation.

---
*PR created automatically by Jules for task [507603364067670609](https://jules.google.com/task/507603364067670609) started by @ql-owo-lp*