### PR TITLE
🚀 Nova: Add viral growth loop to customer referral embed widget

### DIFF
--- a/src/e2e/customer-referral.spec.ts
+++ b/src/e2e/customer-referral.spec.ts
@@ -45,6 +45,15 @@ test.describe('Customer Referral Program Growth Loop', () => {
 
         const html = await response.text();
         expect(html).toContain('Give $20, Get $25');
+        expect(html).toContain('⚡ Powered by OHC');
+
+        // Check the backend embed API endpoint directly when branding is hidden
+        const responseNoBranding = await request.get('/api/v1/growth/customer-referral/embed?tenant=maya-cakes&give=20&get=25&hideBranding=true');
+        expect(responseNoBranding.status()).toBe(200);
+
+        const htmlNoBranding = await responseNoBranding.text();
+        expect(htmlNoBranding).toContain('Give $20, Get $25');
+        expect(htmlNoBranding).not.toContain('⚡ Powered by OHC');
     });
 
     test('should show soft paywall when attempting to remove branding without pro', async ({ page }) => {

--- a/src/ui/next/src/app/api/v1/growth/customer-referral/embed/route.ts
+++ b/src/ui/next/src/app/api/v1/growth/customer-referral/embed/route.ts
@@ -1,10 +1,21 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  const tenant = searchParams.get('tenant') || 'unknown';
-  const give = searchParams.get('give') || '10';
-  const get = searchParams.get('get') || '10';
+  const tenant = searchParams.get("tenant") || "unknown";
+  const give = searchParams.get("give") || "10";
+  const get = searchParams.get("get") || "10";
+
+  const hideBranding =
+    searchParams.get("hide_branding") === "true" ||
+    searchParams.get("hideBranding") === "true";
+
+  const brandingHtml = hideBranding
+    ? ""
+    : `
+<div style="font-family: sans-serif; text-align: center; font-size: 12px; margin-top: 8px;">
+  <a href="${request.nextUrl.origin}/api/v1/growth/referrals/click?target=/onboarding&ref=${encodeURIComponent(tenant)}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a>
+</div>`;
 
   const html = `
 <!DOCTYPE html>
@@ -94,14 +105,15 @@ export async function GET(request: NextRequest) {
       </div>
     </form>
   </div>
+  ${brandingHtml}
 </body>
 </html>
 `;
 
   return new NextResponse(html, {
     headers: {
-      'Content-Type': 'text/html',
-      'Cache-Control': 'public, max-age=3600',
+      "Content-Type": "text/html",
+      "Cache-Control": "public, max-age=3600",
     },
   });
 }


### PR DESCRIPTION
Product-use evidence:
Persona: Maya - Home Baker
CUJ Attempted: Created a new "Customer Referral Program" from the dashboard, selected give $20 get $25, and clicked "Generate Widget Embed" to get the HTML code to paste into Maya's external site.
Gap Observed: The generated `iframe` widget preview inside the modal looked correct, but when the raw `/api/v1/growth/customer-referral/embed` HTML was fetched by the iframe, it did not include the "Powered by OHC" viral loop footer. This meant anyone who viewed Maya's widget on her external site would not be acquired as an OHC lead.
User Experience Reason: Every widget built on the OHC platform should act as a viral acquisition channel ("Powered by OHC"). We need to make sure the generated HTML embed API endpoint correctly injects this viral loop link, while conditionally respecting the "hideBranding" parameter for Pro users.
Post-fix flow: Repeat the flow. Click the Generate button, verify the URL returned in the code block. When rendering the widget HTML directly, verify the "Powered by OHC" link correctly displays with Maya's tenant ID, driving new leads to the onboarding flow while properly tracking the referral metrics.

Superpowers loaded:
- mobile-first
- ui-testing

Changes:
- Append conditionally rendered "Powered by OHC" branding link inside the `customer-referral/embed` API route.
- Implement tests to verify `hideBranding` toggle works.

---
*PR created automatically by Jules for task [8659051589176724524](https://jules.google.com/task/8659051589176724524) started by @ql-owo-lp*