### PR TITLE
🛡️ Sentry: [reliability fix] ML-Resilience 60-second timeouts

### DIFF
--- a/src/server/workers/migration_worker.rs
+++ b/src/server/workers/migration_worker.rs
@@ -84,7 +84,7 @@ impl MigrationWorker {
     async fn perform_migration(db: &Arc<DB>, tenant_id: &str, url: &str) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
         // Fetch content
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(60))
             .build()?;
         let res = client.get(url).send().await?;
         if !res.status().is_success() {

--- a/src/server/workers/missed_lead_recovery_worker.rs
+++ b/src/server/workers/missed_lead_recovery_worker.rs
@@ -160,7 +160,7 @@ impl MissedLeadRecoveryWorker {
                     }
                 };
 
-                match tokio::time::timeout(Duration::from_secs(30), llm_call).await {
+                match tokio::time::timeout(Duration::from_secs(60), llm_call).await {
                     Ok(Ok(reply)) => {
                         if !reply.trim().is_empty() {
                             // Extract JSON block if surrounded by markdown


### PR DESCRIPTION
# Spec: ML-Resilience 60-Second Timeout Rule

This implements the ML-Resilience specifications, primarily focusing on ensuring AI agent jobs maintain a 60-second timeout with an automatic retry max of 3. 

### Changes
- Updated `timeout()` duration from `30` to `60` seconds in `src/server/workers/missed_lead_recovery_worker.rs`.
- Updated `timeout()` duration from `30` to `60` seconds in `src/server/workers/migration_worker.rs` for parity with LLM timeout expectations.
- Verified `db.rs` correctly applies `MAX_DB_RETRY_ATTEMPTS` to LLM retries via `max_attempts`. 

### Testing
- `bazelisk test //...` completed successfully (100% green).
- `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"` completed successfully (100% green).

---
*PR created automatically by Jules for task [13580507502704081341](https://jules.google.com/task/13580507502704081341) started by @ql-owo-lp*