### PR TITLE
fix: Enforce strict telemetry privacy boundaries in standalone mode

### DIFF
--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -235,7 +235,7 @@ impl ModeEnforcer for StandaloneModeEnforcer {
         cfg.multitenant = false;
 
         // Strict opt-in constraint for local sovereignty in standalone
-        let explicit_opt_in = std::env::var("OHC_TELEMETRY_ENABLED").unwrap_or_else(|_| "false".to_string()) == "true";
+        let explicit_opt_in = std::env::var("OHC_TELEMETRY_ENABLED").map(|s| s.to_lowercase() == "true").unwrap_or(false);
         if explicit_opt_in {
             tracing::info!("standalone: Telemetry explicitly opted-in by user.");
             cfg.telemetry_enabled = true;

--- a/src/server/sync/autodream_sync.rs
+++ b/src/server/sync/autodream_sync.rs
@@ -133,7 +133,7 @@ pub async fn process_forecast_tick(db: Arc<DB>) -> Result<(), Box<dyn std::error
         let total_synced = synced_embeddings + synced_missions;
         let total_failed = failed_embeddings + failed_missions;
 
-        if total_synced > 0 {
+        if total_synced > 0 && ::server_config::get().telemetry_enabled {
             let _ = sqlx::query(
                 r#"
                 INSERT INTO telemetry_buffer (metric_name, metric_type, metric_value, labels)
@@ -148,7 +148,7 @@ pub async fn process_forecast_tick(db: Arc<DB>) -> Result<(), Box<dyn std::error
             .await;
         }
 
-        if total_failed > 0 {
+        if total_failed > 0 && ::server_config::get().telemetry_enabled {
             let _ = sqlx::query(
                 r#"
                 INSERT INTO telemetry_buffer (metric_name, metric_type, metric_value, labels)


### PR DESCRIPTION
This addresses the internal audits around multi-tenant and local standalone privacy boundaries where telemetry metrics were bypassing constraints during autodream metric syncing, and standalone defaults could leak config values.

---
*PR created automatically by Jules for task [10541011070596956724](https://jules.google.com/task/10541011070596956724) started by @ql-owo-lp*