### PR TITLE
💰 Miser: Track accurate token cost using centralized calculator

### DIFF
--- a/src/server/api/telemetry.rs
+++ b/src/server/api/telemetry.rs
@@ -51,16 +51,10 @@ pub async fn sync_telemetry_handler(Json(batch): Json<Vec<MetricBatchItem>>) -> 
 
                 // Track cost dynamically
                 if true {
-                    let cost_per_1k = match model {
-                        "claude-3-opus" => 15.0,
-                        "claude-3-sonnet" => 3.0,
-                        "claude-3-haiku" => 0.25,
-                        "gpt-4" => 30.0,
-                        "gpt-4o" => 5.0,
-                        "gpt-3.5-turbo" => 0.5,
-                        _ => 1.0,
-                    };
-                    let cost_usd = (count as f64 / 1000.0) * cost_per_1k;
+                    let input_tokens = if t_type == "input" { count } else { 0 };
+                    let output_tokens = if t_type == "output" { count } else { 0 };
+
+                    let cost_usd = ::server_pricing::calculator::calculate_cost(model, input_tokens, output_tokens, 0);
 
                     let model_string = model.to_string();
                     let tenant_id = item


### PR DESCRIPTION
This PR updates the token cost tracking logic to use the centralized pricing calculator. Previously, `src/server/api/telemetry.rs` used hardcoded pricing values which were outdated and treated all tokens (input/output) identically. This change implements accurate cost tracking by calling `::server_pricing::calculator::calculate_cost`, which correctly accounts for the latest pricing models and distinguishes between input and output token costs. This ensures that the tracked `ohc_llm_cost_total_cents` metric is precise and aligned with current model economics.

---
*PR created automatically by Jules for task [11638769257492886192](https://jules.google.com/task/11638769257492886192) started by @ql-owo-lp*