### PR TITLE
🧙 Wizard: Enhance onboarding UI with OHC Premium Token designs

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -612,6 +612,7 @@ body {
 }
 
 .glass-card {
+  border-radius: 16px;
   background: rgba(255, 255, 255, 0.65);
   -webkit-backdrop-filter: blur(30px) saturate(210%);
   backdrop-filter: blur(30px) saturate(210%);
@@ -743,7 +744,8 @@ button, .app-button, .charge-btn {
 
 .setup-page #setup-screen .setup-nav-button {
   width: fit-content;
-  min-height: 32px;
+  min-height: 44px;
+  min-width: 44px;
   padding: 6px 10px;
   border: 1px solid #d8e0ea;
   border-radius: 999px;
@@ -765,7 +767,7 @@ button, .app-button, .charge-btn {
 
 .setup-page #setup-screen .setup-nav-spacer {
   width: 92px;
-  height: 32px;
+  height: 44px;
 }
 
 .setup-page #setup-screen > div:first-child h1 {
@@ -900,7 +902,8 @@ button, .app-button, .charge-btn {
 .setup-page #setup-screen button[class*="text-[#0066FF]"],
 .setup-page #setup-screen button.self-start {
   width: auto;
-  min-height: 32px;
+  min-height: 44px;
+  min-width: 44px;
   padding: 0;
   border: 0;
   background: transparent !important;


### PR DESCRIPTION
# UI Improvements for Onboarding

This PR updates the core CSS for the OHC NextJS interface to adhere strictly to the OHC Premium Design Guidelines regarding touch targets and glassmorphism styling.

## Changes Included
- **Translucent Glass Update:** Natively applies `border-radius: 16px;` to `.glass-card`.
- **Mobile-First Layout:** Ensures buttons in the setup wizard (`.setup-nav-button`, `.self-start` text buttons) maintain a minimum of `44x44px` target size.
- **Visual Spacing:** Updated `.setup-nav-spacer` to align correctly with the new button sizing.

## E2E and Unit Test Coverage
I have verified the test suites remain passing. I have ran `vitest run src/app/onboarding/page.test.tsx` locally to ensure no logic failures occur due to the restyle.

## UI Verification
- The changes were simulated and tested under a 375px window, successfully interacting through the wizard steps.

---
*PR created automatically by Jules for task [15494574840063008187](https://jules.google.com/task/15494574840063008187) started by @ql-owo-lp*