### PR TITLE
🎨 Canvas: Integrate WhatsApp Business API for Unified Customer Triage

### DIFF
--- a/src/ui/next/src/e2e/whatsapp-flow.spec.ts
+++ b/src/ui/next/src/e2e/whatsapp-flow.spec.ts
@@ -75,4 +75,71 @@ test.describe('WhatsApp Flow CUJ', () => {
     // The previous test also checked for the text so we can assume it works
     await expect(page.getByText(/Draft Reply/i).first()).toBeVisible({ timeout: 15000 }).catch(() => {});
   });
+
+  test('Owner receives a WhatsApp message with media', async ({ page, request }) => {
+    test.setTimeout(300000);
+
+    // 1. Log in
+    await page.goto('/login');
+    await page.getByPlaceholder('Email or Username').fill('maya@ohc.test');
+    await page.getByPlaceholder('Password').fill('password123');
+    await page.getByRole('button', { name: /Log In/i }).click();
+    await expect(page.getByRole('heading', { name: /Dashboard/i }).first()).toBeVisible({ timeout: 30000 });
+
+    // 2. Connect WhatsApp
+    await page.goto('/integrations');
+    const whatsappCard = page.locator('h3', { hasText: 'WhatsApp Cloud API' }).locator('..');
+    await whatsappCard.getByRole('button', { name: /Connect/i }).click();
+    await page.getByRole('button', { name: /Continue with Meta/i }).click();
+    await expect(page.getByText(/WhatsApp Cloud API connected/i)).toBeVisible();
+
+    // 3. Trigger inbound message via webhook with media
+    const apiBase = process.env.OHC_API_URL || process.env.BACKEND_URL || 'http://localhost:18789';
+    const webhookPayload = {
+      "object": "whatsapp_business_account",
+      "entry": [{
+        "id": "WHATSAPP_BUSINESS_ACCOUNT_ID",
+        "changes": [{
+          "value": {
+            "messaging_product": "whatsapp",
+            "metadata": {
+              "display_phone_number": "tenant-whatsapp-id",
+              "phone_number_id": "PHONE_NUMBER_ID"
+            },
+            "contacts": [{
+              "profile": {
+                "name": "Test Customer"
+              },
+              "wa_id": "14155238886"
+            }],
+            "messages": [{
+              "from": "14155238886",
+              "id": "wamid.HBgLMTQxNTUyMzg4ODYVAgASGCQzNTQ2QUU2QzJDNDZBODg2RTRBNzUwRTJDNzAzRUQ1QgA=",
+              "timestamp": "1669894451",
+              "image": {
+                "id": "media-12345",
+                "caption": "Can you make a cake like this?"
+              },
+              "type": "image"
+            }]
+          },
+          "field": "messages"
+        }]
+      }]
+    };
+
+    const response = await request.post(`${apiBase}/api/v1/webhooks/meta`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: webhookPayload,
+    });
+    expect(response.ok()).toBeTruthy();
+
+    // 4. Navigate to Team Page / Inbox to see the draft
+    await page.goto('/inbox');
+
+    // Check that the WhatsApp message text appears with the image markdown
+    await expect(page.getByText(/!\[Image\]\(media-12345\) Can you make a cake like this\?/i).first()).toBeVisible({ timeout: 15000 });
+  });
 });


### PR DESCRIPTION
Resolves #31515

This PR adds support for parsing inbound WhatsApp messages containing image media and updating the Work Triage feed for the owner to preview the image via a markdown link. It also includes the necessary E2E test to verify this newly supported flow.

---
*PR created automatically by Jules for task [12574560243218780604](https://jules.google.com/task/12574560243218780604) started by @ql-owo-lp*