### PR TITLE
✍️ Scribe: WalkthroughTarget fallback and UI updates

### DIFF
--- a/src/ui/next/src/components/Walkthrough.test.tsx
+++ b/src/ui/next/src/components/Walkthrough.test.tsx
@@ -144,4 +144,14 @@ describe('Walkthrough Component', () => {
 
     consoleWarnMock.mockRestore();
   });
+
+  it('WalkthroughTarget gracefully provides a fallback div when no children are provided', async () => {
+    const { WalkthroughTarget } = await import('./Walkthrough');
+    const { container } = render(
+      <WalkthroughTarget id="some-id" className="my-class" />
+    );
+
+    expect(container.innerHTML).toContain('id="some-id"');
+    expect(container.innerHTML).toContain('aria-hidden="true"');
+  });
 });

--- a/src/ui/next/src/components/Walkthrough.tsx
+++ b/src/ui/next/src/components/Walkthrough.tsx
@@ -139,7 +139,7 @@ export function InteractiveWalkthrough({ steps, isOpen, onClose, onComplete }: W
         role="dialog"
         aria-label={`${currentStep.title} walkthrough step`}
         id="walkthrough-bubble"
-        className="ohc-walkthrough-bubble fixed z-[10000] bg-white/80 dark:bg-black/60 backdrop-blur-xl saturate-[210%] border border-white/50 dark:border-white/20 shadow-2xl rounded-3xl p-6 w-[300px] max-w-[calc(100vw-32px)] font-inter animate-pop-in"
+        className="ohc-walkthrough-bubble fixed z-[10000] bg-white/80 dark:bg-black/60 backdrop-blur-xl saturate-[210%] border border-white/50 dark:border-white/20 shadow-[0_8px_32px_rgba(0,0,0,0.15)] rounded-3xl p-6 w-[300px] max-w-[calc(100vw-32px)] font-inter animate-pop-in"
         style={bubbleStyle}
       >
         {targetRect && (
@@ -185,10 +185,10 @@ export function InteractiveWalkthrough({ steps, isOpen, onClose, onComplete }: W
  * It wraps its children in a relative container with the specified ID, which is then
  * targeted by the walkthrough overlay and speech bubble logic.
  */
-export function WalkthroughTarget({ id, children, className = "" }: { id: string, children: ReactNode, className?: string }) {
+export function WalkthroughTarget({ id, children, className = "" }: { id: string, children?: ReactNode, className?: string }) {
   return (
     <div id={id} className={`relative ${className}`}>
-      {children}
+      {children || <div className="hidden" aria-hidden="true" />}
     </div>
   );
 }


### PR DESCRIPTION
Implements resilient `WalkthroughTarget` fallback for missing children and aligns styling with macOS translucent glass tokens as requested. Includes corresponding test coverage.

---
*PR created automatically by Jules for task [4033466542192228675](https://jules.google.com/task/4033466542192228675) started by @ql-owo-lp*