### PR TITLE
Fix onboarding glassmorphism styling and tests

### DIFF
--- a/src/e2e/tests/onboarding_glassmorphism.spec.ts
+++ b/src/e2e/tests/onboarding_glassmorphism.spec.ts
@@ -47,13 +47,18 @@ test.describe('Onboarding Glassmorphism UI Audit', () => {
   test('onboarding inputs and buttons use 8px border radius', async ({ page }) => {
     await page.goto('/onboarding');
 
+    // Start wizard to reach an input
+    await page.getByText('Start My Business').click();
+
     // Check an input
     const input = page.locator('#setup-screen input').first();
     const borderRadiusInput = await input.evaluate((el) => window.getComputedStyle(el).borderRadius);
     expect(borderRadiusInput).toBe('8px');
 
     // Check back/forward buttons or action buttons
-    const button = page.locator('#setup-screen button').first();
+    // The very first button might be the `setup-nav-button` which intentionally has a 999px border-radius,
+    // so we skip that one and check the general wizard continuation buttons.
+    const button = page.locator('#setup-screen button:not(.setup-nav-button)').first();
     const borderRadiusButton = await button.evaluate((el) => window.getComputedStyle(el).borderRadius);
     expect(borderRadiusButton).toBe('8px');
   });

--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -748,10 +748,7 @@ button, .app-button, .charge-btn {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border: 1px solid #d8e0ea;
   border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.12);
 }
 
 .setup-page #setup-screen > div:first-child {
@@ -899,7 +896,7 @@ button, .app-button, .charge-btn {
 
 .setup-page #setup-screen button {
   min-height: 44px;
-  border-radius: 16px;
+  border-radius: 8px;
   cursor: pointer;
 }
 
@@ -953,7 +950,7 @@ button, .app-button, .charge-btn {
   min-height: 44px;
   padding: 12px 14px;
   border: 1px solid #cfd8e3;
-  border-radius: 16px;
+  border-radius: 8px;
   background: #ffffff;
   color: #18212f;
   font: inherit;


### PR DESCRIPTION
Fix onboarding glassmorphism styling and tests

- Removed overriding `#ffffff` background from `.setup-page #setup-screen` in `globals.css` so tailwind utility classes (`bg-white/65`) can take effect.
- Updated `border-radius` of inputs and action buttons in `.setup-page #setup-screen` to `8px` instead of `16px`.
- Updated `onboarding_cuj.spec.ts` test to navigate to the intermediate `step-domain` screen properly before navigating to `step-template`.
- Updated `onboarding_glassmorphism.spec.ts` to skip the pill-shaped top navigation buttons when asserting `8px` border radiuses.
- Triggered `Start My Business` in `onboarding_glassmorphism.spec.ts` so an input element is present before asserting.

---
*PR created automatically by Jules for task [8821491776383959391](https://jules.google.com/task/8821491776383959391) started by @ql-owo-lp*