### PR TITLE
fix: correct current_plan reference for manage billing button

### DIFF
--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -200,7 +200,7 @@ export default function CostDashboardPage() {
                       </div>
                   )}
               </div>
-              {data?.department_tier_usage?.current_plan !== 'Free' && (
+              {myPlanData?.current_plan !== 'Free' && (
                   <div className="mt-6 flex flex-col md:flex-row gap-4">
                       <button
                           id="manage-billing-btn"


### PR DESCRIPTION
Fixed an issue where the "Manage Billing" button in the Cost Dashboard incorrectly referenced `data?.department_tier_usage?.current_plan` instead of the fetched `myPlanData?.current_plan`. This ensures the button correctly hides for the Free tier as intended.

Test coverage confirmed with Playwright E2E and Unit Tests.

---
*PR created automatically by Jules for task [3872093562301234271](https://jules.google.com/task/3872093562301234271) started by @ql-owo-lp*