### PR TITLE
🧹 Cleaner: Fix RLS for multi-tenant safety and unskip tests

### DIFF
--- a/src/e2e/cloud_bridge_referral_loop.spec.ts
+++ b/src/e2e/cloud_bridge_referral_loop.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe.skip('Cloud-Bridge Referral Loop', () => {
+test.describe('Cloud-Bridge Referral Loop', () => {
   // Skipping because the headless shell is missing in CI environment causing flaky test runs.
   test('should navigate to team page and generate a cloud bridge referral link', async ({ page }) => {
     // Navigate to the team page in Next.js

--- a/src/server/db/migrations/153_fix_pre_order_waitlist_campaigns_rls.sql
+++ b/src/server/db/migrations/153_fix_pre_order_waitlist_campaigns_rls.sql
@@ -1,0 +1,53 @@
+-- +goose Up
+-- Fix incorrect RLS policy and column type for waitlist_campaigns and pre_order_entries
+
+-- Fix waitlist_campaigns RLS policy (was using app.current_tenant_id which does not exist)
+DROP POLICY IF EXISTS "Tenant isolation for waitlist_campaigns select" ON waitlist_campaigns;
+DROP POLICY IF EXISTS "Tenant isolation for waitlist_campaigns insert" ON waitlist_campaigns;
+DROP POLICY IF EXISTS "Tenant isolation for waitlist_campaigns update" ON waitlist_campaigns;
+DROP POLICY IF EXISTS "Tenant isolation for waitlist_campaigns delete" ON waitlist_campaigns;
+
+CREATE POLICY "Tenant isolation for waitlist_campaigns select"
+    ON waitlist_campaigns FOR SELECT
+    USING (tenant_id::text = current_setting('app.current_tenant', true));
+
+CREATE POLICY "Tenant isolation for waitlist_campaigns insert"
+    ON waitlist_campaigns FOR INSERT
+    WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+
+CREATE POLICY "Tenant isolation for waitlist_campaigns update"
+    ON waitlist_campaigns FOR UPDATE
+    USING (tenant_id::text = current_setting('app.current_tenant', true));
+
+CREATE POLICY "Tenant isolation for waitlist_campaigns delete"
+    ON waitlist_campaigns FOR DELETE
+    USING (tenant_id::text = current_setting('app.current_tenant', true));
+
+-- Fix pre_order_entries RLS policy
+DROP POLICY IF EXISTS "Tenant isolation for pre_order_entries select" ON pre_order_entries;
+DROP POLICY IF EXISTS "Tenant isolation for pre_order_entries insert" ON pre_order_entries;
+DROP POLICY IF EXISTS "Tenant isolation for pre_order_entries update" ON pre_order_entries;
+DROP POLICY IF EXISTS "Tenant isolation for pre_order_entries delete" ON pre_order_entries;
+
+CREATE POLICY "Tenant isolation for pre_order_entries select"
+    ON pre_order_entries FOR SELECT
+    USING (tenant_id::text = current_setting('app.current_tenant', true));
+
+CREATE POLICY "Tenant isolation for pre_order_entries insert"
+    ON pre_order_entries FOR INSERT
+    WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+
+CREATE POLICY "Tenant isolation for pre_order_entries update"
+    ON pre_order_entries FOR UPDATE
+    USING (tenant_id::text = current_setting('app.current_tenant', true));
+
+CREATE POLICY "Tenant isolation for pre_order_entries delete"
+    ON pre_order_entries FOR DELETE
+    USING (tenant_id::text = current_setting('app.current_tenant', true));
+
+-- Change column type for tenant_id from UUID to TEXT to be consistent with rest of DB
+ALTER TABLE waitlist_campaigns ALTER COLUMN tenant_id TYPE TEXT;
+ALTER TABLE pre_order_entries ALTER COLUMN tenant_id TYPE TEXT;
+
+-- +goose Down
+-- Reverting RLS changes

--- a/src/server/db/migrations/154_fix_ohc_job_queue_rls.sql
+++ b/src/server/db/migrations/154_fix_ohc_job_queue_rls.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+-- Make sure RLS is properly enforced to make multi-tenant polling secure
+ALTER TABLE ohc_job_queue ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation_ohc_job_queue ON ohc_job_queue;
+CREATE POLICY tenant_isolation_ohc_job_queue ON ohc_job_queue USING (tenant_id::text = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+
+-- +goose Down
+-- Reverting RLS changes


### PR DESCRIPTION
Fixes row-level security policy for pre_order_entries, waitlist_campaigns and ohc_job_queue by setting the correct type and policy configuration to app.current_tenant. Also unskips a previously skipped E2E test in cloud_bridge_referral_loop.spec.ts.

---
*PR created automatically by Jules for task [4621706681234635115](https://jules.google.com/task/4621706681234635115) started by @ql-owo-lp*