### PR TITLE
fix: Update backend tier pricing to match frontend

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -182,9 +182,9 @@ pub async fn create_checkout_session_handler(
 
     if let Some(tier) = &req.tier {
         amount_usd = match tier.to_lowercase().as_str() {
-            "starter" => 29.0,
-            "pro" => 79.0,
-            "business" => 299.0,
+            "starter" => 9.0,
+            "pro" => 29.0,
+            "business" => 79.0,
             _ => return Err(StatusCode::BAD_REQUEST),
         };
         item_name = tier.clone();

--- a/src/server/pricing/rate_limit.rs
+++ b/src/server/pricing/rate_limit.rs
@@ -101,9 +101,9 @@ impl PlanTier {
     pub fn base_price(&self) -> f64 {
         match self {
             PlanTier::Free => 0.0,
-            PlanTier::Starter => 29.0,
-            PlanTier::Pro => 79.0,
-            PlanTier::Business => 299.0,
+            PlanTier::Starter => 9.0,
+            PlanTier::Pro => 29.0,
+            PlanTier::Business => 79.0,
         }
     }
 
@@ -463,9 +463,9 @@ mod tests {
         assert_eq!(PlanTier::Business.max_products(), None);
 
         assert_eq!(PlanTier::Free.base_price(), 0.0);
-        assert_eq!(PlanTier::Starter.base_price(), 29.0);
-        assert_eq!(PlanTier::Pro.base_price(), 79.0);
-        assert_eq!(PlanTier::Business.base_price(), 299.0);
+        assert_eq!(PlanTier::Starter.base_price(), 9.0);
+        assert_eq!(PlanTier::Pro.base_price(), 29.0);
+        assert_eq!(PlanTier::Business.base_price(), 79.0);
     }
 
     #[test]


### PR DESCRIPTION
The pricing displayed on the frontend for subscription tiers was not correctly reflected in the backend billing and checkout logic. This PR updates `src/server/pricing/rate_limit.rs` and `src/server/api/billing_api.rs` to reflect the correct, lowered pricing of:
- Starter: $9/mo
- Pro: $29/mo
- Business: $79/mo

---
*PR created automatically by Jules for task [4185346325164438470](https://jules.google.com/task/4185346325164438470) started by @ql-owo-lp*