### PR TITLE
fix: resolve E2E setup wizard flows, nextjs 15 build errors, and lints

### DIFF
--- a/src/e2e/setup.spec.ts
+++ b/src/e2e/setup.spec.ts
@@ -32,18 +32,25 @@ test.describe('OHC Setup Wizard Flow', () => {
     await page.locator('[data-testid="next-step-btn"][data-next="step-name"]').click();
     // Name step
     await page.getByTestId('business-name').fill('Test Bakery');
+    await page.locator('[data-testid="next-step-btn"][data-next="step-location"]').click();
+    // Location step
+    await page.getByTestId('location-input').fill('123 Main St, Anytown');
     await page.locator('[data-testid="next-step-btn"][data-next="step-assistant"]').click();
     // Assistant step
     await page.getByTestId('team-support').click();
     await page.getByTestId('assistant-tone').selectOption('Friendly');
     await page.locator('[data-testid="next-step-btn"][data-next="step-admin"]').click();
     // Admin step
+    await page.getByTestId('admin-name').fill('Admin Name');
     await page.getByTestId('admin-email').fill('admin@testbakery.local');
     await page.getByTestId('admin-password').fill('SuperSecretPassword123');
     await page.locator('[data-testid="next-step-btn"][data-next="step-offer"]').click();
     // Offer step
     await page.getByTestId('first-offer').fill('Chocolate Cake');
-    await page.locator('#step-offer [data-testid="next-step-btn"][data-next="step-domain"]').click();
+    await page.locator('#step-offer [data-testid="next-step-btn"][data-next="step-target-audience"]').click();
+    // Target Audience step
+    await page.getByTestId('target-audience').fill('Local families');
+    await page.locator('[data-testid="next-step-btn"][data-next="step-domain"]').click();
     // Domain step
     await page.getByTestId('domain-name').fill('test-bakery');
     await page.locator('[data-testid="next-step-btn"][data-next="step-template"]').click();
@@ -119,12 +126,15 @@ test.describe('OHC Setup Wizard Flow', () => {
     await page.locator('[data-testid="next-step-btn"][data-next="step-name"]').click();
     // Name step - Trigger auto-save
     await page.getByTestId('business-name').fill('AutoSave Bakery');
+    await page.locator('[data-testid="next-step-btn"][data-next="step-location"]').click();
+    // Location step
+    await page.getByTestId('location-input').fill('123 AutoSave St, Anytown');
     // Wait for debounce and localstorage to be populated
     await page.waitForTimeout(600);
     // Reload page
     await page.reload();
-    // Wait for the state to be reloaded (it jumps to step 3 since it was saved)
-    await expect(page.getByTestId('business-name')).toHaveValue('AutoSave Bakery');
+    // Wait for the state to be reloaded
+    await expect(page.getByTestId('location-input')).toHaveValue('123 AutoSave St, Anytown');
     });
   test('should show submit error if start fails', async ({ page }) => {
     const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');

--- a/src/server/workers/daily_ops_routine_worker.rs
+++ b/src/server/workers/daily_ops_routine_worker.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 use crate::db::DB;
-use std::time::Duration;
 use uuid::Uuid;
 use serde_json::json;
 

--- a/src/ui/next/src/app/api/subscriptions/[id]/action/route.ts
+++ b/src/ui/next/src/app/api/subscriptions/[id]/action/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
-export async function POST(req: Request, { params }: { params: { id: string } }) {
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+    const { id } = await params;
     const backendUrl = process.env.BACKEND_URL || 'http://127.0.0.1:18789';
     const tenantId = req.headers.get('x-tenant-id') || 'default';
     const authHeader = req.headers.get('authorization');
@@ -14,7 +15,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
 
     try {
         const body = await req.json();
-        const res = await fetch(`${backendUrl}/api/subscriptions/${params.id}/action`, {
+        const res = await fetch(`${backendUrl}/api/subscriptions/${id}/action`, {
             method: 'POST',
             headers,
             body: JSON.stringify(body),

--- a/src/ui/next/src/app/api/subscriptions/[id]/route.ts
+++ b/src/ui/next/src/app/api/subscriptions/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
-export async function GET(req: Request, { params }: { params: { id: string } }) {
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+    const { id } = await params;
     const backendUrl = process.env.BACKEND_URL || 'http://127.0.0.1:18789';
     const tenantId = req.headers.get('x-tenant-id') || 'default';
     const authHeader = req.headers.get('authorization');
@@ -12,7 +13,7 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     }
 
     try {
-        const res = await fetch(`${backendUrl}/api/subscriptions/${params.id}`, {
+        const res = await fetch(`${backendUrl}/api/subscriptions/${id}`, {
             method: 'GET',
             headers,
         });

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1144,7 +1144,14 @@
       .glassmorphism.container,
       .glassmorphism.card,
       .glassmorphism.panel {
-        border-radius: 16px;
+        border-radius: 16px !important;
+      }
+
+      input.glassmorphism,
+      textarea.glassmorphism,
+      select.glassmorphism,
+      button.glassmorphism {
+        border-radius: 8px !important;
       }
     </style>
 


### PR DESCRIPTION
This PR resolves several failing checks and tests in the repository:

1. **E2E Wizard Flow tests timeout**: The `setup.spec.ts` script was stalling because it was skipping intermediate wizard steps (`step-location`, `admin-name`, `step-target-audience`). I added the necessary Playwright interactions for these steps.
2. **CSS Requirements**: The E2E tests enforcing Apple/UniFi UI guidelines were failing because `.glassmorphism` containers didn't explicitly enforce `16px` border radii and inputs/buttons didn't enforce `8px`. Added correct rules to `setup.html`.
3. **NextJS Build Errors**: NextJS 15 migration requires dynamic route `params` to be typed and awaited as a `Promise<{id: string}>`. Updated the `subscriptions/[id]/route.ts` and `subscriptions/[id]/action/route.ts` endpoints.
4. **Rust Linter Errors**: Removed unused import `std::time::Duration` from `daily_ops_routine_worker.rs`.

Tested passing successfully with `bazelisk test //src/e2e:playwright_shard_1_of_1` and NextJS tests.

---
*PR created automatically by Jules for task [15581287417157382693](https://jules.google.com/task/15581287417157382693) started by @ql-owo-lp*