### PR TITLE
chore(ui): remove "Powered by OHC" footer from setup.html

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -4231,9 +4231,6 @@ initWalkthrough();
 <!-- Authorized deletion line 997 -->
 <!-- Authorized deletion line 998 -->
 <!-- Authorized deletion line 999 -->
-    <footer style="margin-top: 40px; text-align: center; padding: 24px; font-size: 14px; font-weight: 600; background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(30px) saturate(210%); border-top: 1px solid rgba(255, 255, 255, 0.4); border-radius: 24px 24px 0 0; width: 100%; box-sizing: border-box;">
-      <a href="/setup.html?ref=website-builder" id="dashboard-footer-viral-link" style="color: #0066FF; text-decoration: none; display: flex; align-items: center; justify-content: center; gap: 8px;">
-        <span style="background: #0066FF; color: white; padding: 4px 8px; border-radius: 16px; font-size: 10px; font-weight: 800;">OHC</span>
-        Powered by OHC
-      </a>
-    </footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Removed the "Powered by OHC" footer from the `src/ui/tauri/src/ui/setup.html` page to align with the premium UI/UX standards, as part of continuous optimization tasks. Verified the changes locally to ensure no loss of core functionality or UI test failures.

---
*PR created automatically by Jules for task [15255201663745888810](https://jules.google.com/task/15255201663745888810) started by @ql-owo-lp*