### PR TITLE
fix: add approve buttons to Ambassador UI cards

### DIFF
--- a/src/ui/next/src/app/dashboard/AmbassadorReplyCard.tsx
+++ b/src/ui/next/src/app/dashboard/AmbassadorReplyCard.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 
 type AmbassadorReplyCardProps = {
   approval: any;
+  onApprove?: () => void;
+  onDismiss?: () => void;
 };
 
-export const AmbassadorReplyCard: React.FC<AmbassadorReplyCardProps> = ({ approval }) => {
+export const AmbassadorReplyCard: React.FC<AmbassadorReplyCardProps> = ({ approval, onApprove, onDismiss }) => {
   return (
     <div className="mb-4 p-4 rounded-[16px] bg-white/65 dark:bg-[#16161A]/70 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10 flex flex-col gap-3" data-testid="ambassador-reply-card">
       <div className="text-gray-900 font-bold mb-2">1 New Message from {(approval.payload?.source || (approval.proposed_action || approval.context_payload)?.source || (approval.proposed_action || approval.context_payload)?.original_payload?.source || approval.payload?.original_payload?.source || "unknown").replace("_", " ")}</div>
@@ -33,6 +35,33 @@ export const AmbassadorReplyCard: React.FC<AmbassadorReplyCardProps> = ({ approv
       </div>
       <div className="bg-[#0066FF] p-3 rounded-[8px] text-xs text-white shadow-inner">
         {approval.payload?.generated_response || (approval.proposed_action || approval.context_payload)?.generated_response || (approval.proposed_action || approval.context_payload)?.original_payload?.generated_response || approval.payload?.original_payload?.generated_response || "Ready to send."}
+      </div>
+      <div className="flex flex-col sm:flex-row gap-3 w-full mt-2">
+        {onApprove && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onApprove();
+            }}
+            className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all duration-200 shadow-md flex items-center justify-center"
+            aria-label="Send Draft" data-testid="feed-approve-btn"
+          >
+            Send Draft
+          </button>
+        )}
+        {onDismiss && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDismiss();
+            }}
+            className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
+            aria-label="Dismiss"
+            data-testid="feed-dismiss-btn"
+          >
+            Dismiss
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/ui/next/src/app/dashboard/InstagramDMCard.tsx
+++ b/src/ui/next/src/app/dashboard/InstagramDMCard.tsx
@@ -31,7 +31,7 @@ export const InstagramDMCard: React.FC<InstagramDMCardProps> = ({ approval, onAp
               onApprove();
             }}
             className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-pink-600 text-white font-medium hover:bg-pink-700 transition-all duration-200 shadow-md flex items-center justify-center"
-            aria-label="Approve & Send"
+            aria-label="Approve & Send" data-testid="approve-instagram-dm" id="approve-instagram-dm"
           >
             Send Deposit Link
           </button>

--- a/src/ui/next/src/components/feed/AgentActionCard.tsx
+++ b/src/ui/next/src/components/feed/AgentActionCard.tsx
@@ -166,7 +166,7 @@ export const AgentActionCard: React.FC<AgentActionCardProps> = ({
             )}
             {(approval.proposed_action || approval.context_payload)
               ?.feature_type === "ambassador_reply" && (
-              <AmbassadorReplyCard approval={approval} />
+              <AmbassadorReplyCard approval={approval} onApprove={() => handleDecision(approval.id, true, undefined, approval.event_source)} onDismiss={() => handleDecision(approval.id, false, undefined, approval.event_source)} />
             )}
             {(approval.proposed_action || approval.context_payload)
               ?.feature_type === "review" && (


### PR DESCRIPTION
Added the missing interactive approve/dismiss buttons to the `AmbassadorReplyCard` and hooked them up to `handleDecision` in `AgentActionCard`. I also added `data-testid="approve-instagram-dm"` to the approve button in `InstagramDMCard` so the e2e test can locate it. 

Superpowers:
- Exhaustive UI Interaction Verification

Resolves #31208

---
*PR created automatically by Jules for task [5415537293419818091](https://jules.google.com/task/5415537293419818091) started by @ql-owo-lp*