### PR TITLE
feat(integrations): Implement WhatsApp Business egress and config endpoints

### DIFF
--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -41,6 +41,7 @@ SERVER_RS_SRCS = [
     "//src/server/api:payment_ledger.rs",
     "//src/server/api:billing_api.rs",
     "//src/server/api:work_triage.rs",
+    "//src/server/api:settings_integrations.rs",
     "//src/server/api:billing_webhook.rs",
     "//src/server/api:billing_webhook_test.rs",
     "//src/server/api:billing_api_test.rs",

--- a/src/server/api/BUILD.bazel
+++ b/src/server/api/BUILD.bazel
@@ -1,12 +1,14 @@
 
 exports_files([
-        "work_triage.rs","chaos.rs", "sync_gateway.rs"])
+        "work_triage.rs",
+        "settings_integrations.rs","chaos.rs", "sync_gateway.rs"])
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 
 exports_files(
     [
         "work_triage.rs",
+        "settings_integrations.rs",
         "assistant.rs",
         "autodream.rs",
         "terminal_api.rs",
@@ -59,6 +61,7 @@ rust_library(
     name = "server_api",
     srcs = [
         "work_triage.rs",
+        "settings_integrations.rs",
         "assistant.rs",
         "terminal_api.rs",
         "payment_ledger.rs",

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -52,3 +52,4 @@ pub mod proposals;
 pub mod storefront_delivery;
 pub mod unified_inbox_webhook;
 pub mod work_triage;
+pub mod settings_integrations;

--- a/src/server/api/settings_integrations.rs
+++ b/src/server/api/settings_integrations.rs
@@ -1,0 +1,88 @@
+use axum::{
+    extract::{Extension, State},
+    response::IntoResponse,
+    http::StatusCode,
+    routing::post,
+    Router,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use ::server_common::Claims;
+use sqlx::PgPool;
+
+#[derive(Deserialize, Serialize, Clone)]
+pub struct ConnectIntegrationRequest {
+    #[serde(default)]
+    pub integration_id: String,
+    #[serde(default)]
+    pub base_url: String,
+    #[serde(default)]
+    pub bot_token: String,
+    #[serde(default)]
+    pub chat_id: String,
+    #[serde(default)]
+    pub webhook_url: String,
+    #[serde(default)]
+    pub api_token: String,
+    #[serde(default)]
+    pub from_phone: String,
+}
+
+#[derive(Serialize)]
+pub struct SettingResponse {
+    pub success: bool,
+}
+
+pub async fn whatsapp_handler(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Json(payload): Json<ConnectIntegrationRequest>,
+) -> impl IntoResponse {
+    let tenant_id = match claims.organization_id.as_deref() {
+        Some(org_id) => org_id.to_string(),
+        None => return (StatusCode::UNAUTHORIZED, Json(SettingResponse { success: false })).into_response(),
+    };
+
+    let result = sqlx::query(
+        "INSERT INTO settings (tenant_id, twilio_whatsapp_config) VALUES ($1, $2) ON CONFLICT (tenant_id) DO UPDATE SET twilio_whatsapp_config = $2"
+    )
+    .bind(&tenant_id)
+    .bind(sqlx::types::Json(&payload))
+    .execute(&pool)
+    .await;
+
+    match result {
+        Ok(_) => (StatusCode::OK, Json(SettingResponse { success: true })).into_response(),
+        Err(e) => {
+            tracing::error!("Failed to save Twilio WhatsApp config: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(SettingResponse { success: false })).into_response()
+        }
+    }
+}
+
+pub async fn whatsapp_cloud_api_handler(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Json(payload): Json<ConnectIntegrationRequest>,
+) -> impl IntoResponse {
+    let tenant_id = match claims.organization_id.as_deref() {
+        Some(org_id) => org_id.to_string(),
+        None => return (StatusCode::UNAUTHORIZED, Json(SettingResponse { success: false })).into_response(),
+    };
+
+    let result = sqlx::query(
+        "INSERT INTO settings (tenant_id, meta_whatsapp_config) VALUES ($1, $2) ON CONFLICT (tenant_id) DO UPDATE SET meta_whatsapp_config = $2"
+    )
+    .bind(&tenant_id)
+    .bind(sqlx::types::Json(&payload))
+    .execute(&pool)
+    .await;
+
+    match result {
+        Ok(_) => (StatusCode::OK, Json(SettingResponse { success: true })).into_response(),
+        Err(e) => {
+            tracing::error!("Failed to save Meta WhatsApp Cloud API config: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(SettingResponse { success: false })).into_response()
+        }
+    }
+}

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -731,6 +731,13 @@ impl DB {
             }
             DbStore::Sqlite(sqlite_pool) => {
                 let schema = r#"
+                    CREATE TABLE IF NOT EXISTS settings (
+                        tenant_id TEXT PRIMARY KEY,
+                        sms_critical_phone TEXT,
+                        voice_receptionist_number TEXT,
+                        twilio_whatsapp_config TEXT,
+                        meta_whatsapp_config TEXT
+                    );
                     CREATE TABLE IF NOT EXISTS agent_session_data (
                         session_id TEXT PRIMARY KEY,
                         agent_id TEXT NOT NULL,

--- a/src/server/domain/inbox.rs
+++ b/src/server/domain/inbox.rs
@@ -2,6 +2,10 @@ use sqlx::PgPool;
 use serde_json::Value;
 
 pub async fn handle_inbox_action(tenant_id: &str, payload: &Value, pool: &PgPool) -> Result<(), sqlx::Error> {
+    let mut draft_reply_str = String::new();
+    let mut sender_id_str = String::new();
+    let mut source_str = String::new();
+
     if let Some(inbox_id) = payload.get("inbox_message_id").and_then(|v| v.as_str()) {
         tracing::info!("Approved ambassador reply for inbox message: {}", inbox_id);
 
@@ -13,6 +17,8 @@ pub async fn handle_inbox_action(tenant_id: &str, payload: &Value, pool: &PgPool
             .await?;
 
         let draft_reply = payload.get("generated_response").or_else(|| payload.get("draft_reply")).and_then(|v| v.as_str()).unwrap_or("");
+        draft_reply_str = draft_reply.to_string();
+
         tracing::info!("Approved Ambassador draft reply for inbox_id: {}", inbox_id);
         sqlx::query("UPDATE omni_inbox_messages SET status = 'sent', draft_reply = $1 WHERE id = $2 AND tenant_id = $3")
             .bind(draft_reply)
@@ -20,6 +26,87 @@ pub async fn handle_inbox_action(tenant_id: &str, payload: &Value, pool: &PgPool
             .bind(tenant_id)
             .execute(pool)
             .await?;
+
+        // Fallback fetch sender details from omni_inbox_messages if not in payload
+        sender_id_str = payload.get("sender_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        source_str = payload.get("source").and_then(|v| v.as_str()).unwrap_or("").to_string();
+
+        if sender_id_str.is_empty() || source_str.is_empty() {
+            use sqlx::Row;
+            if let Ok(Some(row)) = sqlx::query("SELECT sender_id, source FROM omni_inbox_messages WHERE id = $1 AND tenant_id = $2")
+                .bind(inbox_id)
+                .bind(tenant_id)
+                .fetch_optional(pool)
+                .await
+            {
+                if sender_id_str.is_empty() {
+                    sender_id_str = row.try_get("sender_id").unwrap_or_else(|_| "".to_string());
+                }
+                if source_str.is_empty() {
+                    source_str = row.try_get("source").unwrap_or_else(|_| "".to_string());
+                }
+            }
+        }
     }
+
+    if !sender_id_str.is_empty() && (source_str == "whatsapp" || source_str == "instagram_dm" || source_str == "instagram") {
+        use sqlx::Row;
+
+        // Try Twilio first
+        let twilio_query: Result<Option<sqlx::postgres::PgRow>, _> = sqlx::query("SELECT twilio_whatsapp_config FROM settings WHERE tenant_id = $1")
+            .bind(tenant_id)
+            .fetch_optional(pool)
+            .await;
+
+        let mut handled = false;
+
+        if let Ok(Some(row)) = twilio_query {
+            let twilio_val: Option<serde_json::Value> = row.try_get("twilio_whatsapp_config").unwrap_or(None);
+            if let Some(twilio_cfg) = twilio_val {
+                if let (Some(sid), Some(token), Some(from)) = (
+                    twilio_cfg.get("bot_token").and_then(|v| v.as_str()),
+                    twilio_cfg.get("api_token").and_then(|v| v.as_str()),
+                    twilio_cfg.get("from_phone").and_then(|v| v.as_str())
+                ) {
+                    if !sid.is_empty() && !token.is_empty() {
+                        tracing::info!("Sending WhatsApp message via Twilio for tenant {}", tenant_id);
+                        let client = crate::integrations::twilio::provider::TwilioProvider::new(sid.to_string(), token.to_string());
+                        if let Err(e) = client.send_whatsapp(&sender_id_str, from, &draft_reply_str).await {
+                            tracing::error!("Twilio send_whatsapp failed: {}", e);
+                        } else {
+                            handled = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fallback to Meta Cloud API
+        if !handled {
+            let meta_query: Result<Option<sqlx::postgres::PgRow>, _> = sqlx::query("SELECT meta_whatsapp_config FROM settings WHERE tenant_id = $1")
+                .bind(tenant_id)
+                .fetch_optional(pool)
+                .await;
+
+            if let Ok(Some(row)) = meta_query {
+                let meta_val: Option<serde_json::Value> = row.try_get("meta_whatsapp_config").unwrap_or(None);
+                if let Some(meta_cfg) = meta_val {
+                    if let Some(token) = meta_cfg.get("api_token").and_then(|v| v.as_str()) {
+                        if !token.is_empty() {
+                            tracing::info!("Sending WhatsApp message via Meta for tenant {}", tenant_id);
+                            // We need to use RealMetaClient directly because we need MetaClientWrapper's send_message
+                            use crate::integrations::meta::client::MetaClientWrapper;
+                            let client = crate::integrations::meta::client::RealMetaClient::new(token.to_string());
+                            let platform = if source_str == "instagram" || source_str == "instagram_dm" { "instagram" } else { "whatsapp" };
+                            if let Err(e) = client.send_message(platform, &sender_id_str, &draft_reply_str).await {
+                                tracing::error!("Meta send_message failed: {}", e);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     Ok(())
 }

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6113,6 +6113,8 @@ async fn create_ui_bom_item_handler(
                 axum::response::Json(serde_json::json!({ "success": true }))
             }
         }))
+        .route("/api/v1/settings/integrations/whatsapp", axum::routing::post({ let pool = db.pool.clone(); move |claims, payload| api::settings_integrations::whatsapp_handler(axum::extract::State(pool), claims, payload) }))
+        .route("/api/v1/settings/integrations/whatsapp_cloud_api", axum::routing::post({ let pool = db.pool.clone(); move |claims, payload| api::settings_integrations::whatsapp_cloud_api_handler(axum::extract::State(pool), claims, payload) }))
         .route("/api/settings/voice/provision", axum::routing::post({
             let settings_store = settings_store.clone();
             move |axum::extract::Extension(_user): axum::extract::Extension<::server_common::Claims>| async move {

--- a/src/server/migrations/158_settings_whatsapp.sql
+++ b/src/server/migrations/158_settings_whatsapp.sql
@@ -1,0 +1,3 @@
+CREATE TABLE IF NOT EXISTS settings (tenant_id TEXT PRIMARY KEY, sms_critical_phone TEXT, voice_receptionist_number TEXT, twilio_whatsapp_config JSONB, meta_whatsapp_config JSONB);
+ALTER TABLE settings ADD COLUMN IF NOT EXISTS twilio_whatsapp_config JSONB;
+ALTER TABLE settings ADD COLUMN IF NOT EXISTS meta_whatsapp_config JSONB;


### PR DESCRIPTION
This pull request fully implements the backend requirement for integrating WhatsApp Business (Issue #30895). It establishes the infrastructure for saving WhatsApp provider configurations (Twilio and Meta Cloud API) and correctly dispatches AI-drafted replies back to the customer.\n\n### Changes Made:\n1. **Database Config:** \n   - Created a migration (`158_settings_whatsapp.sql`) to extend the `settings` table with JSON columns for Twilio and Meta WhatsApp configurations.\n   - Updated `src/server/db.rs` to include these schema definitions for new deployments.\n2. **Settings API:** \n   - Implemented `api/v1/settings/integrations/whatsapp` and `api/v1/settings/integrations/whatsapp_cloud_api` (in a new `settings_integrations.rs` module) to properly catch and persist the configurations sent from the frontend `Next.js` interface.\n3. **Message Egress (Dispatching):**\n   - Updated the `handle_inbox_action` module (`src/server/domain/inbox.rs`), resolving a missing egress step where AI drafted replies were updated in the DB but never sent over the wire.\n   - Now, when an action's source is `whatsapp`, `instagram`, or `instagram_dm`, the backend retrieves the respective connection settings from the `settings` table and instantiates the `TwilioProvider` or `MetaClient` to send the outbound message securely.\n\n### Testing & Verification:\n- `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"` completed and passed (asserting integration UI configuration and draft replies mapping correctly).\n- `bazel test //src/server/...` completed entirely ensuring no unit/integration tests failed under the core Rust server.\n\nSuperpowers skill loaded: N/A\n\nInteraction Audit Table: N/A (Focusing on Egress API & Backend architecture)\n\nResolves #30895

---
*PR created automatically by Jules for task [6553160114115435632](https://jules.google.com/task/6553160114115435632) started by @ql-owo-lp*

Resolves #30895