### PR TITLE
⚡ Bolt: [performance improvement] Apply mobile payload shaping to analytics endpoints

### DIFF
--- a/src/e2e/mobile_payload_optimization.spec.ts
+++ b/src/e2e/mobile_payload_optimization.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from './fixtures';
+
+test.describe('Mobile Payload Optimization Verification', () => {
+
+  test('should verify mobile_optimized trims unified feed payload', async ({ memberPage }) => {
+    const response = await memberPage.request.get('/api/ui/dashboard/unified-feed?mobile_optimized=true');
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    // Triage items in unified-feed should NOT have bulky "context" and "action_payload" fields
+    // Ensure that it conforms to the mobile interface
+    if (data.triage && data.triage.length > 0) {
+      expect(data.triage[0]).not.toHaveProperty('context');
+      expect(data.triage[0]).not.toHaveProperty('action_payload');
+      expect(data.triage[0]).toHaveProperty('id');
+      expect(data.triage[0]).toHaveProperty('action_type');
+    }
+
+    // Orders in unified-feed should NOT have "customer_name" or "created_at" in mobile
+    if (data.orders && data.orders.length > 0) {
+      expect(data.orders[0]).not.toHaveProperty('customer_name');
+      expect(data.orders[0]).toHaveProperty('total_amount');
+    }
+  });
+
+  test('should verify mobile_optimized trims orders payload natively', async ({ memberPage }) => {
+    const response = await memberPage.request.get('/api/ui/orders?mobile_optimized=true');
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    if (data.length > 0) {
+      // Mobile orders should only have id, total_amount, status
+      expect(data[0]).toHaveProperty('id');
+      expect(data[0]).toHaveProperty('total_amount');
+      expect(data[0]).toHaveProperty('status');
+
+      expect(data[0]).not.toHaveProperty('customer_name');
+      expect(data[0]).not.toHaveProperty('created_at');
+    }
+  });
+
+  test('should verify mobile_optimized trims bookings payload natively', async ({ memberPage }) => {
+    const response = await memberPage.request.get('/api/ui/bookings?mobile_optimized=true');
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    if (data.length > 0) {
+      // Mobile bookings should only have id, product_title, start_time, status, ai_summary
+      expect(data[0]).toHaveProperty('id');
+      expect(data[0]).toHaveProperty('product_title');
+
+      expect(data[0]).not.toHaveProperty('customer_name');
+      expect(data[0]).not.toHaveProperty('product_id');
+      expect(data[0]).not.toHaveProperty('end_time');
+    }
+  });
+
+  test('should verify mobile_optimized trims inbox payload natively', async ({ memberPage }) => {
+    const response = await memberPage.request.get('/api/ui/inbox?mobile_optimized=true');
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    if (data.length > 0) {
+      // Mobile inbox should only have id, source, status, created_at
+      expect(data[0]).toHaveProperty('id');
+      expect(data[0]).toHaveProperty('source');
+
+      expect(data[0]).not.toHaveProperty('content');
+      expect(data[0]).not.toHaveProperty('original_message');
+      expect(data[0]).not.toHaveProperty('generated_response');
+    }
+  });
+
+  test('should verify mobile_optimized trims supply payload natively', async ({ memberPage }) => {
+    const response = await memberPage.request.get('/api/ui/supply?mobile_optimized=true');
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    if (data.vendors && data.vendors.length > 0) {
+      expect(data.vendors[0]).toHaveProperty('id');
+      expect(data.vendors[0]).toHaveProperty('name');
+      expect(data.vendors[0]).not.toHaveProperty('contact_info');
+    }
+
+    if (data.raw_materials && data.raw_materials.length > 0) {
+      expect(data.raw_materials[0]).toHaveProperty('id');
+      expect(data.raw_materials[0]).toHaveProperty('current_quantity');
+      expect(data.raw_materials[0]).not.toHaveProperty('reorder_threshold');
+    }
+  });
+
+});

--- a/src/server/benchmarks/latency_bench.rs
+++ b/src/server/benchmarks/latency_bench.rs
@@ -746,8 +746,8 @@ pub async fn bench_dashboard_analytics_briefing_latency() {
         let pool1 = pg_pool.clone();
         let pool2 = pg_pool.clone();
         let _ = tokio::join!(
-            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool1),
-            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool2)
+            sqlx::query("SELECT COUNT(*) FROM customers WHERE tenant_id = $1").bind("test_tenant").execute(&pool1),
+            sqlx::query("SELECT id, COALESCE(source, '') AS source, COALESCE(status, '') AS status, CAST(created_at AS text) AS created_at FROM inbox_messages WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT 50").bind("test_tenant").execute(&pool2)
         );
         let duration = start_sim.elapsed();
 
@@ -826,9 +826,9 @@ pub async fn bench_ui_supply_latency() {
         let pool3 = pg_pool.clone();
 
         let _ = tokio::join!(
-            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool1),
-            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool2),
-            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool3)
+            sqlx::query("SELECT id, name FROM vendors WHERE tenant_id = $1 ORDER BY name").bind("test_tenant").execute(&pool1),
+            sqlx::query("SELECT id, name, current_quantity FROM raw_materials WHERE tenant_id = $1 ORDER BY name").bind("test_tenant").execute(&pool2),
+            sqlx::query("SELECT id, finished_good_id, raw_material_id, quantity_required FROM bom_items WHERE tenant_id = $1 ORDER BY id").bind("test_tenant").execute(&pool3)
         );
         let duration = start_sim.elapsed();
 
@@ -1133,7 +1133,12 @@ pub async fn bench_ui_triage_mobile_payload() {
 
         let start_sim = std::time::Instant::now();
         let pool1 = pg_pool.clone();
-        let _ = tokio::spawn(async move { sqlx::query("SELECT pg_sleep(0.010)").execute(&pool1).await }).await;
+        let _ = tokio::spawn(async move {
+            let _ = sqlx::query("SELECT id, status, CAST(created_at AS text) AS created_at, action_type FROM (SELECT t.id, t.tenant_id, t.status, t.created_at, a.action_type FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id UNION ALL SELECT a.id, a.tenant_id, a.status, a.created_at, a.action_type FROM unified_triage_actions a JOIN unified_threads t ON a.thread_id = t.id) sub WHERE tenant_id = $1 AND status != 'resolved' AND status != 'dismissed' ORDER BY created_at DESC LIMIT 50")
+            .bind("test_tenant")
+            .fetch_all(&pool1)
+            .await;
+        }).await;
         let duration = start_sim.elapsed();
 
         println!("  - Mobile Payload Optimization Simulation (Postgres): {:?}", duration);
@@ -1182,7 +1187,7 @@ pub async fn bench_ui_omni_inbox_latency() {
         let pool1 = pg_pool.clone();
 
         let _ = tokio::join!(
-            sqlx::query("SELECT pg_sleep(0.015)").execute(&pool1)
+            sqlx::query("SELECT id, COALESCE(source, '') AS source, COALESCE(status, '') AS status, COALESCE(sender_id, '') AS sender_id, CAST(created_at AS text) AS created_at FROM omni_inbox_messages WHERE tenant_id = $1 AND status != 'resolved' ORDER BY created_at DESC LIMIT 50").bind("test_tenant").execute(&pool1)
         );
         let duration = start_sim.elapsed();
 

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -4322,8 +4322,9 @@ async fn ui_dashboard_analytics_briefing_handler(
 ) -> axum::response::Response {
     use axum::response::IntoResponse;
     let tenant_id = crate::common::auth_utils::ui_tenant_id(&query);
+    let mobile_optimized = query.mobile_optimized.unwrap_or(false);
 
-    let cache_key = format!("ui_analytics_briefing:{}", tenant_id);
+    let cache_key = format!("ui_analytics_briefing:{}:mobile:{}", tenant_id, mobile_optimized);
     let cache = UI_ANALYTICS_BRIEFING_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(get_redis_client()));
 
     if let Some((cached, is_stale)) = cache.get_with_swr(&cache_key).await {
@@ -4339,8 +4340,8 @@ async fn ui_dashboard_analytics_briefing_handler(
             let tenant_id1 = t_bg.clone(); let tenant_id2 = t_bg.clone();
 
             let (metrics_res, inbox_res) = tokio::join!(
-                tokio::spawn(async move { load_ui_dashboard_metrics(&db1, &tenant_id1, false).await }),
-                tokio::spawn(async move { load_ui_inbox_from_db(&db2, &tenant_id2, false).await })
+                tokio::spawn(async move { load_ui_dashboard_metrics(&db1, &tenant_id1, mobile_optimized).await }),
+                tokio::spawn(async move { load_ui_inbox_from_db(&db2, &tenant_id2, mobile_optimized).await })
             );
 
             let metrics_res = metrics_res.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound));
@@ -4373,8 +4374,8 @@ async fn ui_dashboard_analytics_briefing_handler(
     let tenant_id2 = tenant_id.clone();
 
     let (metrics_res, inbox_res) = tokio::join!(
-        tokio::spawn(async move { load_ui_dashboard_metrics(&db1, &tenant_id1, false).await }),
-        tokio::spawn(async move { load_ui_inbox_from_db(&db2, &tenant_id2, false).await })
+        tokio::spawn(async move { load_ui_dashboard_metrics(&db1, &tenant_id1, mobile_optimized).await }),
+        tokio::spawn(async move { load_ui_inbox_from_db(&db2, &tenant_id2, mobile_optimized).await })
     );
 
     let metrics_res = metrics_res.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound));
@@ -4415,13 +4416,14 @@ async fn ui_dashboard_analytics_chat_handler(
     use std::hash::{Hash, Hasher};
 
     let tenant_id = crate::common::auth_utils::ui_tenant_id(&query);
+    let mobile_optimized = query.mobile_optimized.unwrap_or(false);
     let text = payload.message.to_lowercase();
 
     let mut hasher = DefaultHasher::new();
     text.hash(&mut hasher);
     let text_hash = hasher.finish();
 
-    let cache_key = format!("ui_analytics_chat:{}:{}", tenant_id, text_hash);
+    let cache_key = format!("ui_analytics_chat:{}:mobile:{}:{}", tenant_id, mobile_optimized, text_hash);
     let cache = UI_ANALYTICS_CHAT_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(get_redis_client()));
 
     if let Some((cached, is_stale)) = cache.get_with_swr(&cache_key).await {
@@ -4438,8 +4440,8 @@ async fn ui_dashboard_analytics_chat_handler(
             let tenant_id1 = t_bg.clone(); let tenant_id2 = t_bg.clone();
 
             let (inbox_res_handle, metrics_res_handle) = tokio::join!(
-                tokio::spawn(async move { load_ui_inbox_from_db(&db1, &tenant_id1, false).await }),
-                tokio::spawn(async move { load_ui_dashboard_metrics(&db2, &tenant_id2, false).await })
+                tokio::spawn(async move { load_ui_inbox_from_db(&db1, &tenant_id1, mobile_optimized).await }),
+                tokio::spawn(async move { load_ui_dashboard_metrics(&db2, &tenant_id2, mobile_optimized).await })
             );
 
             let inbox_res = inbox_res_handle.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound));
@@ -4474,8 +4476,8 @@ async fn ui_dashboard_analytics_chat_handler(
     let tenant_id2 = tenant_id.clone();
 
     let (inbox_res_handle, metrics_res_handle) = tokio::join!(
-        tokio::spawn(async move { load_ui_inbox_from_db(&db1, &tenant_id1, false).await }),
-        tokio::spawn(async move { load_ui_dashboard_metrics(&db2, &tenant_id2, false).await })
+        tokio::spawn(async move { load_ui_inbox_from_db(&db1, &tenant_id1, mobile_optimized).await }),
+        tokio::spawn(async move { load_ui_dashboard_metrics(&db2, &tenant_id2, mobile_optimized).await })
     );
 
     let inbox_res = inbox_res_handle.unwrap_or_else(|_| Err(sqlx::Error::RowNotFound));


### PR DESCRIPTION
- Replaced `pg_sleep` fake query latencies in benchmarking (`src/server/benchmarks/latency_bench.rs`) with real multi-query workloads ensuring parallelization models real queries.
- Added `mobile_optimized` payload trimming execution validation test via Playwright covering `/api/ui/orders`, `/api/ui/supply`, `/api/ui/inbox`, and `unified-feed`.
- Fixed hardcoded `false` configurations in `src/server/lib.rs` affecting `ui_dashboard_analytics_briefing_handler` and `ui_dashboard_analytics_chat_handler` to properly respect `mobile_optimized` and adjusted their cache keys to store split permutations.

---
*PR created automatically by Jules for task [16447203390835364112](https://jules.google.com/task/16447203390835364112) started by @ql-owo-lp*