### PR TITLE
🔗 Link: [fix inventory lock error message]

### DIFF
--- a/src/e2e/distributed-inventory.spec.ts
+++ b/src/e2e/distributed-inventory.spec.ts
@@ -56,7 +56,7 @@ test.describe('Distributed Inventory Sync via UI', () => {
     await page.locator('#simulate-tap-btn').click();
 
     // We expect an optimistic lock failure indicating it is checked out by another customer
-    await expect(page.getByText(/Error: Oops! Item just sold out.|Processing\/Reserving.../)).toBeVisible();
+    await expect(page.getByText(/Error: Item is currently being checked out.|Processing\/Reserving.../)).toBeVisible();
 
     // 3. We commit the background api checkout
     const commitReq = await request.post('/api/v1/payments/terminal/commit', {
@@ -124,7 +124,7 @@ test.describe('Distributed Inventory Sync via UI', () => {
      await customerPage.getByRole('button', { name: "Pay" }).click();
 
      // Should fail since it's already reserved by POS
-     await expect(customerPage.getByText('Oops! Item just sold out.')).toBeVisible();
+     await expect(customerPage.getByText('Item is currently being checked out.')).toBeVisible();
      await customerContext.close();
   });
 

--- a/src/e2e/test_pos_offline_sync.spec.ts
+++ b/src/e2e/test_pos_offline_sync.spec.ts
@@ -469,5 +469,5 @@ test.describe('Offline-Tolerant POS Terminal Checkout', () => {
     // The backend should return BAD_REQUEST or a specific error message about being locked
     expect(addItemRes.ok()).toBeFalsy();
     const errorJson = await addItemRes.json();
-    expect(errorJson.error).toContain('checked out');
+    expect(errorJson.error).toContain('Item is currently being checked out');
   });

--- a/src/e2e/ui/pos_checkout.spec.ts
+++ b/src/e2e/ui/pos_checkout.spec.ts
@@ -23,7 +23,7 @@ test.describe('POS Checkout - Centralized Inventory', () => {
 
   test('Shows out of stock message when lock fails', async ({ page }) => {
     await page.route('/api/v1/payments/terminal/reserve', async route => {
-      const json = { success: false, error_message: 'Oops! Item just sold out.' };
+      const json = { success: false, error_message: 'Item is currently being checked out.' };
       await route.fulfill({ json });
     });
 
@@ -31,6 +31,6 @@ test.describe('POS Checkout - Centralized Inventory', () => {
     await page.setViewportSize({ width: 375, height: 667 });
 
     // Assuming the user discovers and connects to a reader, and clicks 'Charge'
-    // We'd look for: await expect(page.locator('text=Reservation failed: Oops! Item just sold out.')).toBeVisible();
+    // We'd look for: await expect(page.locator('text=Reservation failed: Item is currently being checked out.')).toBeVisible();
   });
 });

--- a/src/server/services/inventory/service.rs
+++ b/src/server/services/inventory/service.rs
@@ -223,7 +223,7 @@ impl InventoryService {
                 return Ok(ReserveResult {
                     success: false,
                     lock_id: "".to_string(),
-                    error_message: "Oops! Item just sold out.".to_string(),
+                    error_message: "Item is currently being checked out.".to_string(),
                 });
             }
 
@@ -673,7 +673,7 @@ mod tests {
         if std::env::var("OHC_REDIS_URL").is_ok() {
             assert_eq!(success_count, 1, "Only one concurrent request should acquire the lock");
             let failed_res = if res1.success { res2 } else { res1 };
-            assert_eq!(failed_res.error_message, "Oops! Item just sold out.");
+            assert_eq!(failed_res.error_message, "Item is currently being checked out.");
         }
     }
 }

--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -210,7 +210,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
           const reserveData = await reserveRes.json();
           if (!reserveData.success) {
             onOptimisticRollback?.();
-            setStatus('Error: Oops! Item just sold out.');
+            setStatus('Error: Item is currently being checked out.');
             setReserving(false);
 
             const errorDiv = document.createElement('div');
@@ -224,7 +224,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
             errorDiv.style.backdropFilter = 'blur(30px)';
             errorDiv.style.zIndex = '1000';
             errorDiv.innerHTML = `<div style="background: white; padding: 2rem; border-radius: 1rem; box-shadow: 0 10px 30px rgba(0,0,0,0.1); text-align: center; border: 1px solid rgba(255,59,48,0.4);">
-                <h3 style="color: #FF3B30; font-family: Outfit; font-size: 1.25rem; font-weight: bold; margin-bottom: 0.5rem;">Oops! Item just sold out.</h3>
+                <h3 style="color: #FF3B30; font-family: Outfit; font-size: 1.25rem; font-weight: bold; margin-bottom: 0.5rem;">Item is currently being checked out.</h3>
                 <p style="color: #666;">This item was purchased online just now.</p>
                 <button onclick="this.parentElement.parentElement.remove()" style="margin-top: 1rem; padding: 0.5rem 1rem; background: #0066FF; color: white; border-radius: 0.5rem; font-weight: bold; cursor: pointer; border: none;">Got it</button>
             </div>`;
@@ -328,7 +328,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
         const reserveData = await reserveRes.json();
         if (!reserveData.success) {
           onOptimisticRollback?.();
-          setStatus('Error: Oops! Item just sold out.');
+          setStatus('Error: Item is currently being checked out.');
           setReserving(false);
 
           const errorDiv = document.createElement('div');
@@ -342,7 +342,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
           errorDiv.style.backdropFilter = 'blur(30px)';
           errorDiv.style.zIndex = '1000';
           errorDiv.innerHTML = `<div style="background: white; padding: 2rem; border-radius: 1rem; box-shadow: 0 10px 30px rgba(0,0,0,0.1); text-align: center; border: 1px solid rgba(255,59,48,0.4);">
-              <h3 style="color: #FF3B30; font-family: Outfit; font-size: 1.25rem; font-weight: bold; margin-bottom: 0.5rem;">Oops! Item just sold out.</h3>
+              <h3 style="color: #FF3B30; font-family: Outfit; font-size: 1.25rem; font-weight: bold; margin-bottom: 0.5rem;">Item is currently being checked out.</h3>
               <p style="color: #666;">This item was purchased online just now.</p>
               <button onclick="this.parentElement.parentElement.remove()" style="margin-top: 1rem; padding: 0.5rem 1rem; background: #0066FF; color: white; border-radius: 0.5rem; font-weight: bold; cursor: pointer; border: none;">Got it</button>
           </div>`;
@@ -476,7 +476,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
                 const reserveData = await reserveRes.json();
                 if (!reserveData.success) {
                   if (onOptimisticRollback) onOptimisticRollback();
-                  setStatus('Error: Oops! Item just sold out.');
+                  setStatus('Error: Item is currently being checked out.');
                   setReserving(false);
                   return;
                 }


### PR DESCRIPTION
Addresses issue #31630 by changing the error message in the distributed inventory lock mechanism to `Item is currently being checked out` to accurately reflect the temporary lock status. This required modifying the backend service and ensuring all E2E tests properly expect this message.

Superpowers used: `playwright_test_runner`, `docker_compose_up_wait` and `e2e_cuj_verify`.

All Bazel tests and Playwright E2E tests have passed.

---
*PR created automatically by Jules for task [2157132905933852407](https://jules.google.com/task/2157132905933852407) started by @ql-owo-lp*

Resolves #31630