### PR TITLE
fix: unused variable and import warnings and remove dead code comment

### DIFF
--- a/src/agents/builtin/agent.rs
+++ b/src/agents/builtin/agent.rs
@@ -11323,7 +11323,7 @@ mod fail_fast_tests {
 
         // Now check if a pattern was recorded and saved
         let loaded_matcher = crate::sona_patterns::PatternMatcher::load_from_disk(&sona_path_str).await.unwrap();
-        let patterns = loaded_matcher.get_patterns();
+        let _patterns = loaded_matcher.get_patterns();
 
         // Second run, we should see the SONA prompt injected
         struct MockLlmClientSona2;


### PR DESCRIPTION
Fixes compiler warnings and cleans up a dead code placeholder comment.

---
*PR created automatically by Jules for task [9699216142793674484](https://jules.google.com/task/9699216142793674484) started by @ql-owo-lp*