### PR TITLE
feat: Add superpower skills tool

### DIFF
--- a/src/agents/builtin/tools/BUILD.bazel
+++ b/src/agents/builtin/tools/BUILD.bazel
@@ -46,6 +46,7 @@ rust_library(
         "sendmessage.rs",
         "skill.rs",
         "create_skill.rs",
+        "superpowers_tool.rs",
         "sleep.rs",
         "subagent.rs",
         "tail.rs",

--- a/src/agents/builtin/tools/mod.rs
+++ b/src/agents/builtin/tools/mod.rs
@@ -28,6 +28,7 @@ pub mod local_fs_sync;
 pub mod ollama;
 pub mod subagent;
 pub mod head;
+pub mod superpowers_tool;
 pub mod tail;
 pub mod find;
 pub mod hybrid_blob;
@@ -163,7 +164,7 @@ pub fn all_tools(
         checkout::conversational_checkout_tool(),
         quote::generate_quote_tool(),
         aider_pair_programming::aider_pair_programming_tool(),
-
+        superpowers_tool::superpowers_skill_tool(),
 ];
 
     if let Some(llm) = agent_llm {


### PR DESCRIPTION
This change adds the `superpowers_skill_tool` to the builtin agent tools, which instructs the LLM to execute Superpowers skills based on the provided configuration context. 

Modifications:
- Created `src/agents/builtin/tools/superpowers_tool.rs`
- Registered module in `src/agents/builtin/tools/mod.rs`
- Added the module to `BUILD.bazel`

This enables the integration of Superpowers methodology inside the `builtin` agent implementation.

---
*PR created automatically by Jules for task [9902169127326883009](https://jules.google.com/task/9902169127326883009) started by @ql-owo-lp*