### PR TITLE
docs: add Master Catalog attribution for ACON context mechanic

### DIFF
--- a/src/agents/builtin/acon_context.rs
+++ b/src/agents/builtin/acon_context.rs
@@ -1,5 +1,6 @@
 use crate::types::{Message, Role};
 
+/// Master Catalog C.3: Context Window Strategy: ACON Research Metric: Prioritizing reasoning traces over raw tool outputs yields 26-54% token reduction while preserving 95%+ accuracy.
 /// Configuration for the ACON Context Window Strategy.
 #[derive(Debug, Clone)]
 pub struct AconConfig {

--- a/src/agents/builtin/codex_runner.rs
+++ b/src/agents/builtin/codex_runner.rs
@@ -701,7 +701,7 @@ impl AppServer {
                 error: None,
                 meta: None,
             };
-            return serde_json::to_string(&resp).unwrap();
+            serde_json::to_string(&resp).unwrap()
         } else if req.method == "goose_mcp_execute" {
             let mut registry = crate::goose::GooseMcpRegistry::new();
             registry.register(std::sync::Arc::new(crate::goose::SampleExtension));
@@ -724,7 +724,7 @@ impl AppServer {
                     meta: None,
                 },
             };
-            return serde_json::to_string(&resp).unwrap();
+            serde_json::to_string(&resp).unwrap()
         } else if req.method == "get_sona_patterns" {
             // SOTA Harness Pattern: Ruflo SONA neural patterns
             // Retrieve all learned trajectory patterns


### PR DESCRIPTION
Adds missing Master Catalog attribution comment for ACON context mechanic to fulfill Roulette Protocol.

---
*PR created automatically by Jules for task [15246432039531186669](https://jules.google.com/task/15246432039531186669) started by @ql-owo-lp*