### PR TITLE
fix(billing): Use dynamic BASE_URL for Stripe billing portal return_url

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -158,7 +158,8 @@ pub async fn create_billing_portal_session_handler(
         }
     } else {
         // Fallback if Stripe config is missing
-        Ok(Json(CreateBillingPortalSessionResponse { url: "https://example.com/pricing".to_string() }))
+        let base_url = std::env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:18789".to_string());
+        Ok(Json(CreateBillingPortalSessionResponse { url: format!("{}/pricing.html", base_url) }))
     }
 }
 

--- a/src/server/integrations/stripe/client.rs
+++ b/src/server/integrations/stripe/client.rs
@@ -150,7 +150,8 @@ impl StripeClient {
 
         let mut form = std::collections::HashMap::new();
         form.insert("customer".to_string(), customer_id.to_string());
-        form.insert("return_url".to_string(), "https://example.com/pricing".to_string());
+        let base_url = std::env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:18789".to_string());
+        form.insert("return_url".to_string(), format!("{}/pricing.html", base_url));
 
         let res = reqwest::Client::new()
             .post(format!("{}/v1/billing_portal/sessions", Self::api_base()))


### PR DESCRIPTION
Fixed an issue where the Stripe billing portal integration used a placeholder URL `https://example.com/pricing` for redirects. Replaced it with a dynamic `BASE_URL` with a local fallback.

---
*PR created automatically by Jules for task [17745356777309887777](https://jules.google.com/task/17745356777309887777) started by @ql-owo-lp*