### PR TITLE
feat(billing): separate plan and cost dashboard widgets

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6835,7 +6835,7 @@ async fn create_ui_bom_item_handler(
             axum::response::Html(include_str!("../ui/tauri/src/ui/referrals.html"))
         }))
         .route("/plan", axum::routing::get(|| async {
-            axum::response::Html(include_str!("../ui/tauri/src/ui/cost-dashboard.html"))
+            axum::response::Html(include_str!("../ui/tauri/src/ui/plan.html"))
         }))
         .route("/cost-dashboard", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/cost-dashboard.html"))

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -655,7 +655,7 @@
       <div class="assistant-entry-container" style="margin-bottom: 24px; display: flex; flex-wrap: wrap; gap: 16px; justify-content: center;">
         <a href="assistant.html" class="btn-primary" style="width: auto; text-decoration: none;">Open WorkBuddy Assistant</a>
         <a href="pos.html" class="btn-outline" style="width: auto; text-decoration: none;">Quick Charge POS</a>
-        <a href="cost-dashboard.html" class="btn-outline" style="width: auto; text-decoration: none;">My Plan</a>
+        <a href="plan.html" class="btn-outline" style="width: auto; text-decoration: none;">My Plan</a>
         <a href="agent-audit-dashboard.html" class="btn-outline" style="width: auto; text-decoration: none;">Agent Audit Dashboard</a>
         <a href="booking-dashboard.html" class="btn-outline" style="width: auto; text-decoration: none;">Booking Dashboard</a>
       </div>

--- a/src/ui/tauri/src/ui/plan.html
+++ b/src/ui/tauri/src/ui/plan.html
@@ -264,7 +264,7 @@
 
             <button class="btn-primary" onclick="window.location.href='pricing.html'">Upgrade</button>
             <button id="manage-billing-btn" class="btn-outline" style="margin-top: 12px;">Manage Billing</button>
-            <button id="view-detailed-costs" class="btn-outline" style="margin-top: 12px;">View Detailed Costs</button>
+            <button id="view-detailed-costs" class="btn-outline" style="margin-top: 12px;" onclick="window.location.href='cost-dashboard.html'">View Detailed Costs</button>
             <button class="btn-outline" id="download-invoice-btn" style="margin-top: 12px;">Download Invoice</button>
             <button class="btn-outline" id="cancel-subscription-btn" style="margin-top: 12px; color: red; border-color: red;">Cancel Subscription</button>
             <div id="plan-message" style="margin-top: 12px; font-weight: 500; font-size: 14px; color: #34C759; display: none;"></div>
@@ -273,7 +273,7 @@
 
           <!-- Cost Dashboard Widget -->
           <div class="ohc-growth-card glassmorphism" id="cost-dashboard-widget" style="display:none;">
-            <h1 style="margin-top: 0; font-size: 20px; border-bottom: 1px solid rgba(0,0,0,0.1); padding-bottom: 12px; margin-bottom: 20px;">Cost Transparency Dashboard</h1><button id="back-to-my-plan" class="btn-outline" style="margin-bottom: 12px; display: inline-block; cursor: pointer;" onclick="window.location.href='plan.html'">Back to My Plan</button>
+            <h1 style="margin-top: 0; font-size: 20px; border-bottom: 1px solid rgba(0,0,0,0.1); padding-bottom: 12px; margin-bottom: 20px;">Cost Transparency Dashboard</h1><button id="back-to-my-plan" class="btn-outline" style="margin-bottom: 12px; display: inline-block; cursor: pointer;">Back to My Plan</button>
 
 
 
@@ -690,9 +690,9 @@
             });
         }
 
-        // Default to Cost Dashboard
-        if (myPlanWidget) myPlanWidget.style.display = 'none';
-        if (costDashboardWidget) costDashboardWidget.style.display = 'block';
+        // Default to My Plan
+        if (myPlanWidget) myPlanWidget.style.display = 'block';
+        if (costDashboardWidget) costDashboardWidget.style.display = 'none';
     });
 </script>
 


### PR DESCRIPTION
- Copies `cost-dashboard.html` to `plan.html` and creates logic separation.
- Routes `/plan` to `plan.html`.
- Sets dashboard.html "My Plan" button to route to `plan.html`.
- This ensures E2E tests for Cost Dashboard and My Plan loops succeed cleanly.

---
*PR created automatically by Jules for task [3441198488328179521](https://jules.google.com/task/3441198488328179521) started by @ql-owo-lp*