### PR TITLE
🔗 Link: Agent-Driven Field Service & Dynamic Resource Scheduling Architecture

### DIFF
--- a/src/proto/app.proto
+++ b/src/proto/app.proto
@@ -367,6 +367,8 @@ message CreateQuoteRequest {
   string customer_id = 2;
   repeated QuoteLineItem line_items = 3;
   int64 required_deposit = 4;
+  optional string service_id = 5;
+  optional string proposed_slot_id = 6;
 }
 
 message FetchQuoteRequest {
@@ -380,6 +382,8 @@ message QuoteResponse {
   int64 total_amount_cents = 4;
   int64 required_deposit = 5;
   repeated QuoteLineItem line_items = 6;
+  optional string service_id = 7;
+  optional string proposed_slot_id = 8;
 }
 
 message BookingResource {

--- a/src/server/services/booking.rs
+++ b/src/server/services/booking.rs
@@ -1492,14 +1492,68 @@ impl BookingEngineService for NativeBookingService {
 
         crate::common::auth_utils::set_org_context(&mut *tx, &tenant_id).await.map_err(|e| Status::internal(e.to_string()))?;
 
+        let _capacity_lock = if let (Some(service_id), Some(slot_id)) = (req.service_id.as_deref(), req.proposed_slot_id.as_deref()) {
+            let soft_locks = self.soft_lock_store();
+            // Assuming proposed_slot_id implies a start and end time that we should know or look up.
+            // For now, if we don't have the explicit time block in the request, we look it up from the slot,
+            // or just use the proposed_slot_id itself as a stand-in if the slot exists.
+            // Given the signature `acquire_capacity_lock(&self, tenant_id, product_id, start_time, end_time, owner, ttl)`,
+            // we will query the slot first.
+
+            let slot_row = sqlx::query("SELECT start_time, end_time FROM booking_slots WHERE id = $1 AND tenant_id = $2")
+                .bind(slot_id)
+                .bind(&tenant_id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| Status::internal(e.to_string()))?;
+
+            if let Some(row) = slot_row {
+                let start_time: DateTime<Utc> = row.try_get("start_time").unwrap();
+                let end_time: DateTime<Utc> = row.try_get("end_time").unwrap();
+
+                let lock = soft_locks
+                    .acquire_capacity_lock(
+                        &tenant_id,
+                        service_id,
+                        start_time,
+                        end_time,
+                        &quote_id,
+                        TIMESLOT_LOCK_TTL,
+                    )
+                    .await
+                    .map_err(Status::internal)?;
+
+                if lock.is_none() {
+                    let _ = tx.rollback().await;
+                    return Err(Status::already_exists("Proposed time slot is currently being held or is unavailable"));
+                }
+
+                // Update the booking slot status to soft_locked
+                sqlx::query("UPDATE booking_slots SET status = 'soft_locked', updated_at = CURRENT_TIMESTAMP WHERE id = $1 AND tenant_id = $2")
+                    .bind(slot_id)
+                    .bind(&tenant_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| Status::internal(e.to_string()))?;
+
+                lock
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         sqlx::query(
-            "INSERT INTO quotes (id, tenant_id, customer_id, status, required_deposit) VALUES ($1, $2, $3, $4, $5)"
+            "INSERT INTO quotes (id, tenant_id, customer_id, status, required_deposit, service_id, proposed_slot_id) VALUES ($1, $2, $3, $4, $5, $6, $7)"
         )
         .bind(&quote_id)
         .bind(&tenant_id)
         .bind(uuid::Uuid::parse_str(&req.customer_id).unwrap_or_else(|_| uuid::Uuid::new_v4()))
         .bind("DRAFT")
         .bind(req.required_deposit)
+        .bind(&req.service_id)
+        .bind(&req.proposed_slot_id)
         .execute(&mut *tx)
         .await
         .map_err(|e| Status::internal(e.to_string()))?;
@@ -1537,6 +1591,8 @@ impl BookingEngineService for NativeBookingService {
             total_amount_cents,
             required_deposit: req.required_deposit,
             line_items: req.line_items,
+            service_id: req.service_id,
+            proposed_slot_id: req.proposed_slot_id,
         }))
     }
 
@@ -1595,6 +1651,8 @@ impl BookingEngineService for NativeBookingService {
                 total_amount_cents: row.try_get("total_amount").unwrap_or_default(),
                 required_deposit: row.try_get("required_deposit").unwrap_or_default(),
                 line_items,
+                service_id: row.try_get("service_id").ok(),
+                proposed_slot_id: row.try_get("proposed_slot_id").ok(),
             }))
         } else {
             Err(Status::not_found("Quote not found"))


### PR DESCRIPTION
Implementation of the `service_id` and `proposed_slot_id` missing fields in `app.proto` and `booking.rs` to support dynamic field service quoting. In addition to parsing and passing the new fields in `create_quote` and `fetch_quote`, it uses the `BookingSoftLockStore` to check capacity and temporarily reserve the requested time slot using `acquire_capacity_lock`.

Tests for both backend and frontend Playwright specs were run via `bazelisk` to verify changes pass.

---
*PR created automatically by Jules for task [18153045801717053140](https://jules.google.com/task/18153045801717053140) started by @ql-owo-lp*

Resolves #31174