### PR TITLE
Fix Unified Agent Feed mobile aria-label

### DIFF
--- a/src/e2e/dashboard-feed-mobile.spec.ts
+++ b/src/e2e/dashboard-feed-mobile.spec.ts
@@ -51,4 +51,24 @@ test.describe('Unified Agent Feed Mobile MVP', () => {
       await expect(page.getByTestId(testId as string)).toHaveCount(0);
     }
   });
+
+  test('renders feed sections correctly on mobile', async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+    const feedSection = page.locator('section[aria-label="Unified Agent Feed"]');
+    await expect(feedSection).toBeVisible();
+
+    // Check tabs touch targets
+    const proposalsTab = page.locator('button:has-text("Proposals")');
+    await expect(proposalsTab).toBeVisible();
+    const proposalsTabBox = await proposalsTab.boundingBox();
+    expect(proposalsTabBox?.width).toBeGreaterThanOrEqual(44);
+    expect(proposalsTabBox?.height).toBeGreaterThanOrEqual(44);
+
+    const activityTab = page.locator('button:has-text("Activity Feed")');
+    await expect(activityTab).toBeVisible();
+    const activityTabBox = await activityTab.boundingBox();
+    expect(activityTabBox?.width).toBeGreaterThanOrEqual(44);
+    expect(activityTabBox?.height).toBeGreaterThanOrEqual(44);
+  });
 });

--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -721,7 +721,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
     <section
       id="triage-queue"
       className="app-panel mb-6 w-full overflow-hidden"
-      aria-label="Action Required"
+      aria-label="Unified Agent Feed"
     >
       <h2 className="text-2xl font-bold font-outfit text-[#1D1D1F] dark:text-[#F5F5F7] mb-2 hidden md:block">
         Action Required


### PR DESCRIPTION
Resolves #31380

Fixes the aria-label in UnifiedAgentFeed.tsx to "Unified Agent Feed" and adds a missing test case in dashboard-feed-mobile.spec.ts to assert the Proposals and Activity Feed tabs meet the 44x44px touch target requirement.

The `aria-label` previously was `"Action Required"` which caused e2e tests to fail. Added new e2e test cases.

Product-use evidence:
- Evaluated Unified Agent Feed on mobile resolution. Fixed missing aria label issue. Run e2e tests to pass successfully.

---
*PR created automatically by Jules for task [646426805931635132](https://jules.google.com/task/646426805931635132) started by @ql-owo-lp*