### PR TITLE
🤖 Implementer: Harness Upgrade - ACON Strategy & Test Coverage

### DIFF
--- a/src/agents/builtin/acon_context.rs
+++ b/src/agents/builtin/acon_context.rs
@@ -5,12 +5,15 @@ use crate::types::{Message, Role};
 pub struct AconConfig {
     /// Number of recent messages to preserve completely.
     pub preserve_recent_messages_count: usize,
+    /// Do not omit outputs shorter than this length (in chars) as it wastes tokens.
+    pub preserve_short_outputs: Option<usize>,
 }
 
 impl Default for AconConfig {
     fn default() -> Self {
         Self {
             preserve_recent_messages_count: 2,
+            preserve_short_outputs: Some(100),
         }
     }
 }
@@ -39,9 +42,17 @@ impl AconStrategy {
                             && !tr.content.starts_with("[ACON:")
                             && !tr.content.is_empty()
                         {
-                            tr.content =
-                                "[ACON: Tool output omitted to prioritize reasoning traces.]"
-                                    .to_string();
+                            let content_len = tr.content.len();
+                            // Do not mask short outputs to avoid wasting tokens on the omission message
+                            if let Some(short_threshold) = self.config.preserve_short_outputs {
+                                if content_len <= short_threshold {
+                                    continue;
+                                }
+                            }
+                            tr.content = format!(
+                                "[ACON: Tool output omitted to prioritize reasoning traces. Original length: {} chars.]",
+                                content_len
+                            );
                         }
                     }
                 }
@@ -69,7 +80,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_results: vec![ToolResult {
                     tool_call_id: "call_1".to_string(),
-                    content: "Massive log output".to_string(),
+                    content: "Massive log output that exceeds the one hundred character limit to ensure that it gets properly truncated by the ACON strategy. We need to be absolutely sure this is long enough.".to_string(),
                     error: String::new(),
                 }],
                 response_id: None,
@@ -89,7 +100,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_results: vec![ToolResult {
                     tool_call_id: "call_2".to_string(),
-                    content: "Another tool result".to_string(),
+                    content: "Another tool result that is also very long, much longer than a hundred characters, because if it's too short, it will simply be preserved completely due to the short output threshold!".to_string(),
                     error: String::new(),
                 }],
                 response_id: None,
@@ -107,14 +118,15 @@ mod tests {
 
         let config = AconConfig {
             preserve_recent_messages_count: 2,
+            preserve_short_outputs: Some(100),
         };
         apply_acon_strategy(&mut messages, &config);
 
         // First tool message should be masked (it is outside the preserved count)
-        assert_eq!(
-            messages[0].tool_results[0].content,
-            "[ACON: Tool output omitted to prioritize reasoning traces.]"
+        assert!(
+            messages[0].tool_results[0].content.contains("[ACON: Tool output omitted to prioritize reasoning traces.")
         );
+        assert!(messages[0].tool_results[0].content.contains("Original length:"));
 
         // Assistant message reasoning is preserved
         assert_eq!(
@@ -123,6 +135,41 @@ mod tests {
         );
 
         // Second tool message is within the recent preserved count
-        assert_eq!(messages[2].tool_results[0].content, "Another tool result");
+        assert_eq!(messages[2].tool_results[0].content, "Another tool result that is also very long, much longer than a hundred characters, because if it's too short, it will simply be preserved completely due to the short output threshold!");
+    }
+
+    #[test]
+    fn test_apply_acon_strategy_preserves_short_outputs() {
+        let mut messages = vec![
+            Message {
+                role: Role::Tool,
+                content: String::new(),
+                tool_calls: vec![],
+                tool_results: vec![ToolResult {
+                    tool_call_id: "call_1".to_string(),
+                    content: "Short output".to_string(),
+                    error: String::new(),
+                }],
+                response_id: None,
+                previous_response_id: None,
+            },
+            Message {
+                role: Role::Assistant,
+                content: "Final reasoning".to_string(),
+                tool_calls: vec![],
+                tool_results: vec![],
+                response_id: None,
+                previous_response_id: None,
+            },
+        ];
+
+        let config = AconConfig {
+            preserve_recent_messages_count: 0,
+            preserve_short_outputs: Some(100),
+        };
+        apply_acon_strategy(&mut messages, &config);
+
+        // Short tool message should NOT be masked, because it's under 100 chars
+        assert_eq!(messages[0].tool_results[0].content, "Short output");
     }
 }

--- a/src/agents/builtin/agentic_seek.rs
+++ b/src/agents/builtin/agentic_seek.rs
@@ -6,7 +6,7 @@ use crate::provider::{Credentials, Provider, ProviderType, Transport};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// agenticSeek: Fully local agent, no API costs
+/// agenticSeek Unique Harness Innovations: Fully local agent, no API costs
 pub struct AgenticSeekProvider {
     pub local_endpoint: String,
     pub model_name: String,
@@ -89,5 +89,20 @@ mod tests {
         assert!(!(config.enable_visual_verification));
         assert!(!(config.enable_llmcompiler_plan_and_execute));
         assert_eq!(config.max_iterations, 25);
+    }
+
+
+    #[test]
+    fn test_agentic_seek_provider_traits() {
+        let provider = AgenticSeekProvider::new("http://localhost:11434", "llama3");
+        assert_eq!(provider.provider_type(), ProviderType::AgenticSeek);
+        assert!(provider.description().contains("agenticSeek"));
+        assert_eq!(provider.supported_roles(), vec!["local_agent".to_string()]);
+        assert!(provider.is_authenticated());
+        assert!(provider.authenticate(Credentials {
+            api_key: "".to_string(),
+            oauth_token: "".to_string(),
+            extra: HashMap::new(),
+        }).is_ok());
     }
 }

--- a/src/agents/builtin/autogen.rs
+++ b/src/agents/builtin/autogen.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 /// Master Catalog A: Framework Implementation Archetypes: AutoGen.
+/// AutoGen Unique Harness Innovations: Block-based visual workflow, Agent Marketplace, Agent Protocol
+/// Implements 5 mechanical patterns: sequential, concurrent (fan-out/fan-in), group chat, handoff, and magentic (manager agent dynamically updating a task ledger).
 
 /// Configuration for an Agent participating in the Group Chat.
 #[derive(Clone)]

--- a/src/agents/builtin/goose/mod.rs
+++ b/src/agents/builtin/goose/mod.rs
@@ -1,5 +1,5 @@
 //! goose (Agentic AI) Implementation Pattern
-//! SOTA Harness Innovations: Rust + TypeScript UI, 70+ MCP extensions
+//! goose (Agentic AI) Unique Harness Innovations: Rust + TypeScript UI, 70+ MCP extensions
 //!
 //! This module implements a basic bridge and UI stub pattern that enables
 //! the agent to interact with a theoretical TypeScript UI and host MCP extensions.

--- a/src/agents/builtin/pi.rs
+++ b/src/agents/builtin/pi.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Pi (pi-agent-core): TypeScript monorepo architecture archetype.
+/// Pi Unique Harness Innovations: pi-agent-core TypeScript monorepo.
 /// This Rust provider models the Pi harness structure for monorepo and TypeScript agent integration.
 pub struct PiProvider {
     pub local_endpoint: String,
@@ -92,5 +93,19 @@ mod tests {
         assert!(config.enable_visual_verification);
         assert!(!(config.enable_llmcompiler_plan_and_execute));
         assert_eq!(config.max_iterations, 30);
+    }
+
+    #[test]
+    fn test_pi_provider_traits() {
+        let provider = PiProvider::new("http://localhost:11434", "pi-model");
+        assert_eq!(provider.provider_type(), ProviderType::Pi);
+        assert!(provider.description().contains("Pi"));
+        assert_eq!(provider.supported_roles(), vec!["pi_agent".to_string(), "monorepo_specialist".to_string()]);
+        assert!(provider.is_authenticated());
+        assert!(provider.authenticate(Credentials {
+            api_key: "".to_string(),
+            oauth_token: "".to_string(),
+            extra: HashMap::new(),
+        }).is_ok());
     }
 }


### PR DESCRIPTION
This PR refactors the ACON context strategy to include a threshold for preserving short outputs and includes the original length in the masked string. It also adds unit tests for the `pi` and `agenticSeek` provider traits.

---
*PR created automatically by Jules for task [3333512798052923415](https://jules.google.com/task/3333512798052923415) started by @ql-owo-lp*