### PR TITLE
Fix Docker Hub rate limits and optimize DB datetime parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ From the root of the repository, you must explicitly run the onboarding CLI:
 
 This premium onboarding flow eliminates friction and ensures maximum developer velocity for Day One setup.
 
+### Local Build & Launch (Docker Hub Fallback)
+If you encounter Docker Hub rate limits (`You have reached your unauthenticated pull rate limit`), you can bypass them by building and loading the OCI images locally using Bazel:
+```bash
+bazel run //deploy:load_all_images
+cd deploy && docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
+```
+This flow utilizes local `server`, `agent`, and `ohc-core` images without requiring an external pull. It also leverages your local cache for base images like Postgres and Valkey.
+
 ## Identity
 
 One Human Corp employs the **OHC-HA Hybrid Architecture** for its identity and security framework, ensuring zero-trust verification seamlessly across both localized and cloud-native deployments.

--- a/deploy/docker-compose.override.yml
+++ b/deploy/docker-compose.override.yml
@@ -9,9 +9,11 @@ services:
 
   postgres:
     image: mirror.gcr.io/ankane/pgvector:v0.5.1
+    pull_policy: missing
     command: ["postgres", "-c", "wal_level=logical"]
 
   valkey:
     image: mirror.gcr.io/library/redis:alpine
+    pull_policy: missing
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -90,6 +90,13 @@ pub struct SearchResult {
 }
 
 
+fn parse_sqlite_datetime(s: &str) -> Result<chrono::DateTime<chrono::Utc>, sqlx::Error> {
+    chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
+        .map(|nd| chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(nd, chrono::Utc))
+        .or_else(|_| chrono::DateTime::parse_from_rfc3339(s).map(|d| d.with_timezone(&chrono::Utc)))
+        .map_err(|e| sqlx::Error::Decode(Box::new(e)))
+}
+
 impl DB {
     pub async fn query_available_slots(&self, tenant_id: &str, service_id: &str) -> Result<Vec<AvailableSlot>, sqlx::Error> {
         match &self.store {
@@ -136,18 +143,12 @@ impl DB {
                     // Sqlite might return string or integer for DateTime depending on the setup.
                     // To handle safely:
                     let start_time = match row.try_get::<String, _>("start_time") {
-                        Ok(s) => chrono::NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S")
-                            .map(|nd| chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(nd, chrono::Utc))
-                            .or_else(|_| chrono::DateTime::parse_from_rfc3339(&s).map(|d| d.with_timezone(&chrono::Utc)))
-                            .map_err(|e| sqlx::Error::Decode(Box::new(e)))?,
+                        Ok(s) => parse_sqlite_datetime(&s)?,
                         Err(_) => row.get::<chrono::DateTime<chrono::Utc>, _>("start_time"),
                     };
 
                     let end_time = match row.try_get::<String, _>("end_time") {
-                        Ok(s) => chrono::NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S")
-                            .map(|nd| chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(nd, chrono::Utc))
-                            .or_else(|_| chrono::DateTime::parse_from_rfc3339(&s).map(|d| d.with_timezone(&chrono::Utc)))
-                            .map_err(|e| sqlx::Error::Decode(Box::new(e)))?,
+                        Ok(s) => parse_sqlite_datetime(&s)?,
                         Err(_) => row.get::<chrono::DateTime<chrono::Utc>, _>("end_time"),
                     };
 
@@ -1800,6 +1801,15 @@ CREATE TABLE IF NOT EXISTS omni_inbox_messages (
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_sqlite_datetime() {
+        let dt1 = parse_sqlite_datetime("2023-10-25 14:30:00").unwrap();
+        assert_eq!(dt1.to_rfc3339(), "2023-10-25T14:30:00+00:00");
+
+        let dt2 = parse_sqlite_datetime("2023-10-25T14:30:00Z").unwrap();
+        assert_eq!(dt2.to_rfc3339(), "2023-10-25T14:30:00+00:00");
+    }
 
     #[test]
     fn test_db_new_fails_without_server() {


### PR DESCRIPTION
Resolves the Docker Hub rate limit issue by documenting the local build flow and relying on local images via `pull_policy: missing`. Additionally refactored duplicate SQLite parsing logic in `db.rs` to adhere to codebase optimization guidelines.

---
*PR created automatically by Jules for task [7812579878526489930](https://jules.google.com/task/7812579878526489930) started by @ql-owo-lp*