### PR TITLE
🎥 Lens Audit: fix dashboard E2E test link expectation for milestones

### DIFF
--- a/src/ui/next/src/e2e/dashboard_ux.spec.ts
+++ b/src/ui/next/src/e2e/dashboard_ux.spec.ts
@@ -44,9 +44,9 @@ test.describe('Dashboard UX', () => {
     await page.goto('/dashboard');
 
     await expect(page.locator('a[href="/referrals"]').first()).toBeVisible();
-    await expect(page.locator('a[href="/milestones"]')).toBeVisible();
-    await expect(page.locator('a[href="/milestones"] h3')).toHaveText('Milestones');
-    await expect(page.locator('a[href="/milestones"] div.text-2xl', { hasText: '🏆' })).toHaveAttribute('aria-hidden', 'true');
+    await expect(page.locator('a[href="/milestone-alerts"]')).toBeVisible();
+    await expect(page.locator('a[href="/milestone-alerts"] h3')).toHaveText('Milestones');
+    await expect(page.locator('a[href="/milestone-alerts"] div.text-2xl', { hasText: '🏆' })).toHaveAttribute('aria-hidden', 'true');
     await expect(page.locator('a[href="/share-cards"]')).toBeVisible();
   });
 });


### PR DESCRIPTION
Fix a discrepancy between the dashboard UI and the E2E test for the milestones link. The dashboard links to `/milestone-alerts` but the test was checking for `/milestones`.

---
*PR created automatically by Jules for task [9927744707731010503](https://jules.google.com/task/9927744707731010503) started by @ql-owo-lp*