### PR TITLE
🗺️ Guide: [Zero Click Instant Build - Image URL separation]

### DIFF
--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -1072,6 +1072,8 @@ async fn handle_send_receipt(
 #[derive(Debug, serde::Deserialize)]
 pub struct ZeroClickGenerateRequest {
     pub prompt: String,
+    #[serde(default)]
+    pub image_url: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -2491,6 +2493,7 @@ mod tests {
 
         let req = ZeroClickGenerateRequest {
             prompt: "I sell coffee".to_string(),
+            image_url: None,
         };
 
         // Note: the actual OnboardingAgent requires external API calls, but we can verify
@@ -2727,6 +2730,7 @@ mod tests {
 
         let req = ZeroClickGenerateRequest {
             prompt: "I am a home baker selling cakes.".to_string(),
+            image_url: None,
         };
 
         let auth_info = ::server_auth::orchestration::AuthInfo {
@@ -3258,7 +3262,12 @@ pub async fn handle_zero_click_generate(
         state.hub.clone()
     );
 
-    let intake_data = agent.process_intake(&req.prompt).await.map_err(|e| {
+    let mut combined_prompt = req.prompt.clone();
+    if let Some(image_url) = &req.image_url {
+        combined_prompt.push_str(&format!("\nImage provided: {}", image_url));
+    }
+
+    let intake_data = agent.process_intake(&combined_prompt).await.map_err(|e| {
         tracing::error!("Intake error: {}", e);
         axum::http::StatusCode::INTERNAL_SERVER_ERROR
     })?;

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -3685,7 +3685,8 @@
                   "X-User-ID": "e2e-admin-user",
                 },
                 body: JSON.stringify({
-                  prompt: bioInput + (imageUrl ? " " + imageUrl : ""),
+                  prompt: bioInput,
+                  image_url: imageUrl ? imageUrl : undefined
                 }),
               },
             );


### PR DESCRIPTION
This pull request updates the "Instant Build" functionality in the Day One onboarding setup.

Previously, the `instant-image-url` was manually concatenated directly onto the user's `bioInput` string before being sent to the `/api/v1/growth/zero-click-builder/generate` endpoint. This could reduce the clarity of the prompt given to the AI.

This PR adds a distinct `image_url: Option<String>` to the `ZeroClickGenerateRequest` struct and ensures the frontend properly sends `image_url: imageUrl` as a separate JSON field. The Rust backend then explicitly formats the image URL on a new line (e.g., `\nImage provided: {url}`) prior to passing the combined string to `agent.process_intake()`. Tests were updated to accommodate the struct changes.

---
*PR created automatically by Jules for task [1854908019812567883](https://jules.google.com/task/1854908019812567883) started by @ql-owo-lp*