### PR TITLE
Refactor inline validation borders to use CSS classes in setup.html

### DIFF
--- a/src/e2e/tauri_onboarding_cross_device.spec.ts
+++ b/src/e2e/tauri_onboarding_cross_device.spec.ts
@@ -122,6 +122,7 @@ test.describe('Tauri Setup UI Cross Device State', () => {
     await page.fill('#admin-password', 'password123');
     await page.getByRole('button', { name: 'Next' }).click();
     await expect(page.locator('#email-error')).toBeVisible();
+    await expect(page.locator('#admin-email')).toHaveClass(/invalid-input/);
   });
 
   test('Setup UI requires at least 8 chars password', async ({ page }) => {
@@ -153,6 +154,7 @@ test.describe('Tauri Setup UI Cross Device State', () => {
     await page.fill('#admin-password', 'pass');
     await page.getByRole('button', { name: 'Next' }).click();
     await expect(page.locator('#password-error')).toBeVisible();
+    await expect(page.locator('#admin-password')).toHaveClass(/invalid-input/);
   });
 
   test('Setup UI allows finishing setup', async ({ page }) => {

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -139,6 +139,11 @@
         text-align: left;
       }
 
+      .invalid-input {
+        border-color: #FF3B30 !important;
+        background-color: rgba(255, 59, 48, 0.05) !important;
+      }
+
       .text-\[\#FF3B30\] { color: #FF3B30 !important; }
       .border-\[\#FF3B30\] { border-color: #FF3B30 !important; }
       .border-\[\#FF3B30\]\/30 { border-color: rgba(255, 59, 48, 0.3) !important; border-width: 1px !important; border-style: solid !important; border-radius: 16px; padding: 10px !important; }
@@ -1654,7 +1659,7 @@
       inputs.name.addEventListener('input', () => {
           if (inputs.name.value.trim().length >= 3) {
               errors.name.style.display = 'none';
-              inputs.name.style.borderColor = 'rgba(255, 255, 255, 0.5)';
+              inputs.name.classList.remove('invalid-input');
           }
           if (inputs.domainName) {
               const suggested = generateSubdomain(inputs.name.value);
@@ -1669,28 +1674,28 @@
       inputs.adminEmail.addEventListener('input', () => {
           if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(inputs.adminEmail.value.trim())) {
               errors.adminEmail.style.display = 'none';
-              inputs.adminEmail.style.borderColor = 'rgba(255, 255, 255, 0.5)';
+              inputs.adminEmail.classList.remove('invalid-input');
           }
       });
 
       inputs.adminPassword.addEventListener('input', () => {
           if (inputs.adminPassword.value.trim().length >= 8 && /\d/.test(inputs.adminPassword.value)) {
               errors.adminPassword.style.display = 'none';
-              inputs.adminPassword.style.borderColor = 'rgba(255, 255, 255, 0.5)';
+              inputs.adminPassword.classList.remove('invalid-input');
           }
       });
 
       inputs.assistantName.addEventListener('input', () => {
           if (inputs.assistantName.value.trim().length > 0) {
               errors.assistantName.style.display = 'none';
-              inputs.assistantName.style.borderColor = 'rgba(255, 255, 255, 0.5)';
+              inputs.assistantName.classList.remove('invalid-input');
           }
       });
 
       inputs.firstOffer.addEventListener('input', () => {
           if (inputs.firstOffer.value.trim().length > 0) {
               errors.firstOffer.style.display = 'none';
-              inputs.firstOffer.style.borderColor = 'rgba(255, 255, 255, 0.5)';
+              inputs.firstOffer.classList.remove('invalid-input');
           }
       });
 
@@ -1808,22 +1813,22 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           else if (stepId === 'step-categories') {
               if (inputs.categories.value.trim() === '') {
                   errors.categories.style.display = 'block';
-                  inputs.categories.style.borderColor = '#FF3B30';
+                  inputs.categories.classList.add('invalid-input');
                   isValid = false;
               } else {
                   errors.categories.style.display = 'none';
-                  inputs.categories.style.borderColor = '';
+                  inputs.categories.classList.remove('invalid-input');
                   state.categories = inputs.categories.value.trim();
               }
           }
           else if (stepId === 'step-name') {
               if (inputs.name.value.trim().length < 3) {
                   errors.name.style.display = 'block';
-                  inputs.name.style.borderColor = '#FF3B30';
+                  inputs.name.classList.add('invalid-input');
                   isValid = false;
               } else {
                   errors.name.style.display = 'none';
-                  inputs.name.style.borderColor = '';
+                  inputs.name.classList.remove('invalid-input');
                   state.businessName = inputs.name.value.trim();
                   state.tagline = inputs.tagline.value.trim();
               }
@@ -1831,21 +1836,21 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           else if (stepId === 'step-assistant') {
               if (inputs.assistantName.value.trim() === '') {
                   errors.assistantName.style.display = 'block';
-                  inputs.assistantName.style.borderColor = '#FF3B30';
+                  inputs.assistantName.classList.add('invalid-input');
                   isValid = false;
               } else {
                   errors.assistantName.style.display = 'none';
-                  inputs.assistantName.style.borderColor = '';
+                  inputs.assistantName.classList.remove('invalid-input');
                   state.assistantName = inputs.assistantName.value.trim();
               }
 
               if (!inputs.assistantTone.value) {
                   errors.assistantTone.style.display = 'block';
-                  inputs.assistantTone.style.borderColor = '#FF3B30';
+                  inputs.assistantTone.classList.add('invalid-input');
                   isValid = false;
               } else {
                   errors.assistantTone.style.display = 'none';
-                  inputs.assistantTone.style.borderColor = '';
+                  inputs.assistantTone.classList.remove('invalid-input');
                   state.assistantTone = inputs.assistantTone.value;
               }
           }
@@ -1857,21 +1862,21 @@ if (state.capabilities && document.getElementById('cap-draft')) {
               if (emailVal === '' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailVal)) {
                   errors.adminEmail.style.display = 'block';
                   errors.adminEmail.innerText = emailVal === '' ? 'Admin Email is required.' : 'Please enter a valid email address.';
-                  inputs.adminEmail.style.borderColor = '#FF3B30';
+                  inputs.adminEmail.classList.add('invalid-input');
                   stepValid = false;
               } else {
                   errors.adminEmail.style.display = 'none';
-                  inputs.adminEmail.style.borderColor = '';
+                  inputs.adminEmail.classList.remove('invalid-input');
               }
 
               if (passVal === '' || passVal.length < 8 || !/\d/.test(passVal)) {
                   errors.adminPassword.style.display = 'block';
                   errors.adminPassword.innerText = passVal === '' ? 'Password is required.' : 'Password must be at least 8 characters and contain a number.';
-                  inputs.adminPassword.style.borderColor = '#FF3B30';
+                  inputs.adminPassword.classList.add('invalid-input');
                   stepValid = false;
               } else {
                   errors.adminPassword.style.display = 'none';
-                  inputs.adminPassword.style.borderColor = '';
+                  inputs.adminPassword.classList.remove('invalid-input');
               }
 
               if (stepValid) {
@@ -1884,11 +1889,11 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           else if (stepId === 'step-offer') {
               if (inputs.firstOffer.value.trim() === '') {
                   errors.firstOffer.style.display = 'block';
-                  inputs.firstOffer.style.borderColor = '#FF3B30';
+                  inputs.firstOffer.classList.add('invalid-input');
                   isValid = false;
               } else {
                   errors.firstOffer.style.display = 'none';
-                  inputs.firstOffer.style.borderColor = '';
+                  inputs.firstOffer.classList.remove('invalid-input');
                   state.first_offer = inputs.firstOffer.value.trim();
               }
           }
@@ -1896,11 +1901,11 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           else if (stepId === 'step-domain') {
               if (inputs.domainName.value.trim().length < 3) {
                   errors.domainName.style.display = 'block';
-                  inputs.domainName.style.borderColor = '#FF3B30';
+                  inputs.domainName.classList.add('invalid-input');
                   isValid = false;
               } else {
                   errors.domainName.style.display = 'none';
-                  inputs.domainName.style.borderColor = '';
+                  inputs.domainName.classList.remove('invalid-input');
                   state.domain = inputs.domainName.value.trim();
               }
           }
@@ -1908,11 +1913,11 @@ if (state.capabilities && document.getElementById('cap-draft')) {
           else if (stepId === 'step-template') {
               if (inputs.templateSelection.value === '') {
                   errors.templateSelection.style.display = 'block';
-                  inputs.templateSelection.style.borderColor = '#FF3B30';
+                  inputs.templateSelection.classList.add('invalid-input');
                   isValid = false;
               } else {
                   errors.templateSelection.style.display = 'none';
-                  inputs.templateSelection.style.borderColor = '';
+                  inputs.templateSelection.classList.remove('invalid-input');
                   state.templateSelection = inputs.templateSelection.value;
               }
           }
@@ -2083,7 +2088,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
               generateStorefrontBtn.disabled = true;
           }
           instantBioInputEl.addEventListener('input', () => {
-              instantBioInputEl.style.borderColor = '';
+              instantBioInputEl.classList.remove('invalid-input');
               if (instantErrorEl) {
                   instantErrorEl.style.display = 'none';
                   instantErrorEl.classList.remove('animate-shake');
@@ -2365,7 +2370,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
                   instantErrorEl.classList.add('animate-shake');
                   instantErrorEl.style.color = '#FF3B30';
                   instantErrorEl.style.borderColor = 'rgba(255, 59, 48, 0.3)';
-                  instantBioInputEl.style.borderColor = '#FF3B30';
+                  instantBioInputEl.classList.add('invalid-input');
                   return;
               }
 
@@ -2373,7 +2378,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
               instantErrorEl.classList.remove('animate-shake');
                   instantErrorEl.style.color = '';
                   instantErrorEl.style.borderColor = '';
-              instantBioInputEl.style.borderColor = '';
+              instantBioInputEl.classList.remove('invalid-input');
               generateStorefrontBtn.disabled = true;
               generateStorefrontBtn.innerHTML = '<div class="spinner" style="border-top-color: #ffffff; width: 20px; height: 20px; border-width: 2px;"></div>Building Your Business...';
               goToStep('step-loading');
@@ -2420,7 +2425,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
                   instantErrorEl.style.display = 'block';
                   instantErrorEl.style.color = '#FF3B30';
                   instantErrorEl.style.borderColor = 'rgba(255, 59, 48, 0.3)';
-                  instantBioInputEl.style.borderColor = '#FF3B30';
+                  instantBioInputEl.classList.add('invalid-input');
                   generateStorefrontBtn.disabled = false;
                   delete generateStorefrontBtn.dataset.submitting;
                   generateStorefrontBtn.innerHTML = "Next";
@@ -2536,7 +2541,7 @@ if (state.capabilities && document.getElementById('cap-draft')) {
                   instantErrorEl.style.display = 'block';
                   instantErrorEl.style.color = '#FF3B30';
                   instantErrorEl.style.borderColor = 'rgba(255, 59, 48, 0.3)';
-                  instantBioInputEl.style.borderColor = '#FF3B30';
+                  instantBioInputEl.classList.add('invalid-input');
                   generateStorefrontBtn.disabled = false;
                   delete generateStorefrontBtn.dataset.submitting;
                   generateStorefrontBtn.innerHTML = "Next";


### PR DESCRIPTION
Refactored inline validation borders to use CSS classes in `setup.html`.

Replaced inline `style.borderColor` manipulation with a consistent `invalid-input`
CSS class according to OHC Premium Design Standards.

Also updated E2E testing to assert against the presence of this new class.

---
*PR created automatically by Jules for task [7804119299169486527](https://jules.google.com/task/7804119299169486527) started by @ql-owo-lp*