### PR TITLE
chore(e2e): remove mocked network requests from documentation tests

### DIFF
--- a/src/ui/next/src/e2e/help.spec.ts
+++ b/src/ui/next/src/e2e/help.spec.ts
@@ -1,65 +1,6 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Help Center", () => {
-  test.beforeEach(async ({ page }) => {
-    // Mock backend API responses for tests
-    await page.route("**/api/help", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify([
-          {
-            category: "Getting Started",
-            id: "getting-started-1",
-            title: "Getting Started with Your Store",
-            desc: "Welcome to OneHumanCorp!",
-            link: "/help/getting-started-1",
-          },
-          {
-            category: "My Store",
-            id: "my-store",
-            title: "My Store",
-            desc: "My store info",
-            link: "/help/my-store",
-          },
-          {
-            category: "Payments",
-            id: "accept-payments",
-            title: "Accepting Payments",
-            desc: "Learn how to accept credit cards.",
-            link: "/help/accept-payments",
-          },
-        ]),
-      });
-    });
-
-    await page.route("**/api/help/search*", async (route) => {
-      const url = new URL(route.request().url());
-      const query = url.searchParams.get("q") || "";
-      if (query.toLowerCase().includes("my store")) {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify([
-            {
-              category: "My Store",
-              id: "my-store",
-              title: "My Store",
-              desc: "My store info",
-              link: "/help/my-store",
-            },
-          ]),
-        });
-      } else {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify([]),
-        });
-      }
-    });
-  });
-
   test("renders help center and navigates to an article", async ({ page }) => {
     await page.goto("/help");
 
@@ -79,8 +20,6 @@ test.describe("Help Center", () => {
     );
     await searchInput.fill("Getting Started");
 
-    // The mock backend search for "Getting Started" returns [] based on our mock setup, so we don't click it via search.
-    // Instead we just click the visible link from the initial load.
     // Wait for search debounce to complete and clear it
     await searchInput.fill("");
 
@@ -116,14 +55,14 @@ test.describe("Help Center", () => {
       "Search for help articles and videos...",
     );
 
-    await searchInput.fill("My Store");
+    await searchInput.fill("Adding Products");
 
     // Wait for UI to update (non-matching articles should disappear)
     await expect(
       page.locator('a[href="/help/getting-started-1"]'),
     ).not.toBeVisible({ timeout: 10000 });
 
-    const articleLink = page.locator('a[href="/help/my-store"]');
+    const articleLink = page.locator('a[href="/help/add-products"]');
     await expect(articleLink).toBeVisible({ timeout: 10000 });
   });
 

--- a/src/ui/next/src/e2e/tooltips.spec.ts
+++ b/src/ui/next/src/e2e/tooltips.spec.ts
@@ -1,43 +1,6 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Tooltips", () => {
-  test.beforeEach(async ({ page }) => {
-    // Catch-all route to prevent network requests hanging the page load
-    await page.route("**/*", async (route, request) => {
-      const url = request.url();
-      if (url.includes("/api/tooltips")) {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({
-            "api-docs-tooltip": "Direct API access is only for custom integrations.",
-            "settings-delivery-tooltip": "Turn this on to offer local delivery to your customers.",
-          }),
-        });
-      } else if (url.includes("/api/api-docs-spec")) {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({
-            openapi: "3.0.0",
-            info: {
-              title: "OHC Advanced API Reference",
-              version: "1.0.0",
-            },
-            paths: {},
-          }),
-        });
-      } else if (url.includes("/api/ui/swagger-ui.css") || url.includes("/api/ui/swagger-ui-bundle.js")) {
-        await route.fulfill({
-          status: 200,
-          contentType: "text/plain",
-          body: "",
-        });
-      } else {
-        await route.continue();
-      }
-    });
-  });
 
   test("renders tooltip on hover", async ({ page }) => {
     // Navigate to a page that contains a tooltip

--- a/src/ui/next/src/e2e/videos.spec.ts
+++ b/src/ui/next/src/e2e/videos.spec.ts
@@ -1,29 +1,6 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("In-App Video Tutorials", () => {
-  test.beforeEach(async ({ page }) => {
-    // Mock backend API response for videos
-    await page.route("**/api/videos", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify([
-          {
-            id: 1,
-            title: "How to set up your first store easily",
-            duration: "1:15",
-            video_url: "https://example.com/video1.mp4",
-          },
-          {
-            id: 2,
-            title: "Connecting a bank account to accept payments",
-            duration: "0:45",
-            video_url: "https://example.com/video2.mp4",
-          },
-        ]),
-      });
-    });
-  });
 
   test("renders videos tab, fetches videos, and opens/closes the modal player", async ({
     page,
@@ -47,7 +24,7 @@ test.describe("In-App Video Tutorials", () => {
 
     // Wait for the videos to be fetched and rendered
     const firstVideoTitle = page.locator("p", {
-      hasText: "How to set up your first store easily",
+      hasText: "How to set up your store in 5 minutes",
     });
     await expect(firstVideoTitle).toBeVisible();
 
@@ -73,7 +50,7 @@ test.describe("In-App Video Tutorials", () => {
     // Verify the video title is shown in the modal header
     await expect(
       modalContainer.locator("h3", {
-        hasText: "How to set up your first store easily",
+        hasText: "How to set up your store in 5 minutes",
       }),
     ).toBeVisible();
 


### PR DESCRIPTION
Removed mocked network requests from the Playwright E2E tests for the help center, tooltips, and video tutorials, and updated the test assertions to reflect real backend data. This ensures full compliance with the repository's strict "no mocks" mandate for E2E tests.

---
*PR created automatically by Jules for task [2325845169103152925](https://jules.google.com/task/2325845169103152925) started by @ql-owo-lp*