### PR TITLE
perf: parallelize database queries in chaos report handler

### DIFF
--- a/src/server/api/chaos.rs
+++ b/src/server/api/chaos.rs
@@ -20,28 +20,33 @@ pub struct ChaosReportResponse {
 pub async fn get_chaos_report_handler(
     State(pool): State<PgPool>,
 ) -> impl IntoResponse {
-    let mut histograms = vec![];
-    let mut errors = vec![];
+    let (histograms_res, errors_res, latency_p99_cloud_res, latency_p99_standalone_res, error_rate_llm_outage_res) = tokio::join!(
+        sqlx::query("SELECT value FROM telemetry_buffer WHERE metric_name = 'api_latency' ORDER BY timestamp DESC LIMIT 20").fetch_all(&pool),
+        sqlx::query("SELECT value FROM telemetry_buffer WHERE metric_name = 'error_rate' ORDER BY timestamp DESC LIMIT 20").fetch_all(&pool),
+        sqlx::query_scalar::<_, f64>("SELECT value FROM telemetry_buffer WHERE metric_name = 'api_latency' AND labels_json LIKE '%\"mode\":\"cloud\"%' ORDER BY value DESC LIMIT 1 OFFSET (SELECT CAST(COUNT(*) * 0.01 AS INTEGER) FROM telemetry_buffer WHERE metric_name = 'api_latency' AND labels_json LIKE '%\"mode\":\"cloud\"%')").fetch_optional(&pool),
+        sqlx::query_scalar::<_, f64>("SELECT value FROM telemetry_buffer WHERE metric_name = 'api_latency' AND labels_json LIKE '%\"mode\":\"standalone\"%' ORDER BY value DESC LIMIT 1 OFFSET (SELECT CAST(COUNT(*) * 0.01 AS INTEGER) FROM telemetry_buffer WHERE metric_name = 'api_latency' AND labels_json LIKE '%\"mode\":\"standalone\"%')").fetch_optional(&pool),
+        sqlx::query_scalar::<_, f64>("SELECT value FROM telemetry_buffer WHERE metric_name = 'error_rate_llm_outage' ORDER BY timestamp DESC LIMIT 1").fetch_optional(&pool),
+    );
 
-    if let Ok(rows) = sqlx::query("SELECT value FROM telemetry_buffer WHERE metric_name = 'api_latency' ORDER BY timestamp DESC LIMIT 20").fetch_all(&pool).await {
+    let mut histograms = vec![];
+    if let Ok(rows) = histograms_res {
         for row in rows {
             let val: f64 = row.try_get("value").unwrap_or(0.0);
             histograms.push(val as i32);
         }
     }
 
-    if let Ok(rows) = sqlx::query("SELECT value FROM telemetry_buffer WHERE metric_name = 'error_rate' ORDER BY timestamp DESC LIMIT 20").fetch_all(&pool).await {
+    let mut errors = vec![];
+    if let Ok(rows) = errors_res {
         for row in rows {
             let val: f64 = row.try_get("value").unwrap_or(0.0);
             errors.push(val as f32);
         }
     }
 
-    let latency_p99_cloud = sqlx::query_scalar::<_, f64>("SELECT value FROM telemetry_buffer WHERE metric_name = 'api_latency' AND labels_json LIKE '%\"mode\":\"cloud\"%' ORDER BY value DESC LIMIT 1 OFFSET (SELECT CAST(COUNT(*) * 0.01 AS INTEGER) FROM telemetry_buffer WHERE metric_name = 'api_latency' AND labels_json LIKE '%\"mode\":\"cloud\"%')").fetch_optional(&pool).await.unwrap_or(None).map(|v| format!("{:.0}ms", v)).unwrap_or_else(|| "N/A".to_string());
-
-    let latency_p99_standalone = sqlx::query_scalar::<_, f64>("SELECT value FROM telemetry_buffer WHERE metric_name = 'api_latency' AND labels_json LIKE '%\"mode\":\"standalone\"%' ORDER BY value DESC LIMIT 1 OFFSET (SELECT CAST(COUNT(*) * 0.01 AS INTEGER) FROM telemetry_buffer WHERE metric_name = 'api_latency' AND labels_json LIKE '%\"mode\":\"standalone\"%')").fetch_optional(&pool).await.unwrap_or(None).map(|v| format!("{:.0}ms", v)).unwrap_or_else(|| "N/A".to_string());
-
-    let error_rate_llm_outage = sqlx::query_scalar::<_, f64>("SELECT value FROM telemetry_buffer WHERE metric_name = 'error_rate_llm_outage' ORDER BY timestamp DESC LIMIT 1").fetch_optional(&pool).await.unwrap_or(None).map(|v| format!("{:.1}% (Handled via Graceful Pause)", v * 100.0)).unwrap_or_else(|| "N/A".to_string());
+    let latency_p99_cloud = latency_p99_cloud_res.unwrap_or(None).map(|v| format!("{:.0}ms", v)).unwrap_or_else(|| "N/A".to_string());
+    let latency_p99_standalone = latency_p99_standalone_res.unwrap_or(None).map(|v| format!("{:.0}ms", v)).unwrap_or_else(|| "N/A".to_string());
+    let error_rate_llm_outage = error_rate_llm_outage_res.unwrap_or(None).map(|v| format!("{:.1}% (Handled via Graceful Pause)", v * 100.0)).unwrap_or_else(|| "N/A".to_string());
 
     Json(ChaosReportResponse {
         latency_histograms: histograms,


### PR DESCRIPTION
**⚡ Bolt: Optimize chaos report API latency through parallel execution**

- **Superpowers Used**: Systematic Debugging, Parallel Execution Analysis.
- **Problem**: The `get_chaos_report_handler` in `src/server/api/chaos.rs` executed 5 independent database queries (`api_latency` histogram, `error_rate` histogram, `latency_p99_cloud`, `latency_p99_standalone`, `error_rate_llm_outage`) sequentially using `.await` on each `sqlx::query`. This resulted in unnecessary cumulative latency.
- **Solution**: Refactored the handler to use `tokio::join!` to execute all 5 database queries concurrently on the `PgPool`.
- **Expected Improvement**: Significantly reduced latency for the `/api/chaos` endpoint under load by parallelizing the I/O bound database fetches.
- **Product-use evidence**: N/A for continuous codebase optimization mandate.
- **Verification**: Verified via `bazel test //...` and `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"` that behavior is fully preserved and tests passed hermetically.

Continuous optimization mandate successfully executed.

---
*PR created automatically by Jules for task [5854089501337757703](https://jules.google.com/task/5854089501337757703) started by @ql-owo-lp*