### PR TITLE
feat(growth): add 50th order, 1000 orders and 10k revenue milestones

### DIFF
--- a/src/e2e/e2e-seed.sql
+++ b/src/e2e/e2e-seed.sql
@@ -561,6 +561,10 @@ VALUES
 INSERT INTO business_milestones (id, tenant_id, milestone_type, reached_at) VALUES
 ('ms_e2e_revenue_1k', 'e2e-tenant', 'revenue_1k', CURRENT_TIMESTAMP)
 ON CONFLICT DO NOTHING;
+
+INSERT INTO business_milestones (id, tenant_id, milestone_type, reached_at) VALUES
+('ms_e2e_revenue_10k', 'e2e-milestone-tenant', 'revenue_10k', CURRENT_TIMESTAMP)
+ON CONFLICT DO NOTHING;
 UPDATE tenants SET plan_tier = 'Starter' WHERE id = 'e2e-tenant';
 INSERT INTO tenants (id, name, industry, plan_tier, has_claimed_trial_extension)
 VALUES

--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -1909,10 +1909,28 @@ async fn handle_check_milestones(
             reached: reached_types.contains(&"revenue_1k".to_string()),
         },
         Milestone {
+            id: "50th_order".to_string(),
+            title: "🔥 50th Order!".to_string(),
+            description: "You've successfully processed your 50th order on OHC.".to_string(),
+            reached: reached_types.contains(&"50th_order".to_string()),
+        },
+        Milestone {
             id: "100_orders".to_string(),
             title: "📦 Century of Orders".to_string(),
             description: "You've successfully fulfilled 100 orders on OHC!".to_string(),
             reached: reached_types.contains(&"100_orders".to_string()),
+        },
+        Milestone {
+            id: "1000_orders".to_string(),
+            title: "👑 1,000 Orders!".to_string(),
+            description: "A monumental achievement! 1,000 orders fulfilled on OHC!".to_string(),
+            reached: reached_types.contains(&"1000_orders".to_string()),
+        },
+        Milestone {
+            id: "revenue_10k".to_string(),
+            title: "💎 Five-Figure Club".to_string(),
+            description: "Your business has surpassed $10,000 in total revenue!".to_string(),
+            reached: reached_types.contains(&"revenue_10k".to_string()),
         },
     ];
     Json(MilestonesResponse { milestones })
@@ -1955,8 +1973,14 @@ async fn handle_get_milestone(
 
         if types.contains(&"revenue_100k".to_string()) {
             best_milestone_id = "revenue_100k".to_string();
+        } else if types.contains(&"1000_orders".to_string()) {
+            best_milestone_id = "1000_orders".to_string();
+        } else if types.contains(&"revenue_10k".to_string()) {
+            best_milestone_id = "revenue_10k".to_string();
         } else if types.contains(&"100_orders".to_string()) {
             best_milestone_id = "100_orders".to_string();
+        } else if types.contains(&"50th_order".to_string()) {
+            best_milestone_id = "50th_order".to_string();
         } else if types.contains(&"revenue_1k".to_string()) {
             best_milestone_id = "revenue_1k".to_string();
         } else if types.contains(&"10th_order".to_string()) {
@@ -1977,11 +2001,29 @@ async fn handle_get_milestone(
             "I just hit $100k in revenue running my business on OHC! 🚀",
             "$500 Credit"
         ),
+        "1000_orders" => (
+            "1,000th Order Delivered! 👑",
+            "An incredible milestone! Share your success to unlock $100 in credits.",
+            "I just hit my 1,000th order using OHC to run my business! 🚀",
+            "$100 Credit"
+        ),
+        "revenue_10k" => (
+            "Five-Figure Club! 💎",
+            "You crossed $10k in revenue. Share to unlock $75 in credits.",
+            "I just hit $10k in revenue running my business on OHC! 🚀",
+            "$75 Credit"
+        ),
         "100_orders" => (
             "100th Order Delivered! 🎉",
             "You're growing fast. Share your success to unlock $50 in OHC credits.",
             "I just hit my 100th order using OHC to run my business! 🚀 Check them out and get $50 off your first month:",
             "$50 Credit"
+        ),
+        "50th_order" => (
+            "50th Order! 🔥",
+            "You're halfway to 100! Share your success to unlock $30 in OHC credits.",
+            "I just hit my 50th order using OHC! 🚀",
+            "$30 Credit"
         ),
         "revenue_1k" => (
             "Four-Figure Club! 💰",
@@ -2067,10 +2109,13 @@ async fn handle_get_milestone_card(
     let (title, sub, icon, grad_start, grad_end) = match milestone_id {
         "first_sale" => ("First Sale!", "Unlocked on OHC", "💰", "#667eea", "#764ba2"),
         "10th_order" => ("10th Order!", "Business is booming", "📈", "#ff9a9e", "#fecfef"),
+        "50th_order" => ("50th Order!", "Halfway to 100", "🔥", "#ff9a9e", "#fecfef"),
         "100_visitors" => ("100 Visitors!", "Traffic is soaring", "🚀", "#a1c4fd", "#c2e9fb"),
         "5_referrals" => ("High Connector!", "Referred 5 businesses", "🤝", "#f6d365", "#fda085"),
         "revenue_1k" => ("Four-Figure Club", "Crossed $1k in Revenue!", "💰", "#f43f5e", "#fb923c"),
+        "revenue_10k" => ("Five-Figure Club", "Crossed $10k in Revenue!", "💎", "#a18cd1", "#fbc2eb"),
         "100_orders" => ("Century of Orders", "100 sales fulfilled", "📦", "#ffecd2", "#fcb69f"),
+        "1000_orders" => ("1,000 Orders!", "A monumental achievement", "👑", "#f6d365", "#fda085"),
         _ => ("Success Milestone!", "Built with OHC", "✨", "#667eea", "#764ba2"),
     };
 

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1453,9 +1453,14 @@
               const iconMap = {
                   'first_sale': '🎉',
                   '10th_order': '📈',
+                  '50th_order': '🔥',
+                  '100_orders': '📦',
+                  '1000_orders': '👑',
                   '100_visitors': '🚀',
                   '5_referrals': '🤝',
-                  'revenue_1k': '💰'
+                  'revenue_1k': '💰',
+                  'revenue_10k': '💎',
+                  'revenue_100k': '🌟'
               };
               document.getElementById('milestone-icon').innerText = iconMap[reachedMilestone.id] || '✨';
 

--- a/src/ui/tauri/src/ui/milestones.html
+++ b/src/ui/tauri/src/ui/milestones.html
@@ -394,9 +394,14 @@
         switch (id) {
           case 'first_sale': return '🎉';
           case '10th_order': return '📈';
+          case '50th_order': return '🔥';
+          case '100_orders': return '📦';
+          case '1000_orders': return '👑';
           case '100_visitors': return '🚀';
           case '5_referrals': return '🤝';
           case 'revenue_1k': return '💰';
+          case 'revenue_10k': return '💎';
+          case 'revenue_100k': return '🌟';
           default: return '🏆';
         }
       };


### PR DESCRIPTION
**Product-use evidence:**
- **Persona:** Maya (Home Baker) / Growing Business Owner.
- **Observed Bug/Gap:** Reaching a milestone like 50 orders or 10k revenue didn't trigger any notification in the dashboard.
- **Cause:** The `handle_check_milestones` and `handle_get_milestone` didn't have these milestones defined and only stopped at `10th_order`, `100_orders`, `revenue_1k`, `revenue_100k`.
- **Resolution:** Added the missing milestones to `growth.rs` and mapped them correctly in `dashboard.html` and `milestones.html`. Checked the Playwright testing functionality and verified it passes cleanly via Bazel.

---

Implemented new growth milestones for OHC platform:
1. `50th_order`
2. `1000_orders`
3. `revenue_10k`

Mapped custom icons and generated shareable success UI for them.

---
*PR created automatically by Jules for task [10298355028716823540](https://jules.google.com/task/10298355028716823540) started by @ql-owo-lp*