### PR TITLE
🗺️ Guide: Add admin name validation in setup onboarding

### DIFF
--- a/src/e2e/tauri_onboarding_admin.spec.ts
+++ b/src/e2e/tauri_onboarding_admin.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+
+// we just use the raw test instead of the fixture that requires login to /dashboard
+test.describe('Tauri Onboarding Admin Setup', () => {
+  test('Requires admin name on step-admin', async ({ page }) => {
+    // Navigate to the onboarding route directly
+    await page.goto(`file://${process.cwd()}/src/ui/tauri/src/ui/setup.html`);
+
+    // We expect the setup to redirect or load the initial step
+    await page.waitForSelector('#step-initial .next-step-btn');
+    await page.click('#step-initial .next-step-btn');
+
+    // Step Context
+    await page.waitForSelector('#step-context:not([style*="display: none"])');
+    await page.click('[data-testid="context-local"]');
+    await page.click('#step-context .next-step-btn');
+
+    // Step Categories
+    await page.waitForSelector('#step-categories:not([style*="display: none"])');
+
+    // evaluate business categories dropdown to have a value, test environment may mock it
+    await page.evaluate(() => {
+        const sel = document.getElementById('business-categories') as HTMLSelectElement;
+        if (sel) {
+            const opt = document.createElement('option');
+            opt.value = 'Baking';
+            opt.text = 'Baking';
+            sel.appendChild(opt);
+            sel.value = 'Baking';
+        }
+    });
+    // await page.selectOption('#business-categories', 'Baking');
+    await page.click('#step-categories .next-step-btn');
+
+    // Step Name
+    await page.waitForSelector('#step-name:not([style*="display: none"])');
+    await page.fill('#business-name', 'Test Business');
+    await page.click('#step-name .next-step-btn');
+
+    // Step Assistant
+    await page.waitForSelector('#step-assistant:not([style*="display: none"])');
+    await page.fill('#assistant-name', 'Jarvis');
+    await page.evaluate(() => {
+        const sel = document.getElementById('assistant-tone') as HTMLSelectElement;
+        if (sel) {
+            const opt = document.createElement('option');
+            opt.value = 'Friendly';
+            opt.text = 'Friendly';
+            sel.appendChild(opt);
+            sel.value = 'Friendly';
+        }
+    });
+    await page.click('#step-assistant .next-step-btn');
+
+    // Step Admin
+    await page.waitForSelector('#step-admin:not([style*="display: none"])');
+
+    // Try to proceed without filling out the admin name
+    await page.click('#step-admin .next-step-btn');
+
+    // Verify admin-name error appears
+    const isErrorVisible = await page.evaluate(() => {
+        const err = document.getElementById('admin-name-error');
+        return err && window.getComputedStyle(err).display === 'block';
+    });
+    expect(isErrorVisible).toBe(true);
+
+    // Fill in the admin name
+    await page.fill('#admin-name', 'Test Admin');
+    await page.click('#step-admin .next-step-btn');
+
+    // Verify error is gone
+    const isErrorStillVisible = await page.evaluate(() => {
+        const err = document.getElementById('admin-name-error');
+        return err && window.getComputedStyle(err).display === 'block';
+    });
+    expect(isErrorStillVisible).toBe(false);
+  });
+});

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1976,6 +1976,20 @@
         <p>Set up your login details.</p>
 
         <input
+          type="text"
+          id="admin-name"
+          data-testid="admin-name"
+          class="glassmorphism"
+          placeholder="Your Name (e.g. Maya)"
+          inputmode="text"
+          autocomplete="name"
+          enterkeyhint="next"
+        />
+        <div id="admin-name-error" class="error-msg" aria-live="polite">
+          Please enter your name.
+        </div>
+
+        <input
           type="email"
           id="admin-email"
           data-testid="admin-email"
@@ -2482,6 +2496,7 @@
         tagline: document.getElementById("business-tagline"),
         assistantName: document.getElementById("assistant-name"),
         assistantTone: document.getElementById("assistant-tone"),
+        adminName: document.getElementById("admin-name"),
         adminEmail: document.getElementById("admin-email"),
         adminPassword: document.getElementById("admin-password"),
         firstOffer: document.getElementById("first-offer"),
@@ -2497,6 +2512,7 @@
         name: document.getElementById("name-error"),
         assistantName: document.getElementById("assistant-name-error"),
         assistantTone: document.getElementById("tone-error"),
+        adminName: document.getElementById("admin-name-error"),
         adminEmail: document.getElementById("email-error"),
         adminPassword: document.getElementById("password-error"),
         firstOffer: document.getElementById("offer-error"),
@@ -2800,6 +2816,7 @@
         state.tagline = inputs.tagline.value;
         state.assistantName = inputs.assistantName.value;
         state.assistantTone = inputs.assistantTone.value;
+        state.adminName = inputs.adminName.value;
         state.first_offer = inputs.firstOffer.value;
         state.templateSelection = inputs.templateSelection.value;
         if (inputs.domainName) state.domain = inputs.domainName.value;
@@ -2944,9 +2961,19 @@
             state.assistantTone = inputs.assistantTone.value;
           }
         } else if (stepId === "step-admin") {
+          const nameVal = inputs.adminName.value.trim();
           const emailVal = inputs.adminEmail.value.trim();
           const passVal = inputs.adminPassword.value.trim();
           let stepValid = true;
+
+          if (nameVal === "") {
+            errors.adminName.style.display = "block";
+            inputs.adminName.classList.add("invalid-input");
+            stepValid = false;
+          } else {
+            errors.adminName.style.display = "none";
+            inputs.adminName.classList.remove("invalid-input");
+          }
 
           if (emailVal === "" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailVal)) {
             errors.adminEmail.style.display = "block";


### PR DESCRIPTION
- Added `admin-name` input to `step-admin` in `src/ui/tauri/src/ui/setup.html`
- Implemented `validateStep` logic for `admin-name`
- Updated JS objects to capture and store the admin name during onboarding
- Added `tauri_onboarding_admin.spec.ts` test
- Dogfooded workflow with Playwright to verify the UI interaction
- Applied `superpowers` flow check

---
*PR created automatically by Jules for task [9229641797760511164](https://jules.google.com/task/9229641797760511164) started by @ql-owo-lp*