### PR TITLE
Fix flaky tests: prevent false timeouts in db execute_with_retry by using std::time::Instant

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -681,12 +681,12 @@ impl DB {
         let mut backoff = std::time::Duration::from_millis(1);
 
         // Enforce the 60-second ML-Resilience rule for database operations
-        let start_time = tokio::time::Instant::now();
+        let start_time = std::time::Instant::now();
         let timeout_duration = std::time::Duration::from_secs(60);
 
         loop {
-            // Note: Since tokio::time::Instant interacts with paused time during tests,
-            // we will evaluate whether the time has eclipsed the timeout here.
+            // Note: Since std::time::Instant does not interact with paused time during tests,
+            // it accurately tracks real elapsed time without causing false timeouts in simulated time tests.
             if start_time.elapsed() >= timeout_duration {
                 return Err(E::from(format!(
                     "Database operation '{}' timed out",


### PR DESCRIPTION
Modified `src/server/db.rs` to use `std::time::Instant::now()` instead of `tokio::time::Instant::now()` to track elapsed real time accurately. This prevents false timeouts in ML-Resilience 60s timeout enforcement logic when tests use `#[tokio::test(start_paused = true)]` and manipulate simulated time. Verified by running `bazelisk test //...` which resulted in 100% test pass rate with 0 flakes.

---
*PR created automatically by Jules for task [7433287682926905825](https://jules.google.com/task/7433287682926905825) started by @ql-owo-lp*