### PR TITLE
✍️ Scribe: [new documentation feature]

### DIFF
--- a/src/ui/next/src/components/HelpChat.tsx
+++ b/src/ui/next/src/components/HelpChat.tsx
@@ -252,10 +252,10 @@ export function HelpChat() {
                 className={`flex flex-col ${msg.sender === "user" ? "items-end" : "items-start"}`}
               >
                 <div
-                  className={`px-4 py-3 rounded-2xl max-w-[85%] leading-relaxed shadow-sm backdrop-blur-md saturate-[210%] ${
+                  className={`px-4 py-3 rounded-2xl max-w-[85%] leading-relaxed shadow-sm saturate-[210%] ${
                     msg.sender === "user"
-                      ? "bg-blue-600/95 text-white rounded-br-sm border border-blue-500/50"
-                      : "bg-white/80 dark:bg-black/50 border border-white/50 dark:border-white/20 text-gray-900 dark:text-gray-100 rounded-bl-sm"
+                      ? "bg-blue-600/80 backdrop-blur-xl text-white rounded-br-sm border border-white/20"
+                      : "bg-white/80 dark:bg-black/50 backdrop-blur-md border border-white/50 dark:border-white/20 text-gray-900 dark:text-gray-100 rounded-bl-sm"
                   }`}
                   dangerouslySetInnerHTML={{
                     __html: DOMPurify.sanitize(msg.text),

--- a/src/ui/next/src/components/TooltipRegistry.tsx
+++ b/src/ui/next/src/components/TooltipRegistry.tsx
@@ -62,6 +62,16 @@ export function TooltipProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
+  useEffect(() => {
+    const handleScroll = () => {
+      setActiveTooltip(null);
+    };
+    window.addEventListener('scroll', handleScroll, true);
+    return () => {
+      window.removeEventListener('scroll', handleScroll, true);
+    };
+  }, []);
+
   return (
     <TooltipContext.Provider value={{ activeTooltip, setActiveTooltip, tooltipRect, setTooltipRect, tooltipText, setTooltipText, getTooltip: (id: string) => tooltips[id] }}>
       {children}


### PR DESCRIPTION
- Added a scroll event listener in TooltipRegistry.tsx to properly close tooltips when scrolling the window.
- Updated Tailwind CSS classes in HelpChat.tsx for the user messages to match the Translucent Glass UI theme.

Product-use evidence:
Persona: Non-technical owner.
Flow attempted: Hovered over a tooltip and scrolled the page. The tooltip remained on screen, which looks broken. Clicked the Help chat widget, the user messages had the wrong UI look compared to the new Translucent glass design.
Gap observed: Tooltips not dismissed on scroll. HelpChat bubble lacking the Translucent glass design.
Fix: Added scroll event listener. Added tailwind classes.

---
*PR created automatically by Jules for task [13999488194916685689](https://jules.google.com/task/13999488194916685689) started by @ql-owo-lp*