### PR TITLE
feat(ui): Polish cost dashboard and pricing pages with glassmorphism

### DIFF
--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -257,7 +257,7 @@ export default function CostDashboardPage() {
                 </svg>
                 <div>
                     <h3 className="text-sm font-semibold text-amber-800">Budget Alert</h3>
-                    <p className="text-sm text-amber-700 mt-1">Cost Soft Limit friendly prompt shows. Your projected monthly cost ({formatCurrency(data.projected_monthly_cost)}) is reaching your plan's soft limit. Soft Limit Approaching. Keep your business momentum with a higher tier for better bulk rates!</p>
+                    <p className="text-sm text-amber-700 mt-1">Heads up! Your projected monthly cost ({formatCurrency(data.projected_monthly_cost)}) is reaching your plan's soft limit. Soft Limit Approaching. Upgrade to a higher tier to avoid disruption and secure better bulk rates!</p>
                 </div>
             </div>
         )}

--- a/src/ui/next/src/app/plan/page.tsx
+++ b/src/ui/next/src/app/plan/page.tsx
@@ -106,7 +106,7 @@ export default function MyPlanPage() {
       <main className="p-4 md:p-8 flex-1 max-w-4xl mx-auto w-full flex flex-col gap-6">
 
         {/* Status Snapshot */}
-        <section className="app-card ohc-growth-card glass-card shadow-lg hover:shadow-2xl transition-all duration-300 p-6">
+        <section className="app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:shadow-2xl transition-all duration-300 p-6 rounded-2xl">
             <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
                 <div>
                     <h2 className="text-2xl font-bold font-outfit text-gray-900 flex items-center gap-2">
@@ -141,7 +141,7 @@ export default function MyPlanPage() {
         </section>
 
         {/* Current Usage Section */}
-        <section className="app-card ohc-growth-card glass-panel shadow-lg hover:shadow-2xl transition-all duration-300 mt-4">
+        <section className="app-card ohc-growth-card glass-panel backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:shadow-2xl transition-all duration-300 mt-4 rounded-2xl overflow-hidden">
           <div className="app-panel-header backdrop-blur-md bg-white/70 px-6 py-4 border-b border-white/40 bg-transparent">
              <h2 className="app-panel-title text-xl font-bold font-outfit text-gray-900">Your Current Usage</h2>
           </div>

--- a/src/ui/next/src/app/pricing/page.tsx
+++ b/src/ui/next/src/app/pricing/page.tsx
@@ -101,7 +101,7 @@ export default function PricingPage() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 w-full">
           {/* Free Tier */}
-          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
+          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Free</h3>
               <p className="text-xl font-semibold mb-4 text-gray-900">$0 <span className="text-sm font-normal text-gray-500">/ month</span></p>
@@ -128,7 +128,7 @@ export default function PricingPage() {
           </div>
 
           {/* Starter Tier */}
-          <div className="p-6 flex flex-col justify-between relative app-card ohc-growth-card glass-card shadow-xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
+          <div className="p-6 flex flex-col justify-between relative app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-xl rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
             <div className="absolute top-0 right-0 bg-indigo-600 text-white text-xs font-bold px-3 py-1 rounded-bl-xl rounded-tr-2xl">Recommended</div>
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Starter</h3>
@@ -157,7 +157,7 @@ export default function PricingPage() {
           </div>
 
           {/* Pro Tier */}
-          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
+          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Pro</h3>
               <p className="text-xl font-semibold mb-4 text-gray-900">$79 <span className="text-sm font-normal text-gray-500">/ month</span></p>
@@ -184,7 +184,7 @@ export default function PricingPage() {
           </div>
 
           {/* Business Tier */}
-          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
+          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Business</h3>
               <p className="text-xl font-semibold mb-4 text-gray-900">$299 <span className="text-sm font-normal text-gray-500">/ month</span></p>


### PR DESCRIPTION
Updates the UI styling on the Cost Dashboard, Pricing page, and My Plan page to use a premium macOS Translucent Glass aesthetic.
Also improves the hardcoded Budget Alert text to be more friendly and professional, while ensuring existing E2E tests still pass.

---
*PR created automatically by Jules for task [14068502410147724902](https://jules.google.com/task/14068502410147724902) started by @ql-owo-lp*