### PR TITLE
⚙️ Consolidator: Fix memory pipeline concurrency via transactional queue

### DIFF
--- a/src/server/workers/agent_memory_pipeline.rs
+++ b/src/server/workers/agent_memory_pipeline.rs
@@ -80,52 +80,64 @@ impl AgentMemoryPipeline {
                 }
             }
             DbStore::Postgres => {
-                let mut conn = self.db.pool.acquire().await?;
-                // Fetch the rows, bypassing RLS locally for the read
-                sqlx::query("SET LOCAL app.current_tenant = ''").execute(&mut *conn).await?;
-                let rows = sqlx::query("SELECT s.session_id, s.agent_id, s.context_data, a.tenant_id FROM agent_session_data s JOIN agents a ON s.agent_id = a.id ORDER BY s.last_accessed ASC LIMIT 100")
-                    .fetch_all(&mut *conn)
-                    .await?;
-                drop(conn);
-
-                for row in rows {
-                    use sqlx::Row;
-                    let session_id: String = row.get("session_id");
-                    let agent_id: String = row.get("agent_id");
-                    let context_data: String = row.get("context_data");
-                    let tenant_id: String = row.get("tenant_id");
-
-                    let embedding = match self.embedding_api.generate_embedding(&context_data).await {
-                        Ok(emb) => emb,
-                        Err(e) => {
-                            ::server_telemetry::record_error_signal("[bug] AgentMemoryPipeline: failed to generate embedding");
-                            tracing::error!("AgentMemoryPipeline: failed to generate embedding: {}", e);
-                            vec![0.0; 1536]
-                        }
-                    };
-
-                    let emb_str = format!("[{}]", embedding.iter().map(|f| f.to_string()).collect::<Vec<_>>().join(","));
-                    let mem_id = Uuid::new_v4();
-
+                for _ in 0..100 {
                     let mut tx = self.db.pool.begin().await?;
-                    ::server_common::auth_utils::set_org_context(&mut *tx, &tenant_id).await?;
+                    // Fetch one row, bypassing RLS locally for the read
+                    sqlx::query("SET LOCAL app.current_tenant = ''").execute(&mut *tx).await?;
 
-                    sqlx::query("INSERT INTO consolidated_memory (id, tenant_id, agent_id, source_type, content, embedding) VALUES ($1, $2, $3, $4, $5, $6::vector)")
-                        .bind(mem_id.to_string())
-                        .bind(&tenant_id)
-                        .bind(&agent_id)
-                        .bind("SESSION_DATA")
-                        .bind(&context_data)
-                        .bind(&emb_str)
-                        .execute(&mut *tx)
-                        .await?;
+                    let row = sqlx::query("
+                        SELECT s.session_id, s.agent_id, s.context_data, a.tenant_id
+                        FROM agent_session_data s
+                        JOIN agents a ON s.agent_id = a.id
+                        ORDER BY s.last_accessed ASC
+                        LIMIT 1
+                        FOR UPDATE OF s SKIP LOCKED
+                    ")
+                    .fetch_optional(&mut *tx)
+                    .await?;
 
-                    sqlx::query("DELETE FROM agent_session_data WHERE session_id = $1")
-                        .bind(&session_id)
-                        .execute(&mut *tx)
-                        .await?;
+                    if let Some(row) = row {
+                        use sqlx::Row;
+                        let session_id: String = row.get("session_id");
+                        let agent_id: String = row.get("agent_id");
+                        let context_data: String = row.get("context_data");
+                        let tenant_id: String = row.get("tenant_id");
 
-                    tx.commit().await?;
+                        let embedding = match self.embedding_api.generate_embedding(&context_data).await {
+                            Ok(emb) => emb,
+                            Err(e) => {
+                                ::server_telemetry::record_error_signal("[bug] AgentMemoryPipeline: failed to generate embedding");
+                                tracing::error!("AgentMemoryPipeline: failed to generate embedding: {}", e);
+                                vec![0.0; 1536]
+                            }
+                        };
+
+                        let emb_str = format!("[{}]", embedding.iter().map(|f| f.to_string()).collect::<Vec<_>>().join(","));
+                        let mem_id = Uuid::new_v4();
+
+                        ::server_common::auth_utils::set_org_context(&mut *tx, &tenant_id).await?;
+
+                        sqlx::query("INSERT INTO consolidated_memory (id, tenant_id, agent_id, source_type, content, embedding) VALUES ($1, $2, $3, $4, $5, $6::vector)")
+                            .bind(mem_id.to_string())
+                            .bind(&tenant_id)
+                            .bind(&agent_id)
+                            .bind("SESSION_DATA")
+                            .bind(&context_data)
+                            .bind(&emb_str)
+                            .execute(&mut *tx)
+                            .await?;
+
+                        sqlx::query("DELETE FROM agent_session_data WHERE session_id = $1")
+                            .bind(&session_id)
+                            .execute(&mut *tx)
+                            .await?;
+
+                        tx.commit().await?;
+                    } else {
+                        // No more rows available
+                        tx.rollback().await?;
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR fixes a critical concurrency bug in the memory consolidation pipeline (`src/server/workers/agent_memory_pipeline.rs`). 

**Problem:**
The worker was previously executing a non-transactional `SELECT ... LIMIT 100` query, generating embeddings for the sessions, and then doing a `DELETE` in a separate transaction. If multiple memory pipeline workers ran concurrently, they would fetch the exact same 100 rows, duplicate the work (and LLM API costs), and race to delete them.

**Solution:**
Replaced the disconnected pattern with a transactional queue dequeue loop:
- Processes rows one at a time up to a maximum of 100.
- Uses `SELECT ... FOR UPDATE OF s SKIP LOCKED` to lock only the `agent_session_data` row during processing.
- Explicitly limits the lock to `OF s` to ensure the joined `agents` table is not inadvertently locked during the slow LLM API call.
- Executes the embedding generation, `INSERT` into `consolidated_memory`, and `DELETE` from `agent_session_data` inside the same transaction, committing safely upon success.

**Verification:**
- Ran full backend test suite (`bazelisk test //...`), all 99 tests pass.
- Playwright E2E tests passing.
- Code review approved.

---
*PR created automatically by Jules for task [14152768822877933762](https://jules.google.com/task/14152768822877933762) started by @ql-owo-lp*