### PR TITLE
🤖 Implementer: Harness Upgrade - Error Handling: LLM-Recoverable ToolMessages

### DIFF
--- a/src/agents/builtin/plan_and_execute.rs
+++ b/src/agents/builtin/plan_and_execute.rs
@@ -255,10 +255,26 @@ impl PlanAndExecuteOrchestrator {
                 drop(st);
 
                 let res = crate::tool_executor_engine::ToolExecutionEngine::execute_tool_with_langgraph_mechanics(tool, &ohc_builtin_agent_core::types::ToolCall{id: task.task_id.clone(), name: task.tool_name.clone(), arguments: resolved_args}, 2)
-                    .await
-                    .map_err(|e| format!("Tool execution failed: {}", e))?;
+                    .await;
+
+                let final_res = match res {
+                    Ok(r) => r,
+                    Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg)) => {
+                        ohc_builtin_agent_core::types::format_llm_recoverable_error(&msg)
+                    }
+                    Err(ohc_builtin_agent_core::types::ToolError::UserFixable(msg)) => {
+                        return Err(format!("USER_FIXABLE: {}", msg));
+                    }
+                    Err(ohc_builtin_agent_core::types::ToolError::Fatal(msg)) => {
+                        return Err(format!("Fatal tool error: {}", msg));
+                    }
+                    Err(ohc_builtin_agent_core::types::ToolError::Unexpected(msg)) => {
+                        return Err(format!("Unexpected tool error: {}", msg));
+                    }
+                    Err(e) => return Err(format!("Tool execution failed: {}", e)),
+                };
                 let mut st = state.write().await;
-                LLMCompilerStateReducer::reduce(&mut st, task.task_id.clone(), res);
+                LLMCompilerStateReducer::reduce(&mut st, task.task_id.clone(), final_res);
             }
 
             tasks_to_run = remaining_tasks;


### PR DESCRIPTION
# Implement Error Handling: LLM-Recoverable ToolMessages

### Description
Following the Roulette Protocol, this PR implements the `Error Handling: LLM-Recoverable ToolMessages` mechanic from the Master Catalog. 

During an audit of the execution handlers across the project (`gather_act_verify`, `actor_model`, etc), it was discovered that `src/agents/builtin/plan_and_execute.rs` was breaking this mechanic during sequential task execution. It was blindly mapping `execute_tool_with_langgraph_mechanics` errors using `.map_err(|e| format!("Tool execution failed: {}", e))?`, completely losing the `ToolError::LlmRecoverable` context and terminating the planner.

### Changes
*   Updated `src/agents/builtin/plan_and_execute.rs` to correctly pattern match on the `Result` from `execute_tool_with_langgraph_mechanics`.
*   When a `ToolError::LlmRecoverable(msg)` is caught, it now invokes `ohc_builtin_agent_core::types::format_llm_recoverable_error(&msg)` and feeds the formatted self-correction message into `LLMCompilerStateReducer::reduce` just like a standard tool output.
*   This ensures that the executing agent receives the specific formatting/parsing error and can self-correct, rather than the loop crashing fatally.

### Verification
*   Ran pure Rust unit and integration tests via `bazelisk test //src/agents/builtin/...` which passed successfully.
*   Ran full project test suite via `bazelisk test //...` successfully (99/99 passed).
*   Ran E2E tests via `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"` which passed successfully.

### Superpowers Skills Loaded
* No specific superpowers were needed outside of standard Rust/Bazel conventions for this specific targeted backend bug fix.

### Product-use evidence
This change fixes a backend agent harness execution mechanic that was causing internal `plan_and_execute` loops to prematurely fail out. No user-facing UI CUJs were modified. This fixes the reliability of underlying multi-step execution.

---
*PR created automatically by Jules for task [2612299438815008512](https://jules.google.com/task/2612299438815008512) started by @ql-owo-lp*