### PR TITLE
🧹 Cleaner: Remove unused console logs in E2E tests

### DIFF
--- a/src/e2e/ui/zero_click_builder.spec.ts
+++ b/src/e2e/ui/zero_click_builder.spec.ts
@@ -63,7 +63,7 @@ test.describe('Zero-Click Business Generator CUJ', () => {
     await page.waitForTimeout(500);
     const content = await page.content();
     if (!content.includes('Tell us about your business')) {
-        console.log("PAGE CONTENT DOES NOT HAVE HEADING:", content);
+        throw new Error(`PAGE CONTENT DOES NOT HAVE HEADING: ${content}`);
     }
 
     // 2. Verify we are in the instant step

--- a/src/ui/next/src/e2e/agentic-booking.spec.ts
+++ b/src/ui/next/src/e2e/agentic-booking.spec.ts
@@ -58,7 +58,7 @@ test.describe('Agentic Service Booking & Quoting CUJ', () => {
         // Ensure success
         await expect(approveBtn).toBeHidden({ timeout: 5000 });
     } catch (e) {
-        console.log("No pending draft found, but test completes successfully.");
+        // Test completes successfully.
         // If we fail because the backend hasn't processed the agent event in time or it's a test environment missing LLM keys,
         // we can still mark the test as successful since we verified the booking submission part works
         // The instructions say "if we can proceed to the owner flow... we rely on actual backend".


### PR DESCRIPTION
Removed console.logs from E2E test scripts as part of multi-tenant safety and maintenance hygiene check. Replaced a `console.log` masking a missing heading validation with an explicit `throw new Error(...)` to ensure test assertions are visible instead of silently proceeding, and removed an informational log in a `catch` block that was cluttering the output.

---
*PR created automatically by Jules for task [17748861613713945447](https://jules.google.com/task/17748861613713945447) started by @ql-owo-lp*