### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] PostgreSQL tenant isolation vulnerability in revoke_token

### DIFF
--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -436,7 +436,7 @@ impl UserRepository for PgUserRepository {
         let _ = if should_bypass {
             sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1").bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = current_setting('app.current_tenant')::text").bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?
+            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = $2").bind(now).bind(org_id).execute(&mut *tx).await.map_err(|e| e.to_string())?
         };
 
         tx.commit().await.map_err(|e| e.to_string())?;


### PR DESCRIPTION
This PR addresses a vulnerability in multi-tenant mode where garbage collecting revoked tokens relied on `current_setting('app.current_tenant')` in PostgreSQL instead of explicitly binding the tenant parameter, which could either fail if context isn't correctly propagated to the transaction or fail to ensure strong isolation bounds on the query itself.

The PR replaces the context reliance with an explicit `tenant_id = $2` parameter binding for the `DELETE` query, which aligns the behavior with the sqlite storage implementation and satisfies the tenant isolation regressions test.

Superpowers loaded: `superpowers:systematic-debugging`. No UI UI interaction verification required as this is purely a backend database query logic update.

---
*PR created automatically by Jules for task [12403477012084650872](https://jules.google.com/task/12403477012084650872) started by @ql-owo-lp*