### PR TITLE
style(ui): Apply explicit Tailwind dark mode glassmorphism token classes

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -614,27 +614,30 @@ body {
 }
 
 .glassmorphism {
-  border-radius: 16px;
   background: rgba(255, 255, 255, 0.65);
-  -webkit-backdrop-filter: blur(30px) saturate(210%);
   backdrop-filter: blur(30px) saturate(210%);
   border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 16px;
 }
 
 @media (prefers-color-scheme: dark) {
   .glassmorphism {
-    border-radius: 16px;
     background: rgba(22, 22, 26, 0.7);
-    -webkit-backdrop-filter: blur(30px) saturate(210%);
     backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
   }
 }
 
-.glass-card {
+html.dark .glassmorphism {
+  background: rgba(22, 22, 26, 0.7);
+  backdrop-filter: blur(30px) saturate(210%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 16px;
+}
+
+.glass-card {
   background: rgba(255, 255, 255, 0.65);
-  -webkit-backdrop-filter: blur(30px) saturate(210%);
   backdrop-filter: blur(30px) saturate(210%);
   border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 16px;
@@ -643,11 +646,17 @@ body {
 @media (prefers-color-scheme: dark) {
   .glass-card {
     background: rgba(22, 22, 26, 0.7);
-    -webkit-backdrop-filter: blur(30px) saturate(210%);
     backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 16px;
   }
+}
+
+html.dark .glass-card {
+  background: rgba(22, 22, 26, 0.7);
+  backdrop-filter: blur(30px) saturate(210%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
 }
 
 .app-shell .app-card,


### PR DESCRIPTION
### Description
Added explicit `html.dark` styling to the `.glassmorphism` and `.glass-card` classes to ensure consistent premium macOS-style translucent aesthetics regardless of how the app manages dark mode internally, cleaning up old overrides and satisfying the Visual Excellence Mandate.

### Product-use evidence
**Persona:** Maintainer / SRE / Frontend Auditor
**Attempted Flow:** Verified the application's global CSS styling rules.
**Observed Gap:** The glassmorphism and glass-card components relied solely on `@media (prefers-color-scheme: dark)` queries, which could fail to render the premium design if the user manually toggles dark mode via a UI element (which generally adds a `.dark` class to the `html` element). Furthermore, the CSS declarations were inconsistent and unnecessarily included `-webkit` prefixes which PostCSS and Autoprefixer already handle.
**Fix:** Refined `.glassmorphism` and `.glass-card` in `src/ui/next/src/app/globals.css` to exactly match the required Light and Dark mode Translucent Glass properties and added `html.dark` explicit selectors to ensure the styles are resilient to different dark mode mechanisms.

### Technical details
- Added `html.dark .glassmorphism` and `html.dark .glass-card` to `src/ui/next/src/app/globals.css`.
- Removed redundant `-webkit-backdrop-filter` declarations (handled by build tools).
- Reordered CSS properties to match standard conventions.

### Testing
- `bazel test //...` verified no regressions.
- `bazel test //src/e2e:playwright` verified UI tests continue to pass.

---
*PR created automatically by Jules for task [13517636824426613707](https://jules.google.com/task/13517636824426613707) started by @ql-owo-lp*