### PR TITLE
🚀 Nova: Replace hardcoded Powered by OHC link in testimonial widget

### DIFF
--- a/src/ui/next/src/app/testimonial-widget/page.test.tsx
+++ b/src/ui/next/src/app/testimonial-widget/page.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import TestimonialWidgetGenerator from './page';
 
+vi.mock('../components/PoweredByOHC', () => ({
+  PoweredByOHC: () => <div data-testid="powered-by-ohc" />,
+}));
+
 describe('Testimonial Widget Generator', () => {
     beforeEach(() => {
         Object.assign(navigator, {
@@ -23,6 +27,7 @@ describe('Testimonial Widget Generator', () => {
 
         const authorInput = screen.getByDisplayValue('Jane Doe');
         expect(authorInput).toBeDefined();
+        expect(screen.getByTestId('powered-by-ohc')).toBeDefined();
     });
 
     it('updates live preview URL when settings change', () => {

--- a/src/ui/next/src/app/testimonial-widget/page.tsx
+++ b/src/ui/next/src/app/testimonial-widget/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
+import { PoweredByOHC } from '../components/PoweredByOHC';
 
 export default function TestimonialWidgetGenerator() {
   const [tenant, setTenant] = useState('my-business');
@@ -164,10 +165,8 @@ export default function TestimonialWidgetGenerator() {
                             {authorName}
                         </div>
 
-                        <div className={`mt-5 pt-3 border-t text-center text-xs ${theme === 'dark' ? 'border-gray-700 text-gray-400' : 'border-gray-100 text-gray-500'}`}>
-                            <a href={`/api/v1/growth/referrals/click?target=/onboarding&ref=${tenant}`} target="_blank" rel="noopener noreferrer" className="font-bold hover:underline" style={{ color: '#6b7280' }}>
-                                ⚡ Powered by OHC
-                            </a>
+                        <div className={`mt-5 pt-4 border-t flex justify-center ${theme === 'dark' ? 'border-gray-700' : 'border-gray-100'}`}>
+                            <PoweredByOHC tenantId={tenant} />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This PR replaces the hardcoded "Powered by OHC" link in the testimonial widget generator's preview with the standard `PoweredByOHC` component.

### Product-use evidence
- **Persona:** Maya, Home Baker
- **Flow attempted:** Navigated to the Testimonial Widget Generator page.
- **Gap observed:** The live preview section of the widget contained a plain, hardcoded link for "Powered by OHC", which lacked the premium visual styling found in other widget generators that use the `PoweredByOHC` component.
- **Reason for fix:** Consistent styling of the viral "Powered by OHC" branding helps drive referral growth. The widget needs to look professional when embedded on user sites.
- **Post-fix UI flow:** After the fix, the preview successfully renders the standard `PoweredByOHC` pill widget with its hover popover functionality.

### Changes
- Updated `src/ui/next/src/app/testimonial-widget/page.tsx` to use the `PoweredByOHC` component.
- Updated `src/ui/next/src/app/testimonial-widget/page.test.tsx` to correctly mock the component and assert its presence.

---
*PR created automatically by Jules for task [16407535664108886485](https://jules.google.com/task/16407535664108886485) started by @ql-owo-lp*