### PR TITLE
style(ui): Refine setup.html to meet OHC Premium Glassmorphism standards

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -72,13 +72,15 @@
         font-size: 14px;
         margin-bottom: 20px;
       }
+      select,
+      textarea,
       input {
         width: 100%;
         padding: 14px;
         min-height: 44px !important;
         margin-bottom: 20px;
         border: 1px solid rgba(255, 255, 255, 0.4);
-        border-radius: 16px;
+        border-radius: 8px !important;
         box-sizing: border-box;
         font-size: 16px;
         background: rgba(255, 255, 255, 0.65);
@@ -89,31 +91,15 @@
           background 0.2s,
           box-shadow 0.2s;
       }
-      select.glassmorphism,
-      textarea.glassmorphism,
-      input.glassmorphism {
-        border-radius: 8px;
-        min-height: 44px;
-        background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(30px) saturate(210%);
-        -webkit-backdrop-filter: blur(30px) saturate(210%);
-        border: 1px solid rgba(255, 255, 255, 0.4);
-      }
 
       @media (prefers-color-scheme: dark) {
-        select.glassmorphism,
-        textarea.glassmorphism,
-        input.glassmorphism {
-          border-radius: 8px;
+        select,
+        textarea,
+        input {
           background: rgba(22, 22, 26, 0.7);
           border: 1px solid rgba(255, 255, 255, 0.1);
+          color: #f5f5f7;
         }
-      }
-
-      select,
-      textarea,
-      input {
-        border-radius: 8px;
       }
       input:focus,
       textarea:focus,
@@ -126,18 +112,14 @@
       button,
       input,
       select,
-      textarea,
-      .glassmorphism {
-        border-radius: 16px;
+      textarea {
+        border-radius: 8px;
         min-height: 44px;
         min-width: 44px;
         box-sizing: border-box;
       }
-      button,
-      input,
-      select,
-      textarea {
-        border-radius: 8px !important;
+      .glassmorphism {
+        border-radius: 16px;
       }
       button {
         min-width: 44px;
@@ -146,7 +128,7 @@
         border: none;
         padding: 14px 24px;
         min-height: 44px !important;
-        border-radius: 16px;
+        border-radius: 8px;
         font-size: 16px;
         font-weight: 600;
         cursor: pointer;
@@ -615,7 +597,7 @@
         min-height: 44px !important;
         margin-bottom: 20px;
         border: 1px solid rgba(255, 255, 255, 0.4);
-        border-radius: 16px;
+        border-radius: 8px;
         box-sizing: border-box;
         font-size: 16px;
         background: rgba(255, 255, 255, 0.65);
@@ -1010,9 +992,6 @@
           width: 10px;
           height: 10px;
         }
-        .step-indicator.active {
-          transform: scale(1.2);
-        }
         .radio-option {
           min-height: 44px;
           min-width: 44px;
@@ -1028,7 +1007,7 @@
           min-height: 44px;
           min-width: 44px;
           box-sizing: border-box;
-          border-radius: 16px;
+          border-radius: 8px;
         }
         h1 {
           font-size: 20px;


### PR DESCRIPTION
- **What**: This change refines the CSS in `src/ui/tauri/src/ui/setup.html` to fully align with the OHC Premium Design Standards ("Apple / UniFi" style). 
- **Why**: As directed by the `ux_analysis_onboarding.md` analysis document, the setup wizard lacked proper CSS structure for the "translucent glass" requirements (i.e. explicitly applying a `16px` border-radius to containers and `8px` to form inputs).
- **How**:
  - CSS updates directly target `.container`, `.glassmorphism`, `input`, `select`, `textarea`, and `button` classes.
  - Simplified media queries for dark mode ensuring text color is visible and backgrounds are consistent.
  - De-duplicated the `.step-indicator` hover/active scaling states.
  - Verified with `playwright test src/e2e/setup.spec.ts`.

---
*PR created automatically by Jules for task [13188369177346814917](https://jules.google.com/task/13188369177346814917) started by @ql-owo-lp*