### PR TITLE
Fix remaining E2E test failures

### DIFF
--- a/src/e2e/playwright/unified-agent-feed.mobile.spec.ts
+++ b/src/e2e/playwright/unified-agent-feed.mobile.spec.ts
@@ -31,9 +31,9 @@ test.describe('Unified Agent Feed Mobile MVP', () => {
     expect(activityTabBox?.width).toBeGreaterThanOrEqual(44);
     expect(activityTabBox?.height).toBeGreaterThanOrEqual(44);
 
-    // Check action cards if they appear (mock data might be empty so we wait to see if any buttons exist or the "All caught up!" state shows)
+    // Check action cards if they appear (mock data might be empty so we wait to see if any buttons exist or the "No items need your attention right now." state shows)
     const approveButtons = page.locator('button:has-text("Approve")');
-    const caughtUpText = page.locator('text=All caught up!');
+    const caughtUpText = page.locator('text=No items need your attention right now');
 
     // Wait for either the list to load items or show the empty state
     await Promise.race([

--- a/src/e2e/triage-feed-agent.spec.ts
+++ b/src/e2e/triage-feed-agent.spec.ts
@@ -60,7 +60,7 @@ test.describe('Agentic Work Triage Feed', () => {
 
     // It should either show the empty state or an empty feed, but given we might have real data,
     // let's just ensure it loads without crashing and either shows items or caught up state.
-    const emptyState = page.locator('text=All caught up');
+    const emptyState = page.locator('text=No items need your attention right now');
     const feed = page.locator('[data-testid^="triage-card-"]').first();
 
     // Wait for either to be visible

--- a/src/e2e/ui/triage_action_feed.spec.ts
+++ b/src/e2e/ui/triage_action_feed.spec.ts
@@ -38,7 +38,7 @@ test.describe('Triage Action Feed UI', () => {
 
     if (await emptyState.isVisible()) {
       // Empty state path
-      await expect(emptyState).toContainText('All caught up!');
+      await expect(emptyState).toContainText('No items need your attention right now');
     } else {
       // Populated path
       const firstCard = listItems.first();

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
This PR fixes remaining E2E test failures caused by an outdated text assertion in the `unified-agent-feed.mobile.spec.ts`, `triage-feed-agent.spec.ts`, and `triage_action_feed.spec.ts` files. It also fixes a build issue caused by a misconfigured `tsconfig.json` file in `src/ui/next`.

---
*PR created automatically by Jules for task [11565821935115207703](https://jules.google.com/task/11565821935115207703) started by @ql-owo-lp*