### PR TITLE
fix: Log stagnant queued jobs to dead letters in daemon

### DIFF
--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -476,7 +476,8 @@ impl HybridSyncDaemon {
             }
         }
 
-        let res_queued_sqlite = sqlx::query("DELETE FROM sub_agent_queue WHERE status = \'QUEUED\' AND created_at < datetime(\'now\', \'-24 hour\')")
+        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE status = 'QUEUED' AND created_at < datetime('now', '-24 hour')").execute(&self.sqlite_pool).await;
+        let res_queued_sqlite = sqlx::query("DELETE FROM sub_agent_queue WHERE status = 'QUEUED' AND created_at < datetime('now', '-24 hour')")
             .execute(&self.sqlite_pool)
             .await;
         if let Ok(res) = res_queued_sqlite {
@@ -495,7 +496,8 @@ impl HybridSyncDaemon {
             }
         }
 
-        let res_queued_pg = sqlx::query("DELETE FROM sub_agent_queue WHERE status = \'QUEUED\' AND created_at < NOW() - INTERVAL \'24 hours\'")
+        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload::text, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE status = 'QUEUED' AND created_at < NOW() - INTERVAL '24 hours'").execute(&self.pg_pool).await;
+        let res_queued_pg = sqlx::query("DELETE FROM sub_agent_queue WHERE status = 'QUEUED' AND created_at < NOW() - INTERVAL '24 hours'")
             .execute(&self.pg_pool)
             .await;
         if let Ok(res) = res_queued_pg {


### PR DESCRIPTION
This PR ensures that when the hybrid sync daemon prunes stagnant `QUEUED` jobs from the `sub_agent_queue` table, it logs them to the `department_dead_letters` table. Previously, the daemon would just delete them. This brings the daemon cleanup logic in parity with the standard queue cleanup logic.

Changes made:
- In `src/server/orchestration/hybrid_sync/daemon.rs`, added an `INSERT INTO department_dead_letters ... SELECT ...` query before deleting `QUEUED` jobs for both the SQLite and PostgreSQL pruning paths.
- Categorizes the error message with the `[cleanup]` tag as required by the maintenance protocols.

---
*PR created automatically by Jules for task [17991789907848492941](https://jules.google.com/task/17991789907848492941) started by @ql-owo-lp*