### PR TITLE
fix: adjust mobile padding on the onboarding wizard step 4 to prevent layout overflow

### DIFF
--- a/src/e2e/wizard_mobile_layout.spec.ts
+++ b/src/e2e/wizard_mobile_layout.spec.ts
@@ -83,4 +83,25 @@ test.describe('Wizard and Onboarding flows', () => {
 
     await expect(page.locator('#business-categories')).toBeVisible();
   });
+
+  test('Loading state padding check on mobile layout', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/onboarding');
+
+    // Attempt to access step 4 loading state directly if possible, or intercept network and check
+    await page.evaluate(() => {
+        window.localStorage.setItem('onboarding-storage-v4', JSON.stringify({
+            state: { step: 4 }
+        }));
+    });
+
+    await page.reload();
+
+    // Check loading indicator container doesn't overflow
+    const container = page.locator('.animate-fade-in');
+    await expect(container).toBeVisible();
+
+    const containerWidth = await container.evaluate(el => el.clientWidth);
+    expect(containerWidth).toBeLessThanOrEqual(375);
+  });
 });

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -1414,7 +1414,7 @@ export default function OnboardingWizard() {
           )}
 
           {step === 4 && (
-             <div aria-live="polite" className="flex flex-col flex-1 justify-center items-center text-center animate-fade-in bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] backdrop-saturate-[210%] border border-white/40 dark:border-white/10 rounded-[16px] shadow-2xl p-8">
+             <div aria-live="polite" className="flex flex-col flex-1 justify-center items-center text-center animate-fade-in bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] backdrop-saturate-[210%] border border-white/40 dark:border-white/10 rounded-[16px] shadow-2xl p-4 sm:p-8">
                <div className="w-24 h-24 relative mb-8">
                  <div className="absolute inset-0 border-4 border-[#0066FF]/20 rounded-full"></div>
                  <div className="absolute inset-0 border-4 border-[#0066FF] rounded-full border-t-transparent animate-spin"></div>


### PR DESCRIPTION
Changed a hardcoded `p-8` style to `p-4 sm:p-8` in the `src/ui/next/src/app/onboarding/page.tsx` file to fix an overflow issue on 375px mobile screens, and also created a Playwright E2E test verifying this adjustment.

---
*PR created automatically by Jules for task [6983383218199178882](https://jules.google.com/task/6983383218199178882) started by @ql-owo-lp*