### PR TITLE
chore: Enforce local sovereignty and PII guardrails in Standalone Mode

### DIFF
--- a/src/server/interop/protocol.rs
+++ b/src/server/interop/protocol.rs
@@ -219,7 +219,7 @@ impl InteropProtocol {
         use prost::Message as ProstMessage;
         use std::sync::atomic::Ordering;
 
-        tracing::info!(job_id = %job_id, tenant_id = %tenant_id, action_name = %action_name, "Dispatching background job");
+        tracing::info!(job_id = %job_id, tenant_id = %tenant_id, action_name = %action_name, "Dispatching background job"); // pii-safe
 
         let received = Arc::new(AtomicBool::new(false));
         let rx = received.clone();

--- a/src/server/orchestration/hybrid_sync/daemon_test.rs
+++ b/src/server/orchestration/hybrid_sync/daemon_test.rs
@@ -1,5 +1,10 @@
 #[cfg(test)]
+use std::sync::Mutex;
+use std::sync::LazyLock;
+pub static ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
 mod tests {
+
     use super::super::daemon::HybridSyncDaemon;
     use serde_json::json;
     use sqlx::postgres::PgPoolOptions;
@@ -263,42 +268,29 @@ async fn test_hybrid_sync_daemon_telemetry_opt_out() {
         .await
         .unwrap();
 
-    // The async env issue... temp_env is synchronous
-    let _old_telemetry = std::env::var("OHC_TELEMETRY_ENABLED");
-    let _old_standalone = std::env::var("OHC_STANDALONE_MODE");
+    let _lock = ENV_MUTEX.lock().unwrap();
+    temp_env::with_vars(
+        [
+            ("OHC_TELEMETRY_ENABLED", Some("false")),
+            ("OHC_STANDALONE_MODE", Some("true")),
+        ],
+        || {
+            // We must block on the async task since temp_env runs synchronously
+            tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
+                let daemon = super::daemon::HybridSyncDaemon::new(sqlite_pool.clone(), pg_pool.clone());
+                daemon.sync_telemetry_step().await.unwrap();
 
-    unsafe {
-        std::env::set_var("OHC_TELEMETRY_ENABLED", "false");
-        std::env::set_var("OHC_STANDALONE_MODE", "true");
-    }
-
-    // We also need to reload config somehow... or actually our change reads ::server_config::get().
-    // We can't really reload standard OnceLock easily so we'll just check if it blocks.
-    let daemon = super::daemon::HybridSyncDaemon::new(sqlite_pool.clone(), pg_pool.clone());
-    daemon.sync_telemetry_step().await.unwrap();
-
-    // Check that it's still pending
-    let row = sqlx::query("SELECT sync_status FROM telemetry_buffer")
-        .fetch_one(&sqlite_pool)
-        .await
-        .unwrap();
-    use sqlx::Row;
-    let status: String = row.get("sync_status");
-    assert_eq!(status, "pending");
-
-    unsafe {
-        if let Ok(val) = _old_telemetry {
-            std::env::set_var("OHC_TELEMETRY_ENABLED", val);
-        } else {
-            std::env::remove_var("OHC_TELEMETRY_ENABLED");
+                // Check that it's still pending
+                let row = sqlx::query("SELECT sync_status FROM telemetry_buffer")
+                    .fetch_one(&sqlite_pool)
+                    .await
+                    .unwrap();
+                use sqlx::Row;
+                let status: String = row.get("sync_status");
+                assert_eq!(status, "pending");
+            });
         }
-
-        if let Ok(val) = _old_standalone {
-            std::env::set_var("OHC_STANDALONE_MODE", val);
-        } else {
-            std::env::remove_var("OHC_STANDALONE_MODE");
-        }
-    }
+    );
 }
 
 #[tokio::test]

--- a/src/server/pii_leakage_check.sh
+++ b/src/server/pii_leakage_check.sh
@@ -12,7 +12,7 @@ SRCDIR=${1:-src/server}
 FILES=$(find "$SRCDIR" -name "*.rs" 2>/dev/null || true)
 
 # comprehensive PII keyword list based on src/server/telemetry/mod.rs
-PII_KEYWORDS="password|secret|key|token|auth|cookie|credential|email|phone|ssn|address|pii|credit_card"
+PII_KEYWORDS="\b(password|secret|key|token|auth|cookie|credential|email|phone|ssn|address|name|pii|jwt|bearer|sessionid|payload|credit|card|cvv|dob|birth|passport|bank|account|stripe|billing|ipaddress|macaddress|geolocation|medical|health|salary|tax|socialsecurity|creditcard|deviceid|gps|latitude|longitude)\b"
 
 for FILE in $FILES; do
     # Exclude the telemetry modules and tests from the leakage check as they deal with these strings intentionally

--- a/src/server/sync/service.rs
+++ b/src/server/sync/service.rs
@@ -35,7 +35,8 @@ impl SyncDeltas for CloudSyncService {
         let telemetry_enabled = env::var("OHC_TELEMETRY_ENABLED").unwrap_or_else(|_| "false".to_string()) == "true";
 
         if is_standalone && !telemetry_enabled {
-            tracing::debug!("Standalone mode, telemetry disabled, syncing anyway but without telemetry tracking.");
+            tracing::debug!("Standalone mode, telemetry disabled, skipping cloud delta sync entirely to enforce local sovereignty.");
+            return Ok(());
         }
 
         let mut futures = Vec::new();

--- a/src/server/telemetry_test.rs
+++ b/src/server/telemetry_test.rs
@@ -1,5 +1,8 @@
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+    use std::sync::LazyLock;
+    pub static ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
     use serde_json;
     use temp_env;
     use tokio;
@@ -251,6 +254,7 @@ mod tests {
 
     #[test]
     fn test_buffer_metric_respects_standalone() {
+        let _lock = crate::tests::ENV_MUTEX.lock().unwrap();
         temp_env::with_vars(vec![("OHC_STANDALONE_MODE", Some("true"))], || {
             tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
         let db_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/ohc".to_string());
@@ -286,6 +290,7 @@ mod tests {
 
     #[test]
     fn test_init_telemetry_standalone_opt_out() {
+        let _lock = crate::tests::ENV_MUTEX.lock().unwrap();
         temp_env::with_vars(
             [
                 ("OHC_STANDALONE_MODE", Some("true")),
@@ -307,6 +312,7 @@ mod tests {
 
     #[test]
     fn test_init_telemetry_standalone_opt_in() {
+        let _lock = crate::tests::ENV_MUTEX.lock().unwrap();
         temp_env::with_vars(
             [
                 ("OHC_STANDALONE_MODE", Some("true")),
@@ -660,6 +666,7 @@ fn test_record_error_signal() {
         // Enforce Local Sovereignty
         // Ensures that OHC_STANDALONE_MODE properly overrides any implicit telemetry activation.
         // It must default to false unless OHC_TELEMETRY_ENABLED is explicitly "true".
+        let _lock = crate::tests::ENV_MUTEX.lock().unwrap();
         temp_env::with_vars(
             [
                 ("OHC_STANDALONE_MODE", Some("true")),


### PR DESCRIPTION
This PR enforces strict local data sovereignty and PII protection for the OHC platform:

1. **Local Sovereignty in Standalone Mode**: 
   - Updates `CloudSyncService::sync_deltas` to abort cloud synchronization if `is_standalone` is true and telemetry is not explicitly opted in.
   - Patches parallel test execution flakiness in `telemetry_test.rs` and `daemon_test.rs` that were sharing mutating environment state by locking around a `std::sync::Mutex`.

2. **PII Leakage Prevention**:
   - Updates `src/server/pii_leakage_check.sh` to leverage standard word boundary markers (`\b`) while validating the full list of parsed sensitive keywords exported from `src/server/telemetry/mod.rs` (including `medical`, `health`, `salary`, `ipaddress`, etc.).
   - Explicitly suppresses false positives natively within the `src/server/interop/protocol.rs` tracing log logic via `// pii-safe`.

---
*PR created automatically by Jules for task [2690262214142421208](https://jules.google.com/task/2690262214142421208) started by @ql-owo-lp*