### PR TITLE
fix(orchestration): parallel join state validation and ui components

### DIFF
--- a/src/agents/builtin/visual_workflow.rs
+++ b/src/agents/builtin/visual_workflow.rs
@@ -459,6 +459,9 @@ impl WorkflowExecutor {
                                     merged_data.push(val.clone());
                                 }
                             }
+                            if merged_data.is_empty() {
+                                return Err(format!("ParallelJoin failed: missing expected state keys {:?}", state_keys));
+                            }
                             merged_data.sort();
                             let merged_string = serde_json::to_string(&merged_data)
                                 .unwrap_or_else(|_| "[]".to_string());

--- a/src/e2e/tests/visual_workflow.spec.ts
+++ b/src/e2e/tests/visual_workflow.spec.ts
@@ -16,11 +16,23 @@ test.describe('Visual Workflow Builder', () => {
     await page.getByRole('button', { name: '+ Add LLM Node' }).click();
     await expect(page.locator('text=node-2')).toBeVisible();
 
-    // 3. Connect the nodes
-    await page.getByRole('button', { name: 'Connect from previous' }).click();
-    await expect(page.locator('text=node-1 → node-2')).toBeVisible();
+    // 3. Add Parallel Fork Node
+    await page.getByRole('button', { name: '+ Add Parallel Fork Node' }).click();
+    await expect(page.locator('text=node-3')).toBeVisible();
 
-    // 4. Run the workflow (Since it calls fetch, it should show Waiting or an Error/Result)
+    // 4. Add Parallel Join Node
+    await page.getByRole('button', { name: '+ Add Parallel Join Node' }).click();
+    await expect(page.locator('text=node-4')).toBeVisible();
+
+    // 5. Connect the nodes
+    await page.locator('div').filter({ hasText: /^node-2LlmConnect from previous$/ }).getByRole('button').click();
+    await expect(page.locator('text=node-1 → node-2')).toBeVisible();
+    await page.locator('div').filter({ hasText: /^node-3ParallelForkConnect from previous$/ }).getByRole('button').click();
+    await expect(page.locator('text=node-2 → node-3')).toBeVisible();
+    await page.locator('div').filter({ hasText: /^node-4ParallelJoinConnect from previous$/ }).getByRole('button').click();
+    await expect(page.locator('text=node-3 → node-4')).toBeVisible();
+
+    // 6. Run the workflow (Since it calls fetch, it should show Waiting or an Error/Result)
     await page.getByRole('button', { name: '▶ Run Workflow' }).click();
 
     // We either expect a result or an error since the backend may or may not be mocked

--- a/src/ui/next/src/app/visual-workflow/page.tsx
+++ b/src/ui/next/src/app/visual-workflow/page.tsx
@@ -16,6 +16,8 @@ export default function VisualWorkflowPage() {
     if (type === "Llm") data = { prompt_template: "Translate to French: {input}" };
     if (type === "Input") data = { name: "input" };
     if (type === "Output") data = {};
+    if (type === "ParallelFork") data = { targets: [] };
+    if (type === "ParallelJoin") data = { state_keys: [], output_key: "joined_output" };
 
     setNodes([...nodes, { id, type, data }]);
   };
@@ -78,6 +80,18 @@ export default function VisualWorkflowPage() {
           onClick={() => addNode("Output")}
         >
           + Add Output Node
+        </button>
+        <button
+          className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-2 rounded shadow transition"
+          onClick={() => addNode("ParallelFork")}
+        >
+          + Add Parallel Fork Node
+        </button>
+        <button
+          className="bg-teal-500 hover:bg-teal-600 text-white px-4 py-2 rounded shadow transition"
+          onClick={() => addNode("ParallelJoin")}
+        >
+          + Add Parallel Join Node
         </button>
 
         <button


### PR DESCRIPTION
- Adds validation to `ParallelJoin` inside `visual_workflow.rs` to return an error when `merged_data` is completely empty.
- Adds "Add Parallel Fork Node" and "Add Parallel Join Node" buttons in the Next.js visual-workflow UI so end users can actually build concurrent steps.
- Integrates testing coverage for the new buttons in Playwright E2E tests `visual_workflow.spec.ts`.

---
*PR created automatically by Jules for task [11419407615743598006](https://jules.google.com/task/11419407615743598006) started by @ql-owo-lp*