### PR TITLE
🔗 Link: [Implement 'Approve All' Action Feed Button]

### DIFF
--- a/src/e2e/agent_feed.spec.ts
+++ b/src/e2e/agent_feed.spec.ts
@@ -52,4 +52,72 @@ test.describe('Agentic Unified Intake & Action Feed', () => {
     await expect(approveBtn).toBeVisible();
     await approveBtn.click();
   });
+
+  test('should display Approve All button when there are multiple items', async ({ page }) => {
+    // Mock the API for this specific test to ensure we have multiple items
+    await page.route('**/api/ui/dashboard/unified-feed*', async route => {
+      await route.fulfill({
+        status: 200,
+        json: {
+          metrics: {},
+          orders: [],
+          inbox: [],
+          supply: {}
+        }
+      });
+    });
+
+    await page.route('**/api/agent-feed*', async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          json: {
+            items: [
+              {
+                id: "item_1",
+                tenant_id: "t1",
+                event_source: "New Order",
+                lifecycle_state: "PENDING_APPROVAL",
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                proposed_action: { title: "Fulfill Now", description: "3 new orders to fulfill" }
+              },
+              {
+                id: "item_2",
+                tenant_id: "t1",
+                event_source: "Customer Inquiry",
+                lifecycle_state: "PENDING_APPROVAL",
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                proposed_action: { title: "Reply", description: "Drafted reply to customer" }
+              }
+            ]
+          }
+        });
+      } else if (route.request().method() === 'PUT') {
+        await route.fulfill({ status: 200, json: { success: true } });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto('/dashboard');
+
+    // Wait for the feed container on dashboard
+    await expect(page.locator('#triage-queue')).toBeVisible({ timeout: 15000 });
+
+    // The Approve All button should be visible
+    const approveAllBtn = page.getByTestId('approve-all-btn');
+    await expect(approveAllBtn).toBeVisible();
+
+    // Check multiple cards are present
+    const cards = page.getByTestId(/triage-card-/);
+    expect(await cards.count()).toBeGreaterThan(1);
+
+    // Click Approve All
+    await approveAllBtn.click();
+
+    // Verify it clears the items and shows empty state
+    await expect(page.getByTestId('triage-feed-empty')).toBeVisible();
+  });
 });

--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -613,6 +613,57 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
     }
   };
 
+  const handleApproveAll = async () => {
+    if (!items || items.length === 0) return;
+
+    const itemsToApprove = [...items];
+    // Optimistically clear items
+    setItems([]);
+
+    if (isOffline) {
+      itemsToApprove.forEach((item) => {
+        enqueueAction({
+          id: item.id,
+          type: "APPROVE_FEED_ITEM",
+          payload: {
+            id: item.id,
+            approved: true,
+            event_source: item.event_source,
+          },
+        });
+      });
+      const current = await getActions();
+      setOfflineActionsCount(current.length);
+      return;
+    }
+
+    try {
+      for (const item of itemsToApprove) {
+        const res = await fetch(`/api/agent-feed/${item.id}`, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            "x-tenant-id": tenantId(),
+            "x-user-id": "default",
+          },
+          body: JSON.stringify({
+            state: "APPROVED",
+          }),
+        });
+        if (!res.ok) {
+          setItems((prev) => [...prev, item]); // Restore failed item
+          console.error(`Failed to approve item ${item.id}`);
+        }
+      }
+    } catch (err) {
+      console.error("Bulk approve failed", err);
+      setItems((prev) => {
+        const existingIds = new Set(prev.map(p => p.id));
+        return [...prev, ...itemsToApprove.filter(item => !existingIds.has(item.id))];
+      }); // Restore all on major error
+    }
+  };
+
   const handleDecision = async (
     id: string,
     approved: boolean,
@@ -737,6 +788,18 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
                 <div className="w-full max-w-md text-left">
                   <GrowthReferralWidget />
                 </div>
+              </div>
+            )}
+            {items.length > 1 && (
+              <div className="flex justify-end mb-4 w-full" style={{ zIndex: 10, position: "relative" }}>
+                <button
+                  onClick={handleApproveAll}
+                  className="min-h-[44px] px-6 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all duration-200 shadow-md flex items-center justify-center"
+                  aria-label="Approve All"
+                  data-testid="approve-all-btn"
+                >
+                  Approve All
+                </button>
               </div>
             )}
             {items.map((approval) => (


### PR DESCRIPTION
Resolves #31292

This PR adds an "Approve All" button to the Unified Agent Feed when there are multiple items requiring approval.

- **Changes made:**
  - In `src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx`, added `handleApproveAll` function that iterates through `itemsToApprove` and makes a `PUT` request to `/api/agent-feed/${id}` to approve them individually while preserving the "Proposals" vs "Activity" UI state.
  - Placed an "Approve All" button cleanly at the top of the action card stack.
  - Ensured UI correctly updates on errors, falling back nicely.
  - Added new E2E test to verify "Approve All" UI functionality in `src/e2e/agent_feed.spec.ts`.

- **Verification:**
  - Ran `bazel test //...` which is all green.
  - Ran `bazel test //src/e2e:playwright` which passes with the mocked API responses.
  - Visually verified the UI via Playwright screenshot generation to ensure the button is properly formatted and does not cause visual regressions on smaller widths.

---
*PR created automatically by Jules for task [10635496092855636368](https://jules.google.com/task/10635496092855636368) started by @ql-owo-lp*