### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Tenant Leakage in Multitenant Connections

### DIFF
--- a/src/server/common/auth_utils.rs
+++ b/src/server/common/auth_utils.rs
@@ -37,7 +37,7 @@ where
     } else {
         // We use session scope (false) because set_org_context might be called on a raw connection outside a transaction.
         // Pool hooks (before_acquire / after_release) safely wipe session states using DISCARD ALL and SET app.current_tenant = ''.
-        query("SELECT set_config('app.current_tenant', $1, false);")
+        query("SELECT set_config('role', session_user, false), set_config('app.current_tenant', $1, false);")
             .bind(org_id)
             .execute(executor)
             .await?;


### PR DESCRIPTION
This PR fixes a critical multitenancy data leakage vulnerability where a database connection pool state was improperly retained. In cloud multi-tenant mode, if a connection was used to query using an elevated 'system' role, the SQL command executed `SET ROLE ohc_bypassrls`. This role state could remain when setting the context back to a generic tenant's `app.current_tenant`, causing later standard operations to inadvertently bypass row-level security (RLS). 

By ensuring we revert the role back to `session_user` before applying the tenant configuration within `auth_utils.rs` `set_org_context`, connection instances correctly restrict scope dynamically per request and maintain secure tenant isolation. Tests passed.

---
*PR created automatically by Jules for task [5181780048182656935](https://jules.google.com/task/5181780048182656935) started by @ql-owo-lp*