### PR TITLE
✍️ Scribe: Implement API Documentation access in Help Center

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -92,6 +92,7 @@ pub fn get_articles() -> Vec<HelpArticle> {
         HelpArticle { category: "AI Agents".to_string(), title: "Activate AI Support".to_string(), desc: "Let our AI handle customer inquiries and triage your inbox.".to_string(), link: "/help/ai-support".to_string() },
         HelpArticle { category: "Marketing".to_string(), title: "Grow Your Audience".to_string(), desc: "Use our built-in tools to run promotions and track performance.".to_string(), link: "/help/marketing-tools".to_string() },
         HelpArticle { category: "Account & Billing".to_string(), title: "Manage Billing".to_string(), desc: "Update your subscription and payment methods.".to_string(), link: "/help/billing-settings".to_string() },
+        HelpArticle { category: "Advanced".to_string(), title: "API Documentation".to_string(), desc: "Interactive API reference for connecting external services to your workspace.".to_string(), link: "/api-docs".to_string() },
     ]
 }
 

--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -34,6 +34,7 @@ export default function HelpCenterPage() {
   }, []);
 
   const filteredArticles = articles.filter(a => a.category !== "Advanced");
+  const advancedArticles = articles.filter(a => a.category === "Advanced");
 
   const filteredVideos = videos.filter(video =>
     video.title.toLowerCase().includes(debouncedSearchQuery.toLowerCase())
@@ -110,6 +111,29 @@ export default function HelpCenterPage() {
             {filteredVideos.length > 0 && (
               <div className="pt-4">
                  <VideoTutorialList videos={filteredVideos} loading={false} />
+              </div>
+            )}
+
+            {advancedArticles.length > 0 && (
+              <div className="space-y-10 sm:space-y-12 flex flex-col pt-8">
+                {Array.from(new Set(advancedArticles.map(a => a.category || "General"))).map((category) => (
+                  <section key={category} className="flex flex-col">
+                    <div className="flex items-center mb-4 sm:mb-6">
+                      <h2 className="text-xl sm:text-2xl font-bold font-outfit text-gray-900">{category}</h2>
+                      <div className="ml-4 flex-grow border-t border-gray-200/50"></div>
+                    </div>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 flex-col">
+                      {advancedArticles.filter(a => (a.category || "General") === category).map((article, idx) => (
+                        <Link key={idx} href={article.link} className="block group">
+                          <div className="backdrop-blur-[40px] saturate-[210%] bg-white/70 dark:bg-white/10 border border-white/40 p-5 sm:p-6 rounded-[24px] shadow-[0_8px_32px_rgba(0,0,0,0.08)] group-hover:border-blue-300 group-hover:shadow-[0_0_15px_rgba(59,130,246,0.5)] group-hover:-translate-y-1 hover:bg-white/80 transition-all duration-300 cursor-pointer h-full flex flex-col min-h-[120px] sm:min-h-[140px]">
+                            <h3 className="text-lg sm:text-xl font-bold font-outfit text-blue-600 mb-2 sm:mb-3 group-hover:text-blue-700">{article.title}</h3>
+                            <p className="text-sm sm:text-base text-gray-600 leading-relaxed flex-grow">{article.desc}</p>
+                          </div>
+                        </Link>
+                      ))}
+                    </div>
+                  </section>
+                ))}
               </div>
             )}
           </div>


### PR DESCRIPTION
✍️ Scribe: [new documentation feature] Add Advanced API Documentation section and API Route docs.

### Product-use evidence
**Persona**: Nora - Agency Principal / Developer proxy  
**CUJ Attempted**: Nora wants to integrate a custom tool and needs API documentation. She logs into OHC, clicks the "?" help icon, scrolls to the bottom for developer resources, and clicks "API Documentation" to open the Swagger UI reference.  
**CUJ Gap Observed**: The `/api-docs` URL existed, but no link was shown anywhere for technical owners to access it from the standard Help Center.  
**Fix**: Added the `Advanced` category with the "API Documentation" link to the help backend API. Rendered this specifically at the very bottom of the Help Center so non-technical users aren't confused, but operators who need API integrations can find it.  
**Superpowers Applied**: Loaded `superpowers/ux` for transparent UI elements, testing methodology applied.

### Implementation Details:
- Appended `Advanced` category link in `src/server/api/docs.rs`.
- Separated `advancedArticles` in `src/ui/next/src/app/help/page.tsx` rendering it below `VideoTutorialList` so it doesn't pollute normal articles.
- Verified `/api-docs` page exists and functions properly as the swagger UI via playwright E2E screenshot checks.

---
*PR created automatically by Jules for task [8871760241613672346](https://jules.google.com/task/8871760241613672346) started by @ql-owo-lp*