### PR TITLE
fix: budget alert for free tier

### DIFF
--- a/src/server/pricing/budget.rs
+++ b/src/server/pricing/budget.rs
@@ -98,6 +98,9 @@ impl BudgetManager {
     }
 
     pub fn is_projected_cost_over_threshold(&self, projected_cost_cents: i64) -> bool {
+        if self.total_limit <= 0.0 {
+            return projected_cost_cents > 0;
+        }
         let limit_threshold_cents = ((self.total_limit * 100.0) * (self.alert_threshold_percent / 100.0)).round() as i64;
         projected_cost_cents >= limit_threshold_cents
     }
@@ -247,6 +250,11 @@ mod tests {
         assert!(!manager.is_projected_cost_over_threshold(700)); // $7
         assert!(manager.is_projected_cost_over_threshold(800)); // $8
         assert!(manager.is_projected_cost_over_threshold(1500)); // $15
+
+        let zero_manager = BudgetManager::new(0.0);
+        assert!(zero_manager.is_projected_cost_over_threshold(800));
+        assert!(zero_manager.is_projected_cost_over_threshold(1));
+        assert!(!zero_manager.is_projected_cost_over_threshold(0));
     }
 
     #[test]


### PR DESCRIPTION
Fixes an issue where free-tier users with a limit of 0.0 were triggering budget alerts incorrectly. Adds proper handling for the `total_limit <= 0.0` edge case.

---
*PR created automatically by Jules for task [12348871867373531726](https://jules.google.com/task/12348871867373531726) started by @ql-owo-lp*