### PR TITLE
⚙️ Triage Feed: Add missing SQLite test schemas and fix E2E test IDs

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -882,7 +882,36 @@ impl DB {
                     CREATE INDEX IF NOT EXISTS idx_customer_timeline_tenant_customer ON customer_timeline(tenant_id, customer_id);
                     CREATE INDEX IF NOT EXISTS idx_shared_tasks_organization_id ON shared_tasks(organization_id);
                     CREATE INDEX IF NOT EXISTS idx_shared_tasks_status ON shared_tasks(status);
-                    CREATE TABLE IF NOT EXISTS omni_inbox_messages (
+
+                    CREATE TABLE IF NOT EXISTS triage_items (
+                        id TEXT PRIMARY KEY,
+                        tenant_id TEXT NOT NULL,
+                        customer_id TEXT,
+                        source TEXT,
+                        priority TEXT,
+                        context TEXT,
+                        status TEXT DEFAULT 'pending',
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    );
+                    CREATE TABLE IF NOT EXISTS triage_proposed_actions (
+                        id TEXT PRIMARY KEY,
+                        triage_item_id TEXT NOT NULL REFERENCES triage_items(id) ON DELETE CASCADE,
+                        tenant_id TEXT NOT NULL,
+                        action_type TEXT,
+                        payload TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    );
+                    CREATE TABLE IF NOT EXISTS auto_reply_policies (
+                        id TEXT PRIMARY KEY,
+                        tenant_id TEXT NOT NULL,
+                        enabled BOOLEAN NOT NULL DEFAULT 1,
+                        delay_minutes INTEGER NOT NULL DEFAULT 5,
+                        tone_instructions TEXT DEFAULT '',
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        UNIQUE(tenant_id)
+                    );
+CREATE TABLE IF NOT EXISTS omni_inbox_messages (
                         id TEXT PRIMARY KEY,
                         tenant_id TEXT NOT NULL,
                         source TEXT NOT NULL,

--- a/src/ui/next/src/components/feed/AgentActionCard.tsx
+++ b/src/ui/next/src/components/feed/AgentActionCard.tsx
@@ -1489,7 +1489,7 @@ export const AgentActionCard: React.FC<AgentActionCardProps> = ({
               }
               className="w-full min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-green-500 text-white font-medium hover:bg-green-600 transition-all duration-200 shadow-md flex items-center justify-center mb-3"
               aria-label="Approve proposal"
-              data-testid="approve-proposal"
+              data-testid={`triage-approve-${approval.id}`}
             >
               Approve
             </button>


### PR DESCRIPTION
This PR addresses failures in the Playwright E2E test suite related to the Work Triage Feed workflow.

-   **Backend:** Added missing table schemas (`triage_items`, `triage_proposed_actions`, `auto_reply_policies`) to the `DbStore::Sqlite` memory database initialization in `src/server/db.rs`. This resolves the 500 Internal Server Errors encountered when simulating triage items in test mode.
-   **Frontend:** Updated the `data-testid` for the approval button in `src/ui/next/src/components/feed/AgentActionCard.tsx` from the hardcoded `approve-proposal` to the dynamic `triage-approve-${approval.id}` expected by `triage-feed-agent.spec.ts`.

Both unit and Playwright E2E tests are now fully passing locally.

Resolves #30854

---
*PR created automatically by Jules for task [14757840959790923951](https://jules.google.com/task/14757840959790923951) started by @ql-owo-lp*