### PR TITLE
Fix IDOR and Tenant Leakage in Postgres and SQLite Modes

### DIFF
--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -395,6 +395,7 @@ impl Store {
     }
 
     pub fn create_user(&self, username: String, email: String, password: String, roles: Vec<String>, org_id: String) -> Result<User, String> {
+        self.validate_org_id(&org_id)?;
         if username.is_empty() {
             return Err("username is required".to_string());
         }

--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -436,7 +436,7 @@ impl UserRepository for PgUserRepository {
         let _ = if should_bypass {
             sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1").bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?
         } else {
-            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = $2").bind(now).bind(org_id).execute(&mut *tx).await.map_err(|e| e.to_string())?
+            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = current_setting('app.current_tenant')::text").bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?
         };
 
         tx.commit().await.map_err(|e| e.to_string())?;
@@ -669,7 +669,7 @@ mod security_tests {
             .connect_lazy(&database_url)
             .unwrap();
 
-        let uid = uuid::Uuid::new_v4().to_string();
+        let uid = sqlx::types::Uuid::new_v4().to_string();
         let repo = PgUserRepository::new(pool.clone());
         let user = User {
             id: format!("test-id-pg-parity-{}", uid),


### PR DESCRIPTION
Fix IDOR in Postgres token revocation. Enforce tenant_id context properly. Ensure store user creation is correctly validated against the requesting organization ID.

---
*PR created automatically by Jules for task [17401139533238363844](https://jules.google.com/task/17401139533238363844) started by @ql-owo-lp*