### PR TITLE
chore: align backend pricing models with UI tiers

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -182,9 +182,9 @@ pub async fn create_checkout_session_handler(
 
     if let Some(tier) = &req.tier {
         amount_usd = match tier.to_lowercase().as_str() {
-            "starter" => 9.0,
-            "pro" => 29.0,
-            "business" => 79.0,
+            "starter" => 29.0,
+            "pro" => 79.0,
+            "business" => 299.0,
             _ => return Err(StatusCode::BAD_REQUEST),
         };
         item_name = tier.clone();

--- a/src/server/pricing/rate_limit.rs
+++ b/src/server/pricing/rate_limit.rs
@@ -101,9 +101,9 @@ impl PlanTier {
     pub fn base_price(&self) -> f64 {
         match self {
             PlanTier::Free => 0.0,
-            PlanTier::Starter => 9.0,
-            PlanTier::Pro => 29.0,
-            PlanTier::Business => 79.0,
+            PlanTier::Starter => 29.0,
+            PlanTier::Pro => 79.0,
+            PlanTier::Business => 299.0,
         }
     }
 
@@ -496,9 +496,9 @@ mod tests {
         assert_eq!(PlanTier::Business.max_products(), None);
 
         assert_eq!(PlanTier::Free.base_price(), 0.0);
-        assert_eq!(PlanTier::Starter.base_price(), 9.0);
-        assert_eq!(PlanTier::Pro.base_price(), 29.0);
-        assert_eq!(PlanTier::Business.base_price(), 79.0);
+        assert_eq!(PlanTier::Starter.base_price(), 29.0);
+        assert_eq!(PlanTier::Pro.base_price(), 79.0);
+        assert_eq!(PlanTier::Business.base_price(), 299.0);
     }
 
     #[test]


### PR DESCRIPTION
Fixes pricing inconsistencies between backend threshold assumptions and frontend actual tier prices.
Updates starter tier to $29, pro to $79, and business to $299 in the billing API and rate limiter defaults.

---
*PR created automatically by Jules for task [7834872080355218289](https://jules.google.com/task/7834872080355218289) started by @ql-owo-lp*