### PR TITLE
🔗 Link: [Architecture] Edge-Cached Dynamic Storefronts for Instant Discovery

### DIFF
--- a/src/server/builder/builder_test.rs
+++ b/src/server/builder/builder_test.rs
@@ -213,6 +213,26 @@ async fn test_builder_api() {
         .send().await.unwrap();
     assert_eq!(res.status(), 202); // ACCEPTED
 
+    // Edge Cache Test
+    let res = client.get(&format!("{}/builder/edge/{}/{}", base_url, tenant_id, site.id))
+        .send().await.unwrap();
+    assert_eq!(res.status(), 200);
+    assert_eq!(res.headers().get("Cache-Control").unwrap(), "public, s-maxage=60, stale-while-revalidate=86400");
+    assert!(res.headers().get("Cache-Tag").is_some());
+    assert!(res.headers().get("Surrogate-Key").is_some());
+    assert!(res.headers().get("ETag").is_some());
+
+    // Test cache invalidation via operations agent / cache invalidator
+    let cache = super::edge::get_edge_cache();
+    // Wait briefly for background cache generation from edge fetch
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Send invalidation event like operations agent does
+    cache.invalidate_by_tag(&format!("tenant-id:{}", tenant_id)).await;
+
+    // Cache should be cleared
+    assert!(cache.get(&format!("edge_site_{}_{}_{}", tenant_id, site.id, "en-US")).await.is_none());
+
     // Clean up
     let _ = sqlx::query("DELETE FROM builder_sites WHERE id = $1").bind(site.id).execute(&pool).await;
 }

--- a/src/server/builder/edge.rs
+++ b/src/server/builder/edge.rs
@@ -127,10 +127,18 @@ pub async fn handle_edge_request_impl(
 
     if let Some((mut cached_html, stale)) = cache.get_with_swr(&cache_key).await {
         cached_html = inject_dynamic_inventory(cached_html, tenant_id, &state.pool, cache.clone()).await;
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        std::hash::Hash::hash(&cached_html, &mut hasher);
+        let etag = format!("\"{:x}\"", std::hash::Hasher::finish(&hasher));
+
         let mut response = Html(cached_html).into_response();
         let cache_tag = format!("tenant-id:{}", tenant_id);
-        if let Ok(val) = cache_tag.parse() {
-            response.headers_mut().insert("Cache-Tag", val);
+        if let Ok(val) = cache_tag.parse::<axum::http::HeaderValue>() {
+            response.headers_mut().insert("Cache-Tag", val.clone());
+            response.headers_mut().insert("Surrogate-Key", val);
+        }
+        if let Ok(etag_val) = etag.parse::<axum::http::HeaderValue>() {
+            response.headers_mut().insert(axum::http::header::ETAG, etag_val);
         }
         response.headers_mut().insert(
             CACHE_CONTROL,
@@ -171,11 +179,19 @@ pub async fn handle_edge_request_impl(
         // A real system would use a broadcast channel, but for edge workers returning a slightly delayed or stale is better
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         if let Some((cached_html, _)) = cache.get_with_swr(&cache_key).await {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            std::hash::Hash::hash(&cached_html, &mut hasher);
+            let etag = format!("\"{:x}\"", std::hash::Hasher::finish(&hasher));
+
             let mut response = Html(cached_html).into_response();
-        let cache_tag = format!("tenant-id:{}", tenant_id);
-        if let Ok(val) = cache_tag.parse() {
-            response.headers_mut().insert("Cache-Tag", val);
-        }
+            let cache_tag = format!("tenant-id:{}", tenant_id);
+            if let Ok(val) = cache_tag.parse::<axum::http::HeaderValue>() {
+                response.headers_mut().insert("Cache-Tag", val.clone());
+                response.headers_mut().insert("Surrogate-Key", val);
+            }
+            if let Ok(etag_val) = etag.parse::<axum::http::HeaderValue>() {
+                response.headers_mut().insert(axum::http::header::ETAG, etag_val);
+            }
             response.headers_mut().insert(
                 CACHE_CONTROL,
                 axum::http::HeaderValue::from_static("public, s-maxage=60, stale-while-revalidate=86400"),
@@ -194,11 +210,19 @@ pub async fn handle_edge_request_impl(
     let (mut html, tags) = result?;
     html = inject_dynamic_inventory(html, tenant_id, &state.pool, cache.clone()).await;
 
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::hash::Hash::hash(&html, &mut hasher);
+    let etag = format!("\"{:x}\"", std::hash::Hasher::finish(&hasher));
+
     let mut response = Html(html).into_response();
     if !tags.is_empty() {
-        if let Ok(cache_tag) = tags.join(", ").parse() {
-            response.headers_mut().insert("Cache-Tag", cache_tag);
+        if let Ok(cache_tag) = tags.join(", ").parse::<axum::http::HeaderValue>() {
+            response.headers_mut().insert("Cache-Tag", cache_tag.clone());
+            response.headers_mut().insert("Surrogate-Key", cache_tag);
         }
+    }
+    if let Ok(etag_val) = etag.parse::<axum::http::HeaderValue>() {
+        response.headers_mut().insert(axum::http::header::ETAG, etag_val);
     }
     response.headers_mut().insert(
         CACHE_CONTROL,
@@ -378,6 +402,18 @@ pub async fn regenerate_cache(
             ⚡ Powered by OHC
         </div>
     </div>
+    <script>
+        // Hydrate cart from localStorage to keep edge HTML generic
+        document.addEventListener('DOMContentLoaded', () => {
+            const cartItems = JSON.parse(localStorage.getItem('cart') || '[]');
+            const cartCount = cartItems.reduce((acc, item) => acc + item.quantity, 0);
+            const cartBadge = document.getElementById('cart-badge');
+            if (cartBadge) {
+                cartBadge.innerText = cartCount;
+                cartBadge.style.display = cartCount > 0 ? 'inline-block' : 'none';
+            }
+        });
+    </script>
     </body>
     </html>
     "#);


### PR DESCRIPTION
- Added ETag and Surrogate-Key headers to storefront responses.
- Added client-side cart hydration script to edge storefront response to decouple user specific info.
- Added integration tests to check the headers and operations agent invalidation events.

---
*PR created automatically by Jules for task [14399569121097347795](https://jules.google.com/task/14399569121097347795) started by @ql-owo-lp*

Resolves #30853