### PR TITLE
[SRE] Triage stagnant backlog items categorization and manifest excellence

### DIFF
--- a/deploy/helm/ohc/templates/hpa.yaml
+++ b/deploy/helm/ohc/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.backend.autoscaling.enabled (not .Values.backend.vpa.enabled) }}
+{{- if and .Values.backend.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -44,7 +44,7 @@ spec:
           averageUtilization: {{ .Values.backend.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end }}
 ---
-{{- if and .Values.ohcCore.enabled .Values.ohcCore.autoscaling.enabled (not .Values.ohcCore.vpa.enabled) }}
+{{- if and .Values.ohcCore.enabled .Values.ohcCore.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -90,7 +90,7 @@ spec:
           averageUtilization: {{ .Values.ohcCore.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end }}
 ---
-{{- if and .Values.chatwoot.enabled .Values.chatwoot.autoscaling.enabled (not .Values.chatwoot.vpa.enabled) }}
+{{- if and .Values.chatwoot.enabled .Values.chatwoot.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -136,7 +136,7 @@ spec:
           averageUtilization: {{ .Values.chatwoot.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end }}
 ---
-{{- if and .Values.powersync.enabled .Values.powersync.autoscaling.enabled (not .Values.powersync.vpa.enabled) }}
+{{- if and .Values.powersync.enabled .Values.powersync.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deploy/helm/ohc/templates/vpa.yaml
+++ b/deploy/helm/ohc/templates/vpa.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-backend
   updatePolicy:
-    updateMode: {{ if .Values.backend.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}
+    updateMode: "Auto"
   resourcePolicy:
     containerPolicies:
       - containerName: backend
@@ -32,7 +32,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-core
   updatePolicy:
-    updateMode: {{ if .Values.ohcCore.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}
+    updateMode: "Auto"
   resourcePolicy:
     containerPolicies:
       - containerName: ohc-core
@@ -53,7 +53,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-chatwoot
   updatePolicy:
-    updateMode: {{ if .Values.chatwoot.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}
+    updateMode: "Auto"
   resourcePolicy:
     containerPolicies:
       - containerName: chatwoot
@@ -74,7 +74,7 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-powersync
   updatePolicy:
-    updateMode: {{ if .Values.powersync.autoscaling.enabled }}"Off"{{ else }}"Auto"{{ end }}
+    updateMode: "Auto"
   resourcePolicy:
     containerPolicies:
       - containerName: powersync

--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -443,7 +443,7 @@ impl HybridSyncDaemon {
 
     pub async fn prune_stuck_agent_missions(&self) -> Result<(), Box<dyn std::error::Error>> {
         // SQLite
-        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_failed', 'agent_missions', json_object('id', id, 'payload', json(COALESCE(payload, '{}'))), '[bug] Mission became stuck' FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hours') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hours')))").execute(&self.sqlite_pool).await;
+        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_failed', 'agent_missions', json_object('id', id, 'payload', json(COALESCE(payload, '{}'))), '[cleanup] Mission became stuck' FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hours') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hours')))").execute(&self.sqlite_pool).await;
         let res_sqlite = sqlx::query("DELETE FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hours') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hours')))")
             .execute(&self.sqlite_pool)
             .await;
@@ -454,7 +454,7 @@ impl HybridSyncDaemon {
         }
 
         // PG
-        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'mission_failed', 'agent_missions', json_build_object('id', id, 'payload', COALESCE(payload::jsonb, '{}'::jsonb))::text, '[bug] Mission became stuck' FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))").execute(&self.pg_pool).await;
+        let _ = sqlx::query("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'mission_failed', 'agent_missions', json_build_object('id', id, 'payload', COALESCE(payload::jsonb, '{}'::jsonb))::text, '[cleanup] Mission became stuck' FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))").execute(&self.pg_pool).await;
         let res_pg = sqlx::query("DELETE FROM agent_missions WHERE (status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))")
             .execute(&self.pg_pool)
             .await;

--- a/src/server/sip.rs
+++ b/src/server/sip.rs
@@ -199,9 +199,9 @@ impl SipDB {
 
                 let is_standalone = crate::is_standalone_runtime();
                 let query_str = if is_standalone {
-                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_stuck', 'agent_missions', payload, '[bug] Mission became stuck' FROM agent_missions WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
+                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_stuck', 'agent_missions', payload, '[cleanup] Mission became stuck' FROM agent_missions WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
                 } else {
-                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'mission_stuck', 'agent_missions', payload, '[bug] Mission became stuck' FROM agent_missions WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
+                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'mission_stuck', 'agent_missions', payload, '[cleanup] Mission became stuck' FROM agent_missions WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
                 };
                 sqlx::query(query_str)
                     .bind(stuck_threshold.naive_utc())

--- a/src/server/telemetry/mod.rs
+++ b/src/server/telemetry/mod.rs
@@ -44,7 +44,7 @@ pub fn categorize_error_signal(err_msg: &str) -> &'static str {
         "feature"
     } else if lower.contains("deprecated") || lower.contains("legacy") || lower.contains("refactor") {
         "refactor"
-    } else if lower.contains("leak") || lower.contains("garbage") || lower.contains("clean up") || lower.contains("cleanup") {
+    } else if lower.contains("leak") || lower.contains("garbage") || lower.contains("clean up") || lower.contains("cleanup") || lower.contains("stagnant") || lower.contains("stuck") {
         "cleanup"
     } else if lower.contains("doc") || lower.contains("comment") || lower.contains("readme") {
         "docs"

--- a/src/server/telemetry_test.rs
+++ b/src/server/telemetry_test.rs
@@ -680,3 +680,8 @@ fn test_record_error_signal() {
             },
         );
 }
+#[test]
+fn test_categorize_stuck_error_signal() {
+    assert_eq!(::server_telemetry::categorize_error_signal("stuck item found"), "cleanup");
+    assert_eq!(::server_telemetry::categorize_error_signal("stagnant backlog item"), "cleanup");
+}


### PR DESCRIPTION
- Removed mutual exclusivity of HPA/VPA allowing K8s workloads to have VPA `Auto` updates while keeping autoscaling.
- Changed string representation from `[bug] Mission became stuck` to `[cleanup] Mission became stuck`.
- Added logic to `categorize_error_signal` to match `stuck` and `stagnant` as `cleanup`.
- Added unit tests for telemetry coverage.

---
*PR created automatically by Jules for task [15596557082971885923](https://jules.google.com/task/15596557082971885923) started by @ql-owo-lp*