### PR TITLE
🛡️ Sentinel: Tenant Isolation and Local File Storage Hardening

### DIFF
--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -436,7 +436,7 @@ impl UserRepository for PgUserRepository {
         let _ = if should_bypass {
             sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1").bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = $2").bind(now).bind(org_id).execute(&mut *tx).await.map_err(|e| e.to_string())?
+            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = current_setting('app.current_tenant')::text").bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?
         };
 
         tx.commit().await.map_err(|e| e.to_string())?;

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -288,43 +288,37 @@ impl DB {
                         }
 
                         if !db_path.exists() {
-                            if let Ok(file) = OpenOptions::new()
+                            let file = OpenOptions::new()
                                 .read(true)
                                 .write(true)
                                 .create_new(true) // Prevent TOCTOU vulnerabilities
                                 .mode(0o600)
-                                .open(&db_path)
-                            {
-                                if let Ok(metadata) = file.metadata() {
-                                    let mut perms = metadata.permissions();
-                                    if (perms.mode() & 0o777) != 0o600 {
-                                        perms.set_mode(0o600);
-                                        if let Err(e) = file.set_permissions(perms) {
-                                            tracing::error!(
-                                                "Failed to securely update existing standalone database file permissions: {}",
-                                                e
-                                            );
-                                            return Err(e.into());
-                                        }
-                                    }
+                                .open(&db_path)?;
+
+                            let metadata = file.metadata()?;
+                            let mut perms = metadata.permissions();
+                            if (perms.mode() & 0o777) != 0o600 {
+                                perms.set_mode(0o600);
+                                if let Err(e) = file.set_permissions(perms) {
+                                    tracing::error!(
+                                        "Failed to securely update existing standalone database file permissions: {}",
+                                        e
+                                    );
+                                    return Err(e.into());
                                 }
                             }
                         } else {
-                            if let Ok(file) =
-                                OpenOptions::new().read(true).write(true).open(&db_path)
-                            {
-                                if let Ok(metadata) = file.metadata() {
-                                    let mut perms = metadata.permissions();
-                                    if (perms.mode() & 0o777) != 0o600 {
-                                        perms.set_mode(0o600);
-                                        if let Err(e) = file.set_permissions(perms) {
-                                            tracing::error!(
-                                                "Failed to securely update existing standalone database file permissions: {}",
-                                                e
-                                            );
-                                            return Err(e.into());
-                                        }
-                                    }
+                            let file = OpenOptions::new().read(true).write(true).open(&db_path)?;
+                            let metadata = file.metadata()?;
+                            let mut perms = metadata.permissions();
+                            if (perms.mode() & 0o777) != 0o600 {
+                                perms.set_mode(0o600);
+                                if let Err(e) = file.set_permissions(perms) {
+                                    tracing::error!(
+                                        "Failed to securely update existing standalone database file permissions: {}",
+                                        e
+                                    );
+                                    return Err(e.into());
                                 }
                             }
                         }


### PR DESCRIPTION
This pull request resolves two major security vulnerabilities identified in the audit:

1. **Tenant Isolation Leakage (Cloud Mode):** Fixed `postgres_store.rs` `revoke_token` to explicitly respect PostgreSQL row-level security boundaries by removing `AND tenant_id = $2` with hardcoded parameter binding, replacing it with `AND tenant_id = current_setting('app.current_tenant')::text`.
2. **Local Storage Hardening (Standalone Mode):** Corrected a fallback issue in `db.rs` during SQLite Standalone database initialization. The code previously wrapped permission setup in `if let Ok` bounds, failing open when local file I/O operations errored, allowing local databases to default to insecure permissions instead of enforcing the required `0o600` bounds. Any failure now correctly returns an error instead of continuing execution.

---
*PR created automatically by Jules for task [3735854310810740849](https://jules.google.com/task/3735854310810740849) started by @ql-owo-lp*