### PR TITLE
Fix onboarding registration and mapping

### DIFF
--- a/src/server/services/onboarding/onboarding_agent.rs
+++ b/src/server/services/onboarding/onboarding_agent.rs
@@ -606,7 +606,7 @@ Your response:",
 
         sqlx::query(
             r#"
-            INSERT INTO users (id, username, email, password_hash, roles, active, organization_id, oidc_subject, created_at, updated_at)
+            INSERT INTO users (id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             "#
         )


### PR DESCRIPTION
Fixes an issue with onboarding backend user creation where `organization_id` was mapped instead of `tenant_id` causing failure on signup.
Updates the Tauri UI payload to send keys as `snake_case` according to backend `StartOnboardingRequest` struct.

---
*PR created automatically by Jules for task [5639478081721394570](https://jules.google.com/task/5639478081721394570) started by @ql-owo-lp*