### PR TITLE
fix: TooltipRegistry test console error mock restore

### DIFF
--- a/src/ui/next/src/components/TooltipRegistry.test.tsx
+++ b/src/ui/next/src/components/TooltipRegistry.test.tsx
@@ -99,16 +99,18 @@ describe('TooltipRegistry', () => {
 describe('useTooltip Hook sync', () => {
   it('throws an error if used outside TooltipProvider', () => {
     const originalError = console.error;
-    console.error = vi.fn();
+    console.error = () => {};
 
     const TestComponent = () => {
       useTooltip();
       return <div />;
     };
 
-    expect(() => render(<TestComponent />)).toThrow('useTooltip must be used within a TooltipProvider');
-
-    console.error = originalError;
+    try {
+      expect(() => render(<TestComponent />)).toThrow('useTooltip must be used within a TooltipProvider');
+    } finally {
+      console.error = originalError;
+    }
   });
 });
 


### PR DESCRIPTION
The test `useTooltip Hook sync` in `TooltipRegistry.test.tsx` was overriding `console.error` but could potentially fail to restore it if the assertion inside threw. This PR fixes this by ensuring `console.error` is always restored using a `try/finally` block.

---
*PR created automatically by Jules for task [2118068175330945383](https://jules.google.com/task/2118068175330945383) started by @ql-owo-lp*