### PR TITLE
Fix horizontal scrolling in setup wizard mobile layout

### DIFF
--- a/src/e2e/setup-wizard.spec.ts
+++ b/src/e2e/setup-wizard.spec.ts
@@ -38,6 +38,12 @@ test.describe('Setup Wizard 375px Flow', () => {
         await expect(stepContext).toBeVisible();
         await expect(stepContext).not.toHaveCSS('overflow-x', 'scroll'); // No horizontal scroll
 
+        const personaRow = page.locator('.persona-row');
+        await expect(personaRow).toHaveCSS('flex-direction', 'column');
+
+        const workContextCards = page.locator('#context-group');
+        await expect(workContextCards).toHaveCSS('flex-direction', 'column');
+
         // Click Storefront context card
         const storefrontCard = page.getByTestId('context-storefront');
         await expect(storefrontCard).toBeVisible();

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1041,7 +1041,7 @@
         }
       }
 
-      @media (max-width: 375px) {
+      @media (max-width: 414px) {
         .container {
           padding: 16px;
           margin: 0;
@@ -1061,11 +1061,15 @@
           border-radius: 8px;
         }
         .work-context-cards {
-          grid-template-columns: 1fr;
+          display: flex;
+          flex-direction: column;
+        }
+        .persona-row {
+          flex-direction: column;
         }
         .radio-group {
           grid-template-columns: 1fr;
-        } /* Added if it was a grid */
+        }
         .stepper {
           gap: 8px;
           padding: 0 10px;


### PR DESCRIPTION
Fix horizontal scrolling in setup wizard mobile layout by enforcing flex column on 414px displays and add E2E assertions

---
*PR created automatically by Jules for task [5347540995311349656](https://jules.google.com/task/5347540995311349656) started by @ql-owo-lp*