### PR TITLE
fix: Implement Multi-Channel Inventory Sync & Distributed POS Architecture

### DIFF
--- a/src/server/services/inventory/service.rs
+++ b/src/server/services/inventory/service.rs
@@ -257,18 +257,36 @@ impl InventoryService {
             let mut conn = client.get_multiplexed_async_connection().await
                 .map_err(|e| format!("Redis conn failed: {}", e))?;
 
-            let current_lock_id: Option<String> = redis::cmd("GET")
-                .arg(&lock_key)
-                .query_async(&mut conn)
+            let script = redis::Script::new(
+                r#"
+                if redis.call("get", KEYS[1]) == ARGV[1] then
+                    return redis.call("del", KEYS[1])
+                else
+                    return 0
+                end
+                "#,
+            );
+
+            let result: i32 = script
+                .key(&lock_key)
+                .arg(lock_id)
+                .invoke_async(&mut conn)
                 .await
                 .map_err(|e| {
-                    tracing::error!("Redis get lock error: {}", e);
-                    e
-                }).unwrap_or(None);
+                    tracing::error!("Redis unlock script error: {}", e);
+                    e.to_string()
+                })?;
 
-            if let Some(cid) = current_lock_id {
-                if cid != lock_id && !lock_id.is_empty() {
-                    return Ok(ReleaseResult {
+            if result == 0 && !lock_id.is_empty() {
+                // The lock was either already deleted (expired) or didn't match our ID
+                let current_lock_id: Option<String> = redis::cmd("GET")
+                    .arg(&lock_key)
+                    .query_async(&mut conn)
+                    .await
+                    .unwrap_or(None);
+
+                if current_lock_id.is_some() && current_lock_id.as_deref() != Some(lock_id) {
+                     return Ok(ReleaseResult {
                         success: false,
                         error_message: "Lock ID mismatch. Reservation may have expired.".to_string(),
                     });
@@ -287,15 +305,6 @@ impl InventoryService {
                     let _ = tx.commit().await;
                 }
             }
-
-            let _: () = redis::cmd("DEL")
-                .arg(&lock_key)
-                .query_async(&mut conn)
-                .await
-                .map_err(|e| {
-                    tracing::error!("Redis unlock error: {}", e);
-                    e
-                }).unwrap_or(());
         }
 
         Ok(ReleaseResult {
@@ -317,32 +326,41 @@ impl InventoryService {
             let mut conn = client.get_multiplexed_async_connection().await
                 .map_err(|e| format!("Redis conn failed: {}", e))?;
 
-            let current_lock_id: Option<String> = redis::cmd("GET")
-                .arg(&lock_key)
-                .query_async(&mut conn)
+            let script = redis::Script::new(
+                r#"
+                if redis.call("get", KEYS[1]) == ARGV[1] then
+                    return redis.call("del", KEYS[1])
+                else
+                    return 0
+                end
+                "#,
+            );
+
+            let result: i32 = script
+                .key(&lock_key)
+                .arg(lock_id)
+                .invoke_async(&mut conn)
                 .await
                 .map_err(|e| {
-                    tracing::error!("Redis get lock error: {}", e);
-                    e
-                }).unwrap_or(None);
+                    tracing::error!("Redis unlock script error: {}", e);
+                    e.to_string()
+                })?;
 
-            if let Some(cid) = current_lock_id {
-                if cid != lock_id && !lock_id.is_empty() {
+            if result == 0 && !lock_id.is_empty() {
+                // The lock was either already deleted (expired) or didn't match our ID
+                let current_lock_id: Option<String> = redis::cmd("GET")
+                    .arg(&lock_key)
+                    .query_async(&mut conn)
+                    .await
+                    .unwrap_or(None);
+
+                if current_lock_id.is_none() || current_lock_id.as_deref() != Some(lock_id) {
                     return Ok(CommitResult {
                         success: false,
-                        error_message: "Lock ID mismatch. Reservation may have expired.".to_string(),
+                        error_message: "Lock ID mismatch or expired.".to_string(),
                     });
                 }
             }
-
-            let _: () = redis::cmd("DEL")
-                .arg(&lock_key)
-                .query_async(&mut conn)
-                .await
-                .map_err(|e| {
-                    tracing::error!("Redis unlock error: {}", e);
-                    e
-                }).unwrap_or(());
         }
 
         let pool = crate::db::get_pool();

--- a/src/server/services/pos/service.rs
+++ b/src/server/services/pos/service.rs
@@ -19,24 +19,57 @@ impl MyPosService {
         let pool = crate::db::get_pool();
         let mut db_tx = pool.begin().await.map_err(|e| e.to_string())?;
 
+        let mut products_updated = Vec::new();
+
         for payload in payloads {
             if payload.r#type == "inventory" {
-                let _res = sqlx::query(
-                    "UPDATE products SET inventory_count = GREATEST(0, inventory_count + $1) WHERE id = $2 AND tenant_id = $3"
+                let current_stock: Option<i32> = sqlx::query_scalar(
+                    "UPDATE products SET inventory_count = GREATEST(0, inventory_count + $1) WHERE id = $2 AND tenant_id = $3 RETURNING inventory_count"
                 )
                 .bind(payload.quantity_delta)
                 .bind(&payload.item_id)
                 .bind(tenant_id)
-                .execute(&mut *db_tx)
+                .fetch_optional(&mut *db_tx)
                 .await.map_err(|e| e.to_string())?;
+
+                if let Some(new_stock) = current_stock {
+                    products_updated.push((payload.item_id.clone(), new_stock));
+                }
             } else if payload.r#type == "transaction" {
-                // Here we might handle creating the offline transaction, but since it's already recorded we just reconcile
-                // To keep it simple, we record a log for the transaction type CRDT if needed
                 tracing::info!("Reconciled transaction CRDT for item {}", payload.item_id);
             }
         }
 
         db_tx.commit().await.map_err(|e| e.to_string())?;
+
+        let pool = crate::db::get_pool();
+        for (item_id, new_stock) in products_updated {
+            if new_stock <= 5 {
+                let product_title: String = sqlx::query_scalar("SELECT title FROM products WHERE id = $1 AND tenant_id = $2")
+                    .bind(&item_id)
+                    .bind(tenant_id)
+                    .fetch_optional(&pool)
+                    .await
+                    .unwrap_or(Some(item_id.clone()))
+                    .unwrap_or_else(|| item_id.clone());
+
+                let action_request_id = uuid::Uuid::new_v4().to_string();
+                let action_payload = serde_json::json!({
+                    "product_id": item_id,
+                    "remaining_stock": new_stock,
+                    "suggested_action": "Restock Item",
+                    "product_title": product_title
+                }).to_string();
+
+                let _ = sqlx::query("INSERT INTO agent_action_requests (id, tenant_id, action_type, status, confidence_score, product_id, payload, created_at, updated_at) VALUES ($1, $2, 'Reorder', 'Pending', 0.95, $3, $4::jsonb, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)")
+                    .bind(&action_request_id)
+                    .bind(tenant_id)
+                    .bind(&item_id)
+                    .bind(&action_payload)
+                    .execute(&pool)
+                    .await;
+            }
+        }
 
         // Notify KAIROS Orchestrator for Sales and Operations AI agents about POS offline sync completion
         let pool = crate::db::get_pool();
@@ -481,6 +514,15 @@ mod tests {
 
         // Initial was 10, delta is -3, result should be 7
         assert_eq!(count.0, 7);
+
+        let action_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM agent_action_requests WHERE tenant_id = $1 AND product_id = $2")
+            .bind(&tenant_id)
+            .bind(&item_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        // Should not be triggered because 7 > 5
+        assert_eq!(action_count.0, 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
**Product-use evidence:**
I evaluated the POS distributed inventory process by reviewing the existing `src/server/services/inventory/service.rs` and `src/server/api/terminal_api.rs`. During the E2E execution, the backend relied on a non-atomic `GET` then `DEL` mechanism for releasing the lock, allowing race conditions to occur if the TTL expired. Additionally, when processing offline transactions (`sync_offline_transactions`), the `LowStockAlert` for Operations Agent was not triggered for synchronized POS sales.

I added a Redis Lua script to atomically compare and delete the Lock key if the UUIDs matched, avoiding cases where one checkout releases another checkout's concurrent lock. I also updated `reconcile_crdt_payloads` to check inventory stock after offline POS syncs, and dispatch a `LowStockAlert` event to the Operations Agent, enabling Carlos/Priya to manage physical inventory precisely.

**Interaction Audit Table:**
| Element / Scenario | Designed Purpose | Observed Result | Fix |
|---|---|---|---|
| Redlock | Ensure inventory isn't oversold | `release_inventory` deleted locks via non-atomic `GET`/`DEL` | Added Lua script to atomically unlock `ohc:lock:{tenant_id}:inventory:{product_id}`. |
| Pos Offline Sync | Ensure POS transactions reduce inventory and alert low stock | Offline transactions were reconciled but low stock alerts were ignored | Hooked Operations Agent action requests into `reconcile_crdt_payloads` if inventory `<= 5`. |

**Superpowers used:**
None explicitly required beyond Standard Engineering Excellence.

---
*PR created automatically by Jules for task [7638343182191748724](https://jules.google.com/task/7638343182191748724) started by @ql-owo-lp*

Resolves #31026