### PR TITLE
fix(ui): ensure buttons in ReviewFeedCard meet 44px min-height constraint

### DIFF
--- a/src/ui/next/src/app/dashboard/ReviewFeedCard.tsx
+++ b/src/ui/next/src/app/dashboard/ReviewFeedCard.tsx
@@ -32,7 +32,7 @@ const CardContent = ({ children, className }: any) => <div className={`p-6 pt-0 
 const CardFooter = ({ children, className }: any) => <div className={`flex items-center p-6 pt-0 ${className}`}>{children}</div>;
 const Button = ({ children, variant, size, className, disabled, onClick }: any) => {
   const baseStyle = "inline-flex items-center min-h-[44px] min-w-[44px] justify-center rounded-md text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50";
-  const sizeStyle = size === "sm" ? "h-8 px-3 text-xs" : "h-9 px-4 py-2";
+  const sizeStyle = size === "sm" ? "h-11 px-3 text-xs" : "h-11 px-4 py-2";
   let vStyle = "bg-gray-900 text-gray-50 hover:bg-gray-900/90";
   if (variant === "outline") vStyle = "border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900";
   if (variant === "ghost") vStyle = "hover:bg-gray-100 hover:text-gray-900";


### PR DESCRIPTION
Ensures the buttons within the ReviewFeedCard component comply with the 44px mobile-first minimum touch target height by changing 'h-8' and 'h-9' Tailwind classes to 'h-11'.

---
*PR created automatically by Jules for task [5518929127277019764](https://jules.google.com/task/5518929127277019764) started by @ql-owo-lp*