### PR TITLE
fix: Sanitizing and prioritizing the agent_missions queue

### DIFF
--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -443,7 +443,7 @@ impl HybridSyncDaemon {
 
     pub async fn prune_stuck_agent_missions(&self) -> Result<(), Box<dyn std::error::Error>> {
         // Find and fail stuck missions in sqlite pool
-        let res_sqlite = sqlx::query("UPDATE agent_missions SET status = 'FAILED', sync_error = '[bug] Mission became stuck', last_synced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hour') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hour')))")
+        let res_sqlite = sqlx::query("UPDATE agent_missions SET status = 'FAILED', sync_error = '[bug] Mission became stuck', last_synced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hour') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hour')))")
             .execute(&self.sqlite_pool)
             .await;
         if let Ok(res) = res_sqlite {
@@ -452,13 +452,33 @@ impl HybridSyncDaemon {
             }
         }
 
+        // Clean up stagnant PENDING items older than 24 hours in SQLite
+        let res_pending_sqlite = sqlx::query("DELETE FROM agent_missions WHERE status = 'PENDING' AND (last_synced_at < datetime('now', '-24 hour') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-24 hour')))")
+            .execute(&self.sqlite_pool)
+            .await;
+        if let Ok(res) = res_pending_sqlite {
+            if res.rows_affected() > 0 {
+                info!("Pruned {} stuck PENDING agent missions from SQLite", res.rows_affected());
+            }
+        }
+
         // Find and fail stuck missions in pg pool
-        let res_pg = sqlx::query("UPDATE agent_missions SET status = 'FAILED', sync_error = '[bug] Mission became stuck', last_synced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))")
+        let res_pg = sqlx::query("UPDATE agent_missions SET status = 'FAILED', sync_error = '[bug] Mission became stuck', last_synced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))")
             .execute(&self.pg_pool)
             .await;
         if let Ok(res) = res_pg {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck agent missions from PostgreSQL", res.rows_affected());
+            }
+        }
+
+        // Clean up stagnant PENDING items older than 24 hours in PostgreSQL
+        let res_pending_pg = sqlx::query("DELETE FROM agent_missions WHERE status = 'PENDING' AND (last_synced_at < NOW() - INTERVAL '24 hours' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '24 hours'))")
+            .execute(&self.pg_pool)
+            .await;
+        if let Ok(res) = res_pending_pg {
+            if res.rows_affected() > 0 {
+                info!("Pruned {} stuck PENDING agent missions from PostgreSQL", res.rows_affected());
             }
         }
 

--- a/src/server/orchestration/hybrid_sync/daemon_test.rs
+++ b/src/server/orchestration/hybrid_sync/daemon_test.rs
@@ -564,6 +564,72 @@ async fn test_hybrid_sync_pos_offline_transactions() {
     }
 
     #[tokio::test]
+    async fn test_prune_stuck_pending_missions() {
+        let sqlite_pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+
+        sqlx::query("CREATE TABLE IF NOT EXISTS agent_missions (
+                id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                payload TEXT,
+                synced_to_cloud BOOLEAN DEFAULT false,
+                sync_error TEXT,
+                updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                last_synced_at TEXT
+            )").execute(&sqlite_pool).await.unwrap();
+
+        let database_url = std::env::var("OHC_DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/test".to_string());
+
+        let pg_pool = match tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            sqlx::postgres::PgPoolOptions::new().connect(&database_url),
+        )
+        .await
+        {
+            Ok(Ok(p)) => p,
+            _ => return,
+        };
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS agent_missions (
+                id VARCHAR PRIMARY KEY,
+                status VARCHAR NOT NULL,
+                payload TEXT,
+                tenant_id VARCHAR,
+                sync_error TEXT,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                last_synced_at TIMESTAMP
+            )",
+        )
+        .execute(&pg_pool)
+        .await
+        .unwrap();
+
+        // Insert stuck pending tasks (last_synced_at older than 24 hours)
+        sqlx::query("INSERT INTO agent_missions (id, status, last_synced_at) VALUES ('stuck_pending_sqlite', 'PENDING', datetime('now', '-25 hour'))")
+            .execute(&sqlite_pool).await.unwrap();
+
+        sqlx::query("INSERT INTO agent_missions (id, status, last_synced_at) VALUES ('stuck_pending_pg', 'PENDING', NOW() - INTERVAL '25 hours')")
+            .execute(&pg_pool).await.unwrap();
+
+        let daemon = super::daemon::HybridSyncDaemon::new(sqlite_pool.clone(), pg_pool.clone());
+        daemon.prune_stuck_agent_missions().await.unwrap();
+
+        // Verify SQLite mission is deleted
+        let row_sqlite = sqlx::query("SELECT status FROM agent_missions WHERE id = 'stuck_pending_sqlite'")
+            .fetch_optional(&sqlite_pool).await.unwrap();
+        assert!(row_sqlite.is_none());
+
+        // Verify PG mission is deleted
+        let row_pg = sqlx::query("SELECT status FROM agent_missions WHERE id = 'stuck_pending_pg'")
+            .fetch_optional(&pg_pool).await.unwrap();
+        assert!(row_pg.is_none());
+    }
+
+    #[tokio::test]
     async fn test_prune_stuck_queued_items() {
         let sqlite_pool = sqlx::sqlite::SqlitePoolOptions::new()
             .connect("sqlite::memory:")


### PR DESCRIPTION
# Description
Sanitized the `agent_missions` queue by ensuring `PENDING` items stuck for over 24 hours are removed (similar to `sub_agent_queue`). Fixed tests and ran `bazelisk test //...` successfully.

### Testing
- `test_prune_stuck_pending_missions` added to verify stuck `PENDING` items are appropriately deleted from SQLite and PostgreSQL environments.
- Ran all unit tests and playwright tests: they complete perfectly.

---
*PR created automatically by Jules for task [7314000223311979170](https://jules.google.com/task/7314000223311979170) started by @ql-owo-lp*