### PR TITLE
💰 Miser: Fix sqlx postgres jsonb casting error in PayoutBatcher

### DIFF
--- a/src/server/integrations/stripe/payout_batcher.rs
+++ b/src/server/integrations/stripe/payout_batcher.rs
@@ -49,7 +49,7 @@ impl PayoutBatcher {
 
     async fn get_pending_balance_tx(tx: &mut sqlx::Transaction<'_, sqlx::Postgres>, account_id: &str) -> Result<i64, String> {
         let row = sqlx::query(
-            "SELECT COALESCE(CAST(SUM(CAST(state_change->>'amount' AS BIGINT)) AS BIGINT), 0) as balance
+            "SELECT COALESCE(CAST(SUM((state_change->>'amount')::BIGINT) AS BIGINT), 0) as balance
              FROM ohc_universal_ledger
              WHERE tenant_id = $1 AND action_type = 'PayoutBatchEvent'"
         )


### PR DESCRIPTION
Fixes an issue where `sqlx` failed to parse the nested `CAST(state_change->>'amount' AS BIGINT)` inside `PayoutBatcher::get_pending_balance_tx`. This replaces it with the equivalent shorthand `(state_change->>'amount')::BIGINT`, resolving the failing `test_record_payout_with_pool` test. All test cases now pass perfectly.

---
*PR created automatically by Jules for task [14298155997779217390](https://jules.google.com/task/14298155997779217390) started by @ql-owo-lp*