### PR TITLE
Fix stuck agent_missions queue jam and database connections

### DIFF
--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -442,8 +442,9 @@ impl HybridSyncDaemon {
     }
 
     pub async fn prune_stuck_agent_missions(&self) -> Result<(), Box<dyn std::error::Error>> {
-        // Find and fail stuck missions in sqlite pool
-        let res_sqlite = sqlx::query("UPDATE agent_missions SET status = 'FAILED', sync_error = 'bug: Mission became stuck', last_synced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hour') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hour')))")
+        // SQLite
+        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'mission_failed', 'agent_missions', COALESCE(payload, '{}'), 'bug: Mission became stuck' FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hour') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hour')))").execute(&self.sqlite_pool).await;
+        let res_sqlite = sqlx::query("DELETE FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hour') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hour')))")
             .execute(&self.sqlite_pool)
             .await;
         if let Ok(res) = res_sqlite {
@@ -452,8 +453,9 @@ impl HybridSyncDaemon {
             }
         }
 
-        // Find and fail stuck missions in pg pool
-        let res_pg = sqlx::query("UPDATE agent_missions SET status = 'FAILED', sync_error = 'bug: Mission became stuck', last_synced_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))")
+        // PG
+        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'mission_failed', 'agent_missions', COALESCE(payload::text, '{}'), 'bug: Mission became stuck' FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))").execute(&self.pg_pool).await;
+        let res_pg = sqlx::query("DELETE FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))")
             .execute(&self.pg_pool)
             .await;
         if let Ok(res) = res_pg {

--- a/src/server/orchestration/hybrid_sync/daemon_test.rs
+++ b/src/server/orchestration/hybrid_sync/daemon_test.rs
@@ -541,20 +541,20 @@ async fn test_hybrid_sync_pos_offline_transactions() {
         daemon.prune_stuck_agent_missions().await.unwrap();
         daemon.prune_stuck_sub_agent_queue().await.unwrap();
 
-        // Verify SQLite mission is failed
+        // Verify SQLite mission is failed (now deleted)
         let row_sqlite = sqlx::query("SELECT status FROM agent_missions WHERE id = 'stuck_mission_sqlite'")
-            .fetch_one(&sqlite_pool).await.unwrap();
-        use sqlx::Row;
-        assert_eq!(row_sqlite.get::<String, _>("status"), "FAILED");
+            .fetch_optional(&sqlite_pool).await.unwrap();
+        assert!(row_sqlite.is_none());
 
-        // Verify PG mission is failed
+        // Verify PG mission is failed (now deleted)
         let row_pg = sqlx::query("SELECT status FROM agent_missions WHERE id = 'stuck_mission_pg'")
-            .fetch_one(&pg_pool).await.unwrap();
-        assert_eq!(row_pg.get::<String, _>("status"), "FAILED");
+            .fetch_optional(&pg_pool).await.unwrap();
+        assert!(row_pg.is_none());
 
         // Verify SQLite queue is failed
         let row_queue_sqlite = sqlx::query("SELECT status FROM sub_agent_queue WHERE id = 'stuck_queue_sqlite'")
             .fetch_one(&sqlite_pool).await.unwrap();
+        use sqlx::Row;
         assert_eq!(row_queue_sqlite.get::<String, _>("status"), "FAILED");
 
         // Verify PG queue is failed
@@ -689,13 +689,12 @@ async fn test_hybrid_sync_pos_offline_transactions() {
         daemon.prune_stuck_agent_missions().await.unwrap();
 
         // Verify SQLite mission failure category
-        let row_sqlite = sqlx::query("SELECT sync_error FROM agent_missions WHERE id = 'stuck_mission_sqlite_cat'")
+        let dl_sqlite: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE id = 'stuck_mission_sqlite_cat'")
             .fetch_one(&sqlite_pool).await.unwrap();
-        use sqlx::Row;
-        assert!(row_sqlite.get::<String, _>("sync_error").contains("bug:"));
+        assert_eq!(dl_sqlite.0, 1);
 
         // Verify PG mission failure category
-        let row_pg = sqlx::query("SELECT sync_error FROM agent_missions WHERE id = 'stuck_mission_pg_cat'")
+        let dl_pg: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE id = 'stuck_mission_pg_cat'")
             .fetch_one(&pg_pool).await.unwrap();
-        assert!(row_pg.get::<String, _>("sync_error").contains("bug:"));
+        assert_eq!(dl_pg.0, 1);
     }


### PR DESCRIPTION
I have resolved the queue jam problem that allowed stuck/stagnant agent missions to pile up in the database.
- Upgraded `prune_stuck_agent_missions` in `src/server/orchestration/hybrid_sync/daemon.rs` to insert a dead-letter entry into `department_dead_letters` and fully DELETE the `agent_missions` row instead of just updating it to FAILED.
- Corrected unit tests in `src/server/orchestration/hybrid_sync/daemon_test.rs` to expect `agent_missions` deletion and `department_dead_letters` creation correctly for the stagnant tasks.
- Corrected connection pool limitations for tests (bumping from 100 to 200 `max_connections`) in `src/server/benchmarks/latency_bench.rs` that were producing flake panics.
- All tests pass locally using `bazel test //...`.

---
*PR created automatically by Jules for task [14231377292370512750](https://jules.google.com/task/14231377292370512750) started by @ql-owo-lp*