### PR TITLE
💰 Miser: Add `get_tenant_bandwidth_savings` to Tracker

### DIFF
--- a/src/server/billing.rs
+++ b/src/server/billing.rs
@@ -218,6 +218,14 @@ impl Tracker {
         }
     }
 
+    pub fn get_tenant_bandwidth_savings(&self, tenant_id: &str) -> f64 {
+        if let Some(ref auditor) = self.auditor {
+            auditor.get_tenant_bandwidth_savings(tenant_id)
+        } else {
+            0.0
+        }
+    }
+
     pub fn get_storage_cost_cents(&self, bytes: i64) -> i64 {
         let cost_per_gb = if let Some(ref auditor) = self.auditor { auditor.get_cost_per_gb_month() } else { 0.10 };
         crate::pricing::calculator::calculate_storage_cost_cents(bytes, &crate::pricing::calculator::CostConfig { cost_per_gb_month: cost_per_gb, ..Default::default() })


### PR DESCRIPTION
The `get_tenant_bandwidth_savings` method was previously implemented in the `CostAuditor` but was not mapped into the `Tracker` object, causing it to be missing or zeroed out on the billing dashboard page. This patch ensures it routes accurately to the auditor, returning `0.0` as a default.

---
*PR created automatically by Jules for task [4285470083343073656](https://jules.google.com/task/4285470083343073656) started by @ql-owo-lp*