### PR TITLE
feat: add viral loyalty widget e2e test

### DIFF
--- a/src/e2e/viral-loyalty-widget.spec.ts
+++ b/src/e2e/viral-loyalty-widget.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Viral Loyalty Widget', () => {
+  test('should load the widget and generate a loyalty program', async ({ page }) => {
+    await page.goto('/ui/viral-loyalty-widget.html');
+
+    await expect(page.locator('h1')).toHaveText('Viral Loyalty Widget Generator');
+    const generateBtn = page.locator('#generate-btn');
+    await expect(generateBtn).toBeVisible();
+
+    const emptyStamps = page.locator('.stamp.empty');
+    await expect(emptyStamps).toHaveCount(4);
+
+    await generateBtn.click();
+
+    await expect(generateBtn).toBeDisabled();
+    await expect(generateBtn).toHaveText('Generating...');
+
+    const resultArea = page.locator('#result-area');
+    await expect(resultArea).toBeVisible({ timeout: 5000 });
+
+    const filledStamps = page.locator('.stamp.filled');
+    await expect(filledStamps).toHaveCount(4);
+
+    const shareLink = page.locator('#share-link');
+    await expect(shareLink).toHaveValue(/loyalty\/join\?ref=/);
+  });
+});


### PR DESCRIPTION
This PR adds E2E testing for the Viral Loyalty Widget.

- Added `src/e2e/viral-loyalty-widget.spec.ts` which tests the `viral-loyalty-widget.html` page.
- Verifies initial widget state (empty stamps, visible generate button).
- Navigates the form and triggers generation, verifying the UI animation logic (button loading state).
- Asserts that all stamps fill correctly, result area is shown, and the generated share link is presented.

Tested against local Bazel build. All E2E tests have passed.

---
*PR created automatically by Jules for task [2481183753250190622](https://jules.google.com/task/2481183753250190622) started by @ql-owo-lp*