### PR TITLE
🔗 Link: [multi-channel inventory sync and distributed POS architecture]

### DIFF
--- a/src/server/services/inventory/service.rs
+++ b/src/server/services/inventory/service.rs
@@ -452,6 +452,25 @@ impl InventoryService {
                     .bind(&action_payload)
                     .execute(&mut *tx)
                     .await;
+
+                let feed_id = Uuid::new_v4().to_string();
+                let feed_payload = serde_json::json!({
+                    "product_id": product_id,
+                    "remaining_stock": new_stock,
+                    "message": message,
+                });
+                let proposed_action = serde_json::json!({
+                    "action": "Review and approve restock order"
+                });
+                let _ = sqlx::query(
+                    "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state) VALUES ($1, $2, 'operations', $3::jsonb, $4::jsonb, 'PENDING_APPROVAL')"
+                )
+                .bind(&feed_id)
+                .bind(tenant_id)
+                .bind(&feed_payload)
+                .bind(&proposed_action)
+                .execute(&mut *tx)
+                .await;
             }
         } else {
             let current_stock: Option<i32> = sqlx::query_scalar("SELECT available_quantity FROM products WHERE id = $1 AND tenant_id = $2")
@@ -520,6 +539,54 @@ mod tests {
     use super::*;
     use crate::db::DbStore;
     use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_commit_inventory_low_stock() {
+        if std::env::var("OHC_DATABASE_URL").is_err() {
+            return;
+        }
+
+        let pool = crate::db::get_pool();
+        let _db = Arc::new(crate::db::DB {
+            pool: pool.clone(),
+            store: DbStore::Postgres,
+        });
+
+        let tenant_id = "test_inventory_tenant";
+        let product_id = "test_product_low_stock";
+
+        let _ = sqlx::query("INSERT INTO tenants (id, name) VALUES ($1, 'Test Tenant') ON CONFLICT DO NOTHING")
+            .bind(tenant_id)
+            .execute(&pool)
+            .await;
+
+        let _ = sqlx::query("INSERT INTO products (id, tenant_id, name, inventory_count, available_quantity) VALUES ($1, $2, 'Test Product', 6, 6) ON CONFLICT DO NOTHING")
+            .bind(product_id)
+            .bind(tenant_id)
+            .execute(&pool)
+            .await;
+
+        let _ = sqlx::query("UPDATE products SET inventory_count = 6, available_quantity = 6, locked_quantity = 0 WHERE id = $1 AND tenant_id = $2")
+            .bind(product_id)
+            .bind(tenant_id)
+            .execute(&pool)
+            .await;
+
+        let redis_client_opt = None;
+        let service = Arc::new(InventoryService::new(redis_client_opt));
+
+        let res = service.commit_inventory(tenant_id, product_id, 2, "").await.unwrap();
+        assert!(res.success);
+
+        let feed_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM agent_feed_items WHERE tenant_id = $1 AND context_payload->>'product_id' = $2")
+            .bind(tenant_id)
+            .bind(product_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        assert!(feed_count.0 > 0);
+    }
 
     #[tokio::test]
     async fn test_reserve_inventory_concurrent_redlock() {

--- a/src/server/workers/pos_sync_worker.rs
+++ b/src/server/workers/pos_sync_worker.rs
@@ -204,6 +204,25 @@ impl PosSyncWorker {
                     sqlx::query("INSERT INTO department_tasks (id, tenant_id, department, event_type, payload, status) VALUES ($1, $2, 'operations', 'LowStockAlert', $3::jsonb, 'PENDING')")
                         .bind(job_id).bind(&job.tenant_id).bind(&job_payload).execute(&mut *tx).await
                         .map_err(|e| e.to_string())?;
+
+                    let feed_id = uuid::Uuid::new_v4().to_string();
+                    let feed_payload = serde_json::json!({
+                        "product_id": product_id,
+                        "remaining_stock": new_stock,
+                        "message": message,
+                    });
+                    let proposed_action = serde_json::json!({
+                        "action": "Review and approve restock order"
+                    });
+                    let _ = sqlx::query(
+                        "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state) VALUES ($1, $2, 'operations', $3::jsonb, $4::jsonb, 'PENDING_APPROVAL')"
+                    )
+                    .bind(&feed_id)
+                    .bind(&job.tenant_id)
+                    .bind(&feed_payload)
+                    .bind(&proposed_action)
+                    .execute(&mut *tx)
+                    .await;
                 }
 
                 if is_conflict {
@@ -391,6 +410,25 @@ impl PosSyncWorker {
                                 sqlx::query("INSERT INTO department_tasks (id, tenant_id, department, event_type, payload, status) VALUES ($1, $2, 'operations', 'LowStockAlert', $3::jsonb, 'PENDING')")
                                     .bind(job_id).bind(&job.tenant_id).bind(&job_payload).execute(&mut *tx).await
                                     .map_err(|e| e.to_string())?;
+
+                                let feed_id = uuid::Uuid::new_v4().to_string();
+                                let feed_payload = serde_json::json!({
+                                    "product_id": product_id,
+                                    "remaining_stock": new_stock,
+                                    "message": message,
+                                });
+                                let proposed_action = serde_json::json!({
+                                    "action": "Review and approve restock order"
+                                });
+                                let _ = sqlx::query(
+                                    "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state) VALUES ($1, $2, 'operations', $3::jsonb, $4::jsonb, 'PENDING_APPROVAL')"
+                                )
+                                .bind(&feed_id)
+                                .bind(&job.tenant_id)
+                                .bind(&feed_payload)
+                                .bind(&proposed_action)
+                                .execute(&mut *tx)
+                                .await;
                             }
 
                             if is_conflict {
@@ -708,5 +746,9 @@ mod tests {
         let action_request_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM agent_action_requests WHERE tenant_id = 'tenant-worker-test-low' AND product_id = 'prod-worker-test-2' AND action_type = 'Reorder'")
             .fetch_one(&pool).await.unwrap();
         assert!(action_request_count.0 > 0);
+
+        let agent_feed_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM agent_feed_items WHERE tenant_id = 'tenant-worker-test-low' AND context_payload->>'product_id' = 'prod-worker-test-2'")
+            .fetch_one(&pool).await.unwrap();
+        assert!(agent_feed_count.0 > 0);
     }
 }


### PR DESCRIPTION
🔗 Link: [multi-channel inventory sync and distributed POS architecture]

Resolves #31026

This PR resolves the multi-channel inventory sync and distributed POS architecture problem:
1. Updated `commit_inventory` in `src/server/services/inventory/service.rs` to insert a "Low Stock" action card into the `agent_feed_items` table whenever stock falls to 5 or below after an online or tap-to-pay checkout.
2. Updated the `offline_pos_sync` logic in `src/server/workers/pos_sync_worker.rs` to perform the same insertion into `agent_feed_items` when an offline transaction causes stock to drop to 5 or below without conflicts.
3. Modified the unit tests in both files (`test_pos_sync_worker_low_stock` and `test_commit_inventory_low_stock`) to verify that these rows are correctly inserted. All tests pass successfully.

Loaded superpowers skills:
- None

Product-use evidence:
- **Persona:** Boutique Operator (Priya).
- **Flow Attempted:** Tap-to-pay transaction or online purchase of an item reaching low stock.
- **Gap:** When an item reaches low stock (<= 5), the Operations Agent correctly issues a Reorder request but the Action Card is not manifested in the new Unified Agent Feed (`agent_feed_items`).
- **User-Experience Reason:** The owner needs to see the Action Card in their Agent Feed to know when they need to reorder stock and take action promptly.
- **Post-Fix Flow:** Low stock Action Cards are now surfaced correctly in the Agent Feed upon transaction checkout or offline sync.

---
*PR created automatically by Jules for task [6429460126630441400](https://jules.google.com/task/6429460126630441400) started by @ql-owo-lp*