### PR TITLE
🚀 Nova: [new growth feature] Lead Magnet Generator Growth Loop

### DIFF
--- a/src/ui/next/src/app/dashboard/page.tsx
+++ b/src/ui/next/src/app/dashboard/page.tsx
@@ -1020,6 +1020,17 @@ export default function Dashboard() {
             </Link>
             </WithTooltip>
 
+            <WithTooltip id="lead-magnet-tooltip" defaultText="Capture emails and grow your audience.">
+            <Link href="/lead-magnet-generator" className="block glassmorphism p-6 min-h-[44px] rounded-[16px] hover:shadow-lg transition-all hover:-translate-y-0.5 group border border-white/40 dark:border-white/10">
+              <div className="flex items-start justify-between mb-4">
+                <div className="w-12 h-12 rounded-full bg-indigo-50 dark:bg-indigo-900/30 flex items-center justify-center text-2xl group-hover:scale-110 transition-transform">🧲</div>
+                <div className="text-indigo-600 dark:text-indigo-400 font-semibold text-sm bg-indigo-50 dark:bg-indigo-900/30 px-3 py-1 rounded-full">Leads</div>
+              </div>
+              <h3 className="text-xl font-bold font-outfit text-[#1D1D1F] dark:text-[#F5F5F7] mb-2">Lead Magnet Generator</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">Capture emails and grow your audience.</p>
+            </Link>
+            </WithTooltip>
+
             <WithTooltip id="link-in-bio-tooltip" defaultText="One link to rule them all. Drive social traffic to your store.">
             <Link href="/link-in-bio-generator" className="block glassmorphism p-6 min-h-[44px] rounded-[16px] hover:shadow-lg transition-all hover:-translate-y-0.5 group border border-white/40 dark:border-white/10">
               <div className="flex items-start justify-between mb-4">

--- a/src/ui/next/src/e2e/lead-magnet-generator.spec.ts
+++ b/src/ui/next/src/e2e/lead-magnet-generator.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from './fixtures';
+
+test.describe('Lead Magnet Generator Growth Loop', () => {
+  test('Merchant uses Lead Magnet Generator and sees soft paywall', async ({ page, request, loginAs, adminUser }) => {
+    // Navigate and login
+    await loginAs(page, adminUser);
+
+    // Navigate to dashboard
+    await page.goto('/dashboard');
+
+    // Ensure pro is false
+    await page.evaluate(() => {
+        localStorage.setItem('has_pro', 'false');
+    });
+
+    // Find the link to lead magnet generator
+    const leadMagnetButton = page.locator('a[href="/lead-magnet-generator"]');
+    await expect(leadMagnetButton).toBeVisible();
+    await leadMagnetButton.click();
+
+    // 1. Merchant navigates to lead magnet generator page
+    await page.waitForURL('**/lead-magnet-generator');
+
+    // Check baseline: the page should be loaded
+    const titleHeader = page.locator('h1', { hasText: 'Lead Magnet Generator' });
+    await expect(titleHeader).toBeVisible();
+
+    // Configure Widget
+    await page.fill('input[type="text"] >> nth=0', 'Get 10% Off');
+    await page.fill('textarea', 'Sign up for our newsletter to get 10% off your first order.');
+    await page.fill('input[type="text"] >> nth=1', 'Subscribe Now');
+
+    // Check preview updates
+    await expect(page.locator('h3', { hasText: 'Get 10% Off' })).toBeVisible();
+    await expect(page.locator('p', { hasText: 'Sign up for our newsletter to get 10% off your first order.' })).toBeVisible();
+
+    // 2. Merchant tries to remove branding without Pro
+    const removeBrandingCheckbox = page.locator('input[type="checkbox"]');
+    await removeBrandingCheckbox.check();
+
+    // 3. Soft paywall appears
+    const upgradeHeader = page.locator('h3', { hasText: 'Upgrade to OHC Pro' });
+    await expect(upgradeHeader).toBeVisible();
+
+    // 4. Click Keep Branding
+    const keepBrandingBtn = page.locator('button', { hasText: 'Keep Branding' });
+    await keepBrandingBtn.click();
+
+    // 5. Verify the soft paywall closes
+    await expect(upgradeHeader).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
This PR implements the missing "Lead Magnet Generator" E2E tests, verifying that the merchant can successfully generate embeddable lead capture widgets. It also includes adding a link from the dashboard so that business owners can discover and utilize the feature.

Product-use evidence:
Persona: Maya the Baker
Browser flow: Logged into OHC and navigated to `/dashboard`.
CUJ Gap: The link for the "Lead Magnet Generator" was entirely missing from the "Sales & Virality" section of the dashboard, making the feature inaccessible to users like Maya.
Post-fix flow: Logged into OHC, navigated to `/dashboard`, verified the "Lead Magnet Generator" link exists. Clicked it and successfully rendered `/lead-magnet-generator` and interacted with the configuration UI. Attempted to remove the branding, and was successfully greeted by the soft paywall trial extension.

All Playwright tests passed successfully.

---
*PR created automatically by Jules for task [7917759704531453313](https://jules.google.com/task/7917759704531453313) started by @ql-owo-lp*