### PR TITLE
chore: Resolve triage report issues

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -146,7 +146,7 @@ def go_repositories():
         name = "com_github_cncf_xds_go",
         build_file_generation = "on",
         importpath = "github.com/cncf/xds/go",
-        urls = ["https://github.com/cncf/xds/archive/e9ce68804cb4.tar.gz"],
+        urls = ["https://codeload.github.com/cncf/xds/tar.gz/e9ce68804cb4"],
         sum = "h1:Rjjh4E6iCUSW3n8E14lM6j1D0aRzDtdGk1iZ/g78A58=",
         version = "v0.0.0-20230607035331-e9ce68804cb4",
     )

--- a/src/server/services/inventory/service.rs
+++ b/src/server/services/inventory/service.rs
@@ -36,7 +36,6 @@ impl InventoryService {
         Self { redis_client }
     }
 
-    #[inline]
     // Redis Redlock pattern for distributed lock
     #[inline]
     fn get_lock_key(tenant_id: &str, product_id: &str) -> String {

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"

--- a/src/ui/next/vitest.config.ts
+++ b/src/ui/next/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
-    setupFiles: ['./vitest.setup.ts'],
+    setupFiles: [path.resolve(__dirname, './vitest.setup.ts')],
     globals: true,
     exclude: [
       '**/node_modules/**',


### PR DESCRIPTION
Fixes issues reported in `docs/reports/triage_report.md` and `docs/reports/root_cause.md`:
- Fixed Bazel `xds+` network fetch failure by updating `repositories.bzl` URL to `codeload.github.com`.
- Fixed Vitest setup configuration by properly resolving the absolute path using `path.resolve` in `src/ui/next/vitest.config.ts`.
- Removed `unused attribute #[inline]` warning in `src/server/services/inventory/service.rs`.
- Fixed React JSX configuration in `src/ui/next/tsconfig.json` to eliminate Next.js frontend compilation warnings.

The modifications have been rigorously tested to verify that the Vitest test suites completely pass and all warnings are handled correctly.

---
*PR created automatically by Jules for task [15428671154533873624](https://jules.google.com/task/15428671154533873624) started by @ql-owo-lp*