### PR TITLE
feat: Zero-click conversational onboarding

### DIFF
--- a/src/ui/next/src/app/onboarding/page.test.tsx
+++ b/src/ui/next/src/app/onboarding/page.test.tsx
@@ -838,7 +838,7 @@ describe('OnboardingWizard', () => {
     await user.click(backButton);
 
     expect(screen.getByText('10-Minute Setup Wizard')).toBeInTheDocument();
-    expect(useOnboardingStore.getState().step).toBe(0);
+    expect(useOnboardingStore.getState().step).toBe(-2);
   });
 
   it('Step 3: Passes initial_products from localStorage to /api/onboarding/start', async () => {

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -112,8 +112,8 @@ export default function OnboardingWizard() {
     updateState({ error: '' });
     setValidationError('');
     setValidationErrors({});
-    updateState({ step: 0 });
-    syncStateToBackend({ step: 0 });
+    updateState({ step: -2 });
+    syncStateToBackend({ step: -2 });
   };
 
   const handleSaveDraft = async () => {
@@ -637,7 +637,7 @@ export default function OnboardingWizard() {
             </div>
           )}
 
-          {step === 0 && (
+          {step === -2 && (
             <div className="flex flex-col justify-center items-center gap-4 flex-1 animate-fade-in">
               <div className="w-16 h-16 bg-[#eef2ff] dark:bg-[#0066FF]/20 rounded-full flex items-center justify-center mb-6">
                 <svg className="w-8 h-8 text-[#0066FF]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -674,9 +674,9 @@ export default function OnboardingWizard() {
             </div>
           )}
 
-          {step === -2 && (
+          {step === 0 && (
             <div className="flex flex-col flex-1 animate-fade-in w-full h-full max-h-full">
-              <button onClick={() => { updateState({ step: 0 }); syncStateToBackend({ step: 0 }); }} className="self-start text-[#0066FF] text-sm font-semibold mb-4 flex items-center gap-1 min-h-[44px] min-w-[44px] p-2">
+              <button onClick={() => { updateState({ step: -2 }); syncStateToBackend({ step: -2 }); }} className="self-start text-[#0066FF] text-sm font-semibold mb-4 flex items-center gap-1 min-h-[44px] min-w-[44px] p-2">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg> Back
               </button>
               <h2 className="text-3xl font-bold font-outfit text-[#1D1D1F] dark:text-[#F5F5F7] mb-2 text-center">Setup Assistant</h2>
@@ -724,8 +724,8 @@ export default function OnboardingWizard() {
                     <input
                       type="text"
                       id="chat-input"
-                      value={bio}
-                      onChange={(e) => updateState({ bio: e.target.value })}
+                      value={chatInput}
+                      onChange={(e) => setChatInput(e.target.value)}
                       onKeyDown={(e) => {
                          if (e.key === 'Enter') handleSendChatMessage();
                       }}
@@ -749,7 +749,7 @@ export default function OnboardingWizard() {
 
           {step === -1 && (
             <div className="flex flex-col justify-center items-center gap-4 flex-1 animate-fade-in">
-              <button onClick={() => { updateState({ step: 0 }); syncStateToBackend({ step: 0 }); }} className="self-start text-[#0066FF] text-sm font-semibold mb-4 flex items-center gap-1 min-h-[44px] min-w-[44px] p-2">
+              <button onClick={() => { updateState({ step: -2 }); syncStateToBackend({ step: -2 }); }} className="self-start text-[#0066FF] text-sm font-semibold mb-4 flex items-center gap-1 min-h-[44px] min-w-[44px] p-2">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg> Back
               </button>
               <h2 className="text-3xl font-bold font-outfit text-[#1D1D1F] dark:text-[#F5F5F7] mb-2">Tell us about your business</h2>
@@ -807,7 +807,7 @@ export default function OnboardingWizard() {
 
               {chatStep === 1 && (
                 <div className="flex flex-col justify-center items-center gap-4 flex-1 animate-fade-in">
-                  <button onClick={() => { updateState({ step: 0 }); syncStateToBackend({ step: 0 }); }} className="self-start text-[#0066FF] text-sm font-semibold mb-4 flex items-center gap-1">
+                  <button onClick={() => { updateState({ step: -2 }); syncStateToBackend({ step: -2 }); }} className="self-start text-[#0066FF] text-sm font-semibold mb-4 flex items-center gap-1">
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg> Back
                   </button>
                   <h2 className="text-3xl font-bold font-outfit text-[#1D1D1F] dark:text-[#F5F5F7] mb-2">What's the name of your business?</h2>


### PR DESCRIPTION
feat(onboarding): implement zero-click conversational onboarding

Resolves #30913

This PR replaces the default multi-step onboarding wizard with a conversational AI "Zero-Click Onboarding Agent".

Key changes:
- Swapped `step: 0` (Setup Assistant) and `step: -2` (10-Minute Setup Wizard) so the conversational UI is the default view.
- Removed the manual friction where users without admin email/password were forcibly sent to the manual form. The onboarding now proceeds seamlessly to API `/start` and `/launch`.
- Users are seamlessly redirected to the `/dashboard` upon successful setup launch.
- Fixed a local regression involving the manual intro `instant-bio` state mapping to match the original architecture while still passing unit tests.

---
*PR created automatically by Jules for task [18046520150308703424](https://jules.google.com/task/18046520150308703424) started by @ql-owo-lp*