### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Correct Helm podSelectors for NetworkIsolation

### DIFF
--- a/deploy/helm/ohc/templates/network-policy.yaml
+++ b/deploy/helm/ohc/templates/network-policy.yaml
@@ -2,13 +2,13 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "ohc.fullname" . }}-backend
+  name: {{ .Release.Name }}-backend
   labels:
     {{- include "ohc.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ include "ohc.fullname" . }}-backend
+      app: {{ .Release.Name }}-backend
   policyTypes:
     - Ingress
     - Egress
@@ -19,7 +19,7 @@ spec:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
           podSelector:
             matchLabels:
-              app: {{ include "ohc.fullname" . }}-core
+              app: {{ .Release.Name }}-ohc-core
     - from:
         - namespaceSelector:
             matchLabels:
@@ -93,13 +93,13 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "ohc.fullname" . }}-core
+  name: {{ .Release.Name }}-ohc-core
   labels:
     {{- include "ohc.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ include "ohc.fullname" . }}-core
+      app: {{ .Release.Name }}-ohc-core
   policyTypes:
     - Ingress
     - Egress
@@ -152,13 +152,13 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "ohc.fullname" . }}-chatwoot
+  name: {{ .Release.Name }}-chatwoot
   labels:
     {{- include "ohc.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ include "ohc.fullname" . }}-chatwoot
+      app: {{ .Release.Name }}-chatwoot
   policyTypes:
     - Ingress
     - Egress
@@ -211,13 +211,13 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "ohc.fullname" . }}-powersync
+  name: {{ .Release.Name }}-powersync
   labels:
     {{- include "ohc.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ include "ohc.fullname" . }}-powersync
+      app: {{ .Release.Name }}-powersync
   policyTypes:
     - Ingress
     - Egress
@@ -288,19 +288,19 @@ spec:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
           podSelector:
             matchLabels:
-              app: {{ include "ohc.fullname" . }}-backend
+              app: {{ .Release.Name }}-backend
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
           podSelector:
             matchLabels:
-              app: {{ include "ohc.fullname" . }}-core
+              app: {{ .Release.Name }}-ohc-core
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
           podSelector:
             matchLabels:
-              app: {{ include "ohc.fullname" . }}-chatwoot
+              app: {{ .Release.Name }}-chatwoot
       ports:
         - protocol: TCP
           port: {{ .Values.valkey.service.port }}
@@ -340,25 +340,25 @@ spec:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
           podSelector:
             matchLabels:
-              app: {{ include "ohc.fullname" . }}-backend
+              app: {{ .Release.Name }}-backend
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
           podSelector:
             matchLabels:
-              app: {{ include "ohc.fullname" . }}-core
+              app: {{ .Release.Name }}-ohc-core
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
           podSelector:
             matchLabels:
-              app: {{ include "ohc.fullname" . }}-chatwoot
+              app: {{ .Release.Name }}-chatwoot
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
           podSelector:
             matchLabels:
-              app: {{ include "ohc.fullname" . }}-powersync
+              app: {{ .Release.Name }}-powersync
       ports:
         - protocol: TCP
           port: 5432


### PR DESCRIPTION
This pull request resolves a critical flaw in Kubernetes NetworkPolicies for the OHC Helm chart, where podSelectors failed to match the actual labels used by the workloads (`ohc.fullname` vs `.Release.Name`), resulting in completely broken cluster network policies.

In `deploy/helm/ohc/templates/network-policy.yaml`, the `matchLabels` were updated across all backend, ohc-core, chatwoot, and powersync components to match their deployments' actual specs perfectly, strictly tightening the pod selections.

**Superpowers used:**
* Investigated the helm `podSelectors` across `backend-deployment.yaml` and found the mismatch between label names.

**Other checks:**
* Audited Row Level Security (RLS) on all `src/server/db/migrations` files. No missing `ENABLE ROW LEVEL SECURITY` discovered.
* Checked `.ohc_sqlite_key` for TOCTOU and symlink attacks in `mod.rs` & `db.rs` -- it is adequately secured.
* Inspected Thin Client OAuth flow for Path Traversal / Open Redirects - inputs are strictly verified or sanitized.

---
*PR created automatically by Jules for task [16019046480892919098](https://jules.google.com/task/16019046480892919098) started by @ql-owo-lp*