### PR TITLE
🤖 Implementer: Harness Upgrade - Fix autodream build failure

### DIFF
--- a/src/agents/builtin/autodream/mod.rs
+++ b/src/agents/builtin/autodream/mod.rs
@@ -1,5 +1,3 @@
-#[path = "store.rs"]
-pub mod store;
 use ::server_lib::db::DB;
 use std::sync::Arc;
 use tracing::{info, debug};


### PR DESCRIPTION
I attempted to implement the "Error Handling: LangGraph Mechanic (4-types)" pattern from the Master Catalog. However, my analysis revealed that this pattern is already completely implemented in `src/agents/builtin/tool_executor_engine.rs` (`ToolExecutionEngine::execute_tool_with_langgraph_mechanics`) and fully integrated into the orchestration loop in `src/agents/builtin/agent.rs`. Comprehensive tests for all four error types (Transient, LlmRecoverable, UserFixable, Fatal/Unexpected) also exist in `src/agents/builtin/tool_executor_engine_tests.rs`. 

While reviewing the codebase and running the tests, I encountered a build failure caused by a missing `store.rs` file referenced in `src/agents/builtin/autodream/mod.rs`. This PR resolves the build failure by removing the invalid module reference, allowing the `bazel test //...` suite to pass successfully.

### Product-use evidence
Not applicable for this background infrastructure fix.

### Superpowers applied
No specific superpowers were required beyond standard investigation and debugging practices.

### Checklist
- [x] Code compiles correctly
- [x] `bazelisk test //...` passes 100%
- [x] Removed dead code/invalid references preventing compilation

---
*PR created automatically by Jules for task [18768878796065897](https://jules.google.com/task/18768878796065897) started by @ql-owo-lp*