### PR TITLE
✍️ Scribe: In-App Help Tooltips & Layout Fixes

### DIFF
--- a/src/ui/next/src/app/api-docs/page.tsx
+++ b/src/ui/next/src/app/api-docs/page.tsx
@@ -28,13 +28,13 @@ export default function ApiDocsPage() {
   return (
     <div className="min-h-screen bg-[#F5F5F7]/80 p-8 backdrop-blur-[30px] saturate-[210%] font-inter flex flex-col items-center">
       <style dangerouslySetInnerHTML={{__html: `
-        .swagger-ui { background: white; border-radius: 12px; padding: 24px; }
-        .swagger-ui .wrapper { max-width: 100%; overflow-x: hidden; padding: 0 10px; }
-        .swagger-ui .opblock-body pre { white-space: pre-wrap; word-wrap: break-word; overflow-x: auto; max-width: 100%; }
-        .swagger-ui table { display: block; overflow-x: auto; max-width: 100%; }
-        .swagger-ui .markdown p { word-break: break-word; }
-        .swagger-ui .info { margin: 20px 0; }
-        .swagger-ui .scheme-container { background: transparent; padding: 10px 0; margin-bottom: 20px; border-radius: 12px; box-shadow: none; border: 1px solid rgba(0,0,0,0.1); }
+        .swagger-ui { background: white; border-radius: 12px; padding: 24px; width: 100%; box-sizing: border-box; }
+        .swagger-ui .wrapper { width: 100%; max-width: 100vw; overflow-x: hidden; padding: 0 10px; box-sizing: border-box; }
+        .swagger-ui .opblock-body pre { white-space: pre-wrap; word-wrap: break-word; overflow-x: auto; max-width: 100%; box-sizing: border-box; }
+        .swagger-ui table { display: block; overflow-x: auto; max-width: 100%; box-sizing: border-box; }
+        .swagger-ui .markdown p { word-break: break-word; box-sizing: border-box; }
+        .swagger-ui .info { margin: 20px 0; box-sizing: border-box; }
+        .swagger-ui .scheme-container { background: transparent; padding: 10px 0; margin-bottom: 20px; border-radius: 12px; box-shadow: none; border: 1px solid rgba(0,0,0,0.1); box-sizing: border-box; width: 100%; }
       `}} />
       <div data-testid="api-docs-title" className="w-full max-w-6xl bg-yellow-50/80 backdrop-blur-[30px] saturate-[210%] border-l-4 border-yellow-400 p-4 mb-8 rounded-r-xl shadow-sm font-inter">
         <div className="text-yellow-700 text-sm">


### PR DESCRIPTION
This pull request adds contextual tooltips to the OneHumanCorp Help Center widget as requested in the documentation features spec. It ensures the "close" buttons, "chat send" buttons, and video "close" buttons are properly wrapped with clear, plain-language text using `WithTooltip`. It also fixes a bug causing horizontal scrolling on the Advanced API Reference SwaggerUI pages.

---
*PR created automatically by Jules for task [2904528841710178614](https://jules.google.com/task/2904528841710178614) started by @wbbsuper*