### PR TITLE
Fix VPA updateMode conditionally & update github codeload url

### DIFF
--- a/deploy/helm/ohc/templates/vpa.yaml
+++ b/deploy/helm/ohc/templates/vpa.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-backend
   updatePolicy:
-    updateMode: "Off"
+    updateMode: {{ if .Values.backend.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}
   resourcePolicy:
     containerPolicies:
       - containerName: backend
@@ -32,7 +32,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-core
   updatePolicy:
-    updateMode: "Off"
+    updateMode: {{ if .Values.ohcCore.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}
   resourcePolicy:
     containerPolicies:
       - containerName: ohc-core
@@ -53,7 +53,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-chatwoot
   updatePolicy:
-    updateMode: "Off"
+    updateMode: {{ if .Values.chatwoot.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}
   resourcePolicy:
     containerPolicies:
       - containerName: chatwoot
@@ -74,7 +74,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-powersync
   updatePolicy:
-    updateMode: "Off"
+    updateMode: {{ if .Values.powersync.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}
   resourcePolicy:
     containerPolicies:
       - containerName: powersync

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -146,7 +146,7 @@ def go_repositories():
         name = "com_github_cncf_xds_go",
         build_file_generation = "on",
         importpath = "github.com/cncf/xds/go",
-        urls = ["https://github.com/cncf/xds/archive/e9ce68804cb4.tar.gz"],
+        urls = ["https://codeload.github.com/cncf/xds/tar.gz/e9ce68804cb4"],
         sum = "h1:Rjjh4E6iCUSW3n8E14lM6j1D0aRzDtdGk1iZ/g78A58=",
         version = "v0.0.0-20230607035331-e9ce68804cb4",
     )


### PR DESCRIPTION
- Conditionally set VPA updateMode to "Off" in Helm charts only when autoscaling is enabled; otherwise use "Auto". This prevents conflict with HPA when autoscaling is enabled, and correctly defaults to Auto.
- Replaced the github tar.gz repository URL in `repositories.bzl` with codeload.github.com to prevent download resolution failures on build in constrained environments.

---
*PR created automatically by Jules for task [11608202791507799056](https://jules.google.com/task/11608202791507799056) started by @ql-owo-lp*