### PR TITLE
🎥 Lens Audit: Remove UI mock data in agent terminal and payment ledger

### DIFF
--- a/src/ui/next/src/app/agent-terminal/page.tsx
+++ b/src/ui/next/src/app/agent-terminal/page.tsx
@@ -44,16 +44,11 @@ export default function AgentTerminalPage() {
       });
 
       if (!res.ok) {
-        // Fallback for mocked execution if backend is not running or endpoint fails
-        setTimeout(() => {
-          setOutput((prev) => [...prev, `hello\n`]);
-          setLoading(false);
-        }, 500);
-        return;
+        throw new Error(`Failed to start session: ${res.statusText}`);
       }
 
       const data = await res.json();
-      setOutput((prev) => [...prev, data.output || 'hello\n']);
+      setOutput((prev) => [...prev, data.output]);
     } catch (err: any) {
       setOutput((prev) => [...prev, `Error: ${err.message}`]);
     } finally {

--- a/src/ui/next/src/app/payments/page.tsx
+++ b/src/ui/next/src/app/payments/page.tsx
@@ -43,29 +43,11 @@ export default function PaymentLedger() {
 
       const intentData = await intentRes.json();
 
-      // Simulate Stripe Webhook
-      const webhookRes = await fetch("/api/payments/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          type_field: "payment_intent.succeeded",
-          data: {
-            object: {
-              id: "pi_mock_" + Date.now(),
-              metadata: {
-                tenant_id: "e2e-tenant", // Using default E2E tenant
-                idempotency_key: intentData.idempotency_key
-              }
-            }
-          }
-        })
-      });
-
-      if (webhookRes.ok) {
+      if (intentData.status === "succeeded" || intentData.client_secret) {
         setStatus("Approved");
         fetchBalance();
       } else {
-        setStatus("Failed");
+        setStatus("Failed to initialize");
       }
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
This pull request removes mock data (`pi_mock_1234` ID creation) and simulated `setTimeout` fallbacks from the frontend in `src/ui/next/src/app/agent-terminal/page.tsx` and `src/ui/next/src/app/payments/page.tsx`. This change ensures that data consistently flows through the real application stack and properly captures failure states instead of surfacing misleading fake data, adhering to the "ZERO Mock Data in UI" architectural mandate.

---
*PR created automatically by Jules for task [2021361042490503113](https://jules.google.com/task/2021361042490503113) started by @ql-owo-lp*