### PR TITLE
Fix cross-tenant token deletion vulnerability

### DIFF
--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -436,7 +436,7 @@ impl UserRepository for PgUserRepository {
         let _ = if should_bypass {
             sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1").bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = current_setting('app.current_tenant')::text").bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?
+            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = $2").bind(now).bind(org_id).execute(&mut *tx).await.map_err(|e| e.to_string())?
         };
 
         tx.commit().await.map_err(|e| e.to_string())?;


### PR DESCRIPTION
Fix cross-tenant token deletion vulnerability

In `src/server/auth/postgres_store.rs`, the `revoke_token` garbage collection logic was previously deleting expired tokens matching the `current_tenant` parameter which could be problematic due to dirty connection pools or unset session variables. It now uses a parameter explicitly bound to `org_id`.

---
*PR created automatically by Jules for task [9262416020153942289](https://jules.google.com/task/9262416020153942289) started by @ql-owo-lp*