### PR TITLE
feat: Mount /api/agents/jobs router and update OpenAI prompt mechanics

### DIFF
--- a/src/agents/builtin/prompt_construction.rs
+++ b/src/agents/builtin/prompt_construction.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::collapsible_if)]
 use crate::agent::AgentRunConfig;
 use crate::types::Message;
-/// Master Catalog B.5. Prompt Construction
+/// Master Catalog B.5. Prompt Construction: Implemented as a strict hierarchical priority stack.
+/// OpenAI Codex Mechanic: 1. Server-controlled System Message (Highest Priority) -> 2. Tool Definitions -> 3. Developer Instructions -> 4. User Instructions (cascading AGENTS.md files, capped at 32 KiB) -> 5. Conversation History.
 use std::fmt::Write;
 
 pub struct PromptBuilder;
@@ -188,7 +189,7 @@ pub async fn load_cascading_instructions(start_dir: Option<&std::path::Path>) ->
     combined
 }
 
-/// 4. User Instructions (capped at 32 KiB)
+/// 4. User Instructions (Cascading AGENTS.md files) (capped at 32 KiB)
 // Prompt Construction: OpenAI Codex Hierarchy
 pub struct HierarchicalPromptBuilder {
     server_system_message: String,
@@ -312,7 +313,7 @@ impl HierarchicalPromptBuilder {
             combined_system.push_str("\n</developer_instructions>");
         }
 
-        // 4. User Instructions
+        // 4. User Instructions (Cascading AGENTS.md files)
         if !self.user_instructions.is_empty() {
             if !combined_system.is_empty() {
                 combined_system.push_str("\n\n");

--- a/src/e2e/tests/agent_activity.spec.ts
+++ b/src/e2e/tests/agent_activity.spec.ts
@@ -3,7 +3,6 @@ import { adminPage } from '../fixtures';
 
 test.describe('Agent Activity Dashboard', () => {
   test('displays active operations correctly', async ({ page }) => {
-    // Note: since we didn't add the route because of build issues, we just test the frontend renders.
     // Navigate to the agent activity page
     await page.goto('/agent-activity');
 
@@ -13,8 +12,17 @@ test.describe('Agent Activity Dashboard', () => {
     // Verify the Active Operations section exists
     await expect(page.locator('h2', { hasText: 'Active Operations' })).toBeVisible();
 
-    // Verify that the table/list shows either "Loading...", "No active", or some jobs.
-    // We just ensure the page doesn't crash
-    await expect(page.locator('.max-w-7xl')).toBeVisible();
+    // Verify that the table/list shows the jobs or "No active" state.
+    // Wait for the "Loading..." to disappear.
+    await expect(page.locator('text=Loading background tasks...')).not.toBeVisible({ timeout: 10000 });
+
+    // It should either show 'No active or recent tasks found' or an actual job card
+    const noActive = page.locator('text=No active or recent tasks found. Your agents are standing by.');
+    const jobCards = page.locator('.glassmorphism.border').filter({ hasText: 'Completed at' }).or(page.locator('.glassmorphism.border').filter({ hasText: 'Started at' }));
+
+    const hasNoActive = await noActive.isVisible();
+    const hasJobs = await jobCards.count() > 0;
+
+    expect(hasNoActive || hasJobs).toBeTruthy();
   });
 });

--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -98,6 +98,8 @@ SERVER_RS_SRCS = [
     "//src/server/api/agents:client_intake.rs",
     "//src/server/api/onboarding:mod.rs",
     "//src/server/api/inbox:srcs",
+    "//src/server/api/ohc_job_queue:handler.rs",
+    "//src/server/api/ohc_job_queue:mod.rs",
     "//src/server/autodream:mod.rs",
     "//src/server/autodream_pipeline:llm_client.rs",
     "//src/server/autodream_pipeline:mod.rs",

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -37,6 +37,7 @@ pub mod booking;
 pub mod recovery;
 pub mod agent_feed;
 pub mod invoice;
+pub mod ohc_job_queue;
 pub mod audio_command;
 pub mod incidents;
 pub mod cart;

--- a/src/server/api/ohc_job_queue/BUILD.bazel
+++ b/src/server/api/ohc_job_queue/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["*.rs"]),
+)
+
+exports_files([
+    "mod.rs",
+    "handler.rs",
+])

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6598,6 +6598,7 @@ async fn create_ui_bom_item_handler(
         .nest("/api/agents/approvals", api::agents::approvals::router(dept_orchestrator.clone()))
         .nest("/api/agents/settings", api::agents::settings::router(dept_orchestrator.clone()))
         .nest("/api/agents/chat", api::agents::chat::router(dept_orchestrator.clone(), semantic_router.clone()))
+        .nest("/api/agents/jobs", api::ohc_job_queue::handler::router())
         .nest("/api/agents/webhook", api::agents::webhook::router(dept_orchestrator.clone()))
         .route("/api/v1/settings/integrations/whatsapp_cloud_api", axum::routing::post(api::integrations_settings::connect_whatsapp_cloud_api).with_state(std::sync::Arc::new(crate::integrations::registry::IntegrationsRegistry::new())))
         .route("/api/v1/settings/integrations/whatsapp", axum::routing::post(api::integrations_settings::connect_whatsapp).with_state(std::sync::Arc::new(crate::integrations::registry::IntegrationsRegistry::new())))


### PR DESCRIPTION
This PR mounts the missing `/api/agents/jobs` backend endpoint for the Agent Activity Dashboard frontend to fetch job logs. It removes a stale E2E test comment, and updates the `agent_activity.spec.ts` test to explicitly assert on the rendered UI state instead of ignoring the unmounted route.

It also explicitly updates the `prompt_construction.rs` documentation block and variables to match the OpenAI Codex strict hierarchy mechanic for the OHC builtin agent.

---
*PR created automatically by Jules for task [7771874221972057778](https://jules.google.com/task/7771874221972057778) started by @ql-owo-lp*