### PR TITLE
chore: remove http://mock fallback from tauri ui setup

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1523,7 +1523,7 @@
           autoSaveTimer = setTimeout(() => {
               saveCurrentState();
 
-              const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : (window.location.hostname === 'mock' ? 'http://mock' : '');
+              const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
               const tenantId = localStorage.getItem("tenant_id") || "e2e-tenant";
               const userId = localStorage.getItem("user_id") || "e2e-admin-user";
 
@@ -1584,7 +1584,7 @@
                 console.error('Tauri get_onboarding_state failed:', err);
             }
         } else {
-            const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : (window.location.hostname === 'mock' ? 'http://mock' : '');
+            const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
             try {
                 const res = await fetch(`${backendUrl}/api/onboarding/draft`, {
                     method: 'GET',
@@ -1752,7 +1752,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
                   window.__TAURI__.core.invoke("save_onboarding_state", { state, tenantId, userId }).catch(console.error);
               } else {
                   localStorage.setItem('onboardingState', JSON.stringify(state));
-                  const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : (window.location.hostname === 'mock' ? 'http://mock' : '');
+                  const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
                   fetch(`${backendUrl}/api/onboarding/draft`, {
                       method: 'POST',
                       headers: { 'Content-Type': 'application/json', 'X-Tenant-ID': tenantId, 'X-User-ID': userId },
@@ -2118,7 +2118,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           chatSendBtn.disabled = true;
 
           try {
-              const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : (window.location.hostname === 'mock' ? 'http://mock' : '');
+              const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
               const res = await fetch(`${backendUrl}/api/onboarding/chat`, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json', 'X-Tenant-ID': localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'e2e-tenant', 'X-User-ID': localStorage.getItem('user_id') || 'e2e-admin-user' },
@@ -2244,7 +2244,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
               approvePublishBtn.innerHTML = '<div class="spinner"></div>Publishing...';
 
               try {
-                  const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : (window.location.hostname === 'mock' ? 'http://mock' : '');
+                  const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
                   if (window.__TAURI__ && window.__TAURI__.core) {
                       await goToStep('step-loading');
 
@@ -2352,7 +2352,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
               goToStep('step-loading');
 
               try {
-                  const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : (window.location.hostname === 'mock' ? 'http://mock' : '');
+                  const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
                   const res = await fetch(`${backendUrl}/api/v1/growth/zero-click-builder/generate`, {
                       method: 'POST',
                       headers: {
@@ -2523,7 +2523,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
             e.target.innerText = "Saving...";
             e.target.disabled = true;
 
-            const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : (window.location.hostname === 'mock' ? 'http://mock' : '');
+            const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
             const tenantId = localStorage.getItem("tenant_id") || "e2e-tenant";
             const userId = localStorage.getItem("user_id") || "e2e-admin-user";
 
@@ -2642,7 +2642,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
                } else {
                  finishBtn.disabled = true;
                  finishBtn.innerHTML = '<div class="spinner"></div>Saving...';
-                 const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : (window.location.hostname === 'mock' ? 'http://mock' : '');
+                 const backendUrl = (window.location.protocol === 'file:' || ["1420", "3000", "8081"].includes(window.location.port)) ? 'http://127.0.0.1:18789' : '';
                  fetch(`${backendUrl}/api/onboarding/start`, {
                      method: 'POST',
                      headers: {


### PR DESCRIPTION
Removed instances of the `http://mock` fallback in `src/ui/tauri/src/ui/setup.html` that were originally matching `window.location.hostname === 'mock'`. Cleaned up the frontend UI codebase by eliminating mock data/states per the issue instructions. Tests executed locally via `bazelisk test //...` and `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"` passed.

---
*PR created automatically by Jules for task [12667664851612341907](https://jules.google.com/task/12667664851612341907) started by @ql-owo-lp*