### PR TITLE
🗺️ Guide: Fix onboarding progress bug

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2715,7 +2715,7 @@
         populateForm();
 
         if (state.step === undefined || state.step === 0) {
-          goToStep("step-initial");
+          goToStep("step-initial", false);
         } else {
           const steps = [
             "step-initial",
@@ -2731,7 +2731,7 @@
             "step-chat",
           ];
           if (state.step < steps.length) {
-            goToStep(steps[state.step]);
+            goToStep(steps[state.step], false);
           }
         }
       }
@@ -2906,10 +2906,9 @@
 
         // Increment step if we are moving forward
 
-        let stepNumber = 0;
         const activeStep = document.querySelector(".step.active");
         if (activeStep) {
-          stepNumber = [
+          const stepIndex = [
             "step-initial",
             "step-context",
             "step-categories",
@@ -2922,9 +2921,10 @@
             "step-instant",
             "step-chat",
           ].indexOf(activeStep.id);
-          if (stepNumber === -1) stepNumber = 0;
+          if (stepIndex !== -1) {
+            state.step = stepIndex;
+          }
         }
-        state.step = stepNumber;
 
         // Always set localStorage directly
         localStorage.setItem("onboardingState", JSON.stringify(state));
@@ -3237,10 +3237,7 @@
         }
       }
 
-      function goToStep(stepId) {
-        saveCurrentState();
-        localStorage.setItem("onboardingState", JSON.stringify(state));
-
+      function goToStep(stepId, shouldSave = true) {
         if (stepId === "step-instant") {
           const instantBioInputEl = document.getElementById("instant-bio");
           const generateStorefrontBtn = document.getElementById("generate-storefront-btn");
@@ -3261,6 +3258,11 @@
         document.getElementById(stepId).classList.add("active");
         document.getElementById(stepId).style.display = "block";
         updateStepper(stepId);
+
+        if (shouldSave) {
+          saveCurrentState();
+          localStorage.setItem("onboardingState", JSON.stringify(state));
+        }
       }
 
       document.querySelectorAll(".next-step-btn").forEach((btn) => {


### PR DESCRIPTION
🗺️ Guide: Fix onboarding progress preservation across navigation.

**Product-use evidence:**
- **Persona:** Maya (Home Baker) / Day One Owner.
- **Observed Bug:** Navigating through the setup wizard manually resulted in the progress always being one step behind, or fully wiped when resuming progress after an interrupted onboarding attempt.
- **Cause:** `saveCurrentState()` relied on `.step.active` being correctly updated. `goToStep()` fired `saveCurrentState()` *before* setting the new active step, meaning it would save the previously completed step. Furthermore, `loadState()` fired a save call upon booting before rendering, which wiped out any pulled data by re-saving Step 0.
- **Resolution:** Adjusted `goToStep` to change the active class first and then call `saveCurrentState()`. Added a `shouldSave` flag so that initial component setup doesn't overwrite backend state. Improved safety bounds in `saveCurrentState()` around index validation.

Verified that Playwright tests and full backend test suites are passing fully and cleanly (tested with `bazelisk test //...` and `bazelisk test //src/e2e:playwright`). No E2E suite changes were needed because the UI changes corrected the real state to match expectations already covered by tests.

---
*PR created automatically by Jules for task [17177299960294855736](https://jules.google.com/task/17177299960294855736) started by @ql-owo-lp*