### PR TITLE
chore: Fix e2e test and rust code health issues

### DIFF
--- a/src/agents/builtin/autodream/mod.rs
+++ b/src/agents/builtin/autodream/mod.rs
@@ -1,5 +1,3 @@
-#[path = "store.rs"]
-pub mod store;
 use ::server_lib::db::DB;
 use std::sync::Arc;
 use tracing::{info, debug};

--- a/src/e2e/setup-wizard.spec.ts
+++ b/src/e2e/setup-wizard.spec.ts
@@ -30,8 +30,8 @@ test.describe('Setup Wizard 375px Flow', () => {
         const initialStep = page.locator('#step-initial');
         await expect(initialStep).toBeVisible();
 
-        // Click Start My Business
-        await page.getByTestId('next-step-btn').first().click();
+        // Click Step-by-Step Setup
+        await page.locator('button:has-text("Step-by-Step Setup")').click();
 
         // Step Context
         const stepContext = page.locator('#step-context');

--- a/src/server/domain/estimator.rs
+++ b/src/server/domain/estimator.rs
@@ -126,7 +126,7 @@ Task: Extract the scope of work and identify the closest matching service from t
     .bind(matched_service_name)
     .bind(matched_price_cents)
     .bind(1)
-    .bind(tenant_id.clone())
+    .bind(tenant_id)
     .execute(pool)
     .await?;
 

--- a/src/server/domain/repository/agent_feed_repo.rs
+++ b/src/server/domain/repository/agent_feed_repo.rs
@@ -1,4 +1,4 @@
-use sqlx::{PgPool, FromRow};
+use sqlx::FromRow;
 use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};

--- a/src/server/services/inventory/service.rs
+++ b/src/server/services/inventory/service.rs
@@ -378,7 +378,7 @@ impl InventoryService {
     ) -> Result<CommitResult, String> {
         let mut all_match = true;
         let mut valid_indices = Vec::new();
-        let mut lock_id_base = "";
+        let lock_id_base;
         let parts: Vec<&str> = lock_id.split(':').collect();
         if parts.len() == 2 {
             lock_id_base = parts[0];

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -3982,15 +3982,6 @@
         });
       }
 
-
-      const instantBioInputEl2 = document.getElementById("instant-bio");
-      const generateStorefrontBtn2 = document.getElementById("generate-storefront-btn");
-      if (instantBioInputEl2 && generateStorefrontBtn2) {
-        instantBioInputEl2.addEventListener("input", (e) => {
-          generateStorefrontBtn2.disabled = e.target.value.trim().length === 0;
-        });
-      }
-
       if (generateStorefrontBtn) {
         generateStorefrontBtn.addEventListener("click", async (e) => {
           e.preventDefault();


### PR DESCRIPTION
I found that the `setup-wizard.spec.ts` test was clicking on the wrong element because `getByTestId('next-step-btn').first()` happened to match a disabled button or another unexpected element. I changed it to explicitly find the `Step-by-Step Setup` button. In `setup.html` I noticed a block of duplicate JavaScript and cleaned that up. Also fixed some Rust compiler warnings related to variables and imports.

---
*PR created automatically by Jules for task [9827164255802250486](https://jules.google.com/task/9827164255802250486) started by @ql-owo-lp*