### PR TITLE
🎥 Lens Audit: Fix website builder E2E test assertion

### DIFF
--- a/src/e2e/lens_audit.spec.ts
+++ b/src/e2e/lens_audit.spec.ts
@@ -22,8 +22,7 @@ test.describe('Lens Audit Visual Checks', () => {
   test('should navigate to website builder', async ({ page }) => {
     await page.goto('/website-builder');
     await page.waitForTimeout(2000);
-    // click the assistant button
-    await expect(page.getByRole('heading', { name: '10-Minute Setup Wizard' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Setup Assistant' }).first()).toBeVisible();
   });
 
   test('should display login fields', async ({ page }) => {


### PR DESCRIPTION
Fix website builder e2e test assertion

Update the website builder e2e test assertion to check for "Setup Assistant" heading instead of "10-Minute Setup Wizard" since the UI has changed.

---
*PR created automatically by Jules for task [12614375227820750486](https://jules.google.com/task/12614375227820750486) started by @ql-owo-lp*