### PR TITLE
💰 Miser: Per-tenant LLM token tracking for billing & abuse prevention

### DIFF
--- a/src/server/api/telemetry.rs
+++ b/src/server/api/telemetry.rs
@@ -70,6 +70,8 @@ pub async fn sync_telemetry_handler(Json(batch): Json<Vec<MetricBatchItem>>) -> 
                         .and_then(Value::as_str)
                         .unwrap_or("unknown_tenant")
                         .to_string();
+                    let count_clone = count;
+                    let model_clone = model_string.clone();
                     tokio::spawn(async move {
                         let pool = crate::db::get_pool();
                         let _ = ::server_telemetry::record_llm_call_cost(&pool, &tenant_id, &model_string, cost_usd).await;
@@ -79,6 +81,13 @@ pub async fn sync_telemetry_handler(Json(batch): Json<Vec<MetricBatchItem>>) -> 
                             "model": model_string.clone()
                         });
                         let _ = ::server_telemetry::buffer_metric_i64(&pool, "ohc_llm_cost_total_cents", "counter", cost_cents, labels_cents).await;
+
+                        if let Ok(redis_url) = std::env::var("REDIS_URL") {
+                            if let Ok(client) = redis::Client::open(redis_url) {
+                                let limiter = ::server_pricing::rate_limit::RedisRateLimiter::new(client);
+                                let _ = limiter.record_token_usage(&tenant_id, &model_clone, count_clone).await;
+                            }
+                        }
                     });
                 }
             }

--- a/src/server/pricing/rate_limit.rs
+++ b/src/server/pricing/rate_limit.rs
@@ -210,6 +210,39 @@ impl RedisRateLimiter {
         conn.set(format!("tenant:{}:tier", tenant_id), tier_str).await.map_err(|e| e.to_string())
     }
 
+    pub async fn record_token_usage(&self, tenant_id: &str, model: &str, tokens: i64) -> Result<(), String> {
+        if tokens <= 0 {
+            return Ok(());
+        }
+        let mut conn = self.get_connection().await?;
+        let now = chrono::Utc::now();
+        let month_key = now.format("%Y-%m").to_string();
+
+        tracing::info!("💰 Miser telemetry: Recording {} tokens for tenant: {} model: {}", tokens, tenant_id, model);
+
+        let tenant_key = format!("tenant:{}:tokens_used:{}", tenant_id, month_key);
+        let model_key = format!("tenant:{}:tokens_used:{}:{}", tenant_id, model, month_key);
+
+        let _ : () = redis::AsyncCommands::incr(&mut conn, &tenant_key, tokens).await.unwrap_or(());
+        let _ : () = redis::AsyncCommands::incr(&mut conn, &model_key, tokens).await.unwrap_or(());
+
+        // Expire keys after ~2 months to save space
+        let _ : () = redis::AsyncCommands::expire(&mut conn, &tenant_key, 60 * 60 * 24 * 60).await.unwrap_or(());
+        let _ : () = redis::AsyncCommands::expire(&mut conn, &model_key, 60 * 60 * 24 * 60).await.unwrap_or(());
+
+        Ok(())
+    }
+
+    pub async fn get_token_usage(&self, tenant_id: &str) -> Result<i64, String> {
+        let mut conn = self.get_connection().await?;
+        let now = chrono::Utc::now();
+        let month_key = now.format("%Y-%m").to_string();
+        let tenant_key = format!("tenant:{}:tokens_used:{}", tenant_id, month_key);
+
+        let count: i64 = redis::AsyncCommands::get(&mut conn, &tenant_key).await.unwrap_or(0);
+        Ok(count)
+    }
+
     pub async fn record_action(&self, tenant_id: &str, agent_id: &str) -> Result<RateLimitStatus, String> {
         if let Some(store) = &self.telemetry_store {
             store.rate_limit_checks_total.add(1, &[opentelemetry::KeyValue::new("tenant_id", tenant_id.to_string())]);
@@ -688,6 +721,31 @@ mod tests {
                 }
                 let status = limiter.record_action(tenant_id, agent_id).await.expect("failed to unwrap");
                 assert!(status.soft_limit_reached);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_record_token_usage() {
+        if let Ok(redis_url) = std::env::var("REDIS_URL") {
+            if let Ok(client) = redis::Client::open(redis_url) {
+                let limiter = RedisRateLimiter::new(client.clone());
+                let tenant_id = "test-tenant-tokens";
+
+                let mut conn = limiter.get_connection().await.expect("failed to unwrap");
+                let now = chrono::Utc::now();
+                let month_key = now.format("%Y-%m").to_string();
+                let tenant_key = format!("tenant:{}:tokens_used:{}", tenant_id, month_key);
+                let _ : () = redis::AsyncCommands::del(&mut conn, &tenant_key).await.unwrap_or(());
+
+                let usage = limiter.get_token_usage(tenant_id).await.expect("failed to get usage");
+                assert_eq!(usage, 0);
+
+                limiter.record_token_usage(tenant_id, "gpt-4o", 1500).await.expect("failed to record tokens");
+                limiter.record_token_usage(tenant_id, "gpt-4o", 500).await.expect("failed to record tokens");
+
+                let usage = limiter.get_token_usage(tenant_id).await.expect("failed to get usage");
+                assert_eq!(usage, 2000);
             }
         }
     }


### PR DESCRIPTION
Implement Per-tenant LLM token tracking in Redis. Added `record_token_usage` and `get_token_usage` to `RedisRateLimiter` to track token usage per tenant. The tracking increments a monthly key (`tenant:{tenant_id}:tokens_used:{month_key}`) in Redis, allowing us to enforce soft limits based on the configured plan tier for billing and abuse prevention. This tracking is called inside `sync_telemetry_handler`.

---
*PR created automatically by Jules for task [8149813066401758390](https://jules.google.com/task/8149813066401758390) started by @ql-owo-lp*