### PR TITLE
fix(growth): correct generate_cloud_invite logic and referrals metrics grid

### DIFF
--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -2478,14 +2478,15 @@ document.addEventListener('DOMContentLoaded', () => {
               });
             } else {
               try {
-                  const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default';
-                  const res = await fetch('/api/v1/growth/team-invites', {
+                  const res = await fetch('/api/v1/growth/referrals/generate', {
                       method: 'POST',
-                      headers: { 'Content-Type': 'application/json' },
-                      body: JSON.stringify({ team_id: tenantId, inviter_id: "owner", invitee_id: "pending" })
+                      headers: {
+                        'authorization': `Bearer ${localStorage.getItem('ohc_token')}`,
+                        'Content-Type': 'application/json'
+                      }
                   });
                   const data = await res.json();
-                  linkInput.value = data.invite_link || "";
+                  linkInput.value = data.referral_link || "";
               } catch(e) {
                   console.error(e);
                   linkInput.value = "";

--- a/src/ui/tauri/src/ui/referrals.html
+++ b/src/ui/tauri/src/ui/referrals.html
@@ -167,6 +167,8 @@
       grid-template-columns: 1fr 1fr;
       gap: 16px;
       margin-top: 20px;
+      width: 100%;
+      box-sizing: border-box;
     }
 
     .metric-box {


### PR DESCRIPTION
- **Fixes dashboard.html:** Updates the fallback API call in `dashboard.html` for "Generate Cloud Invite" from `/api/v1/growth/team-invites` to `/api/v1/growth/referrals/generate`.
- **Fixes referrals.html:** Adds `width: 100%` and `box-sizing: border-box` to `.metrics-grid` to ensure the referral widgets properly align by using grid layouts uniformly.

---
*PR created automatically by Jules for task [17193339245994383711](https://jules.google.com/task/17193339245994383711) started by @ql-owo-lp*