### PR TITLE
🔗 Link: [interop improvement] Fix missing product title for stock alerts

### DIFF
--- a/src/server/services/inventory/service.rs
+++ b/src/server/services/inventory/service.rs
@@ -80,12 +80,20 @@ impl InventoryService {
                     .execute(&pool)
                     .await;
 
+                let product_title: String = sqlx::query_scalar("SELECT title FROM products WHERE id = $1 AND tenant_id = $2")
+                    .bind(product_id)
+                    .bind(tenant_id)
+                    .fetch_optional(&pool)
+                    .await
+                    .unwrap_or(Some(product_id.to_string()))
+                    .unwrap_or_else(|| product_id.to_string());
+
                 // Operations Agent: trigger push notification for out-of-stock/lock failure
                 let job_id = Uuid::new_v4().to_string();
-                let message = format!("{} sold out. Would you like to draft a restock order?", product_id);
+                let message = format!("{} sold out. Would you like to draft a restock order?", product_title);
                 let job_payload = serde_json::json!({
                     "product_id": product_id,
-                    "product_title": product_id,
+                    "product_title": product_title,
                     "remaining_stock": 0,
                     "threshold": 5,
                     "message": message
@@ -408,9 +416,9 @@ impl InventoryService {
                 let job_id = Uuid::new_v4().to_string();
 
                 let message = if new_stock == 0 {
-                    format!("{} sold out. Would you like to draft a restock order?", product_id)
+                    format!("{} sold out. Would you like to draft a restock order?", product_title)
                 } else {
-                    format!("Stock for product {} has dropped to {}.", product_id, new_stock)
+                    format!("Stock for {} has dropped to {}.", product_title, new_stock)
                 };
 
                 let job_payload = serde_json::json!({


### PR DESCRIPTION
This pull request fixes a compilation error in `src/server/services/inventory/service.rs` where the `product_title` variable was missing, resulting in broken product restocking alerts via the Operations Agent. It adds the correct title fetching from the database for the message string formatting and json payloads.

---
*PR created automatically by Jules for task [12687201572283907989](https://jules.google.com/task/12687201572283907989) started by @ql-owo-lp*

Resolves #30999