### PR TITLE
fix: add authorization header to trial extension API requests

### DIFF
--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1303,6 +1303,7 @@
                 method: 'POST',
                 headers: {
                   'Content-Type': 'application/json',
+                  'authorization': 'Bearer ' + localStorage.getItem('ohc_token')
                 }
               });
 
@@ -1366,6 +1367,7 @@
                 method: 'POST',
                 headers: {
                   'Content-Type': 'application/json',
+                  'authorization': 'Bearer ' + localStorage.getItem('ohc_token')
                 }
               });
 

--- a/src/ui/tauri/src/ui/trial-extension.html
+++ b/src/ui/tauri/src/ui/trial-extension.html
@@ -124,6 +124,7 @@
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
+                            'authorization': 'Bearer ' + localStorage.getItem('ohc_token')
                         }
                     });
 


### PR DESCRIPTION
This PR fixes the authorization issue when claiming a trial extension on `dashboard.html` and `trial-extension.html`. 
It ensures that the `ohc_token` from local storage is passed as a `Bearer` token in the `authorization` header.

Fixes an issue where omitting the authentication caused the backend endpoint `/api/v1/growth/trial-extension/claim` to crash or return a `500 Internal Server Error`, breaking the interactive trial extension CUJ.

All existing Playwright E2E and unit tests (`bazel test //...`) have been successfully run.

---
*PR created automatically by Jules for task [1958292110814784930](https://jules.google.com/task/1958292110814784930) started by @ql-owo-lp*