### PR TITLE
🧹 Cleaner: enforce RLS on incidents table

### DIFF
--- a/src/server/migrations/999_missing_rls.sql
+++ b/src/server/migrations/999_missing_rls.sql
@@ -137,3 +137,6 @@ DROP POLICY IF EXISTS tenant_isolation_business_milestones ON business_milestone
 CREATE POLICY tenant_isolation_business_milestones ON business_milestones USING (tenant_id = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id = current_setting('app.current_tenant', true));
 DROP POLICY IF EXISTS tenant_isolation_epics ON epics;
 CREATE POLICY tenant_isolation_epics ON epics USING (tenant_id = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id = current_setting('app.current_tenant', true));
+ALTER TABLE IF EXISTS incidents ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation_incidents ON incidents;
+CREATE POLICY tenant_isolation_incidents ON incidents USING (tenant_id::text = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));


### PR DESCRIPTION
Discovered that the `incidents` table in `src/server/migrations/118_incident_resolution.sql` was missing the mandatory Row Level Security (RLS) enforcement. Added `ALTER TABLE IF EXISTS incidents ENABLE ROW LEVEL SECURITY;` and a tenant isolation policy to `src/server/migrations/999_missing_rls.sql` to maintain system hygiene and ensure multi-tenant safety.

Tests were successfully verified.

---
*PR created automatically by Jules for task [16664029911779624625](https://jules.google.com/task/16664029911779624625) started by @ql-owo-lp*