### PR TITLE
Fix tenant isolation, standalone file hardening, and OAuth proxy XSS

### DIFF
--- a/release/windows/run-ohc.cmd
+++ b/release/windows/run-ohc.cmd
@@ -15,6 +15,7 @@ if not exist ".ohc" mkdir ".ohc"
 set "OHC_SQLITE_KEY_FILE=%CD%\.ohc\sqlite.key"
 if not exist "%OHC_SQLITE_KEY_FILE%" (
   powershell -NoProfile -ExecutionPolicy Bypass -Command "$bytes = New-Object byte[] 32; [Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes); [Convert]::ToBase64String($bytes) | Set-Content -Encoding ASCII -NoNewline $env:OHC_SQLITE_KEY_FILE"
+  icacls "%OHC_SQLITE_KEY_FILE%" /inheritance:r /grant "%USERNAME%:F" /c /q >nul 2>&1
 )
 
 if not defined OHC_SQLITE_KEY (

--- a/src/server/api/oauth/proxy.rs
+++ b/src/server/api/oauth/proxy.rs
@@ -7,6 +7,22 @@ use axum::{
 use serde::Deserialize;
 use std::collections::HashMap;
 
+fn escape_html(s: &str) -> String {
+    let mut escaped = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '&' => escaped.push_str("&amp;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#x27;"),
+            _ => escaped.push(c),
+        }
+    }
+    escaped
+}
+
+
 #[derive(Deserialize)]
 pub struct OAuthCallbackQuery {
     pub code: String,
@@ -52,6 +68,7 @@ pub async fn handle_oauth_callback(
             for (k, v) in query.extra {
                 redirect_url.push_str(&format!("&{}={}", urlencoding::encode(&k), urlencoding::encode(&v)));
             }
+            let safe_redirect_url = escape_html(&redirect_url);
             let html_redirect = format!(
                 r#"<!DOCTYPE html>
 <html>
@@ -64,7 +81,7 @@ pub async fn handle_oauth_callback(
 </head>
 <body>Redirecting...</body>
 </html>"#,
-                redirect_url, redirect_url
+                safe_redirect_url, safe_redirect_url
             );
             return (
                 axum::http::StatusCode::OK,
@@ -88,6 +105,7 @@ mod tests {
     use super::*;
     use axum::extract::Query;
     use std::collections::HashMap;
+
 
 
 
@@ -197,5 +215,28 @@ mod tests {
 
         let response = handle_oauth_callback(Query(query)).await.into_response();
         assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+    }
+
+
+    #[tokio::test]
+    async fn test_xss_in_callback_is_escaped() {
+        let mut extra = HashMap::new();
+        extra.insert("foo".to_string(), "bar\"<script>alert(1)</script>".to_string());
+
+        let query = OAuthCallbackQuery {
+            code: "\"><img src=x onerror=alert(1)>".to_string(),
+            state: "standalone_123e4567-e89b-12d3-a456-426614174000_actualState123".to_string(),
+            extra,
+        };
+
+        let response = handle_oauth_callback(Query(query)).await.into_response();
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+        assert!(!body_str.contains("<script>alert(1)</script>"));
+        assert!(!body_str.contains("\"><img"));
+
     }
 }

--- a/src/server/db/migrations/158_fix_onboarding_tool_integrations_rls.sql
+++ b/src/server/db/migrations/158_fix_onboarding_tool_integrations_rls.sql
@@ -12,7 +12,8 @@ BEGIN
             WHERE tablename = 'onboarding_state' AND policyname = 'tenant_isolation_onboarding_state'
         ) THEN
             CREATE POLICY tenant_isolation_onboarding_state ON onboarding_state
-                USING (tenant_id = current_setting('app.current_tenant', true)::UUID);
+                USING (tenant_id::text = current_setting('app.current_tenant', true))
+                WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
         END IF;
     END IF;
 
@@ -25,7 +26,8 @@ BEGIN
             WHERE tablename = 'tool_integrations' AND policyname = 'tenant_isolation_tool_integrations'
         ) THEN
             CREATE POLICY tenant_isolation_tool_integrations ON tool_integrations
-                USING (tenant_id = current_setting('app.current_tenant', true)::UUID);
+                USING (tenant_id::text = current_setting('app.current_tenant', true))
+                WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
         END IF;
     END IF;
 END $$;


### PR DESCRIPTION
This submission resolves security concerns across multi-tenancy, file storage (Standalone Mode), and proxy connectivity. 

1. **Tenant Isolation:** Patched missing and improperly casted `tenant_id` logic inside the SQL migration (`158_fix_onboarding_tool_integrations_rls.sql`), ensuring cross-tenant queries safely isolate rows for `onboarding_state` and `tool_integrations`.
2. **Local Hardening:** Altered `release/windows/run-ohc.cmd` so that the generated SQLite key gets restricted to the running user (`%USERNAME%:F`) by using `icacls`. Unix equivalents are already applying `.mode(0o600)`.
3. **Thin Client Security:** Solved an HTML injection (reflected XSS) attack vector in `src/server/api/oauth/proxy.rs` where user-supplied `query.code` or `actual_state` values generated a `redirect_url` directly embedded into a `<script>` tag and HTML properties without escaping. Appended unit testing explicitly to check payload rejection.

---
*PR created automatically by Jules for task [5864180433779020661](https://jules.google.com/task/5864180433779020661) started by @ql-owo-lp*