### PR TITLE
fix(tests): Update onboarding UI tests to use Approve & Publish

### DIFF
--- a/src/ui/next/src/app/onboarding/page.test.tsx
+++ b/src/ui/next/src/app/onboarding/page.test.tsx
@@ -257,7 +257,7 @@ describe('OnboardingWizard', () => {
     const passwordInput = screen.getByPlaceholderText(/••••••••/i);
     await user.type(passwordInput, 'mypassword123');
 
-    const launchButton = screen.getByRole('button', { name: /Approve & Go Live/i });
+    const launchButton = screen.getByRole('button', { name: /Approve & Publish/i });
     await user.click(launchButton);
 
     // Verify it transitions to Step 5 (Live Screen) on success
@@ -356,7 +356,7 @@ describe('OnboardingWizard', () => {
 
     await renderOnboardingWizard();
 
-    const launchButton = screen.getByRole('button', { name: /Approve & Go Live/i });
+    const launchButton = screen.getByRole('button', { name: /Approve & Publish/i });
 
     await user.click(launchButton);
 
@@ -869,7 +869,7 @@ describe('OnboardingWizard', () => {
 
     render(<TooltipProvider><OnboardingWizard /></TooltipProvider>);
 
-    const launchButton = await screen.findByRole('button', { name: /Approve & Go Live/i });
+    const launchButton = await screen.findByRole('button', { name: /Approve & Publish/i });
     await user.click(launchButton);
 
     expect(startRequestPayload).toBeDefined();

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -1396,7 +1396,7 @@ export default function OnboardingWizard() {
                       </svg>
                       Launching...
                     </span>
-                  ) : <IconLabel icon="launch">Approve & Go Live</IconLabel>}
+                  ) : <IconLabel icon="launch">Approve & Publish</IconLabel>}
                 </button>
               </div>
             </div>

--- a/src/ui/next/src/e2e/onboarding.spec.ts
+++ b/src/ui/next/src/e2e/onboarding.spec.ts
@@ -43,7 +43,7 @@ test.describe('OnboardingWizard CUJ', () => {
     await page.getByPlaceholder(/you@example.com/i).fill('maya@example.com');
     await page.getByPlaceholder(/••••••••/i).fill('mypassword123');
 
-    await page.getByRole('button', { name: 'Approve & Go Live' }).click();
+    await page.getByRole('button', { name: 'Approve & Publish' }).click();
     await expect(page.getByText("You're Live!")).toBeVisible();
     const storedTenantId = await page.evaluate(() => window.localStorage.getItem('tenant_id'));
     // // expect(storedTenantId).not.toBeNull();
@@ -77,7 +77,7 @@ test.describe('OnboardingWizard CUJ', () => {
     await page.getByPlaceholder(/you@example.com/i).fill('carlos@example.com');
     await page.getByPlaceholder(/••••••••/i).fill('password123');
 
-    await page.getByRole('button', { name: 'Approve & Go Live' }).click();
+    await page.getByRole('button', { name: 'Approve & Publish' }).click();
     await expect(page.getByText("You're Live!")).toBeVisible();
     const storedTenantId = await page.evaluate(() => window.localStorage.getItem('tenant_id'));
     // expect(storedTenantId).not.toBeNull();
@@ -111,7 +111,7 @@ test.describe('OnboardingWizard CUJ', () => {
     await page.getByPlaceholder(/you@example.com/i).fill('leo@music.com');
     await page.getByPlaceholder(/••••••••/i).fill('pass1234');
 
-    await page.getByRole('button', { name: 'Approve & Go Live' }).click();
+    await page.getByRole('button', { name: 'Approve & Publish' }).click();
     await expect(page.getByText("You're Live!")).toBeVisible();
     const storedTenantId = await page.evaluate(() => window.localStorage.getItem('tenant_id'));
     // expect(storedTenantId).not.toBeNull();
@@ -144,7 +144,7 @@ test.describe('OnboardingWizard CUJ', () => {
     await page.getByPlaceholder(/you@example.com/i).fill('fatima@foodcart.com');
     await page.getByPlaceholder(/••••••••/i).fill('halal123');
 
-    await page.getByRole('button', { name: 'Approve & Go Live' }).click();
+    await page.getByRole('button', { name: 'Approve & Publish' }).click();
     await expect(page.getByText("You're Live!")).toBeVisible({ timeout: 5000 });
     const storedTenantId = await page.evaluate(() => window.localStorage.getItem('tenant_id'));
     // expect(storedTenantId).not.toBeNull();
@@ -213,7 +213,7 @@ test.describe('OnboardingWizard CUJ', () => {
     await page.getByPlaceholder(/e.g. Maya Smith/i).fill('Test Admin');
 
     // Attempt to launch store
-    await page.getByRole('button', { name: 'Approve & Go Live' }).click();
+    await page.getByRole('button', { name: 'Approve & Publish' }).click();
 
     // Expect validation errors to be visible
     await expect(page.getByText(/is required/i).first()).toBeVisible();
@@ -221,7 +221,7 @@ test.describe('OnboardingWizard CUJ', () => {
     // Fill in invalid email and password without number
     await page.getByPlaceholder(/you@example.com/i).fill('invalid-email');
     await page.getByPlaceholder(/••••••••/i).fill('password');
-    await page.getByRole('button', { name: 'Approve & Go Live' }).click();
+    await page.getByRole('button', { name: 'Approve & Publish' }).click();
 
     await expect(page.getByText('Please enter a valid email address')).toBeVisible();
     await expect(page.getByText('Password must be at least 8 characters and contain a number')).toBeVisible();
@@ -377,7 +377,7 @@ test.describe('OnboardingWizard CUJ', () => {
     await context.unroute('**/api/onboarding/launch');
     await context.route('**/api/onboarding/launch', route => route.fulfill({ status: 502 }));
 
-    await page.getByRole('button', { name: 'Approve & Go Live' }).click();
+    await page.getByRole('button', { name: 'Approve & Publish' }).click();
     await expect(page.getByText(/failed/i)).toBeVisible();
 
     await context.unroute('**/api/onboarding/launch');


### PR DESCRIPTION
Updated `src/ui/next/src/e2e/onboarding.spec.ts`, `src/ui/next/src/app/onboarding/page.tsx`, and `src/ui/next/src/app/onboarding/page.test.tsx` to use the correct label "Approve & Publish" to match `setup.html`.

---
*PR created automatically by Jules for task [3727180300787060162](https://jules.google.com/task/3727180300787060162) started by @ql-owo-lp*