### PR TITLE
feat: add "Remove branding" option to Link-in-Bio Generator

### DIFF
--- a/src/ui/next/src/app/bio/[tenant]/page.tsx
+++ b/src/ui/next/src/app/bio/[tenant]/page.tsx
@@ -13,6 +13,7 @@ interface BioConfig {
   bio: string;
   theme: 'light' | 'dark';
   links: Link[];
+  remove_branding?: boolean;
 }
 
 export default function PublicBioPage() {
@@ -86,14 +87,16 @@ export default function PublicBioPage() {
         </div>
 
         {/* Viral Loop / Soft Paywall */}
-        <div className="mt-12 pt-8">
-          <a
-            href={`/onboarding?ref=linkinbio_${tenant}`}
-            className={`text-sm font-semibold flex items-center justify-center gap-1 hover:underline ${theme === 'dark' ? 'text-gray-500 hover:text-gray-300' : 'text-gray-400 hover:text-gray-600'}`}
-          >
-            ⚡ Powered by OHC
-          </a>
-        </div>
+        {!config.remove_branding && (
+          <div className="mt-12 pt-8">
+            <a
+              href={`https://ohc.store/join?ref=${tenant}`}
+              className={`text-sm font-semibold flex items-center justify-center gap-1 hover:underline ${theme === 'dark' ? 'text-gray-500 hover:text-gray-300' : 'text-gray-400 hover:text-gray-600'}`}
+            >
+              ⚡ Powered by OHC
+            </a>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/ui/next/src/app/link-in-bio-generator/page.tsx
+++ b/src/ui/next/src/app/link-in-bio-generator/page.tsx
@@ -11,6 +11,7 @@ export default function LinkInBioGeneratorPage() {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
   const [links, setLinks] = useState([{ title: 'Shop Now', url: 'https://ohc.app' }]);
   const [tenant, setTenant] = useState('my-store');
+  const [removeBranding, setRemoveBranding] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [copied, setCopied] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -30,6 +31,7 @@ export default function LinkInBioGeneratorPage() {
              setBio(data.bio || '');
              setTheme(data.theme || 'light');
              setLinks(data.links && data.links.length > 0 ? data.links : [{ title: 'Shop Now', url: 'https://ohc.app' }]);
+             setRemoveBranding(data.remove_branding || false);
           }
         }
       } catch (e) {
@@ -65,7 +67,8 @@ export default function LinkInBioGeneratorPage() {
           store_name: storeName,
           bio,
           theme,
-          links
+          links,
+          remove_branding: removeBranding
         })
       });
       if (res.ok) {
@@ -173,6 +176,23 @@ export default function LinkInBioGeneratorPage() {
             </div>
 
             <div className="glassmorphism rounded-2xl p-6 bg-white border border-gray-100 shadow-sm dark:bg-[#2C2C2E] dark:border-white/10">
+              <h2 className="text-lg font-bold font-outfit text-gray-900 dark:text-white mb-4">Branding</h2>
+              <div className="flex items-center gap-3">
+                <input
+                  type="checkbox"
+                  id="removeBrandingCheckbox"
+                  aria-label="Remove branding"
+                  checked={removeBranding}
+                  onChange={(e) => setRemoveBranding(e.target.checked)}
+                  className="w-5 h-5 text-indigo-600 rounded border-gray-300 focus:ring-indigo-500"
+                />
+                <label htmlFor="removeBrandingCheckbox" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Remove "Powered by OHC" branding
+                </label>
+              </div>
+            </div>
+
+            <div className="glassmorphism rounded-2xl p-6 bg-white border border-gray-100 shadow-sm dark:bg-[#2C2C2E] dark:border-white/10">
               <h2 className="text-lg font-bold font-outfit text-gray-900 dark:text-white mb-4">Theme</h2>
               <div className="flex gap-4">
                 <button
@@ -233,9 +253,11 @@ export default function LinkInBioGeneratorPage() {
                             ))}
                         </div>
 
-                        <div className="mt-auto pt-8 pb-4">
-                            <PoweredByOHC tenantId={tenant} />
-                        </div>
+                        {!removeBranding && (
+                          <div className="mt-auto pt-8 pb-4">
+                              <PoweredByOHC tenantId={tenant} />
+                          </div>
+                        )}
                     </div>
                 </div>
              </div>


### PR DESCRIPTION
This PR implements the missing "Remove branding" feature for the Link-in-Bio Generator to fix failing E2E tests.

### Changes:
- Added a `removeBranding` state and checkbox (with `aria-label="Remove branding"`) to `src/ui/next/src/app/link-in-bio-generator/page.tsx`.
- Updated the generator page to save and load the `remove_branding` setting to/from the API and conditionally render the `PoweredByOHC` component in the preview.
- Updated `src/ui/next/src/app/bio/[tenant]/page.tsx` to read `remove_branding` from the `BioConfig` and hide the footer when true.
- Fixed the href in the public bio page to match the one tested in `link-in-bio.spec.ts` (`https://ohc.store/join?ref=${tenant}`).

### Testing:
- Ran `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)" --test_env=PLAYWRIGHT_GREP="bio"`. The test `link-in-bio.spec.ts` passed successfully.
- Ran all system tests using `bazelisk test //...` and `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"` to ensure no regressions were introduced. All tests passed.

---
*PR created automatically by Jules for task [3986777710389255465](https://jules.google.com/task/3986777710389255465) started by @ql-owo-lp*