### PR TITLE
fix: strictly enforce local sovereignty for standalone telemetry

### DIFF
--- a/deploy/scripts/ohc-standalone.sh
+++ b/deploy/scripts/ohc-standalone.sh
@@ -36,6 +36,9 @@ export OHC_STATUS_DIR="${OHC_RUNTIME_DIR}/status"
 if [ "$OHC_TELEMETRY_ENABLED" != "true" ]; then
   export OHC_TELEMETRY_ENABLED=false
   export DISABLE_TELEMETRY=true
+else
+  export OHC_TELEMETRY_ENABLED=true
+  unset DISABLE_TELEMETRY
 fi
 
 umask 077

--- a/src/server/telemetry_test.rs
+++ b/src/server/telemetry_test.rs
@@ -376,6 +376,9 @@ fn test_standalone_wrapper_audit() {
     let expected_telemetry_check = r#"if [ "$OHC_TELEMETRY_ENABLED" != "true" ]; then
   export OHC_TELEMETRY_ENABLED=false
   export DISABLE_TELEMETRY=true
+else
+  export OHC_TELEMETRY_ENABLED=true
+  unset DISABLE_TELEMETRY
 fi"#;
 
     assert!(


### PR DESCRIPTION
Modified `deploy/scripts/ohc-standalone.sh` to correctly unset `DISABLE_TELEMETRY` and export `OHC_TELEMETRY_ENABLED=true` when explicitly opted in via environment variables. Updated the corresponding validation string in `src/server/telemetry_test.rs` to reflect this stricter local sovereignty enforcement.

---
*PR created automatically by Jules for task [15913380265762730488](https://jules.google.com/task/15913380265762730488) started by @ql-owo-lp*