### PR TITLE
Integrate Pydantic-first Schema Validation Endpoint

### DIFF
--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -94,6 +94,7 @@ SERVER_RS_SRCS = [
     "//src/server/api/agents:translation.rs",
     "//src/server/api/agents:webhook.rs",
     "//src/server/api/agents:client_intake.rs",
+    "//src/server/api/agents:pydantic.rs",
     "//src/server/api/onboarding:mod.rs",
     "//src/server/api/inbox:srcs",
     "//src/server/autodream:mod.rs",

--- a/src/server/api/BUILD.bazel
+++ b/src/server/api/BUILD.bazel
@@ -113,6 +113,7 @@ rust_library(
         "//src/server/api/agents:settings.rs",
         "//src/server/api/agents:translation.rs",
         "//src/server/api/agents:webhook.rs",
+        "//src/server/api/agents:pydantic.rs",
         "//src/server/api/onboarding:mod.rs",
         "//src/server/api/booking:mod.rs",
         "//src/server/api/booking:request.rs",

--- a/src/server/api/agents/BUILD.bazel
+++ b/src/server/api/agents/BUILD.bazel
@@ -13,6 +13,7 @@ exports_files(
         "webhook.rs",
         "client_intake.rs",
         "jobs.rs",
+        "pydantic.rs",
 
 
     ],

--- a/src/server/api/agents/mod.rs
+++ b/src/server/api/agents/mod.rs
@@ -6,3 +6,4 @@ pub mod settings;
 pub mod chat;
 pub mod translation;
 pub mod client_intake;
+pub mod pydantic;

--- a/src/server/api/agents/pydantic.rs
+++ b/src/server/api/agents/pydantic.rs
@@ -17,7 +17,7 @@ pub struct PydanticValidateResponse {
     pub is_recoverable: bool,
 }
 
-pub fn router() -> Router {
+pub fn router<S>() -> Router<S> where S: Clone + Send + Sync + 'static, {
     Router::new().route("/", post(validate_pydantic))
 }
 
@@ -72,7 +72,7 @@ async fn validate_pydantic(
                     is_recoverable: false,
                 }),
             )
-                .into();
+                .into_response();
         }
     }
 
@@ -85,7 +85,7 @@ async fn validate_pydantic(
                 is_recoverable,
             }),
         )
-            .into()
+            .into_response()
     } else {
         (
             axum::http::StatusCode::OK,
@@ -95,6 +95,6 @@ async fn validate_pydantic(
                 is_recoverable: false,
             }),
         )
-            .into()
+            .into_response()
     }
 }

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6614,6 +6614,7 @@ async fn create_ui_bom_item_handler(
         .nest("/api/agents/settings", api::agents::settings::router(dept_orchestrator.clone()))
         .nest("/api/agents/chat", api::agents::chat::router(dept_orchestrator.clone(), semantic_router.clone()))
         .nest("/api/agents/webhook", api::agents::webhook::router(dept_orchestrator.clone()))
+        .nest("/api/agents/pydantic", api::agents::pydantic::router())
         .route("/api/v1/feed/ws", axum::routing::get(api::agent_feed::ws_feed_handler))
         .nest("/api/agent-feed", api::agent_feed::router().with_state(db.pool.clone()))
         .nest("/api/sync", api::sync_gateway::router())


### PR DESCRIPTION
Integrates the `Pydantic-first tool schema validation` mechanic into the server's API structure.

The mechanic was implemented, but the frontend route `/api/agents/pydantic` was not properly routed to `src/server/api/agents/pydantic.rs`. This commit connects the `pydantic.rs` module, updates the `BUILD.bazel` files, and fixes the Axum response traits to make the route functional.

---
*PR created automatically by Jules for task [13000079150044150521](https://jules.google.com/task/13000079150044150521) started by @ql-owo-lp*