### PR TITLE
Fix setup chat missing Back button causing E2E failure

### DIFF
--- a/src/e2e/tauri_onboarding.spec.ts
+++ b/src/e2e/tauri_onboarding.spec.ts
@@ -116,7 +116,7 @@ test.describe('Tauri Onboarding Wizard Flow', () => {
 
     // Since this test specifically verifies the manual steps (Context, Categories, etc.),
     // we will navigate to the manual setup now to continue the existing test flow.
-    await page.locator('#step-chat button').first().click();
+    await page.locator('#step-chat').getByRole('button', { name: 'Back' }).click();
     await expect(page.getByRole('heading', { name: "10-Minute Setup Wizard" })).toBeVisible();
     await expect(page.getByRole('heading', { name: '10-Minute Setup Wizard' })).toBeVisible();
     await page.getByRole('button', { name: 'Start My Business' }).click();

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1398,6 +1398,39 @@
 
       <!-- Step Chat: Conversational Build -->
       <div class="step" id="step-chat">
+        <button
+          onclick="goToStep('step-initial')"
+          style="
+            background: none;
+            border: none;
+            color: #0066ff;
+            padding: 0;
+            box-shadow: none;
+            width: auto;
+            font-size: 14px;
+            min-height: 44px;
+            margin-bottom: 16px;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            font-weight: 600;
+          "
+        >
+          <svg
+            style="width: 16px; height: auto"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+          Back
+        </button>
         <h1>Setup Assistant</h1>
         <p>Talk to our AI to build your business.</p>
 


### PR DESCRIPTION
This commit fixes a failing Playwright E2E test `tauri_onboarding.spec.ts` where it was trying to click the first button in the `#step-chat` div to go back to the manual setup page. Since there was no Back button, it was clicking the wrong button and failing.

Added a "Back" button to `#step-chat` pointing to `step-initial`.
Updated the Playwright test to use `getByRole('button', { name: 'Back' })`.
The fix was verified locally and visually tested.

---
*PR created automatically by Jules for task [15476891374969462909](https://jules.google.com/task/15476891374969462909) started by @ql-owo-lp*