### PR TITLE
test(frontend): Fix failing unit test in checkout page by mocking ShareAndSaveWidget

### DIFF
--- a/src/ui/next/src/app/checkout/page.test.tsx
+++ b/src/ui/next/src/app/checkout/page.test.tsx
@@ -30,6 +30,10 @@ vi.mock('../components/PostPurchaseShareWidget', () => ({
   OneTapReferral: () => <div data-testid="one-tap-referral" />,
 }));
 
+vi.mock('../components/ShareAndSaveWidget', () => ({
+  ShareAndSaveWidget: () => <div data-testid="share-and-save-widget" />,
+}));
+
 describe('CheckoutPage', () => {
   afterEach(() => {
     mockUseSearchParams.mockImplementation(() => new URLSearchParams(''));


### PR DESCRIPTION
The main P0 feature regarding Centralized Inventory & Distributed POS Architecture (specifically, Redis Redlock for reserving inventory across online and POS checkouts) was already implemented thoroughly in the Go backend (`src/server/services/inventory/service.rs`) and integrated with both `/api/billing_api.rs` and `/api/terminal_api.rs`. It also included Playwright tests testing concurrent accesses (`src/ui/next/src/e2e/pos-inventory-sync.spec.ts`) and expected error messages.

However, running frontend unit tests caught a failing unit test in `src/ui/next/src/app/checkout/page.test.tsx` which was caused by the lack of `vi.mock('../components/ShareAndSaveWidget', ...)` that prevented it from rendering the page during Vitest.

This PR adds the missing test mock so that all tests successfully pass. E2E tests have also been verified and pass locally.

---
*PR created automatically by Jules for task [6918816131292516152](https://jules.google.com/task/6918816131292516152) started by @ql-owo-lp*

Resolves #31421