### PR TITLE
🤖 Implementer: Harness Upgrade - AutoGPT Agent Marketplace am_publish_agent

### DIFF
--- a/src/agents/builtin/codex_runner.rs
+++ b/src/agents/builtin/codex_runner.rs
@@ -181,11 +181,17 @@ pub struct JsonRpcError {
 
 pub struct AppServer {
     pub runner: Arc<Runner>,
+    pub marketplace: Arc<crate::tools::marketplace::MarketplaceClient>,
 }
 
 impl AppServer {
     pub fn new(runner: Arc<Runner>) -> Self {
-        Self { runner }
+        let marketplace = Arc::new(crate::tools::marketplace::MarketplaceClient::new(Box::new(crate::tools::marketplace::HttpMarketplaceProvider::new(&std::env::var("AGENT_MARKETPLACE_URL").unwrap_or_else(|_| "https://marketplace.example.com".to_string())))));
+        Self { runner, marketplace }
+    }
+
+    pub fn new_with_marketplace(runner: Arc<Runner>, marketplace: Arc<crate::tools::marketplace::MarketplaceClient>) -> Self {
+        Self { runner, marketplace }
     }
 
     pub async fn handle_request(&self, req_str: &str) -> String {
@@ -262,13 +268,12 @@ impl AppServer {
             };
             return serde_json::to_string(&json_resp).unwrap_or_default();
         } else if req.method == "am_search_agents" {
-            let marketplace = crate::tools::marketplace::MarketplaceClient::new(Box::new(crate::tools::marketplace::HttpMarketplaceProvider::new(&std::env::var("AGENT_MARKETPLACE_URL").unwrap_or_else(|_| "https://marketplace.example.com".to_string()))));
             let query = req
                 .params
                 .get("query")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            let agents = marketplace.search(query).await;
+            let agents = self.marketplace.search(query).await;
             let resp = match agents {
                 Ok(agents) => JsonRpcResponse {
                     jsonrpc: "2.0".to_string(),
@@ -290,13 +295,12 @@ impl AppServer {
             };
             return serde_json::to_string(&resp).unwrap_or_default();
         } else if req.method == "am_fetch_agent" {
-            let marketplace = crate::tools::marketplace::MarketplaceClient::new(Box::new(crate::tools::marketplace::HttpMarketplaceProvider::new(&std::env::var("AGENT_MARKETPLACE_URL").unwrap_or_else(|_| "https://marketplace.example.com".to_string()))));
             let agent_id = req
                 .params
                 .get("agent_id")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            let result = marketplace.fetch_agent(agent_id).await;
+            let result = self.marketplace.fetch_agent(agent_id).await;
             let resp = match result {
                 Ok(agent) => JsonRpcResponse {
                     jsonrpc: "2.0".to_string(),
@@ -318,17 +322,41 @@ impl AppServer {
             };
             return serde_json::to_string(&resp).unwrap_or_default();
         } else if req.method == "am_publish_agent" {
-            let response_obj = JsonRpcResponse {
-                jsonrpc: "2.0".to_string(),
-                id: req.id.clone(),
-                result: None,
-                error: Some(JsonRpcError {
-                    code: -32601,
-                    message: "am_publish_agent is not supported in the new marketplace yet.".to_string(),
-                }),
-                meta: None,
+            let name = req.params.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let description = req.params.get("description").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let author = req.params.get("role").and_then(|v| v.as_str()).unwrap_or("").to_string(); // mapping role to author
+
+            let new_agent = crate::tools::marketplace::MarketplaceAgent {
+                id: "".to_string(),
+                name,
+                description,
+                author,
+                version: "1.0.0".to_string(),
+                endpoint: "http://localhost".to_string(),
             };
-            return serde_json::to_string(&response_obj).unwrap_or_default();
+
+            let published = self.marketplace.publish_agent(new_agent).await;
+
+            let resp = match published {
+                Ok(agent) => JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id: req.id.clone(),
+                    result: serde_json::to_value(agent).ok(),
+                    error: None,
+                    meta: None,
+                },
+                Err(e) => JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id: req.id.clone(),
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: e,
+                    }),
+                    meta: None,
+                },
+            };
+            return serde_json::to_string(&resp).unwrap_or_default();
         } else if req.method == "ap_execute_step" {
             let server = crate::agent_protocol::AgentProtocolServer::new(self.runner.clone());
             let task_id = req
@@ -1132,7 +1160,8 @@ mod tests {
         });
         let agent = Arc::new(Agent::new(client, vec![]));
         let runner = Arc::new(Runner::new(agent));
-        let app_server = AppServer::new(runner);
+        let marketplace = Arc::new(crate::tools::marketplace::MarketplaceClient::new(Box::new(crate::tools::marketplace::test_utils::MockMarketplaceProvider)));
+        let app_server = AppServer::new_with_marketplace(runner, marketplace);
 
         let req_json = r#"{"jsonrpc": "2.0", "id": "1", "method": "run_agent", "params": {"message": "hello"}}"#;
         let resp_json = app_server.handle_request(req_json).await;
@@ -1251,16 +1280,19 @@ mod tests {
         let req_json_am_search = r#"{"jsonrpc": "2.0", "id": "13", "method": "am_search_agents", "params": {"query": "Rust"}}"#;
         let resp_json_am_search = app_server.handle_request(req_json_am_search).await;
         let resp_am_search: JsonRpcResponse = serde_json::from_str(&resp_json_am_search).unwrap();
-        // Skip assertion due to HTTP test failure in local environment. We only test standard methods in tests instead of HTTP providers.
+        assert!(resp_am_search.error.is_none());
 
         // Test Agent Marketplace am_fetch_agent method
-        let req_json_am_fetch = r#"{"jsonrpc": "2.0", "id": "14", "method": "am_fetch_agent", "params": {"agent_id": "Senior Rust Developer"}}"#;
-        let _resp_json_am_fetch = app_server.handle_request(req_json_am_fetch).await;
+        let req_json_am_fetch = r#"{"jsonrpc": "2.0", "id": "14", "method": "am_fetch_agent", "params": {"agent_id": "agent-1"}}"#;
+        let resp_json_am_fetch = app_server.handle_request(req_json_am_fetch).await;
+        let resp_am_fetch: JsonRpcResponse = serde_json::from_str(&resp_json_am_fetch).unwrap();
+        assert!(resp_am_fetch.error.is_none());
+
         // Test Agent Marketplace am_publish_agent method
         let req_json_am_publish = r#"{"jsonrpc": "2.0", "id": "15", "method": "am_publish_agent", "params": {"name": "New Agent", "description": "New", "role": "Tester", "system_prompt": "Test"}}"#;
         let resp_json_am_publish = app_server.handle_request(req_json_am_publish).await;
         let resp_am_publish: JsonRpcResponse = serde_json::from_str(&resp_json_am_publish).unwrap();
-        assert!(resp_am_publish.error.is_some());
+        assert!(resp_am_publish.error.is_none());
 
         // Test Agent Protocol ap_execute_step method
         let req_json_ap_execute = format!(

--- a/src/agents/builtin/json_rpc_server.rs
+++ b/src/agents/builtin/json_rpc_server.rs
@@ -159,9 +159,7 @@ async fn handle_rpc(
             }
         }
         _method => {
-            let app_server = crate::codex_runner::AppServer {
-                runner: state.runner.clone(),
-            };
+            let app_server = crate::codex_runner::AppServer::new(state.runner.clone());
             let req_str = serde_json::to_string(&payload).unwrap_or_default();
             let res_str = app_server.handle_request(&req_str).await;
             if let Ok(resp) = serde_json::from_str::<JsonRpcResponse>(&res_str) {

--- a/src/agents/builtin/tools/marketplace.rs
+++ b/src/agents/builtin/tools/marketplace.rs
@@ -18,6 +18,7 @@ pub struct MarketplaceAgent {
 pub trait MarketplaceProvider: Send + Sync {
     async fn search(&self, query: &str) -> Result<Vec<MarketplaceAgent>, String>;
     async fn fetch_agent(&self, agent_id: &str) -> Result<MarketplaceAgent, String>;
+    async fn publish_agent(&self, agent: MarketplaceAgent) -> Result<MarketplaceAgent, String>;
 }
 
 pub struct HttpMarketplaceProvider {
@@ -70,6 +71,24 @@ impl MarketplaceProvider for HttpMarketplaceProvider {
 
         Ok(agent)
     }
+
+    async fn publish_agent(&self, agent: MarketplaceAgent) -> Result<MarketplaceAgent, String> {
+        let url = format!("{}/agents", self.registry_url);
+        let response = self.http_client.post(&url)
+            .json(&agent)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to publish agent: {}", e))?;
+
+        if !response.status().is_success() {
+            return Err(format!("Marketplace returned status: {}", response.status()));
+        }
+
+        let published_agent: MarketplaceAgent = response.json().await
+            .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+        Ok(published_agent)
+    }
 }
 
 pub struct MarketplaceClient {
@@ -106,9 +125,17 @@ impl MarketplaceClient {
         }
         Ok(agent)
     }
+
+    /// Publish a new agent to the marketplace
+    pub async fn publish_agent(&self, agent: MarketplaceAgent) -> Result<MarketplaceAgent, String> {
+        let published_agent = self.provider.publish_agent(agent).await?;
+        if let Ok(mut cache) = self.cache.write() {
+            cache.insert(published_agent.id.clone(), published_agent.clone());
+        }
+        Ok(published_agent)
+    }
 }
 
-#[cfg(test)]
 pub mod test_utils {
     use super::*;
 
@@ -144,6 +171,16 @@ pub mod test_utils {
                 Err("Not found".to_string())
             }
         }
+
+        async fn publish_agent(&self, mut agent: MarketplaceAgent) -> Result<MarketplaceAgent, String> {
+            if agent.name == "error" {
+                return Err("Mock publish error".to_string());
+            }
+            if agent.id.is_empty() {
+                agent.id = "mock-id-123".to_string();
+            }
+            Ok(agent)
+        }
     }
 }
 
@@ -172,5 +209,33 @@ mod tests {
 
         let not_found = client.fetch_agent("unknown").await;
         assert!(not_found.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_marketplace_publish() {
+        let client = MarketplaceClient::new(Box::new(MockMarketplaceProvider));
+        let new_agent = MarketplaceAgent {
+            id: "".to_string(),
+            name: "New Agent".to_string(),
+            description: "A new test agent".to_string(),
+            author: "Tester".to_string(),
+            version: "1.0".to_string(),
+            endpoint: "http://example.com".to_string(),
+        };
+
+        let published = client.publish_agent(new_agent).await.unwrap();
+        assert_eq!(published.id, "mock-id-123");
+        assert_eq!(published.name, "New Agent");
+
+        let error_agent = MarketplaceAgent {
+            id: "".to_string(),
+            name: "error".to_string(),
+            description: "".to_string(),
+            author: "".to_string(),
+            version: "".to_string(),
+            endpoint: "".to_string(),
+        };
+        let error_res = client.publish_agent(error_agent).await;
+        assert!(error_res.is_err());
     }
 }

--- a/src/agents/builtin/tools/marketplace_tool.rs
+++ b/src/agents/builtin/tools/marketplace_tool.rs
@@ -5,12 +5,19 @@ use serde::Deserialize;
 use std::sync::Arc;
 use super::marketplace::MarketplaceClient;
 
+use super::marketplace::MarketplaceAgent;
+
 // Pydantic-first tool schema validation: MarketplaceArgs
 #[derive(Deserialize)]
 struct MarketplaceArgs {
     action: String,
     query: Option<String>,
     agent_id: Option<String>,
+    agent_name: Option<String>,
+    agent_description: Option<String>,
+    agent_author: Option<String>,
+    agent_version: Option<String>,
+    agent_endpoint: Option<String>,
 }
 
 /// Exposes the marketplace to the agent so it can dynamically fetch new tools/agents.
@@ -38,6 +45,20 @@ impl PydanticToolExecutor<MarketplaceArgs> for MarketplaceToolExecutor {
                 Ok(agent) => Ok(format!("Successfully fetched agent definition:\n{}", serde_json::to_string_pretty(&agent).unwrap_or_default())),
                 Err(e) => Err(ToolError::Transient(e)),
             }
+        } else if action == "publish" {
+            let agent = MarketplaceAgent {
+                id: "".to_string(), // Let server assign
+                name: args.agent_name.unwrap_or_default(),
+                description: args.agent_description.unwrap_or_default(),
+                author: args.agent_author.unwrap_or_default(),
+                version: args.agent_version.unwrap_or_else(|| "1.0.0".to_string()),
+                endpoint: args.agent_endpoint.unwrap_or_default(),
+            };
+
+            match self.client.publish_agent(agent).await {
+                Ok(published) => Ok(format!("Successfully published agent to marketplace:\n{}", serde_json::to_string_pretty(&published).unwrap_or_default())),
+                Err(e) => Err(ToolError::Transient(e)),
+            }
         } else {
             Err(ToolError::LlmRecoverable(format!("Unknown action: {}", action)))
         }
@@ -47,15 +68,15 @@ impl PydanticToolExecutor<MarketplaceArgs> for MarketplaceToolExecutor {
 pub fn marketplace_tool(client: Arc<MarketplaceClient>) -> Tool {
     Tool {
         name: "agent_marketplace".to_string(),
-        description: "Search for and fetch pre-built agents from the AutoGPT Agent Marketplace.".to_string(),
-        is_read_only: true,
+        description: "Search for, fetch, and publish pre-built agents to the AutoGPT Agent Marketplace.".to_string(),
+        is_read_only: false,
         parameters: json!({
             "type": "object",
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["search", "fetch"],
-                    "description": "Action to perform: 'search' to find agents, 'fetch' to get a specific agent's details."
+                    "enum": ["search", "fetch", "publish"],
+                    "description": "Action to perform: 'search' to find agents, 'fetch' to get a specific agent's details, 'publish' to publish a new agent."
                 },
                 "query": {
                     "type": "string",
@@ -64,6 +85,26 @@ pub fn marketplace_tool(client: Arc<MarketplaceClient>) -> Tool {
                 "agent_id": {
                     "type": "string",
                     "description": "The ID of the agent to fetch (used if action is 'fetch')."
+                },
+                "agent_name": {
+                    "type": "string",
+                    "description": "The name of the agent to publish (used if action is 'publish')."
+                },
+                "agent_description": {
+                    "type": "string",
+                    "description": "The description of the agent to publish (used if action is 'publish')."
+                },
+                "agent_author": {
+                    "type": "string",
+                    "description": "The author of the agent to publish (used if action is 'publish')."
+                },
+                "agent_version": {
+                    "type": "string",
+                    "description": "The version of the agent to publish (used if action is 'publish')."
+                },
+                "agent_endpoint": {
+                    "type": "string",
+                    "description": "The endpoint where the agent definition can be fetched (used if action is 'publish')."
                 }
             },
             "required": ["action"]
@@ -105,6 +146,24 @@ mod tests {
         let result = tool.execute.execute(args).await.unwrap();
         assert!(result.contains("Successfully fetched"));
         assert!(result.contains("Data Analyst"));
+    }
+
+    #[tokio::test]
+    async fn test_marketplace_tool_publish() {
+        let client = Arc::new(MarketplaceClient::new(Box::new(MockMarketplaceProvider)));
+        let tool = marketplace_tool(client);
+
+        let args = json!({
+            "action": "publish",
+            "agent_name": "Writer",
+            "agent_description": "Writes essays",
+            "agent_author": "Tester"
+        });
+
+        let result = tool.execute.execute(args).await.unwrap();
+        assert!(result.contains("Successfully published"));
+        assert!(result.contains("mock-id-123"));
+        assert!(result.contains("Writer"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR implements the missing `am_publish_agent` RPC capability from the AutoGPT Unique Harness Innovations: Agent Marketplace standard.

- Updated `MarketplaceProvider` to support `publish_agent`.
- Updated `HttpMarketplaceProvider` to perform actual POST requests.
- Exposed the `publish` action via the LLM `MarketplaceToolExecutor`.
- Fixed the `codex_runner.rs` `AppServer` to properly instantiate `MarketplaceClient` with a dependency injection, preventing hardcoded endpoints and allowing robust hermetic testing.
- Added `MockMarketplaceProvider::publish_agent` test logic and ensured all unit tests pass completely.

I verified everything by running `bazelisk test //src/agents/builtin/...` and confirming all tests pass.

---
*PR created automatically by Jules for task [11892942187885942860](https://jules.google.com/task/11892942187885942860) started by @ql-owo-lp*