### PR TITLE
Apply Premium Token aesthetics to setup wizard components

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -705,11 +705,12 @@
           box-shadow 0.2s;
       }
       .radio-option:hover {
-        background: rgba(255, 255, 255, 0.65);
+        background: rgba(255, 255, 255, 0.85);
       }
       .radio-option.selected {
-        border-color: #0071e3;
-        background: rgba(0, 102, 255, 0.1);
+        border-color: #0066ff;
+        background: rgba(255, 255, 255, 0.65);
+        box-shadow: 0 0 0 1px #0066ff;
       }
       .radio-option input[type="radio"] {
         display: none;
@@ -910,14 +911,17 @@
           min-width: 44px;
           box-sizing: border-box;
           background: rgba(22, 22, 26, 0.7);
-          border-color: rgba(255, 255, 255, 0.2);
+          backdrop-filter: blur(30px) saturate(210%);
+          -webkit-backdrop-filter: blur(30px) saturate(210%);
+          border-color: rgba(255, 255, 255, 0.1);
         }
         .radio-option:hover {
-          background: rgba(22, 22, 26, 0.7);
+          background: rgba(40, 40, 45, 0.7);
         }
         .radio-option.selected {
-          border-color: #0071e3;
-          background: rgba(0, 102, 255, 0.2);
+          border-color: #0066ff;
+          background: rgba(22, 22, 26, 0.7);
+          box-shadow: 0 0 0 1px #0066ff;
         }
         .radio-label {
           color: #f5f5f7;


### PR DESCRIPTION
Fixes the UI gap analyzed in `ux_analysis_onboarding.md` ensuring the onboarding stepper properly reflects OHC premium standards. Specifically targets the `setup.html` page's components by refining the `glassmorphism` definitions and `radio-option` selected visual mappings, which were not correctly exhibiting the macOS translucent glass aesthetics.

User persona: Any non-technical owner using the UI onboarding.
Playwright was utilized to capture UI flows and ensure CSS adjustments render beautifully against design guidelines. No explicit unit logic changes were made, retaining existing workflows functionally robust while substantially improving visual presentation.

---
*PR created automatically by Jules for task [4353428815755730365](https://jules.google.com/task/4353428815755730365) started by @ql-owo-lp*