### PR TITLE
fix(docs): Map 'product' keyword to Add Products help article

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6714,7 +6714,7 @@ async fn create_ui_bom_item_handler(
             if query.contains("getting started") {
                 reply = format!("Based on our help center: {}", help_articles[0].1);
                 link_url = "/help/getting-started-1";
-            } else if query.contains("store") {
+            } else if query.contains("store") || query.contains("product") {
                 reply = format!("Based on our help center: {}", help_articles[1].1);
                 link_url = "/help/add-products";
             } else if query.contains("payment") {


### PR DESCRIPTION
Modified the fallback AI help agent's routing logic to map queries containing the word "product" to the same help article ("Managing My Store" / "add-products") as the word "store", satisfying E2E test assertions and user expectations when asking "How do I add a product?".

---
*PR created automatically by Jules for task [7291296106692213772](https://jules.google.com/task/7291296106692213772) started by @ql-owo-lp*