### PR TITLE
feat: Implement PII redaction for hybrid telemetry synchronization

### DIFF
--- a/src/server/services/sync/telemetry_sync.rs
+++ b/src/server/services/sync/telemetry_sync.rs
@@ -96,7 +96,7 @@ impl TelemetrySyncDaemon {
                             "metric_name": metric_name,
                             "metric_type": metric_type,
                             "value": value,
-                            "labels": serde_json::from_str::<Value>(&labels_json).unwrap_or(Value::Null),
+                            "labels": server_telemetry::redact_interface_pii(serde_json::from_str::<Value>(&labels_json).unwrap_or(Value::Null)),
                             "timestamp": timestamp,
                         });
                         chunk_res.push((id, json));
@@ -128,7 +128,7 @@ impl TelemetrySyncDaemon {
                     "metric_name": metric_name,
                     "metric_type": metric_type,
                     "value": value,
-                    "labels": serde_json::from_str::<Value>(&labels_json).unwrap_or(Value::Null),
+                    "labels": server_telemetry::redact_interface_pii(serde_json::from_str::<Value>(&labels_json).unwrap_or(Value::Null)),
                     "timestamp": timestamp,
                 }));
                 ids.push(id);

--- a/src/server/telemetry/mcp_sync_worker.rs
+++ b/src/server/telemetry/mcp_sync_worker.rs
@@ -16,6 +16,11 @@ impl McpSyncWorker {
         }
     }
 
+    pub fn process_telemetry_labels(labels_json: &str) -> String {
+        let parsed = serde_json::from_str::<serde_json::Value>(labels_json).unwrap_or(serde_json::Value::Null);
+        crate::redact_interface_pii(parsed).to_string()
+    }
+
     pub async fn run(&self) {
         info!("Starting McpSyncWorker...");
         loop {
@@ -46,11 +51,13 @@ impl McpSyncWorker {
             let labels_json: String = row.get("labels_json");
             let timestamp: chrono::NaiveDateTime = row.get("timestamp");
 
+            let redacted_labels_str = Self::process_telemetry_labels(&labels_json);
+
             let res = sqlx::query("INSERT INTO telemetry_buffer (metric_name, metric_type, value, labels_json, timestamp, sync_status) VALUES ($1, $2, $3, $4, $5, 'synced')")
                 .bind(metric_name)
                 .bind(metric_type)
                 .bind(value)
-                .bind(labels_json)
+                .bind(redacted_labels_str)
                 .bind(chrono::DateTime::<Utc>::from_naive_utc_and_offset(timestamp, Utc))
                 .execute(&mut *tx)
                 .await;

--- a/src/server/telemetry/mcp_sync_worker_test.rs
+++ b/src/server/telemetry/mcp_sync_worker_test.rs
@@ -1,11 +1,25 @@
-use sqlx::{SqlitePool, PgPool};
+use sqlx::{SqlitePool, PgPool, Row};
 use super::mcp_sync_worker::McpSyncWorker;
 
 #[tokio::test]
 async fn test_mcp_sync_worker() {
     let sqlite_pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    let pg_pool = PgPool::connect("postgres://ohc:ohc@localhost:5432/ohc").await.unwrap(); // just a dummy for compile
+    // use connect_lazy for a dummy compile so it doesn't try to connect immediately
+    let pg_pool = sqlx::postgres::PgPoolOptions::new().connect_lazy("postgres://ohc:ohc@localhost:5432/ohc").unwrap();
 
     let _worker = McpSyncWorker::new(sqlite_pool, pg_pool);
     // Since we don't have a real postgres instance in unit tests, we'll just test that it compiles and we can create it
+}
+
+#[tokio::test]
+async fn test_mcp_sync_worker_pii_redaction() {
+    let email_label = serde_json::json!({"email": "test@example.com", "other": "value"});
+    let labels_json_str = email_label.to_string();
+
+    let redacted_str = McpSyncWorker::process_telemetry_labels(&labels_json_str);
+
+    assert!(redacted_str.contains("[REDACTED]"));
+    assert!(!redacted_str.contains("test@example.com"));
+    assert!(redacted_str.contains("other"));
+    assert!(redacted_str.contains("value"));
 }


### PR DESCRIPTION
- Scrubbed PII from `labels_json` in telemetry payloads.
- Applied `crate::redact_interface_pii` before logging metrics and syncing.
- Fixed `mcp_sync_worker_test.rs` by verifying JSON processing without needing a real Postgres instance using `sqlx`'s `connect_lazy`.

---
*PR created automatically by Jules for task [4494283385353825721](https://jules.google.com/task/4494283385353825721) started by @ql-owo-lp*