### PR TITLE
⚡ Bolt: Optimize Unified Feed Caching

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -5133,6 +5133,26 @@ async fn ui_dashboard_unified_feed_handler(
         let t_bg = tenant_id.clone();
         let cache_key_bg = cache_key.clone();
         tokio::spawn(async move {
+            let metrics_cache = UI_DASHBOARD_METRICS_CACHE.get();
+            let orders_cache = UI_ORDERS_CACHE.get();
+            let inbox_cache = UI_INBOX_CACHE.get();
+            let triage_cache = UI_TRIAGE_CACHE.get();
+            let priority_tasks_cache = UI_PRIORITY_TASKS_CACHE.get();
+
+            let m_key = format!("ui_dashboard_metrics:{}:mobile:{}", t_bg, mobile_optimized);
+            let o_key = format!("ui_orders:{}:mobile:{}", t_bg, mobile_optimized);
+            let i_key = format!("ui_inbox:{}:mobile:{}", t_bg, mobile_optimized);
+            let t_key = format!("ui_triage:{}:mobile:{}", t_bg, mobile_optimized);
+            let p_key = format!("ui_priority_tasks:{}:mobile:{}", t_bg, mobile_optimized);
+
+            let (m_res, o_res, i_res, tr_res, p_res) = tokio::join!(
+                async { if let Some(c) = metrics_cache { c.get_with_swr(&m_key).await.map(|(v, _)| v) } else { None } },
+                async { if let Some(c) = orders_cache { c.get_with_swr(&o_key).await.map(|(v, _)| v) } else { None } },
+                async { if let Some(c) = inbox_cache { c.get_with_swr(&i_key).await.map(|(v, _)| v) } else { None } },
+                async { if let Some(c) = triage_cache { c.get_with_swr(&t_key).await.map(|(v, _)| v) } else { None } },
+                async { if let Some(c) = priority_tasks_cache { c.get_with_swr(&p_key).await.map(|(v, _)| v) } else { None } }
+            );
+
             let db1 = db_bg.clone(); let t1 = t_bg.clone();
             let db2 = db_bg.clone(); let t2 = t_bg.clone();
             let db3 = db_bg.clone(); let t3 = t_bg.clone();
@@ -5141,24 +5161,32 @@ async fn ui_dashboard_unified_feed_handler(
             let db6 = db_bg.clone(); let t6 = t_bg.clone();
             let db7 = db_bg.clone(); let t7 = t_bg.clone();
 
-            let (metrics_res, orders_res, messages_res, triage_res, approvals_res, agent_feed_res, priority_tasks_res) = tokio::join!(
-                tokio::spawn(async move { load_ui_dashboard_metrics(&db1, &t1, mobile_optimized).await }),
-                tokio::spawn(async move { load_ui_orders_from_db(&db2, &t2, mobile_optimized).await }),
-                tokio::spawn(async move { load_ui_inbox_from_db(&db3, &t3, mobile_optimized).await }),
-                tokio::spawn(async move { load_ui_triage_from_db(&db4, &t4, mobile_optimized).await }),
+            let m_res_clone = m_res.clone();
+            let o_res_clone = o_res.clone();
+            let i_res_clone = i_res.clone();
+            let tr_res_clone = tr_res.clone();
+            let p_res_clone = p_res.clone();
+
+            let (metrics_db, orders_db, messages_db, triage_db, approvals_res, agent_feed_res, priority_tasks_db) = tokio::join!(
+                tokio::spawn(async move { if m_res_clone.is_none() { load_ui_dashboard_metrics(&db1, &t1, mobile_optimized).await.map(|m| serde_json::to_value(m).unwrap_or_default()).ok() } else { None } }),
+                tokio::spawn(async move { if o_res_clone.is_none() { load_ui_orders_from_db(&db2, &t2, mobile_optimized).await.ok() } else { None } }),
+                tokio::spawn(async move { if i_res_clone.is_none() { load_ui_inbox_from_db(&db3, &t3, mobile_optimized).await.ok() } else { None } }),
+                tokio::spawn(async move { if tr_res_clone.is_none() { load_ui_triage_from_db(&db4, &t4, mobile_optimized).await.ok() } else { None } }),
                 tokio::spawn(async move { load_ui_agent_approvals_from_db(&db5, &t5, mobile_optimized).await }),
                 tokio::spawn(async move { load_ui_agent_feed_from_db(&db6, &t6, mobile_optimized).await }),
-                tokio::spawn(async move { load_ui_priority_tasks_from_db(&db7, &t7, mobile_optimized).await })
+                tokio::spawn(async move { if p_res_clone.is_none() { load_ui_priority_tasks_from_db(&db7, &t7, mobile_optimized).await.ok() } else { None } })
             );
 
-            let orders = orders_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-            let inbox = messages_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-            let triage = triage_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+            let metrics_val = m_res.or_else(|| metrics_db.unwrap_or_default()).unwrap_or_default();
+            let orders = o_res.or_else(|| orders_db.unwrap_or_default()).unwrap_or_default();
+            let inbox = i_res.or_else(|| messages_db.unwrap_or_default()).unwrap_or_default();
+            let triage = tr_res.or_else(|| triage_db.unwrap_or_default()).unwrap_or_default();
+            let priority_tasks = p_res.or_else(|| priority_tasks_db.unwrap_or_default()).unwrap_or_default();
             let approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
             let agent_feed = agent_feed_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-            let priority_tasks = priority_tasks_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+
             let result = serde_json::json!({
-                "metrics": metrics_res.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound)).map(|m| serde_json::to_value(m).unwrap_or_default()).unwrap_or_default(),
+                "metrics": metrics_val,
                 "orders": orders,
                 "inbox": inbox,
                 "triage": triage,
@@ -5181,6 +5209,26 @@ async fn ui_dashboard_unified_feed_handler(
         return (axum::http::StatusCode::OK, axum::Json(final_cached)).into_response();
     }
 
+    let metrics_cache = UI_DASHBOARD_METRICS_CACHE.get();
+    let orders_cache = UI_ORDERS_CACHE.get();
+    let inbox_cache = UI_INBOX_CACHE.get();
+    let triage_cache = UI_TRIAGE_CACHE.get();
+    let priority_tasks_cache = UI_PRIORITY_TASKS_CACHE.get();
+
+    let m_key = format!("ui_dashboard_metrics:{}:mobile:{}", tenant_id, mobile_optimized);
+    let o_key = format!("ui_orders:{}:mobile:{}", tenant_id, mobile_optimized);
+    let i_key = format!("ui_inbox:{}:mobile:{}", tenant_id, mobile_optimized);
+    let t_key = format!("ui_triage:{}:mobile:{}", tenant_id, mobile_optimized);
+    let p_key = format!("ui_priority_tasks:{}:mobile:{}", tenant_id, mobile_optimized);
+
+    let (m_res, o_res, i_res, tr_res, p_res) = tokio::join!(
+        async { if let Some(c) = metrics_cache { c.get_with_swr(&m_key).await.map(|(v, _)| v) } else { None } },
+        async { if let Some(c) = orders_cache { c.get_with_swr(&o_key).await.map(|(v, _)| v) } else { None } },
+        async { if let Some(c) = inbox_cache { c.get_with_swr(&i_key).await.map(|(v, _)| v) } else { None } },
+        async { if let Some(c) = triage_cache { c.get_with_swr(&t_key).await.map(|(v, _)| v) } else { None } },
+        async { if let Some(c) = priority_tasks_cache { c.get_with_swr(&p_key).await.map(|(v, _)| v) } else { None } }
+    );
+
     let db1 = db.clone(); let t1 = tenant_id.clone();
     let db2 = db.clone(); let t2 = tenant_id.clone();
     let db3 = db.clone(); let t3 = tenant_id.clone();
@@ -5189,28 +5237,35 @@ async fn ui_dashboard_unified_feed_handler(
     let db7 = db.clone(); let t7 = tenant_id.clone();
     let db8 = db.clone(); let t8 = tenant_id.clone();
 
-    let (metrics_res, orders_res, messages_res, triage_res, approvals_res, agent_feed_res, priority_tasks_res, supply_res) = tokio::join!(
-        tokio::spawn(async move { load_ui_dashboard_metrics(&db1, &t1, mobile_optimized).await }),
-        tokio::spawn(async move { load_ui_orders_from_db(&db2, &t2, mobile_optimized).await }),
-        tokio::spawn(async move { load_ui_inbox_from_db(&db3, &t3, mobile_optimized).await }),
-        tokio::spawn(async move { load_ui_triage_from_db(&db5, &t5, mobile_optimized).await }),
+    let m_res_clone = m_res.clone();
+    let o_res_clone = o_res.clone();
+    let i_res_clone = i_res.clone();
+    let tr_res_clone = tr_res.clone();
+    let p_res_clone = p_res.clone();
+
+    let (metrics_db, orders_db, messages_db, triage_db, approvals_res, agent_feed_res, priority_tasks_db, supply_res) = tokio::join!(
+        tokio::spawn(async move { if m_res_clone.is_none() { load_ui_dashboard_metrics(&db1, &t1, mobile_optimized).await.map(|m| serde_json::to_value(m).unwrap_or_default()).ok() } else { None } }),
+        tokio::spawn(async move { if o_res_clone.is_none() { load_ui_orders_from_db(&db2, &t2, mobile_optimized).await.ok() } else { None } }),
+        tokio::spawn(async move { if i_res_clone.is_none() { load_ui_inbox_from_db(&db3, &t3, mobile_optimized).await.ok() } else { None } }),
+        tokio::spawn(async move { if tr_res_clone.is_none() { load_ui_triage_from_db(&db5, &t5, mobile_optimized).await.ok() } else { None } }),
         tokio::spawn(async move { load_ui_agent_approvals_from_db(&db6, &t6, mobile_optimized).await }),
         tokio::spawn(async move { load_ui_agent_feed_from_db(&db7, &t7, mobile_optimized).await }),
-        tokio::spawn(async move { load_ui_priority_tasks_from_db(&db8, &t8, mobile_optimized).await }),
+        tokio::spawn(async move { if p_res_clone.is_none() { load_ui_priority_tasks_from_db(&db8, &t8, mobile_optimized).await.ok() } else { None } }),
         supply_future
     );
 
-    let orders = orders_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-    let inbox = messages_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-    let triage = triage_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+    let metrics_val = m_res.or_else(|| metrics_db.unwrap_or_default()).unwrap_or_default();
+    let orders = o_res.or_else(|| orders_db.unwrap_or_default()).unwrap_or_default();
+    let inbox = i_res.or_else(|| messages_db.unwrap_or_default()).unwrap_or_default();
+    let triage = tr_res.or_else(|| triage_db.unwrap_or_default()).unwrap_or_default();
+    let priority_tasks = p_res.or_else(|| priority_tasks_db.unwrap_or_default()).unwrap_or_default();
     let approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
     let agent_feed = agent_feed_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
-    let priority_tasks = priority_tasks_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
     let supply_val = supply_res.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound)).unwrap_or_else(|_| serde_json::json!({}));
 
 
     let cacheable_result = serde_json::json!({
-        "metrics": metrics_res.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound)).map(|m| serde_json::to_value(m).unwrap_or_default()).unwrap_or_default(),
+        "metrics": metrics_val,
         "orders": orders,
         "inbox": inbox,
         "triage": triage,


### PR DESCRIPTION
This PR addresses a performance issue where the `ui_dashboard_unified_feed_handler` redundantly fetched all component UI items from the database in parallel, instead of utilizing the already populated caches used by the other individual endpoints (`list_ui_orders_handler`, `list_ui_inbox_handler`, etc.).

By attempting to retrieve from the existing Redis caches (`UI_ORDERS_CACHE`, `UI_INBOX_CACHE`, `UI_TRIAGE_CACHE`, `UI_PRIORITY_TASKS_CACHE`, `UI_DASHBOARD_METRICS_CACHE`) and falling back to DB queries only upon a cache miss, the unified feed loading time will decrease dramatically, improving user experience for the mobile and web unified dashboard shell.

Verified with the test suite. All tests pass hermetically.

---
*PR created automatically by Jules for task [2367313413604912483](https://jules.google.com/task/2367313413604912483) started by @ql-owo-lp*