### PR TITLE
🗺️ Guide: Fix redundant UX styling in Next.js Onboarding and Go Build Mismatch

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ cargo_vendor_repository(
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",
-    version = "1.22.4",
+    version = "1.24.1",
 )
 use_repo(go_sdk, "go_sdk")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -18041,6 +18041,168 @@
           "53f73450fb66075d16be9f206e9177bd972b528168271918c4747903b5596c3d"
         ]
       },
+      "1.24.1": {
+        "aix_ppc64": [
+          "go1.24.1.aix-ppc64.tar.gz",
+          "8d627dc163a4bffa2b1887112ad6194af175dce108d606ed1714a089fb806033"
+        ],
+        "darwin_amd64": [
+          "go1.24.1.darwin-amd64.tar.gz",
+          "addbfce2056744962e2d7436313ab93486660cf7a2e066d171b9d6f2da7c7abe"
+        ],
+        "darwin_arm64": [
+          "go1.24.1.darwin-arm64.tar.gz",
+          "295581b5619acc92f5106e5bcb05c51869337eb19742fdfa6c8346c18e78ff88"
+        ],
+        "dragonfly_amd64": [
+          "go1.24.1.dragonfly-amd64.tar.gz",
+          "e70053f56f7eb93806d80cbd5726f78509a0a467602f7bea0e2c4ee8ed7c3968"
+        ],
+        "freebsd_386": [
+          "go1.24.1.freebsd-386.tar.gz",
+          "3595e2674ed8fe72e604ca59c964d3e5277aafb08475c2b1aaca2d2fd69c24fc"
+        ],
+        "freebsd_amd64": [
+          "go1.24.1.freebsd-amd64.tar.gz",
+          "47d7de8bb64d5c3ee7b6723aa62d5ecb11e3568ef2249bbe1d4bbd432d37c00c"
+        ],
+        "freebsd_arm": [
+          "go1.24.1.freebsd-arm.tar.gz",
+          "04eec3bcfaa14c1370cdf98e8307fac7e4853496c3045afb9c3124a29cbca205"
+        ],
+        "freebsd_arm64": [
+          "go1.24.1.freebsd-arm64.tar.gz",
+          "51aa70146e40cfdc20927424083dc86e6223f85dc08089913a1651973b55665b"
+        ],
+        "freebsd_riscv64": [
+          "go1.24.1.freebsd-riscv64.tar.gz",
+          "3c131d8e3fc285a1340f87813153e24226d3ddbd6e54f3facbd6e4c46a84655e"
+        ],
+        "illumos_amd64": [
+          "go1.24.1.illumos-amd64.tar.gz",
+          "201d09da737ba39d5367f87d4e8b31edaeeb3dc9b9c407cb8cfb40f90c5a727a"
+        ],
+        "linux_386": [
+          "go1.24.1.linux-386.tar.gz",
+          "8c530ecedbc17e42ce10177bea07ccc96a3e77c792ea1ea72173a9675d16ffa5"
+        ],
+        "linux_amd64": [
+          "go1.24.1.linux-amd64.tar.gz",
+          "cb2396bae64183cdccf81a9a6df0aea3bce9511fc21469fb89a0c00470088073"
+        ],
+        "linux_arm64": [
+          "go1.24.1.linux-arm64.tar.gz",
+          "8df5750ffc0281017fb6070fba450f5d22b600a02081dceef47966ffaf36a3af"
+        ],
+        "linux_armv6l": [
+          "go1.24.1.linux-armv6l.tar.gz",
+          "6d95f8d7884bfe2364644c837f080f2b585903d0b771eb5b06044e226a4f120a"
+        ],
+        "linux_loong64": [
+          "go1.24.1.linux-loong64.tar.gz",
+          "19304a4a56e46d04604547d2d83235dc4f9b192c79832560ce337d26cc7b835a"
+        ],
+        "linux_mips": [
+          "go1.24.1.linux-mips.tar.gz",
+          "6347be77fa5359c12a5308c8ab87147c1fc4717b0c216493d1706c3b9fcde22d"
+        ],
+        "linux_mips64": [
+          "go1.24.1.linux-mips64.tar.gz",
+          "1647df415f7030b82d4105670192aa7e8910e18563bb0d505192d72800cc2d21"
+        ],
+        "linux_mips64le": [
+          "go1.24.1.linux-mips64le.tar.gz",
+          "762da594e4ec0f9cf6defae6ef971f5f7901203ee6a2d979e317adec96657317"
+        ],
+        "linux_mipsle": [
+          "go1.24.1.linux-mipsle.tar.gz",
+          "9d8133c7b23a557399fab870b5cf464079c2b623a43b214a7567cf11c254a444"
+        ],
+        "linux_ppc64": [
+          "go1.24.1.linux-ppc64.tar.gz",
+          "132f10999abbaccbada47fa85462db30c423955913b14d6c692de25f4636c766"
+        ],
+        "linux_ppc64le": [
+          "go1.24.1.linux-ppc64le.tar.gz",
+          "0fb522efcefabae6e37e69bdc444094e75bfe824ea6d4cc3cbc70c7ae1b16858"
+        ],
+        "linux_riscv64": [
+          "go1.24.1.linux-riscv64.tar.gz",
+          "eaef4323d5467ff97fb1979c8491764060dade19f02f3275a9313f9a0da3b9c0"
+        ],
+        "linux_s390x": [
+          "go1.24.1.linux-s390x.tar.gz",
+          "6c05e14d8f11094cb56a1c50f390b6b658bed8a7cbd8d1a57e926581b7eabfce"
+        ],
+        "netbsd_386": [
+          "go1.24.1.netbsd-386.tar.gz",
+          "5dbb287d343ea00d58a70b11629f32ee716dc50a6875c459ea2018df0f294cd8"
+        ],
+        "netbsd_amd64": [
+          "go1.24.1.netbsd-amd64.tar.gz",
+          "617aa3faee50ce84c343db0888e9a210c310a7203666b4ed620f31030c9fb32f"
+        ],
+        "netbsd_arm": [
+          "go1.24.1.netbsd-arm.tar.gz",
+          "59a928b7080c4a6ac985946274b7c65ce1cecc0b468ecd992d17b7c12fab9296"
+        ],
+        "netbsd_arm64": [
+          "go1.24.1.netbsd-arm64.tar.gz",
+          "28daa8d0feb4aef2af60cefa3305bb9314de7e8a05cbca41ac548964cdfe89b7"
+        ],
+        "openbsd_386": [
+          "go1.24.1.openbsd-386.tar.gz",
+          "b7382b2f5d99813aeac14db482faa3bfbd47a68880b607fa2a7e669e26bab9cd"
+        ],
+        "openbsd_amd64": [
+          "go1.24.1.openbsd-amd64.tar.gz",
+          "2513b6537c45deead5e641c7ce7502913e7d5e6f0b21c52542fb11f81578690f"
+        ],
+        "openbsd_arm": [
+          "go1.24.1.openbsd-arm.tar.gz",
+          "853c1917d4fc7b144c55a02842aa48542d5cc798dde8db96dc0fdbc263200e04"
+        ],
+        "openbsd_arm64": [
+          "go1.24.1.openbsd-arm64.tar.gz",
+          "6bc207b91e6f6ae3347fb54616a8fb2f5c11983713846a4cef111ff3f4f94d14"
+        ],
+        "openbsd_ppc64": [
+          "go1.24.1.openbsd-ppc64.tar.gz",
+          "4279260e2f2b94ee94e81470d13db7367f4393b061fee60985528fa0fa430df4"
+        ],
+        "openbsd_riscv64": [
+          "go1.24.1.openbsd-riscv64.tar.gz",
+          "6fc4023a0a339ee0778522364a127d94c78e62122288d47d820dba703f81dc07"
+        ],
+        "plan9_386": [
+          "go1.24.1.plan9-386.tar.gz",
+          "b5eb9fafd77146e7e1f748acfd95559580ecc8d2f15abf432a20f58c929c7cd2"
+        ],
+        "plan9_amd64": [
+          "go1.24.1.plan9-amd64.tar.gz",
+          "24dcad6361b141fc8cced15b092351e12a99d2e58d7013204a3013c50daf9fdd"
+        ],
+        "plan9_arm": [
+          "go1.24.1.plan9-arm.tar.gz",
+          "a026ac3b55aa1e6fdc2aaab30207a117eafbe965ed81d3aa0676409f280ddc37"
+        ],
+        "solaris_amd64": [
+          "go1.24.1.solaris-amd64.tar.gz",
+          "8e4f6a77388dc6e5aa481efd5abdb3b9f5c9463bb82f4db074494e04e5c84992"
+        ],
+        "windows_386": [
+          "go1.24.1.windows-386.zip",
+          "b799f4ab264eef12a014c759383ed934056608c483e0f73e34ea6caf9f1df5f9"
+        ],
+        "windows_amd64": [
+          "go1.24.1.windows-amd64.zip",
+          "95666b551453209a2b8869d29d177285ff9573af10f085d961d7ae5440f645ce"
+        ],
+        "windows_arm64": [
+          "go1.24.1.windows-arm64.zip",
+          "e28c4e6d0b913955765b46157ab88ae59bb636acaa12d7bec959aa6900f1cebd"
+        ]
+      },
       "1.25.0": {
         "aix_ppc64": [
           "go1.25.0.aix-ppc64.tar.gz",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onehumancorp/mono
 
-go 1.24.12
+go 1.24.1
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0 // indirect

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -1431,7 +1431,7 @@ export default function OnboardingWizard() {
           )}
 
           {step === 4 && (
-             <div aria-live="polite" className="flex flex-col flex-1 justify-center items-center text-center animate-fade-in bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[16px] shadow-2xl p-4 sm:p-8">
+             <div aria-live="polite" className="flex flex-col flex-1 justify-center items-center text-center animate-fade-in glass-card shadow-2xl p-4 sm:p-8">
                <div className="w-24 h-24 relative mb-8">
                  <div className="absolute inset-0 border-4 border-[#0066FF]/20 rounded-full"></div>
                  <div className="absolute inset-0 border-4 border-[#0066FF] rounded-full border-t-transparent animate-spin"></div>
@@ -1459,7 +1459,7 @@ export default function OnboardingWizard() {
               </p>
 
               <div className="w-full space-y-3 mt-auto">
-                <div className="p-3 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[16px] flex flex-col items-center mb-6">
+                <div className="p-3 glass-card flex flex-col items-center mb-6">
                    <p className="text-xs text-gray-500 dark:text-[#A1A1A6] uppercase font-bold tracking-wider mb-2">Your Shareable Link</p>
                    <div className="flex items-center gap-2">
                       <span className="text-[#0066FF] font-semibold">{generateSubdomain(businessName)}</span>


### PR DESCRIPTION
Replaced redundant and repetitive Tailwind classes in the Onboarding component (like `bg-[rgba(255,255,255,0.65)]`, `backdrop-blur-[30px]`, `rounded-[16px]`) with the OHC-standard `.glass-card` styling from `globals.css`.

This aligns the Next.js onboarding component with the system's "Translucent Glass" mandate. It also updates the underlying `go.mod` and `MODULE.bazel` to unblock `bazelisk` builds and tests. All E2E Playwright tests and local unit tests passed successfully.

---
*PR created automatically by Jules for task [4172808588461973161](https://jules.google.com/task/4172808588461973161) started by @ql-owo-lp*