### PR TITLE
feat(growth): add owner upgrade CTA to PoweredByOHC widget

### DIFF
--- a/src/ui/next/src/app/components/PoweredByOHC.test.tsx
+++ b/src/ui/next/src/app/components/PoweredByOHC.test.tsx
@@ -25,7 +25,7 @@ describe('PoweredByOHC Component', () => {
     expect(baseLink?.getAttribute('href')).toBe(`/onboarding?ref=${testTenantId}&source=footer_widget`);
   });
 
-  it('shows the popover when hovered', async () => {
+  it('shows the visitor popover when hovered and not owner', async () => {
     render(<PoweredByOHC tenantId={testTenantId} />);
 
     // The popover content shouldn't be there initially
@@ -48,5 +48,30 @@ describe('PoweredByOHC Component', () => {
 
     // CTA button text should be present
     expect(screen.getByText(/Create Your Own/i)).toBeDefined();
+  });
+
+  it('shows the upgrade popover when hovered and is owner', async () => {
+    render(<PoweredByOHC tenantId={testTenantId} isOwner={true} />);
+
+    // The popover content shouldn't be there initially
+    expect(screen.queryByText(/Remove Branding/i)).toBeNull();
+
+    // Find the container wrapper and trigger hover
+    const wrapper = screen.getAllByRole('link')[0].parentElement;
+    if (!wrapper) throw new Error("Wrapper not found");
+
+    fireEvent.mouseEnter(wrapper);
+
+    // Wait for the owner popover content to appear
+    expect(screen.getByText(/Remove Branding/i)).toBeDefined();
+
+    // There should now be two links to the upgrade URL (one in base, one in popover CTA)
+    const links = screen.getAllByRole('link');
+    expect(links.length).toBe(2);
+    expect(links[0].getAttribute('href')).toBe(`/pricing?source=footer_widget_upgrade`);
+    expect(links[1].getAttribute('href')).toBe(`/pricing?source=footer_widget_upgrade`);
+
+    // CTA button text should be present
+    expect(screen.getAllByText(/Upgrade to Pro/i).length).toBeGreaterThan(0);
   });
 });

--- a/src/ui/next/src/app/components/PoweredByOHC.tsx
+++ b/src/ui/next/src/app/components/PoweredByOHC.tsx
@@ -4,10 +4,12 @@ import React, { useState, useEffect, useRef } from 'react';
 
 interface PoweredByOHCProps {
   tenantId: string;
+  isOwner?: boolean;
 }
 
-export function PoweredByOHC({ tenantId }: PoweredByOHCProps) {
+export function PoweredByOHC({ tenantId, isOwner = false }: PoweredByOHCProps) {
   const referralUrl = `/onboarding?ref=${tenantId}&source=footer_widget`;
+  const upgradeUrl = `/pricing?source=footer_widget_upgrade`;
   const [isHovered, setIsHovered] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -56,25 +58,45 @@ export function PoweredByOHC({ tenantId }: PoweredByOHCProps) {
               </div>
             </div>
 
-            <h4 className="text-sm font-bold text-gray-900 font-outfit mb-1">
-              Built with OneHumanCorp
-            </h4>
-            <p className="text-xs text-gray-600 mb-3 leading-relaxed">
-              The AI-powered work assistant for modern owners and operators.
-            </p>
+            {isOwner ? (
+              <>
+                <h4 className="text-sm font-bold text-gray-900 font-outfit mb-1">
+                  Remove Branding
+                </h4>
+                <p className="text-xs text-gray-600 mb-3 leading-relaxed">
+                  Upgrade to Pro to remove this watermark and fully white-label your workspace.
+                </p>
 
-            <a
-              href={referralUrl}
-              className="block w-full py-2 px-4 rounded-xl bg-gray-900 text-white text-xs font-semibold tracking-wide hover:bg-gray-800 transition-colors shadow-sm"
-            >
-              Create Your Own
-            </a>
+                <a
+                  href={upgradeUrl}
+                  className="block w-full py-2 px-4 rounded-xl bg-indigo-600 text-white text-xs font-semibold tracking-wide hover:bg-indigo-700 transition-colors shadow-sm"
+                >
+                  Upgrade to Pro
+                </a>
+              </>
+            ) : (
+              <>
+                <h4 className="text-sm font-bold text-gray-900 font-outfit mb-1">
+                  Built with OneHumanCorp
+                </h4>
+                <p className="text-xs text-gray-600 mb-3 leading-relaxed">
+                  The AI-powered work assistant for modern owners and operators.
+                </p>
+
+                <a
+                  href={referralUrl}
+                  className="block w-full py-2 px-4 rounded-xl bg-gray-900 text-white text-xs font-semibold tracking-wide hover:bg-gray-800 transition-colors shadow-sm"
+                >
+                  Create Your Own
+                </a>
+              </>
+            )}
           </div>
         </div>
       )}
 
       <a
-        href={referralUrl}
+        href={isOwner ? upgradeUrl : referralUrl}
         onClick={handleBaseClick}
         className="group flex items-center gap-2 px-4 py-2 rounded-full border border-gray-200 bg-white/50 backdrop-blur-[30px] saturate-[210%] hover:bg-white/80 hover:shadow-sm transition-all text-xs font-semibold text-gray-500 hover:text-indigo-600 uppercase tracking-widest font-outfit z-10 relative"
       >


### PR DESCRIPTION
🚀 Nova: [Interactive Upgrade Widget in PoweredByOHC]

**Product-use evidence:**
*   **Persona**: Jun - Location Manager / Free Tier Owner
*   **Attempted Flow**: As a free-tier owner browsing their own storefront or dashboard widgets, they see the "Powered by OHC" branding.
*   **Observed Gap**: The widget only acted as a referral link ("Create Your Own Workspace"). If the owner wanted to remove it, there was no immediate, in-context path to upgrade.
*   **The Fix**: Added an `isOwner` prop to `PoweredByOHC`. When viewed by the owner, hovering the widget now displays an "Upgrade to Pro to remove this watermark" message with a direct link to `/pricing`. For regular visitors, it retains the existing viral referral loop behavior.

**Interaction Audit Table:**
| Element | Designed Purpose | Observed Result | Fix |
| --- | --- | --- | --- |
| `PoweredByOHC` link (Visitor) | Open onboarding with referral ref | Navigates to `/onboarding?ref=...` | None needed, preserved default behavior |
| `PoweredByOHC` hover (Visitor) | Show "Create Your Own" popup | Renders "Built with OneHumanCorp" | None needed, preserved default behavior |
| `PoweredByOHC` link (Owner) | Direct owner to pricing to remove branding | Now navigates to `/pricing` | Changed URL to `/pricing` when `isOwner=true` |
| `PoweredByOHC` hover (Owner) | Show upgrade CTA popup | Renders "Remove Branding" CTA | Created conditional UI showing "Upgrade to Pro" |

**Superpowers Skills:**
None strictly used manually for this patch size, but adhered to the workflow guidelines.

**Google Engineering Excellence**:
- Added new test cases in `PoweredByOHC.test.tsx` achieving coverage for both owner and non-owner states.
- Verified components render and behave according to specifications via updated `vitest` suite.

---
*PR created automatically by Jules for task [14144558039968640079](https://jules.google.com/task/14144558039968640079) started by @ql-owo-lp*