### PR TITLE
⚡ Bolt: Parallel execution optimization for UI Dashboard Unified Feed Handler

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -5140,15 +5140,17 @@ async fn ui_dashboard_unified_feed_handler(
             let db5 = db_bg.clone(); let t5 = t_bg.clone();
             let db6 = db_bg.clone(); let t6 = t_bg.clone();
             let db7 = db_bg.clone(); let t7 = t_bg.clone();
+            let db8 = db_bg.clone(); let t8 = t_bg.clone();
 
-            let (metrics_res, orders_res, messages_res, triage_res, approvals_res, agent_feed_res, priority_tasks_res) = tokio::join!(
+            let (metrics_res, orders_res, messages_res, triage_res, approvals_res, agent_feed_res, priority_tasks_res, supply_res) = tokio::join!(
                 tokio::spawn(async move { load_ui_dashboard_metrics(&db1, &t1, mobile_optimized).await }),
                 tokio::spawn(async move { load_ui_orders_from_db(&db2, &t2, mobile_optimized).await }),
                 tokio::spawn(async move { load_ui_inbox_from_db(&db3, &t3, mobile_optimized).await }),
                 tokio::spawn(async move { load_ui_triage_from_db(&db4, &t4, mobile_optimized).await }),
                 tokio::spawn(async move { load_ui_agent_approvals_from_db(&db5, &t5, mobile_optimized).await }),
                 tokio::spawn(async move { load_ui_agent_feed_from_db(&db6, &t6, mobile_optimized).await }),
-                tokio::spawn(async move { load_ui_priority_tasks_from_db(&db7, &t7, mobile_optimized).await })
+                tokio::spawn(async move { load_ui_priority_tasks_from_db(&db7, &t7, mobile_optimized).await }),
+                tokio::spawn(async move { load_ui_supply_from_db(&db8, &t8, mobile_optimized).await })
             );
 
             let orders = orders_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
@@ -5157,6 +5159,7 @@ async fn ui_dashboard_unified_feed_handler(
             let approvals = approvals_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
             let agent_feed = agent_feed_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
             let priority_tasks = priority_tasks_res.unwrap_or_else(|_| Ok(vec![])).unwrap_or_default();
+            let supply_val = supply_res.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound)).unwrap_or_else(|_| serde_json::json!({}));
             let result = serde_json::json!({
                 "metrics": metrics_res.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound)).map(|m| serde_json::to_value(m).unwrap_or_default()).unwrap_or_default(),
                 "orders": orders,
@@ -5165,6 +5168,7 @@ async fn ui_dashboard_unified_feed_handler(
                 "pending_approvals": approvals,
                 "agent_feed": agent_feed,
                 "priority_tasks": priority_tasks,
+                "supply": supply_val,
             });
             if let Some(c) = UI_UNIFIED_FEED_CACHE.get() {
                 c.set(&cache_key_bg, result, std::time::Duration::from_secs(10)).await;


### PR DESCRIPTION
Loaded `superpowers` skill and started analyzing `ui_dashboard_unified_feed_handler`, `ui_dashboard_analytics_briefing_handler`, and `ui_dashboard_analytics_chat_handler` in `src/server/lib.rs`.

During my investigation, I noticed that `ui_dashboard_unified_feed_handler` was excluding `load_ui_supply_from_db` from `tokio::join!` in the cache miss background refresh. I corrected this by wrapping the fetch in a `tokio::spawn` within the existing `tokio::join!` block to run concurrently with the other DB calls, and updated the cached object to correctly include the `supply` value. The remaining endpoints were already parallelized.

Tested with `bazelisk test //...` and `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"` verifying everything compiles and passes properly.

---
*PR created automatically by Jules for task [14652297660353575349](https://jules.google.com/task/14652297660353575349) started by @ql-owo-lp*