### PR TITLE
Security: Mitigate TOCTOU vulnerability when reading keys via symlink

### DIFF
--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -189,9 +189,31 @@ impl Store {
                             }
                         }
                     }
-                    if let Ok(bytes) = std::fs::read(&secret_path) {
-                        if bytes.len() >= 32 {
-                            return bytes;
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::OpenOptionsExt;
+                        let mut options = std::fs::OpenOptions::new();
+                        options.read(true);
+                        if !::server_config::get().multitenant {
+                            #[cfg(target_os = "linux")]
+                            options.custom_flags(0x00020000); // O_NOFOLLOW
+                            #[cfg(target_os = "macos")]
+                            options.custom_flags(0x0100); // O_NOFOLLOW
+                        }
+                        if let Ok(mut file) = options.open(&secret_path) {
+                            use std::io::Read;
+                            let mut bytes = Vec::new();
+                            if file.read_to_end(&mut bytes).is_ok() && bytes.len() >= 32 {
+                                return bytes;
+                            }
+                        }
+                    }
+                    #[cfg(not(unix))]
+                    {
+                        if let Ok(bytes) = std::fs::read(&secret_path) {
+                            if bytes.len() >= 32 {
+                                return bytes;
+                            }
                         }
                     }
                 }
@@ -216,9 +238,31 @@ impl Store {
                                 }
                             }
                         }
-                        if let Ok(bytes) = std::fs::read_to_string(&secret_path) {
-                            if !bytes.trim().is_empty() {
-                                return Some(bytes.trim().to_string());
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::OpenOptionsExt;
+                            let mut options = std::fs::OpenOptions::new();
+                            options.read(true);
+                            if !::server_config::get().multitenant {
+                                #[cfg(target_os = "linux")]
+                                options.custom_flags(0x00020000); // O_NOFOLLOW
+                                #[cfg(target_os = "macos")]
+                                options.custom_flags(0x0100); // O_NOFOLLOW
+                            }
+                            if let Ok(mut file) = options.open(&secret_path) {
+                                use std::io::Read;
+                                let mut bytes = String::new();
+                                if file.read_to_string(&mut bytes).is_ok() && !bytes.trim().is_empty() {
+                                    return Some(bytes.trim().to_string());
+                                }
+                            }
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            if let Ok(bytes) = std::fs::read_to_string(&secret_path) {
+                                if !bytes.trim().is_empty() {
+                                    return Some(bytes.trim().to_string());
+                                }
                             }
                         }
                     }

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -351,9 +351,31 @@ impl DB {
                                 }
                             }
                         }
-                        if let Ok(bytes) = std::fs::read_to_string(&secret_path) {
-                            if !bytes.trim().is_empty() {
-                                return bytes.trim().to_string();
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::OpenOptionsExt;
+                            let mut options = std::fs::OpenOptions::new();
+                            options.read(true);
+                            if !crate::config::get().multitenant {
+                                #[cfg(target_os = "linux")]
+                                options.custom_flags(0x00020000); // O_NOFOLLOW
+                                #[cfg(target_os = "macos")]
+                                options.custom_flags(0x0100); // O_NOFOLLOW
+                            }
+                            if let Ok(mut file) = options.open(&secret_path) {
+                                use std::io::Read;
+                                let mut bytes = String::new();
+                                if file.read_to_string(&mut bytes).is_ok() && !bytes.trim().is_empty() {
+                                    return bytes.trim().to_string();
+                                }
+                            }
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            if let Ok(bytes) = std::fs::read_to_string(&secret_path) {
+                                if !bytes.trim().is_empty() {
+                                    return bytes.trim().to_string();
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fixes TOCTOU vulnerability where symbolic links might be swapped securely after metadata check but before the file is opened on local modes. It now natively leverages the Unix kernel flag `O_NOFOLLOW` when using `OpenOptions` explicitly to prevent any symbolic link resolution natively.

---
*PR created automatically by Jules for task [3977401979749084146](https://jules.google.com/task/3977401979749084146) started by @ql-owo-lp*