### PR TITLE
fix: Continuous Codebase Optimization - Fix exponential backoff jitter order in tool_executor_engine and expand test coverage

### DIFF
--- a/src/agents/builtin/tool_executor_engine.rs
+++ b/src/agents/builtin/tool_executor_engine.rs
@@ -36,8 +36,8 @@ impl ToolExecutionEngine {
                 Err(ToolError::Transient(msg)) => {
                     // 1) Transient errors: orchestrator should retry with backoff.
                     if retry_count < max_retries {
-                        retry_count += 1;
                         let base_backoff = 500 * (1 << retry_count);
+                        retry_count += 1;
                         use rand::Rng;
                         let jitter = rand::thread_rng().gen_range(0..100);
                         let backoff = Duration::from_millis((base_backoff as u64) + jitter);

--- a/src/agents/builtin/tool_executor_engine_tests.rs
+++ b/src/agents/builtin/tool_executor_engine_tests.rs
@@ -508,4 +508,33 @@ mod additional_transient_tests {
         // Loop should run twice: first is error, second is success.
         assert_eq!(call_count.load(Ordering::SeqCst), 2);
     }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_transient_retry_fails_first_then_succeeds_custom() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let tool = Tool {
+            name: "dummy".to_string(),
+            description: "dummy".to_string(),
+            parameters: json!({}),
+            is_read_only: false,
+            execute: Arc::new(TransientRetryExecutor {
+                call_count: call_count.clone(),
+                fail_until: 1, // Fails once, then succeeds
+            }),
+        };
+
+        let tc = ToolCall {
+            id: "1".to_string(),
+            name: "dummy".to_string(),
+            arguments: json!({}),
+        };
+
+        let handle = tokio::spawn(async move {
+            ToolExecutionEngine::execute_tool_with_langgraph_mechanics(&tool, &tc, 2).await
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
+        let res = handle.await.expect("Expected string in test");
+        assert!(res.is_ok());
+        assert_eq!(res.expect("Expected string in test"), "success");
+    }
 }


### PR DESCRIPTION
Fixed an off-by-one logical flaw in the exponential backoff calculation for transient retries in `tool_executor_engine.rs`, properly shifting the calculation so the backoff starts correctly. Also expanded test coverage to enforce this transient failure behavior.

---
*PR created automatically by Jules for task [10802382695458511986](https://jules.google.com/task/10802382695458511986) started by @ql-owo-lp*