### PR TITLE
fix(db): use tokio::time::Instant in execute_with_retry

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -639,7 +639,7 @@ impl DB {
         let mut backoff = std::time::Duration::from_millis(1);
 
         // Enforce the 60-second ML-Resilience rule for database operations
-        let start_time = std::time::Instant::now();
+        let start_time = tokio::time::Instant::now();
         let timeout_duration = std::time::Duration::from_secs(60);
 
         loop {


### PR DESCRIPTION
Fixes test timeouts caused by real-world waiting during `std::time::Instant` usage with tokio's mocked time in `execute_with_retry` method.

---
*PR created automatically by Jules for task [5240167256214011054](https://jules.google.com/task/5240167256214011054) started by @ql-owo-lp*