### PR TITLE
fix: Prevent metric cardinality explosion in cost tracking

### DIFF
--- a/src/server/hub.rs
+++ b/src/server/hub.rs
@@ -91,8 +91,7 @@ impl Hub {
 
                 // Blueprint: track cost in cents
                 let cost_cents = (cost * 100.0).round() as i64;
-                let mut labels_cents = labels.clone();
-                labels_cents["cost_cents"] = serde_json::json!(cost_cents);
+                let labels_cents = labels.clone();
                 let _ = ::server_telemetry::buffer_metric_i64(&pool_clone, "ohc_llm_cost_total_cents", "counter", cost_cents, labels_cents).await;
             }
         });

--- a/src/server/telemetry/mod.rs
+++ b/src/server/telemetry/mod.rs
@@ -1328,8 +1328,7 @@ pub async fn record_storage_rw_cost(
         cost_cents,
         serde_json::json!({
             "organization_id": organization_id,
-            "operation": operation,
-            "cost_cents": cost_cents,
+            "operation": operation
         }),
     )
     .await
@@ -1347,8 +1346,7 @@ pub async fn record_email_send_cost(
         "counter",
         cost_cents,
         serde_json::json!({
-            "organization_id": organization_id,
-            "cost_cents": cost_cents,
+            "organization_id": organization_id
         }),
     )
     .await


### PR DESCRIPTION
Fix metric cardinality explosion by removing the dynamic cost value from the labels for cost tracking metrics (`ohc_llm_cost_total_cents`, `ohc_storage_rw_cost`, `ohc_email_send_cost`).

---
*PR created automatically by Jules for task [11506772919333745395](https://jules.google.com/task/11506772919333745395) started by @ql-owo-lp*