### PR TITLE
fix: handle null user roles cleanly in stores

### DIFF
--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -125,8 +125,8 @@ impl UserRepository for PgUserRepository {
         };
 
         // Parse roles from JSON string
-        let roles_json: String = row.get("roles");
-        let roles: Vec<String> = serde_json::from_str(&roles_json).unwrap_or_default();
+        let roles_json: serde_json::Value = row.try_get("roles").unwrap_or_else(|_| serde_json::Value::Null);
+        let roles: Vec<String> = serde_json::from_value(roles_json).unwrap_or_default();
 
         tx.rollback().await.map_err(|e| e.to_string())?;
 
@@ -170,8 +170,8 @@ impl UserRepository for PgUserRepository {
             None => return Err("user not found".to_string()),
         };
 
-        let roles_json: String = row.get("roles");
-        let roles: Vec<String> = serde_json::from_str(&roles_json).unwrap_or_default();
+        let roles_json: serde_json::Value = row.try_get("roles").unwrap_or_else(|_| serde_json::Value::Null);
+        let roles: Vec<String> = serde_json::from_value(roles_json).unwrap_or_default();
 
         tx.rollback().await.map_err(|e| e.to_string())?;
 
@@ -215,8 +215,8 @@ impl UserRepository for PgUserRepository {
             None => return Err("user not found".to_string()),
         };
 
-        let roles_json: String = row.get("roles");
-        let roles: Vec<String> = serde_json::from_str(&roles_json).unwrap_or_default();
+        let roles_json: serde_json::Value = row.try_get("roles").unwrap_or_else(|_| serde_json::Value::Null);
+        let roles: Vec<String> = serde_json::from_value(roles_json).unwrap_or_default();
 
         tx.rollback().await.map_err(|e| e.to_string())?;
 
@@ -260,8 +260,8 @@ impl UserRepository for PgUserRepository {
             None => return Err("user not found".to_string()),
         };
 
-        let roles_json: String = row.get("roles");
-        let roles: Vec<String> = serde_json::from_str(&roles_json).unwrap_or_default();
+        let roles_json: serde_json::Value = row.try_get("roles").unwrap_or_else(|_| serde_json::Value::Null);
+        let roles: Vec<String> = serde_json::from_value(roles_json).unwrap_or_default();
 
         tx.rollback().await.map_err(|e| e.to_string())?;
 
@@ -300,8 +300,8 @@ impl UserRepository for PgUserRepository {
 
         let mut users = Vec::new();
         for row in rows {
-            let roles_json: String = row.get("roles");
-            let roles: Vec<String> = serde_json::from_str(&roles_json).unwrap_or_default();
+            let roles_json: serde_json::Value = row.try_get("roles").unwrap_or_else(|_| serde_json::Value::Null);
+            let roles: Vec<String> = serde_json::from_value(roles_json).unwrap_or_default();
 
             users.push(User {
                 id: row.get("id"),

--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -91,8 +91,8 @@ impl UserRepository for SqliteUserRepository {
             None => return Err("user not found".to_string()),
         };
 
-        let roles_json: String = row.get("roles");
-        let roles: Vec<String> = serde_json::from_str(&roles_json).unwrap_or_default();
+        let roles_json: serde_json::Value = row.try_get("roles").unwrap_or_else(|_| serde_json::Value::Null);
+        let roles: Vec<String> = serde_json::from_value(roles_json).unwrap_or_default();
 
         Ok(User {
             id: row.get("id"),
@@ -128,8 +128,8 @@ impl UserRepository for SqliteUserRepository {
             None => return Err("user not found".to_string()),
         };
 
-        let roles_json: String = row.get("roles");
-        let roles: Vec<String> = serde_json::from_str(&roles_json).unwrap_or_default();
+        let roles_json: serde_json::Value = row.try_get("roles").unwrap_or_else(|_| serde_json::Value::Null);
+        let roles: Vec<String> = serde_json::from_value(roles_json).unwrap_or_default();
 
         Ok(User {
             id: row.get("id"),
@@ -165,8 +165,8 @@ impl UserRepository for SqliteUserRepository {
             None => return Err("user not found".to_string()),
         };
 
-        let roles_json: String = row.get("roles");
-        let roles: Vec<String> = serde_json::from_str(&roles_json).unwrap_or_default();
+        let roles_json: serde_json::Value = row.try_get("roles").unwrap_or_else(|_| serde_json::Value::Null);
+        let roles: Vec<String> = serde_json::from_value(roles_json).unwrap_or_default();
 
         Ok(User {
             id: row.get("id"),
@@ -202,8 +202,8 @@ impl UserRepository for SqliteUserRepository {
             None => return Err("user not found".to_string()),
         };
 
-        let roles_json: String = row.get("roles");
-        let roles: Vec<String> = serde_json::from_str(&roles_json).unwrap_or_default();
+        let roles_json: serde_json::Value = row.try_get("roles").unwrap_or_else(|_| serde_json::Value::Null);
+        let roles: Vec<String> = serde_json::from_value(roles_json).unwrap_or_default();
 
         Ok(User {
             id: row.get("id"),
@@ -236,8 +236,8 @@ impl UserRepository for SqliteUserRepository {
 
         let mut users = Vec::new();
         for row in rows {
-            let roles_json: String = row.get("roles");
-            let roles: Vec<String> = serde_json::from_str(&roles_json).unwrap_or_default();
+            let roles_json: serde_json::Value = row.try_get("roles").unwrap_or_else(|_| serde_json::Value::Null);
+            let roles: Vec<String> = serde_json::from_value(roles_json).unwrap_or_default();
 
             users.push(User {
                 id: row.get("id"),


### PR DESCRIPTION
Changed the user role fetching logic in `postgres_store.rs` and `sqlite_store.rs`. Switched from using `.get("roles")` with `String` to `.try_get("roles")` resolving into `serde_json::Value`, paired with `unwrap_or_else(|_| serde_json::Value::Null)`. This eliminates potential panics during row fetching due to missing or null JSON roles.

---
*PR created automatically by Jules for task [1934808112136514894](https://jules.google.com/task/1934808112136514894) started by @ql-owo-lp*