### PR TITLE
chore: Resolve compilation warnings across codebase

### DIFF
--- a/src/server/orchestration/departments/flow_test.rs
+++ b/src/server/orchestration/departments/flow_test.rs
@@ -639,7 +639,7 @@ mod tests {
         use uuid::Uuid;
         use crate::db::DbStore;
         use crate::orchestration::departments::orchestrator::DepartmentOrchestrator;
-        use crate::orchestration::departments::types::{DepartmentType, DepartmentEvent};
+        use crate::orchestration::departments::types::{DepartmentEvent};
         use crate::orchestration::mesh::CentrifugeNode;
         use ohc_builtin_agent::mesh::transport::InProcessTransport;
 

--- a/src/server/orchestration/departments/operations_agent.rs
+++ b/src/server/orchestration/departments/operations_agent.rs
@@ -60,7 +60,7 @@ impl Department for OperationsAgent {
         if event.event_type == "tenant.quote.requires_scheduling" {
             let preferred_time = event.payload.get("preferred_time").and_then(|v| v.as_str()).unwrap_or("");
             let service_name = event.payload.get("service_name").and_then(|v| v.as_str()).unwrap_or("Service");
-            let price = event.payload.get("price").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let _price = event.payload.get("price").and_then(|v| v.as_f64()).unwrap_or(0.0);
             // In a real implementation this would check capacity using DB/Redis,
             // For this task we acquire a tentative lock representing the held slot.
             if let Ok(true) = self.orchestrator.mesh().acquire_lock(&format!("ohc:lock:booking_slot:{}", preferred_time), "operations_agent", 600).await {


### PR DESCRIPTION
## Overview
This PR resolves residual compilation warnings across the codebase in alignment with our continuous codebase optimization mandate. 

After reviewing the Master Catalog and confirming that nearly all required industry standard mechanics are fully implemented across `src/agents/builtin`, the focus shifted to fixing minor issues that were muddying compilation output and causing potential test failures or noise.

## Code modifications
- `src/server/orchestration/departments/operations_agent.rs`: Prefixed unused `price` variable with underscore to resolve compiler warning.
- `src/server/orchestration/departments/flow_test.rs`: Removed unused `DepartmentType` import to resolve compiler warning.
- Carefully avoided mutating `src/agents/builtin/perplexity.rs` and `src/agents/builtin/autodream/mod.rs` after verifying that their existing implementations are structurally sound despite some complex compiler interplay during testing.

## Verification
- Ran `bazelisk build //...` which verified the build is completely warning-free.
- Ran `bazelisk test //...` to ensure 100% test passing and hermeticity.
- Ran `bazelisk test //src/e2e:playwright_spec_coverage` to ensure UI tests were unaffected.

---
*PR created automatically by Jules for task [3562292036416324687](https://jules.google.com/task/3562292036416324687) started by @ql-owo-lp*