### PR TITLE
test(e2e): remove hardcoded fallback database url to enforce hermetic tests

### DIFF
--- a/src/e2e/global-setup.ts
+++ b/src/e2e/global-setup.ts
@@ -2,7 +2,6 @@ import { chromium, type FullConfig } from '@playwright/test';
 
 
 export default async function globalSetup(config: FullConfig) {
-  process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://ohc:ohc@localhost:5432/ohc?sslmode=disable';
   const baseURL = config.projects[0]?.use?.baseURL as string | undefined;
   if (!baseURL) {
     throw new Error('Playwright baseURL is required for e2e global setup.');


### PR DESCRIPTION
This pull request fixes a hermeticity issue in the Playwright E2E test suite setup.

It removes a hardcoded fallback database URL (`localhost:5432`) from `src/e2e/global-setup.ts`. Playwright tests should strictly use the database instance provisioned by the Bazel test runner, which is dynamically exported via the `DATABASE_URL` environment variable. 

This change enforces test hermeticity and prevents tests from accidentally running against a local development database state, which could lead to test pollution and flakiness.

All repository tests (`bazelisk test //...` and `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"`) pass completely with this change.

---
*PR created automatically by Jules for task [7530657772590541862](https://jules.google.com/task/7530657772590541862) started by @ql-owo-lp*