### PR TITLE
🔨 Forge: AI-Native Universal Work Triage API Integration

### DIFF
--- a/src/server/api/proposals.rs
+++ b/src/server/api/proposals.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use ohc_builtin_agent::gpt_researcher::{GptResearcherManager, PlannerAgent, ExecutionAgent, ResearcherLlmClient};
-use ohc_builtin_agent_core::types::{ChatRequest, ChatResponse, Usage, Message};
+use ohc_builtin_agent::types::{ChatRequest, ChatResponse, Usage, Message};
 
 #[derive(Deserialize)]
 pub struct DraftRequest {

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -3741,7 +3741,7 @@ pub async fn update_ui_triage_action_handler(
                 let mut action_payload_opt = None;
 
                 // Check if there is a proposed action to execute from legacy triage
-                if let Ok(Some(row)) = sqlx::query("SELECT action_type, payload FROM triage_proposed_actions WHERE triage_item_id = $1 AND tenant_id = $2")
+                if let Ok(Some(row)) = sqlx::query("SELECT action_type, payload FROM triage_proposed_actions WHERE triage_item_id = $1 AND tenant_id = $2 UNION ALL SELECT action_type, action_payload AS payload FROM unified_triage_actions WHERE id = $1 AND tenant_id = $2")
                     .bind(&payload.triage_item_id)
                     .bind(&tenant_id)
                     .fetch_optional(&mut *tx)
@@ -3930,6 +3930,11 @@ pub async fn update_ui_triage_action_handler(
                 .execute(&mut *tx)
                 .await;
 
+            let _ = sqlx::query("UPDATE unified_triage_actions SET status = $1 WHERE id = $2 AND tenant_id = $3")
+                .bind(status).bind(&payload.triage_item_id).bind(&tenant_id).execute(&mut *tx).await;
+            let _ = sqlx::query("UPDATE unified_threads SET status = 'resolved' WHERE id = (SELECT thread_id FROM unified_triage_actions WHERE id = $1 AND tenant_id = $2)")
+                .bind(&payload.triage_item_id).bind(&tenant_id).execute(&mut *tx).await;
+
             match sqlx::query("UPDATE triage_items SET status = $1 WHERE id = $2 AND tenant_id = $3").bind(status).bind(&payload.triage_item_id).bind(&tenant_id).execute(&mut *tx).await {
                 Ok(_) => {
                     let _ = tx.commit().await;
@@ -3959,7 +3964,9 @@ pub async fn update_ui_triage_action_handler(
                 let mut action_type_opt = None;
                 let mut action_payload_opt = None;
 
-                if let Ok(Some(row)) = sqlx::query("SELECT action_type, payload FROM triage_proposed_actions WHERE triage_item_id = ? AND tenant_id = ?")
+                if let Ok(Some(row)) = sqlx::query("SELECT action_type, payload FROM triage_proposed_actions WHERE triage_item_id = ? AND tenant_id = ? UNION ALL SELECT action_type, action_payload AS payload FROM unified_triage_actions WHERE id = ? AND tenant_id = ?")
+                    .bind(&payload.triage_item_id)
+                    .bind(&tenant_id)
                     .bind(&payload.triage_item_id)
                     .bind(&tenant_id)
                     .fetch_optional(&mut *tx)
@@ -4150,6 +4157,11 @@ pub async fn update_ui_triage_action_handler(
                 .bind(&tenant_id)
                 .execute(&mut *tx)
                 .await;
+
+            let _ = sqlx::query("UPDATE unified_triage_actions SET status = ? WHERE id = ? AND tenant_id = ?")
+                .bind(status).bind(&payload.triage_item_id).bind(&tenant_id).execute(&mut *tx).await;
+            let _ = sqlx::query("UPDATE unified_threads SET status = 'resolved' WHERE id = (SELECT thread_id FROM unified_triage_actions WHERE id = ? AND tenant_id = ?)")
+                .bind(&payload.triage_item_id).bind(&tenant_id).execute(&mut *tx).await;
 
             match sqlx::query("UPDATE triage_items SET status = ? WHERE id = ? AND tenant_id = ?").bind(status).bind(&payload.triage_item_id).bind(&tenant_id).execute(&mut *tx).await {
                 Ok(_) => {
@@ -4780,9 +4792,9 @@ async fn load_ui_triage_from_db(db: &crate::db::DB, tenant_id: &str, mobile_opti
             match &db1.store {
                 crate::db::DbStore::Postgres => {
                     let query_str = if mobile_optimized {
-                        "SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.status, CAST(t.created_at AS text) AS created_at, a.action_type FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id WHERE t.tenant_id = $1 AND t.status != 'resolved' AND t.status != 'dismissed' ORDER BY t.created_at DESC LIMIT 50"
+                        "SELECT id, tenant_id, customer_id, source, priority, status, CAST(created_at AS text) AS created_at, action_type FROM (SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.status, t.created_at, a.action_type FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id UNION ALL SELECT a.id, a.tenant_id, t.customer_id, t.channel AS source, 'normal' AS priority, a.status, a.created_at, a.action_type FROM unified_triage_actions a JOIN unified_threads t ON a.thread_id = t.id) sub WHERE tenant_id = $1 AND status != 'resolved' AND status != 'dismissed' ORDER BY created_at DESC LIMIT 50"
                     } else {
-                        "SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.context, t.status, CAST(t.created_at AS text) AS created_at, a.action_type, a.payload AS action_payload FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id WHERE t.tenant_id = $1 AND t.status != 'resolved' AND t.status != 'dismissed' ORDER BY t.created_at DESC LIMIT 50"
+                        "SELECT id, tenant_id, customer_id, source, priority, context, status, CAST(created_at AS text) AS created_at, action_type, action_payload FROM (SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.context, t.status, t.created_at, a.action_type, a.payload AS action_payload FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id UNION ALL SELECT a.id, a.tenant_id, t.customer_id, t.channel AS source, 'normal' AS priority, '' AS context, a.status, a.created_at, a.action_type, a.action_payload FROM unified_triage_actions a JOIN unified_threads t ON a.thread_id = t.id) sub WHERE tenant_id = $1 AND status != 'resolved' AND status != 'dismissed' ORDER BY created_at DESC LIMIT 50"
                     };
                     if let Ok(rows) = sqlx::query(query_str).bind(&t_id1).fetch_all(&db1.pool).await {
                         for row in rows {
@@ -4818,9 +4830,9 @@ async fn load_ui_triage_from_db(db: &crate::db::DB, tenant_id: &str, mobile_opti
                 }
                 crate::db::DbStore::Sqlite(pool) => {
                     let query_str = if mobile_optimized {
-                        "SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.status, CAST(t.created_at AS TEXT) AS created_at, a.action_type FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id WHERE t.tenant_id = ? AND t.status != 'resolved' AND t.status != 'dismissed' ORDER BY t.created_at DESC LIMIT 50"
+                        "SELECT id, tenant_id, customer_id, source, priority, status, CAST(created_at AS TEXT) AS created_at, action_type FROM (SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.status, t.created_at, a.action_type FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id UNION ALL SELECT a.id, a.tenant_id, t.customer_id, t.channel AS source, 'normal' AS priority, a.status, a.created_at, a.action_type FROM unified_triage_actions a JOIN unified_threads t ON a.thread_id = t.id) sub WHERE tenant_id = ? AND status != 'resolved' AND status != 'dismissed' ORDER BY created_at DESC LIMIT 50"
                     } else {
-                        "SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.context, t.status, CAST(t.created_at AS TEXT) AS created_at, a.action_type, a.payload AS action_payload FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id WHERE t.tenant_id = ? AND t.status != 'resolved' AND t.status != 'dismissed' ORDER BY t.created_at DESC LIMIT 50"
+                        "SELECT id, tenant_id, customer_id, source, priority, context, status, CAST(created_at AS TEXT) AS created_at, action_type, action_payload FROM (SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.context, t.status, t.created_at, a.action_type, a.payload AS action_payload FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id UNION ALL SELECT a.id, a.tenant_id, t.customer_id, t.channel AS source, 'normal' AS priority, '' AS context, a.status, a.created_at, a.action_type, a.action_payload FROM unified_triage_actions a JOIN unified_threads t ON a.thread_id = t.id) sub WHERE tenant_id = ? AND status != 'resolved' AND status != 'dismissed' ORDER BY created_at DESC LIMIT 50"
                     };
                     if let Ok(rows) = sqlx::query(query_str).bind(&t_id1).fetch_all(pool).await {
                         for row in rows {


### PR DESCRIPTION
Implemented the AI-Native Universal Work Triage feed API as part of the Owner Work Assistant mission.

This PR modifies the core `triage` endpoints to unify legacy `triage_items` with the new `unified_triage_actions`/`unified_threads` models. 

### Changes
- Updated `load_ui_triage_from_db` in `src/server/lib.rs` to seamlessly merge both data models via `UNION ALL` for both SQLite and Postgres.
- Adjusted the payload columns (`context`, `action_payload`) so that they correctly fall back to default values based on the `mobile_optimized` UI flag.
- Updated `update_ui_triage_action_handler` in `src/server/lib.rs` to fetch and update `unified_triage_actions` and `unified_threads` tables respectively when an AI draft action is approved/dismissed.

### Product-Use Evidence
- Persona: Maya (Home Baker) / Carlos (Field Service Owner)
- CUJ Attempted: Navigated to Triage Feed UI from the Dashboard to process new Omni-channel message threads.
- Observed Gap: `unified_threads` AI actions were queued in PostgreSQL but failed to appear in the glassmorphic mobile Triage Feed, forcing owners to manually check `omni_inbox` pages.
- Action: Rewrote the data access layer via `UNION ALL` and extended the `update` handler, natively bringing all new AI tasks to the exact single UI owners use for triage.

Resolves #30743

---
*PR created automatically by Jules for task [323546792429805393](https://jules.google.com/task/323546792429805393) started by @ql-owo-lp*