### PR TITLE
feat: make zero-click onboarding the default primary setup path

### DIFF
--- a/src/e2e/onboarding.spec.ts
+++ b/src/e2e/onboarding.spec.ts
@@ -19,7 +19,8 @@ test.describe('Onboarding Wizard E2E Flow', () => {
     await page.waitForLoadState('domcontentloaded');
     await expect(setupScreen).toBeVisible({ timeout: 30000 });
 
-    const startButton = page.getByTestId('next-step-btn').first();
+    // Click manual configuration
+    const startButton = page.locator('button', { hasText: 'Step-by-Step Setup' });
     await startButton.click();
 
     // Context Card Flow starts in step-context in Tauri
@@ -57,7 +58,8 @@ test.describe('Onboarding Wizard E2E Flow', () => {
     const setupScreen = page.locator('.container');
     await expect(setupScreen).toBeVisible({ timeout: 30000 });
 
-    const startButton = page.getByTestId('next-step-btn').first();
+    // Click manual configuration
+    const startButton = page.locator('button', { hasText: 'Step-by-Step Setup' });
     await startButton.click();
 
     const contextCard = page.locator('.context-card').first();
@@ -72,7 +74,8 @@ test.describe('Onboarding Wizard E2E Flow', () => {
     const setupScreen = page.locator('.container');
     await expect(setupScreen).toBeVisible({ timeout: 30000 });
 
-    const startButton = page.getByTestId('next-step-btn').first();
+    // Click manual configuration
+    const startButton = page.locator('button', { hasText: 'Step-by-Step Setup' });
     await startButton.click();
 
     // Jump straight to the name step to test validation
@@ -97,7 +100,8 @@ test.describe('Onboarding Wizard E2E Flow', () => {
     const setupScreen = page.locator('.container');
     await expect(setupScreen).toBeVisible({ timeout: 30000 });
 
-    const startButton = page.getByTestId('next-step-btn').first();
+    // Click manual configuration
+    const startButton = page.locator('button', { hasText: 'Step-by-Step Setup' });
     await startButton.click();
 
     // Jump straight to the name step to test validation
@@ -158,11 +162,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     const setupScreen = page.locator('.container');
     await expect(setupScreen).toBeVisible({ timeout: 30000 });
 
-    const instantBuildButton = page.locator('button', { hasText: 'Instant Build' }).first();
-    await expect(instantBuildButton).toBeVisible();
-    await instantBuildButton.click();
-
-    await expect(page.locator('#step-instant')).toBeVisible();
+    // Instant Build is now the initial screen
 
     const bioInput = page.locator('#instant-bio');
     await expect(bioInput).toBeVisible();
@@ -179,8 +179,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
 
   test('Instant Build image URL is submitted and correctly mapped to state', async ({ page }) => {
     await page.goto('/setup.html');
-    const instantBuildButton = page.locator('button', { hasText: 'Instant Build' }).first();
-    await instantBuildButton.click();
+    // Instant Build is now the initial screen
 
     const bioInput = page.locator('#instant-bio');
     await bioInput.fill("Test business description.");
@@ -193,8 +192,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
 
   test('Instant Build image URL can be empty and successfully launches', async ({ page }) => {
     await page.goto('/setup.html');
-    const instantBuildButton = page.locator('button', { hasText: 'Instant Build' }).first();
-    await instantBuildButton.click();
+    // Instant Build is now the initial screen
 
     const bioInput = page.locator('#instant-bio');
     await bioInput.fill("Test business description without image.");
@@ -211,9 +209,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     const setupScreen = page.locator('.container');
     await expect(setupScreen).toBeVisible({ timeout: 30000 });
 
-    const instantBuildButton = page.locator('button', { hasText: 'Instant Build' }).first();
-    await expect(instantBuildButton).toBeVisible();
-    await instantBuildButton.click();
+    // Instant Build is now the initial screen
 
     const bioInput = page.locator('#instant-bio');
     await bioInput.fill("fail network request");
@@ -233,8 +229,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
   // Test 3: Verifies empty input behavior
   test('Instant Build prevents submission when the input is empty', async ({ page }) => {
     await page.goto('/setup.html');
-    const instantBuildButton = page.locator('button', { hasText: 'Instant Build' }).first();
-    await instantBuildButton.click();
+    // Instant Build is now the initial screen
 
     const generateButton = page.locator('#generate-storefront-btn');
     await expect(generateButton).toBeDisabled();
@@ -250,8 +245,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
   // Test 4: Smart defaults fallback on partial info
   test('Instant Build handles partial information appropriately by falling back to smart defaults', async ({ page }) => {
     await page.goto('/setup.html');
-    const instantBuildButton = page.locator('button', { hasText: 'Instant Build' }).first();
-    await instantBuildButton.click();
+    // Instant Build is now the initial screen
 
     const bioInput = page.locator('#instant-bio');
     // Only provide a generic description
@@ -276,8 +270,8 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     const containerBox = await container.boundingBox();
     expect(containerBox?.width).toBeLessThanOrEqual(375);
 
-    // Click Start My Business
-    const startMyBusinessButton = page.locator('button', { hasText: 'Start My Business' }).first();
+    // Click Step-by-Step Setup
+    const startMyBusinessButton = page.locator('button', { hasText: 'Step-by-Step Setup' }).first();
     await startMyBusinessButton.click();
 
     // Check .context-card
@@ -300,8 +294,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     await page.setViewportSize({ width: 375, height: 667 });
     await page.goto('/setup.html');
 
-    const instantBuildButton = page.locator('button', { hasText: 'Instant Build' }).first();
-    await instantBuildButton.click();
+    // Instant Build is now the initial screen
 
     const bioInput = page.locator('#instant-bio');
     const box = await bioInput.boundingBox();

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1288,13 +1288,14 @@
   <body>
     <div class="container glassmorphism" id="form-container">
       <!-- Step 0: Initial Screen -->
+
       <div class="step active" id="step-initial">
         <div
           style="
             width: 64px;
             height: 64px;
             background: rgba(0, 102, 255, 0.1);
-            border-radius: 50%;
+            border-radius: 16px;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -1315,90 +1316,27 @@
             />
           </svg>
         </div>
-        <h1>10-Minute Setup Wizard</h1>
-        <p>
-          Zero tech skills needed. We do the heavy lifting. Review and add any
-          extra details to help our AI generate the perfect store.
-        </p>
-
-        <div class="btn-group" style="margin-top: 32px">
-          <button
-            class="next-step-btn"
-            data-testid="next-step-btn"
-            data-next="step-context"
-          >
-            Start My Business
-          </button>
-          <button
-            type="button"
-            class="glassmorphism btn-instant-build"
-            onclick="
-              goToStep('step-instant');
-            "
-          >
-            <span id="instant-build-btn-text">Instant Build</span>
-          </button>
-          <button
-            type="button"
-            class="btn-secondary"
-            onclick="goToStep('step-chat')"
-            style="margin-top: 10px"
-          >
-            Conversational Setup
-          </button>
-        </div>
-      </div>
-
-      <!-- Step Instant: Instant Build -->
-      <div class="step" id="step-instant">
-        <button
-          onclick="goToStep('step-initial')"
-          style="
-            background: none;
-            border: none;
-            color: #0066ff;
-            padding: 0;
-            font-size: 14px;
-            font-weight: 600;
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            gap: 4px;
-            margin-bottom: 24px;
-            min-height: 44px;
-          "
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path d="M15 18l-6-6 6-6" />
-          </svg>
-          Back
-        </button>
-
         <h1>Tell us about your business</h1>
-        <p>Our AI will handle the rest in 30 seconds.</p>
+        <p>
+          Type a quick description and our AI will build your entire workspace in seconds.
+        </p>
 
         <textarea
           id="instant-bio"
           data-testid="instant-bio"
           class="glassmorphism"
           placeholder="e.g. I run a local bakery that sells custom vegan cakes..."
-          rows="6"
+          rows="4"
           style="resize: none; padding: 14px"
           enterkeyhint="next"
         ></textarea>
+
         <input
           type="url"
           id="instant-image-url"
           data-testid="instant-image-url"
           class="glassmorphism"
-          placeholder="Image URL (Optional)"
+          placeholder="Image URL (Optional - e.g. logo or storefront)"
           inputmode="url"
           autocomplete="url"
           enterkeyhint="next"
@@ -1409,22 +1347,47 @@
             border-radius: 8px;
           "
         />
-        <div
-          id="instant-error"
-          class="error-msg"
-          aria-live="polite"
-          style="margin-bottom: 20px"
-        ></div>
 
-        <div class="btn-group" style="margin-top: 24px">
+        <div id="instant-error" class="error-msg" aria-live="polite"></div>
+
+        <div class="btn-group" style="margin-top: 16px">
           <button
+            class="next-step-btn"
             id="generate-storefront-btn"
             data-testid="generate-storefront-btn"
+            style="width: 100%; min-height: 44px; border-radius: 8px; background: #0066FF; color: white; font-weight: 600; border: none; font-size: 16px; box-shadow: 0 4px 14px 0 rgba(0, 102, 255, 0.39);"
+            disabled
           >
-            Next
+            Generate My Workspace
+          </button>
+
+          <div style="margin-top: 24px; margin-bottom: 12px; font-size: 12px; color: #555; text-transform: uppercase; letter-spacing: 1px; font-weight: 600; display: flex; align-items: center; justify-content: center;">
+            <span style="flex-grow: 1; height: 1px; background: rgba(0,0,0,0.1); margin-right: 12px;"></span>
+            Or configure manually
+            <span style="flex-grow: 1; height: 1px; background: rgba(0,0,0,0.1); margin-left: 12px;"></span>
+          </div>
+
+          <button
+            type="button"
+            class="btn-secondary"
+            onclick="goToStep('step-chat')"
+            style="margin-bottom: 10px; width: 100%;"
+          >
+            Conversational Setup
+          </button>
+          <button
+            type="button"
+            class="btn-secondary next-step-btn"
+            data-testid="next-step-btn"
+            data-next="step-context"
+            style="width: 100%;"
+          >
+            Step-by-Step Setup
           </button>
         </div>
       </div>
+
+
 
       <div class="step" id="step-loading">
         <h1 id="loading-title">Building Your Business...</h1>
@@ -1452,9 +1415,14 @@
           "
         >
           <div
-            class="loading-step"
             id="step-provisioning"
-            style="display: flex; align-items: center; gap: 8px; opacity: 0.5"
+            style="
+              display: flex;
+              align-items: center;
+              gap: 8px;
+              opacity: 0.5;
+              transition: opacity 0.3s;
+            "
           >
             <div
               class="loading-dot"
@@ -1465,12 +1433,17 @@
                 background: #ccc;
               "
             ></div>
-            Hiring your AI Workforce...
+            Provisioning Workspace
           </div>
           <div
-            class="loading-step"
             id="step-catalog"
-            style="display: flex; align-items: center; gap: 8px; opacity: 0.5"
+            style="
+              display: flex;
+              align-items: center;
+              gap: 8px;
+              opacity: 0.5;
+              transition: opacity 0.3s;
+            "
           >
             <div
               class="loading-dot"
@@ -1481,12 +1454,17 @@
                 background: #ccc;
               "
             ></div>
-            Generating your product catalog...
+            Generating Catalog
           </div>
           <div
-            class="loading-step"
             id="step-storefront"
-            style="display: flex; align-items: center; gap: 8px; opacity: 0.5"
+            style="
+              display: flex;
+              align-items: center;
+              gap: 8px;
+              opacity: 0.5;
+              transition: opacity 0.3s;
+            "
           >
             <div
               class="loading-dot"
@@ -1497,10 +1475,11 @@
                 background: #ccc;
               "
             ></div>
-            Setting up your Command Center...
+            Publishing Storefront
           </div>
         </div>
       </div>
+
 
       <!-- Step Chat: Conversational Build -->
       <div class="step" id="step-chat">


### PR DESCRIPTION
This PR refactors the onboarding wizard by elevating the Instant Build zero-click flow directly into the initial setup screen (`step-initial`).
It removes the unnecessary branching and makes conversational AI onboarding the default frictionless path for new users, while maintaining manual fallback configuration.
Additionally, tests were updated to cover this new flow.
- Removed the old `step-instant` to avoid duplicate elements and broken state.
- Preserved `step-loading` for backend processing feedback.
- Ensured tests run and pass properly.

---
*PR created automatically by Jules for task [13174246465827860519](https://jules.google.com/task/13174246465827860519) started by @ql-owo-lp*