### PR TITLE
style: remove redundant -webkit-backdrop-filter and enforce visual excellence mandate

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -29,7 +29,7 @@ body {
   top: 0;
   align-self: flex-start;
   background: rgba(255, 255, 255, 0.65);
-  -webkit-backdrop-filter: blur(30px) saturate(210%);
+
   backdrop-filter: blur(30px) saturate(210%);
   border: 1px solid rgba(255, 255, 255, 0.4);
   color: #d8dee8;
@@ -39,7 +39,7 @@ body {
 @media (prefers-color-scheme: dark) {
   .app-sidebar {
     background: rgba(22, 22, 26, 0.7);
-    -webkit-backdrop-filter: blur(30px) saturate(210%);
+
     backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
   }
@@ -154,7 +154,7 @@ body {
   gap: 20px;
   padding: 14px 24px;
   background: rgba(255, 255, 255, 0.65);
-  -webkit-backdrop-filter: blur(30px) saturate(210%);
+
   backdrop-filter: blur(30px) saturate(210%);
   border-bottom: 1px solid rgba(255, 255, 255, 0.4);
   position: sticky;
@@ -165,7 +165,7 @@ body {
 @media (prefers-color-scheme: dark) {
   .app-topbar {
     background: rgba(22, 22, 26, 0.7);
-    -webkit-backdrop-filter: blur(30px) saturate(210%);
+
     backdrop-filter: blur(30px) saturate(210%);
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   }
@@ -218,7 +218,7 @@ body {
 
 .app-card {
   background: rgba(255, 255, 255, 0.65);
-  -webkit-backdrop-filter: blur(30px) saturate(210%);
+
   backdrop-filter: blur(30px) saturate(210%);
   border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 16px;
@@ -228,7 +228,7 @@ body {
 @media (prefers-color-scheme: dark) {
   .app-card {
     background: rgba(22, 22, 26, 0.7);
-    -webkit-backdrop-filter: blur(30px) saturate(210%);
+
     backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 16px;
@@ -237,7 +237,7 @@ body {
 
 .app-panel {
   background: rgba(255, 255, 255, 0.65);
-  -webkit-backdrop-filter: blur(30px) saturate(210%);
+
   backdrop-filter: blur(30px) saturate(210%);
   border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 16px;
@@ -248,7 +248,7 @@ body {
 @media (prefers-color-scheme: dark) {
   .app-panel {
     background: rgba(22, 22, 26, 0.7);
-    -webkit-backdrop-filter: blur(30px) saturate(210%);
+
     backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 16px;
@@ -554,7 +554,7 @@ body {
 
 .ohc-hybrid-panel {
     background: rgba(255, 255, 255, 0.65);
-    -webkit-backdrop-filter: blur(30px) saturate(210%);
+
     backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.4);
     font-family: 'Outfit', 'Inter', sans-serif;
@@ -568,7 +568,7 @@ body {
 @media (prefers-color-scheme: dark) {
     .ohc-hybrid-panel {
         background: rgba(22, 22, 26, 0.7);
-        -webkit-backdrop-filter: blur(30px) saturate(210%);
+
         backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.1);
         color: #F5F5F7;
@@ -708,7 +708,7 @@ button, .app-button, .charge-btn {
 
 .glass-panel {
   background: rgba(255, 255, 255, 0.65);
-  -webkit-backdrop-filter: blur(30px) saturate(210%);
+
   backdrop-filter: blur(30px) saturate(210%);
   border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 16px;
@@ -717,7 +717,7 @@ button, .app-button, .charge-btn {
 @media (prefers-color-scheme: dark) {
   .glass-panel {
     background: rgba(22, 22, 26, 0.7);
-    -webkit-backdrop-filter: blur(30px) saturate(210%);
+
     backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 16px;
@@ -1071,7 +1071,7 @@ select {
 
 .ohc-growth-card {
     background: rgba(255, 255, 255, 0.65);
-    -webkit-backdrop-filter: blur(30px) saturate(210%);
+
     backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.4);
     border-radius: 16px;
@@ -1082,7 +1082,7 @@ select {
 @media (prefers-color-scheme: dark) {
     .ohc-growth-card {
         background: rgba(22, 22, 26, 0.7);
-        -webkit-backdrop-filter: blur(30px) saturate(210%);
+
         backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.1);
     }
@@ -1090,7 +1090,7 @@ select {
 
 html.dark .ohc-growth-card {
     background: rgba(22, 22, 26, 0.7);
-    -webkit-backdrop-filter: blur(30px) saturate(210%);
+
     backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
 }
@@ -1100,5 +1100,12 @@ html.dark .ohc-growth-card {
 }
 
 .app-panel {
+  border-radius: 16px;
+}
+
+html.dark .glass-panel {
+  background: rgba(22, 22, 26, 0.7);
+  backdrop-filter: blur(30px) saturate(210%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 16px;
 }


### PR DESCRIPTION
### Description
Removed redundant `-webkit-backdrop-filter` declarations from `.ohc-growth-card`, `.glass-panel`, `.app-sidebar`, `.app-topbar`, `.app-card`, `.app-panel`, and `.ohc-hybrid-panel` to ensure consistent and standard CSS for the macOS-style translucent aesthetics, effectively applying the Visual Excellence Mandate universally. I also added the explicit `html.dark` selector to `.glass-panel` so it maintains parity with the styling changes applied recently to `.glassmorphism` and `.glass-card`.

### Product-use evidence
**Persona:** Maintainer / SRE / Frontend Auditor
**Attempted Flow:** Validated global UI styling to ensure the Visual Excellence Mandate was properly enforced across all components using Glassmorphism.
**Observed Gap:** The `globals.css` style definitions for various components including `.glass-panel` and `.ohc-growth-card` contained unneeded `-webkit-` vendor prefixes. The `.glass-panel` component was missing an explicit `html.dark` selector fallback, meaning it could incorrectly display a light-mode appearance if a manual dark mode toggle (which relies on `html.dark`) was utilized.
**Fix:** Pruned all `-webkit-backdrop-filter` rules and added the `html.dark` selector to `.glass-panel` so the exact required Light and Dark mode Translucent Glass properties operate seamlessly.

### Technical details
- Removed `-webkit-backdrop-filter: blur(30px) saturate(210%);` from `globals.css`.
- Added `html.dark .glass-panel` to explicitly define the `rgba(22, 22, 26, 0.7)` and `blur(30px)` styles for the `.glass-panel` class.
- Ensured 100% test passing through `bazel test //...` and `bazel test //src/e2e:playwright`.

---
*PR created automatically by Jules for task [3919936244574255195](https://jules.google.com/task/3919936244574255195) started by @ql-owo-lp*