### PR TITLE
Refactor telemetry error signals and dead letter messages

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -238,7 +238,7 @@ impl DB {
                                         }
                                     }
                                 } else {
-                                    ::server_telemetry::record_error_signal("[infra] Failed to securely create DB directory");
+                                    ::server_telemetry::record_error_signal("[bug] Failed to securely create DB directory");
                                     tracing::error!("Failed to securely create DB directory: {}", e);
                                     return Err(e.into());
                                 }
@@ -247,7 +247,7 @@ impl DB {
                         #[cfg(not(unix))]
                         {
                             if let Err(e) = std::fs::create_dir_all(parent) {
-                                ::server_telemetry::record_error_signal("[infra] Failed to create DB directory");
+                                ::server_telemetry::record_error_signal("[bug] Failed to create DB directory");
                                 tracing::error!("Failed to create DB directory: {}", e);
                                 return Err(e.into());
                             }

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -759,7 +759,7 @@ async fn http_login_handler(
     let mut tx = match db.pool.begin().await {
         Ok(tx) => tx,
         Err(e) => {
-            ::server_telemetry::record_error_signal("[BUG] failed to start login transaction");
+            ::server_telemetry::record_error_signal("[bug] failed to start login transaction");
             tracing::error!("failed to start login transaction: {}", e);
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -770,7 +770,7 @@ async fn http_login_handler(
     };
 
     if let Err(e) = ::server_common::auth_utils::set_org_context(&mut *tx, &tenant_id).await {
-        ::server_telemetry::record_error_signal("[INFRA] failed to set tenant context for login");
+        ::server_telemetry::record_error_signal("[bug] failed to set tenant context for login");
         tracing::error!("failed to set tenant context for login: {}", e);
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -794,7 +794,7 @@ async fn http_login_handler(
     {
         Ok(row) => row,
         Err(e) => {
-            ::server_telemetry::record_error_signal("[BUG] failed to query login user");
+            ::server_telemetry::record_error_signal("[bug] failed to query login user");
             tracing::error!("failed to query login user: {}", e);
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -820,7 +820,7 @@ async fn http_login_handler(
         match tokio::task::spawn_blocking(move || bcrypt::verify(&password, &hash)).await {
             Ok(res) => res,
             Err(e) => {
-                ::server_telemetry::record_error_signal("[BUG] spawn_blocking failed for bcrypt");
+                ::server_telemetry::record_error_signal("[bug] spawn_blocking failed for bcrypt");
                 tracing::error!("spawn_blocking failed for bcrypt: {}", e);
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -841,7 +841,7 @@ async fn http_login_handler(
                 .into_response();
         }
         Err(e) => {
-            ::server_telemetry::record_error_signal("[SECURITY] failed to verify auth credential");
+            ::server_telemetry::record_error_signal("[security] failed to verify auth credential");
             tracing::error!("failed to verify auth credential: {}", e); // pii-safe
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -873,7 +873,7 @@ async fn http_login_handler(
     let token = match store.issue_token(&user) {
         Ok(t) => t,
         Err(e) => {
-            ::server_telemetry::record_error_signal("[BUG] failed to issue login token");
+            ::server_telemetry::record_error_signal("[bug] failed to issue login token");
             tracing::error!("failed to issue login token: {}", e); // pii-safe
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1054,7 +1054,7 @@ pub async fn advisory_insights_handler(
             (StatusCode::OK, axum::Json(serde_json::json!({ "summary": output }))).into_response()
         }
         Err(e) => {
-            ::server_telemetry::record_error_signal("[AI] MiniMax advisory insights failed");
+            ::server_telemetry::record_error_signal("[bug] MiniMax advisory insights failed");
             tracing::error!("MiniMax advisory insights failed: {}", e);
             (
                 StatusCode::BAD_GATEWAY,
@@ -1135,7 +1135,7 @@ async fn draft_reply_handler(
     match client.reason(&compressed_prompt).await {
         Ok(output) => (StatusCode::OK, axum::Json(DraftReplyResponse { output })).into_response(),
         Err(e) => {
-            ::server_telemetry::record_error_signal("[AI] MiniMax draft reply failed");
+            ::server_telemetry::record_error_signal("[bug] MiniMax draft reply failed");
             tracing::error!("MiniMax draft reply failed: {}", e);
             (
                 StatusCode::BAD_GATEWAY,
@@ -2603,7 +2603,7 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
     tokio::spawn(async move {
         loop {
             if let Err(e) = agent_memory_pipeline_clone.run().await {
-                ::server_telemetry::record_error_signal("[BUG] Agent Memory Pipeline error");
+                ::server_telemetry::record_error_signal("[bug] Agent Memory Pipeline error");
                 tracing::error!("Agent Memory Pipeline error: {}", e);
             }
             tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
@@ -2744,7 +2744,7 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
         let payload = match serde_json::to_string(&task) {
             Ok(p) => p,
             Err(e) => {
-                ::server_telemetry::record_error_signal("[BUG] Failed to serialize task");
+                ::server_telemetry::record_error_signal("[bug] Failed to serialize task");
                 tracing::error!("Failed to serialize task: {}", e);
                 return;
             }
@@ -2768,7 +2768,7 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
         is_cloud
     );
     if let Err(e) = handoff_manager.start_listener().await {
-        ::server_telemetry::record_error_signal("[INFRA] Failed to start handoff listener");
+        ::server_telemetry::record_error_signal("[bug] Failed to start handoff listener");
         tracing::trace!("Failed to start handoff listener: {}", e);
     }
 
@@ -2806,7 +2806,7 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
                         .register_presence(&heartbeat_agent_id, "online", 60)
                         .await
                     {
-                        ::server_telemetry::record_error_signal("[INFRA] Failed to register builtin agent presence");
+                        ::server_telemetry::record_error_signal("[bug] Failed to register builtin agent presence");
                         tracing::error!("Failed to register builtin agent presence: {}", e);
                     }
                 }
@@ -2862,7 +2862,7 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
                         .register_presence(&agent_id_clone, "active", 30)
                         .await
                     {
-                        ::server_telemetry::record_error_signal("[INFRA] Failed to register presence");
+                        ::server_telemetry::record_error_signal("[bug] Failed to register presence");
                         tracing::error!("Failed to register presence: {}", e);
                     }
                     tokio::time::sleep(std::time::Duration::from_secs(15)).await;
@@ -2989,7 +2989,7 @@ async fn get_inbox_messages_handler(axum::extract::Extension(user): axum::extrac
     let mut tx = match pool.begin().await {
         Ok(t) => t,
         Err(e) => {
-            ::server_telemetry::record_error_signal("[BUG] Failed to begin transaction");
+            ::server_telemetry::record_error_signal("[bug] Failed to begin transaction");
             tracing::error!("Failed to begin transaction: {}", e);
             return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!([]))).into_response();
         }
@@ -2997,7 +2997,7 @@ async fn get_inbox_messages_handler(axum::extract::Extension(user): axum::extrac
 
     let org_id = user.organization_id.unwrap_or_default();
     if let Err(e) = crate::common::auth_utils::set_org_context(&mut *tx, &org_id).await {
-        ::server_telemetry::record_error_signal("[INFRA] Failed to set org context");
+        ::server_telemetry::record_error_signal("[bug] Failed to set org context");
         tracing::error!("Failed to set org context: {}", e);
         return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!([]))).into_response();
     }
@@ -3033,7 +3033,7 @@ async fn get_inbox_messages_handler(axum::extract::Extension(user): axum::extrac
             (axum::http::StatusCode::OK, axum::Json(messages)).into_response()
         }
         Err(e) => {
-            ::server_telemetry::record_error_signal("[BUG] Failed to fetch inbox messages");
+            ::server_telemetry::record_error_signal("[bug] Failed to fetch inbox messages");
             tracing::error!("Failed to fetch inbox messages: {}", e);
             (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!([]))).into_response()
         }
@@ -5537,7 +5537,7 @@ async fn list_ui_orders_handler(
             (axum::http::StatusCode::OK, axum::Json(orders)).into_response()
         },
         Err(e) => {
-            ::server_telemetry::record_error_signal("[BUG] Failed to fetch UI orders");
+            ::server_telemetry::record_error_signal("[bug] Failed to fetch UI orders");
             tracing::error!("Failed to fetch UI orders: {}", e);
             (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!([]))).into_response()
         }
@@ -5710,7 +5710,7 @@ async fn list_ui_inbox_handler(
             (axum::http::StatusCode::OK, axum::Json(messages)).into_response()
         },
         Err(e) => {
-            ::server_telemetry::record_error_signal("[BUG] Failed to fetch UI inbox messages");
+            ::server_telemetry::record_error_signal("[bug] Failed to fetch UI inbox messages");
             tracing::error!("Failed to fetch UI inbox messages: {}", e);
             (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!([]))).into_response()
         }
@@ -5755,7 +5755,7 @@ async fn ui_dashboard_metrics_handler(
             (axum::http::StatusCode::OK, axum::Json(res)).into_response()
         }
         Err(e) => {
-            ::server_telemetry::record_error_signal("[BUG] Failed to fetch UI dashboard metrics");
+            ::server_telemetry::record_error_signal("[bug] Failed to fetch UI dashboard metrics");
             tracing::error!("Failed to fetch UI dashboard metrics: {}", e);
             (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({
                 "active_customers": 0,
@@ -5827,7 +5827,7 @@ async fn create_ui_supply_vendor_handler(
     match result {
         Ok(_) => (axum::http::StatusCode::OK, axum::Json(serde_json::json!({"id": id, "name": name, "contact_info": contact_info}))).into_response(),
         Err(e) => {
-            ::server_telemetry::record_error_signal("[BUG] Failed to create UI supply vendor");
+            ::server_telemetry::record_error_signal("[bug] Failed to create UI supply vendor");
             tracing::error!("Failed to create UI supply vendor: {}", e);
             (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({"error": "database write failed"}))).into_response()
         }
@@ -5855,7 +5855,7 @@ async fn create_ui_raw_material_handler(
     match result {
         Ok(_) => (axum::http::StatusCode::OK, axum::Json(serde_json::json!({"id": id, "name": name, "current_quantity": current_quantity, "reorder_threshold": reorder_threshold}))).into_response(),
         Err(e) => {
-            ::server_telemetry::record_error_signal("[BUG] Failed to create UI raw material");
+            ::server_telemetry::record_error_signal("[bug] Failed to create UI raw material");
             tracing::error!("Failed to create UI raw material: {}", e);
             (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({"error": "database write failed"}))).into_response()
         }
@@ -5883,7 +5883,7 @@ async fn create_ui_bom_item_handler(
     match result {
         Ok(_) => (axum::http::StatusCode::OK, axum::Json(serde_json::json!({"id": id, "finished_good_id": finished_good_id, "raw_material_id": raw_material_id, "quantity_required": quantity_required}))).into_response(),
         Err(e) => {
-            ::server_telemetry::record_error_signal("[BUG] Failed to create UI BOM item");
+            ::server_telemetry::record_error_signal("[bug] Failed to create UI BOM item");
             tracing::error!("Failed to create UI BOM item: {}", e);
             (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({"error": "database write failed"}))).into_response()
         }
@@ -6029,7 +6029,7 @@ async fn create_ui_bom_item_handler(
                 let new_order = req.get("new_order").and_then(|v| v.as_bool()).unwrap_or(false);
 
                 if let Err(e) = settings_store.set_sms_preferences(phone, urgent_booking, failed_payment, new_order) {
-                    ::server_telemetry::record_error_signal("[BUG] Failed to save SMS preferences");
+                    ::server_telemetry::record_error_signal("[bug] Failed to save SMS preferences");
                     tracing::error!("Failed to save SMS preferences: {}", e);
                     return axum::response::Json(serde_json::json!({ "success": false }));
                 }
@@ -6055,7 +6055,7 @@ async fn create_ui_bom_item_handler(
                 let fee = req.get("delivery_fee").and_then(|v| v.as_f64());
 
                 if let Err(e) = settings_store.set_delivery_settings(enabled, radius, fee) {
-                    ::server_telemetry::record_error_signal("[BUG] Failed to save delivery settings");
+                    ::server_telemetry::record_error_signal("[bug] Failed to save delivery settings");
                     tracing::error!("Failed to save delivery settings: {}", e);
                     return axum::response::Json(serde_json::json!({ "success": false }));
                 }
@@ -6099,7 +6099,7 @@ async fn create_ui_bom_item_handler(
                 };
 
                 if let Err(e) = settings_store.set_voice_settings(enabled, number, persona, instructions) {
-                    ::server_telemetry::record_error_signal("[BUG] Failed to save voice settings");
+                    ::server_telemetry::record_error_signal("[bug] Failed to save voice settings");
                     tracing::error!("Failed to save voice settings: {}", e);
                     return axum::response::Json(serde_json::json!({ "success": false }));
                 }
@@ -6122,7 +6122,7 @@ async fn create_ui_bom_item_handler(
                     settings.voice_receptionist_persona,
                     settings.voice_receptionist_instructions,
                 ) {
-                    ::server_telemetry::record_error_signal("[INFRA] Failed to provision voice number");
+                    ::server_telemetry::record_error_signal("[bug] Failed to provision voice number");
                     tracing::error!("Failed to provision voice number: {}", e);
                     return axum::response::Json(serde_json::json!({ "success": false, "error": "Internal error" }));
                 }
@@ -6442,7 +6442,7 @@ async fn create_ui_bom_item_handler(
                         }).await;
 
                         if let Err(e) = result {
-                            ::server_telemetry::record_error_signal("[BUG] Failed to seed data");
+                            ::server_telemetry::record_error_signal("[bug] Failed to seed data");
                             tracing::error!("Failed to seed data: {}", e);
                             return axum::Json(serde_json::json!({ "ok": false, "error": e }));
                         }
@@ -6766,7 +6766,7 @@ async fn create_ui_bom_item_handler(
     tokio::spawn(async move {
         tracing::info!("Mesh WebSocket server listening on {}", mesh_addr);
         if let Err(e) = axum::serve(listener, app.into_make_service()).await {
-            ::server_telemetry::record_error_signal("[INFRA] Mesh server error");
+            ::server_telemetry::record_error_signal("[bug] Mesh server error");
             tracing::trace!("Mesh server error: {}", e);
         }
     });
@@ -6811,11 +6811,11 @@ async fn create_ui_bom_item_handler(
             loop {
                 interval.tick().await;
                 if let Err(e) = cloud_sync_clone.push_pending_missions("system").await {
-                    ::server_telemetry::record_error_signal("[INFRA] failed to push pending missions");
+                    ::server_telemetry::record_error_signal("[bug] failed to push pending missions");
                     tracing::trace!("failed to push pending missions: {}", e);
                 }
                 if let Err(e) = cloud_sync_clone.pull_mission_updates("system").await {
-                    ::server_telemetry::record_error_signal("[INFRA] failed to pull mission updates");
+                    ::server_telemetry::record_error_signal("[bug] failed to pull mission updates");
                     tracing::trace!("failed to pull mission updates: {}", e);
                 }
             }
@@ -6857,11 +6857,11 @@ async fn create_ui_bom_item_handler(
                 _ = prune_interval.tick() => {
                     let sip_db = crate::sip::SipDB::new(hub_for_sched.pool.clone(), "system".to_string());
                     if let Err(e) = sip_db.prune_stale_missions(chrono::Duration::days(7)).await {
-                        ::server_telemetry::record_error_signal("[MAINTENANCE] failed to prune stale missions");
+                        ::server_telemetry::record_error_signal("[cleanup] failed to prune stale missions");
                         tracing::trace!("failed to prune stale missions: {}", e);
                     }
                     if let Err(e) = sip_db.cleanup_stagnant_missions(chrono::Duration::minutes(5)).await {
-                        ::server_telemetry::record_error_signal("[MAINTENANCE] failed to cleanup stagnant missions");
+                        ::server_telemetry::record_error_signal("[cleanup] failed to cleanup stagnant missions");
                         tracing::trace!("failed to cleanup stagnant missions: {}", e);
                     }
                     let job_queue = crate::orchestration::queue::ohc_job_queue::OHCJobQueue::new(std::sync::Arc::new(hub_for_sched.pool.clone()));
@@ -6879,7 +6879,7 @@ async fn create_ui_bom_item_handler(
 
                         // Mark as running
                         if let Err(e) = hub_for_sched.scheduler().mark_running(&task.organization_id, &task.id) {
-                            ::server_telemetry::record_error_signal("[BUG] failed to mark task as running");
+                            ::server_telemetry::record_error_signal("[bug] failed to mark task as running");
                             tracing::trace!("failed to mark task as running: {}", e);
                             continue;
                         }
@@ -6900,7 +6900,7 @@ async fn create_ui_bom_item_handler(
                                 let _ = hub_for_sched.scheduler().mark_done(&task.organization_id, &task.id, true);
                             }
                             Err(e) => {
-                                ::server_telemetry::record_error_signal("[INFRA] failed to publish scheduled task message");
+                                ::server_telemetry::record_error_signal("[bug] failed to publish scheduled task message");
                                 tracing::trace!("failed to publish scheduled task message: {}", e);
                                 let _ = hub_for_sched.scheduler().mark_done(&task.organization_id, &task.id, false);
                             }

--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -443,7 +443,7 @@ impl HybridSyncDaemon {
 
     pub async fn prune_stuck_agent_missions(&self) -> Result<(), Box<dyn std::error::Error>> {
         // SQLite
-        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'mission_failed', 'agent_missions', COALESCE(payload, '{}'), 'bug: Mission became stuck' FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hour') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hour')))").execute(&self.sqlite_pool).await;
+        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'mission_failed', 'agent_missions', COALESCE(payload, '{}'), '[bug] Mission became stuck' FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hour') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hour')))").execute(&self.sqlite_pool).await;
         let res_sqlite = sqlx::query("DELETE FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hour') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hour')))")
             .execute(&self.sqlite_pool)
             .await;
@@ -454,7 +454,7 @@ impl HybridSyncDaemon {
         }
 
         // PG
-        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'mission_failed', 'agent_missions', COALESCE(payload::text, '{}'), 'bug: Mission became stuck' FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))").execute(&self.pg_pool).await;
+        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'mission_failed', 'agent_missions', COALESCE(payload::text, '{}'), '[bug] Mission became stuck' FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))").execute(&self.pg_pool).await;
         let res_pg = sqlx::query("DELETE FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))")
             .execute(&self.pg_pool)
             .await;
@@ -478,7 +478,7 @@ impl HybridSyncDaemon {
             }
         }
 
-        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload, '{}'), 'cleanup: Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE status = 'QUEUED' AND created_at < datetime('now', '-24 hour')").execute(&self.sqlite_pool).await;
+        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE status = 'QUEUED' AND created_at < datetime('now', '-24 hour')").execute(&self.sqlite_pool).await;
         let res_queued_sqlite = sqlx::query("DELETE FROM sub_agent_queue WHERE status = 'QUEUED' AND created_at < datetime('now', '-24 hour')")
             .execute(&self.sqlite_pool)
             .await;
@@ -498,7 +498,7 @@ impl HybridSyncDaemon {
             }
         }
 
-        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload::text, '{}'), 'cleanup: Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE status = 'QUEUED' AND created_at < NOW() - INTERVAL '24 hours'").execute(&self.pg_pool).await;
+        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload::text, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE status = 'QUEUED' AND created_at < NOW() - INTERVAL '24 hours'").execute(&self.pg_pool).await;
         let res_queued_pg = sqlx::query("DELETE FROM sub_agent_queue WHERE status = 'QUEUED' AND created_at < NOW() - INTERVAL '24 hours'")
             .execute(&self.pg_pool)
             .await;

--- a/src/server/queue.rs
+++ b/src/server/queue.rs
@@ -425,7 +425,7 @@ impl TaskQueue for PostgresTaskQueue {
         // Clean up stagnant backlog items: QUEUED jobs stuck for > 24 hours
         sqlx::query(
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
-             SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload::text, '{}'), 'cleanup: Stagnant backlog item stuck in QUEUED for > 24 hours'
+             SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload::text, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours'
              FROM sub_agent_queue
              WHERE status = 'QUEUED' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
         )
@@ -1149,7 +1149,7 @@ impl TaskQueue for SqliteTaskQueue {
         // Clean up stagnant backlog items: QUEUED jobs stuck for > 24 hours
         let _ = sqlx::query(
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
-             SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload, '{}'), 'cleanup: Stagnant backlog item stuck in QUEUED for > 24 hours'
+             SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours'
              FROM sub_agent_queue
              WHERE status = 'QUEUED' AND created_at < datetime('now', '-24 hour')"
         )

--- a/src/server/telemetry_test.rs
+++ b/src/server/telemetry_test.rs
@@ -658,7 +658,7 @@ fn test_record_error_signal() {
     // It's hard to test the opentelemetry meter without mocking the provider,
     // but we can at least test that `record_error_signal` executes without panicking
     // and categorize correctly behind the scenes.
-    ::server_telemetry::record_error_signal("panic: test");
+    ::server_telemetry::record_error_signal("[bug] panic: test");
 }
 
     #[test]


### PR DESCRIPTION
Fixes issues with non-standardized telemetry categories and redundant log cleaning per the infrastructure and maintenance requirements. Standardizes `record_error_signal` and dead-letter insert messages while preserving tracing context to ensure observability and clean builds.

---
*PR created automatically by Jules for task [4314164816269009840](https://jules.google.com/task/4314164816269009840) started by @ql-owo-lp*