### PR TITLE
🤖 Implementer: Harness Upgrade - Verification Loops

### DIFF
--- a/src/agents/builtin/actor_model.rs
+++ b/src/agents/builtin/actor_model.rs
@@ -51,7 +51,10 @@ impl ActorSystem {
     /// SOTA Harness Patterns (2025-2026): 1. Actor-model message passing
     /// Spawns a new actor and returns its handle, encapsulating the channel setup
     /// and registration logic required by the actor framework.
-    pub async fn spawn<A: Actor + 'static>(self: &Arc<Self>, actor: A) -> tokio::task::JoinHandle<()> {
+    pub async fn spawn<A: Actor + 'static>(
+        self: &Arc<Self>,
+        actor: A,
+    ) -> tokio::task::JoinHandle<()> {
         let (tx, rx) = mpsc::channel(100);
         let name = actor.name();
 
@@ -930,11 +933,15 @@ mod tests {
 
         struct DummyActor;
         impl Actor for DummyActor {
-            fn name(&self) -> String { "dummy".to_string() }
-            fn start(&self, mut rx: mpsc::Receiver<ActorMessage>, _sys: Arc<ActorSystem>) -> tokio::task::JoinHandle<()> {
-                tokio::spawn(async move {
-                    while let Some(_) = rx.recv().await {}
-                })
+            fn name(&self) -> String {
+                "dummy".to_string()
+            }
+            fn start(
+                &self,
+                mut rx: mpsc::Receiver<ActorMessage>,
+                _sys: Arc<ActorSystem>,
+            ) -> tokio::task::JoinHandle<()> {
+                tokio::spawn(async move { while let Some(_) = rx.recv().await {} })
             }
         }
 

--- a/src/agents/builtin/codex_runner.rs
+++ b/src/agents/builtin/codex_runner.rs
@@ -689,7 +689,6 @@ impl AppServer {
                     serde_json::to_string(&resp).unwrap_or_else(|_| "{\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32603, \"message\": \"Internal error\"}}".to_string())
                 }
             }
-
         } else if req.method == "goose_mcp_list" {
             let mut registry = crate::goose::GooseMcpRegistry::new();
             registry.register(std::sync::Arc::new(crate::goose::SampleExtension));
@@ -706,7 +705,11 @@ impl AppServer {
             let mut registry = crate::goose::GooseMcpRegistry::new();
             registry.register(std::sync::Arc::new(crate::goose::SampleExtension));
             let ext_id = req.params.get("id").and_then(|v| v.as_str()).unwrap_or("");
-            let ext_args = req.params.get("args").cloned().unwrap_or(serde_json::json!({}));
+            let ext_args = req
+                .params
+                .get("args")
+                .cloned()
+                .unwrap_or(serde_json::json!({}));
             let result = registry.execute_extension(ext_id, ext_args).await;
             let resp = match result {
                 Ok(val) => JsonRpcResponse {
@@ -720,7 +723,10 @@ impl AppServer {
                     jsonrpc: "2.0".to_string(),
                     id: req.id.clone(),
                     result: None,
-                    error: Some(JsonRpcError { code: -32603, message: e }),
+                    error: Some(JsonRpcError {
+                        code: -32603,
+                        message: e,
+                    }),
                     meta: None,
                 },
             };
@@ -1418,13 +1424,16 @@ mod tests {
 mod tests_goose {
     use super::*;
     use crate::llm::LlmClient;
-    use ohc_builtin_agent_core::types::{ChatRequest, ChatResponse, Usage, Message};
+    use ohc_builtin_agent_core::types::{ChatRequest, ChatResponse, Message, Usage};
     use std::sync::Arc;
 
     struct DummyLlm;
     #[async_trait::async_trait]
     impl LlmClient for DummyLlm {
-        async fn chat(&self, _req: ChatRequest) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
+        async fn chat(
+            &self,
+            _req: ChatRequest,
+        ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
             Ok(ChatResponse {
                 response_id: Some("res_1".to_string()),
                 stop_reason: "end".to_string(),
@@ -1447,10 +1456,18 @@ mod tests_goose {
 
         let list_req = r#"{"jsonrpc": "2.0", "id": "1", "method": "goose_mcp_list", "params": {}}"#;
         let list_res_str = server.handle_request(list_req).await;
-        assert!(list_res_str.contains("sample_mcp"), "Response was: {}", list_res_str);
+        assert!(
+            list_res_str.contains("sample_mcp"),
+            "Response was: {}",
+            list_res_str
+        );
 
         let exec_req = r#"{"jsonrpc": "2.0", "id": "2", "method": "goose_mcp_execute", "params": {"id": "sample_mcp", "args": {"echo": "hello test"}}}"#;
         let exec_res_str = server.handle_request(exec_req).await;
-        assert!(exec_res_str.contains("hello test"), "Response was: {}", exec_res_str);
+        assert!(
+            exec_res_str.contains("hello test"),
+            "Response was: {}",
+            exec_res_str
+        );
     }
 }

--- a/src/agents/builtin/jit_retrieval.rs
+++ b/src/agents/builtin/jit_retrieval.rs
@@ -88,7 +88,8 @@ impl JitContextRetriever {
         // Extract potential filenames or function names for JIT snippet retrieval
         let mut potential_files = Vec::new();
         for s in content.split_whitespace() {
-            if s.contains('.') && s.len() > 4 { // likely a file like main.rs, util.ts
+            if s.contains('.') && s.len() > 4 {
+                // likely a file like main.rs, util.ts
                 potential_files.push(s.to_string());
             }
         }
@@ -127,11 +128,18 @@ impl JitContextRetriever {
         if !potential_files.is_empty() {
             let mut snippet_context = String::new();
             for file_hint in potential_files {
-                let cleaned_file_hint: String = file_hint.chars().filter(|c| c.is_alphanumeric() || *c == '.' || *c == '_' || *c == '-').collect();
-                if let Ok(results) = self.memory_store.retrieve(&format!("file:{}", cleaned_file_hint), 1).await {
+                let cleaned_file_hint: String = file_hint
+                    .chars()
+                    .filter(|c| c.is_alphanumeric() || *c == '.' || *c == '_' || *c == '-')
+                    .collect();
+                if let Ok(results) = self
+                    .memory_store
+                    .retrieve(&format!("file:{}", cleaned_file_hint), 1)
+                    .await
+                {
                     for res in results {
-                         snippet_context.push_str(&res);
-                         snippet_context.push_str("\n---\n");
+                        snippet_context.push_str(&res);
+                        snippet_context.push_str("\n---\n");
                     }
                 }
             }
@@ -275,9 +283,7 @@ mod tests {
         let retriever = JitContextRetriever::new(store, "test_session".to_string());
 
         // This prompt contains short words that should be filtered out
-        let messages = vec![Message::user(
-            "It is an error the to of in on as at by be",
-        )];
+        let messages = vec![Message::user("It is an error the to of in on as at by be")];
 
         let context = retriever.retrieve_context(&messages).await.unwrap();
         assert!(context.contains("Relevant Past Session Context (JIT Retrieval)"));

--- a/src/agents/builtin/json_rpc_server.rs
+++ b/src/agents/builtin/json_rpc_server.rs
@@ -59,7 +59,6 @@ async fn handle_rpc(
         });
     }
 
-
     if payload.method == "goose_mcp_list" {
         let mut registry = crate::goose::GooseMcpRegistry::new();
         registry.register(std::sync::Arc::new(crate::goose::SampleExtension));
@@ -76,8 +75,18 @@ async fn handle_rpc(
         let mut registry = crate::goose::GooseMcpRegistry::new();
         registry.register(std::sync::Arc::new(crate::goose::SampleExtension));
         // payload.params is Option<serde_json::Value>
-        let ext_id = payload.params.as_ref().and_then(|p| p.get("id")).and_then(|v| v.as_str()).unwrap_or("");
-        let ext_args = payload.params.as_ref().and_then(|p| p.get("args")).cloned().unwrap_or(serde_json::json!({}));
+        let ext_id = payload
+            .params
+            .as_ref()
+            .and_then(|p| p.get("id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let ext_args = payload
+            .params
+            .as_ref()
+            .and_then(|p| p.get("args"))
+            .cloned()
+            .unwrap_or(serde_json::json!({}));
         let result = registry.execute_extension(ext_id, ext_args).await;
         let resp = match result {
             Ok(val) => JsonRpcResponse {
@@ -90,7 +99,11 @@ async fn handle_rpc(
                 jsonrpc: "2.0".to_string(),
                 id: payload.id.clone(),
                 result: None,
-                error: Some(JsonRpcError { code: -32603, message: e, data: None }),
+                error: Some(JsonRpcError {
+                    code: -32603,
+                    message: e,
+                    data: None,
+                }),
             },
         };
         return Json(resp);

--- a/src/agents/builtin/memory_store.rs
+++ b/src/agents/builtin/memory_store.rs
@@ -848,7 +848,8 @@ impl VectorRepository {
                             .await
                             .map_err(|e| e.to_string())?;
 
-                        let mut records_in_tenant: Vec<MinimalRecord> = Vec::with_capacity(rows.len());
+                        let mut records_in_tenant: Vec<MinimalRecord> =
+                            Vec::with_capacity(rows.len());
                         for row in rows {
                             let emb_str: String = row.try_get("embedding").unwrap_or_else(|_| {
                                 String::from_utf8(row.get::<Vec<u8>, _>("embedding"))

--- a/src/agents/builtin/verification_loops.rs
+++ b/src/agents/builtin/verification_loops.rs
@@ -65,6 +65,40 @@ impl ComputationalGuide for BashComputationalGuide {
     }
 }
 
+pub struct CargoTestGuide {
+    pub workspace_path: Option<String>,
+}
+
+#[async_trait::async_trait]
+impl ComputationalGuide for CargoTestGuide {
+    async fn verify(&self, _code: &str, _context: &str) -> Result<(), String> {
+        let wd = self
+            .workspace_path
+            .clone()
+            .unwrap_or_else(|| ".".to_string());
+        let mut cmd = tokio::process::Command::new("cargo");
+        cmd.arg("test").current_dir(wd);
+
+        match cmd.output().await {
+            Ok(output) => {
+                if !output.status.success() {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    return Err(format!(
+                        "Computational guide verification failed (cargo test).\nStdout: {}\nStderr: {}\nPlease correct your work and use tools to fix the issue before providing the final answer.",
+                        stdout, stderr
+                    ));
+                }
+                Ok(())
+            }
+            Err(e) => Err(format!(
+                "Failed to execute computational guide cargo test: {}",
+                e
+            )),
+        }
+    }
+}
+
 pub struct BashVisualVerifier {
     pub command: String,
     pub workspace_path: Option<String>,
@@ -443,6 +477,54 @@ mod tests {
         // bash usually returns success=false rather than execution error if inside bash -c
         let res_fail = guide_fail.verify("", "").await;
         assert!(res_fail.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_cargo_test_guide() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_string_lossy().to_string();
+
+        // Initialize a dummy cargo project
+        std::process::Command::new("cargo")
+            .arg("init")
+            .arg("--lib")
+            .arg("--name")
+            .arg("test_project")
+            .current_dir(&path)
+            .output()
+            .unwrap();
+
+        let guide = CargoTestGuide {
+            workspace_path: Some(path.clone()),
+        };
+
+        // Valid project should pass
+        let res_pass = guide.verify("", "").await;
+        if res_pass.is_err() {
+            println!("res_pass failed: {:?}", res_pass.clone().err().unwrap());
+        }
+        assert!(res_pass.is_ok());
+
+        // Modify lib.rs to contain a failing test
+        let lib_rs = format!("{}/src/lib.rs", path);
+        std::fs::write(
+            &lib_rs,
+            "
+            #[cfg(test)]
+            mod tests {
+                #[test]
+                fn test_fail() {
+                    assert!(false);
+                }
+            }
+        ",
+        )
+        .unwrap();
+
+        // Project with failing test should return an error containing test output
+        let res_fail = guide.verify("", "").await;
+        assert!(res_fail.is_err());
+        assert!(res_fail.unwrap_err().contains("test_fail"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Implemented `CargoTestGuide` inside `src/agents/builtin/verification_loops.rs` based on the master catalog item: Verification Loops (Quality x3): Computational/Guides (feedforward: linters, type-checkers, unit tests). This runs `cargo test` concurrently using `tokio::process::Command` so it does not block the thread and allows the LLM to self correct. Tests are fully passing!

---
*PR created automatically by Jules for task [622218519736463398](https://jules.google.com/task/622218519736463398) started by @ql-owo-lp*