### PR TITLE
feat(growth): Implement referral leaderboard embed widget

### DIFF
--- a/src/e2e/tests/growth_leaderboard_embed.spec.ts
+++ b/src/e2e/tests/growth_leaderboard_embed.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { adminPage } from '../fixtures';
+
+test.describe('Growth Leaderboard Embed', () => {
+  test('User can view and copy the leaderboard embed, and the embed renders correctly', async ({ page }) => {
+    // Navigate to the referral leaderboard generator UI
+    // We are mocking localStorage before navigation since the script relies on it.
+    await page.addInitScript(() => {
+      window.localStorage.setItem('tenant', 'e2e-tenant');
+      window.localStorage.setItem('tenant_id', 'e2e-tenant');
+    });
+
+    await page.goto('/referral-leaderboard-generator.html');
+
+    // Wait for the preview container to populate (mock API handles it or real API from backend)
+    // We expect the backend to return leaderboard data or an empty state.
+    // The "Embed Code" section should become visible.
+    await expect(page.locator('#embed-section')).toBeVisible({ timeout: 10000 });
+
+    // The copy button should be available
+    const copyButton = page.locator('button', { hasText: 'Copy Embed Code' }).first();
+    await expect(copyButton).toBeEnabled();
+
+    // Try clicking copy
+    await copyButton.click();
+    await expect(page.locator('button', { hasText: 'Copied!' })).toBeVisible();
+
+    // Verify the embed script actually points to the correct widget endpoint
+    const codeBlock = page.locator('#embed-code');
+    const embedText = await codeBlock.innerText();
+    expect(embedText).toContain('/api/v1/growth/embed/widget?type=leaderboard&tenant=e2e-tenant');
+
+    // Now test the actual backend endpoint directly to ensure it renders the HTML
+    await page.goto('/api/v1/growth/embed/widget?type=leaderboard&tenant_id=e2e-tenant');
+
+    // Check for the rendered HTML
+    await expect(page.locator('h3', { hasText: 'Top Referrers' })).toBeVisible();
+    await expect(page.locator('text=Powered by OHC')).toBeVisible();
+  });
+});

--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -3229,6 +3229,7 @@ mod cloud_bridge_tests {
 #[derive(Deserialize, Debug)]
 pub struct EmbedWidgetQuery {
     pub tenant_id: Option<String>,
+    pub tenant: Option<String>,
     pub r#type: Option<String>,
     pub theme: Option<String>,
 }
@@ -3369,10 +3370,10 @@ pub async fn handle_zero_click_generate(
 }
 
 pub async fn handle_embed_widget(
-    Extension(_state): Extension<GrowthState>,
+    Extension(state): Extension<GrowthState>,
     axum::extract::Query(query): axum::extract::Query<EmbedWidgetQuery>
 ) -> axum::response::Html<String> {
-    let tenant = query.tenant_id.unwrap_or_else(|| "default-tenant".to_string());
+    let tenant = query.tenant_id.or(query.tenant).unwrap_or_else(|| "default-tenant".to_string());
     let w_type = query.r#type.unwrap_or_else(|| "booking".to_string());
     let theme = query.theme.unwrap_or_else(|| "light".to_string());
 
@@ -3381,6 +3382,86 @@ pub async fn handle_embed_widget(
 
     let escaped_type = escape_html(&w_type);
     let escaped_tenant = escape_html(&tenant);
+
+    if w_type == "leaderboard" {
+        let rows = sqlx::query("SELECT user_id, conversions FROM referrals WHERE tenant_id = $1 ORDER BY conversions DESC LIMIT 5")
+            .bind(&tenant)
+            .fetch_all(&state.pool)
+            .await;
+
+        let mut leaderboard_html = String::new();
+        let mut has_data = false;
+
+        if let Ok(results) = rows {
+            use sqlx::Row;
+            let mut rank = 1;
+            for row in results {
+                let user_id: String = row.get(0);
+                let conversions: i32 = row.get(1);
+
+                let _rank_class = if rank <= 3 { format!("rank-{}", rank) } else { "".to_string() };
+                let display_name = if user_id.len() > 8 { format!("User {}", &user_id[..4]) } else { user_id.clone() };
+                let rank_color = match rank {
+                    1 => "#FFD700",
+                    2 => "#C0C0C0",
+                    3 => "#CD7F32",
+                    _ => "#64748b"
+                };
+                let rank_size = match rank {
+                    1 => "20px",
+                    2 => "19px",
+                    3 => "18px",
+                    _ => "18px"
+                };
+
+                leaderboard_html.push_str(&format!(
+                    r#"
+                    <div style="display: flex; align-items: center; padding: 12px 0; border-bottom: 1px solid #f1f5f9;">
+                        <div style="font-weight: 700; font-size: {rank_size}; color: {rank_color}; width: 30px;">#{rank}</div>
+                        <div style="flex: 1;">
+                            <p style="font-weight: 600; font-size: 16px; margin: 0; color: {text_color};">{display_name}</p>
+                        </div>
+                        <div style="font-weight: 700; color: #0066FF; font-size: 16px;">{conversions} referrals</div>
+                    </div>
+                    "#
+                ));
+                rank += 1;
+                has_data = true;
+            }
+        }
+
+        if !has_data {
+            leaderboard_html = format!(
+                r#"
+                <div style="text-align: center; padding: 40px 20px; color: #64748b;">
+                  <p style="margin: 0 0 16px 0;">No referrals yet. Be the first!</p>
+                </div>
+                "#
+            );
+        }
+
+        let html = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: {bg_color}; color: {text_color}; margin: 0; padding: 20px; box-sizing: border-box; }}
+  </style>
+</head>
+<body>
+  <div style="background: {bg_color}; border-radius: 16px; padding: 20px; box-shadow: 0 2px 10px rgba(0,0,0,0.02);">
+      <h3 style="margin:0 0 16px 0; font-size:16px;">Top Referrers</h3>
+      {leaderboard_html}
+      <div style="font-family: sans-serif; text-align: center; font-size: 12px; margin-top: 16px;">
+        <a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref={escaped_tenant}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a>
+      </div>
+  </div>
+</body>
+</html>"#
+        );
+        return axum::response::Html(html);
+    }
 
     let html = format!(
         r#"<!DOCTYPE html>

--- a/src/server/utils/tenant_middleware.rs
+++ b/src/server/utils/tenant_middleware.rs
@@ -17,7 +17,7 @@ pub async fn tenant_middleware(req: Request, next: Next) -> Response {
         return next.run(req).await;
     }
 
-    let is_auth_bypass = path.starts_with("/api/v1/auth") || path.starts_with("/api/agents/webhook") || path.starts_with("/api/v1/webhook") || path.starts_with("/health") || path.starts_with("/metrics");
+    let is_auth_bypass = path.starts_with("/api/v1/auth") || path.starts_with("/api/agents/webhook") || path.starts_with("/api/v1/webhook") || path.starts_with("/health") || path.starts_with("/metrics") || path.starts_with("/api/v1/growth/embed");
     if is_auth_bypass {
          return next.run(req).await;
     }

--- a/src/ui/tauri/src/ui/referrals.html
+++ b/src/ui/tauri/src/ui/referrals.html
@@ -324,7 +324,7 @@
         } else {
           // Fallback
           const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-tenant';
-          link = `https://ohc.app/setup.html?ref=${tenantId}`;
+          link = `ohc://join?ref=${tenantId}`;
         }
 
         document.getElementById('referral-link').value = link;
@@ -334,7 +334,7 @@
       } catch (e) {
         console.error("Failed to generate referral link", e);
         const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-tenant';
-        document.getElementById('referral-link').value = `https://ohc.app/setup.html?ref=${tenantId}`;
+        document.getElementById('referral-link').value = `ohc://join?ref=${tenantId}`;
         document.getElementById('loading-state').style.display = 'none';
         document.getElementById('link-state').style.display = 'block';
       }


### PR DESCRIPTION
* Added leaderboard functionality to `/api/v1/growth/embed/widget`.
* Whitelisted `/api/v1/growth/embed` from tenant middleware to allow public access.
* Added E2E playwright test `growth_leaderboard_embed.spec.ts`.
* Updated `referrals.html` fallback link to use the app deep link instead of the `setup.html` web route to better align with the mobile-first nature of OHC growth flows.

---
*PR created automatically by Jules for task [14232360555908520679](https://jules.google.com/task/14232360555908520679) started by @ql-owo-lp*