### PR TITLE
Resolves #31662 - Distributed Edge Caching and Dynamic Storefront SEO Engine

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -3590,7 +3590,7 @@ pub async fn simulate_agent_feed_item_handler(
                 return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({ "success": false, "error": e.to_string() }))).into_response();
             }
         },
-        crate::db::DbStore::Sqlite(ref pool) => {
+        crate::db::DbStore::Sqlite(pool) => {
             if let Err(e) = sqlx::query(
                 "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
             )

--- a/src/server/services/inventory/service.rs
+++ b/src/server/services/inventory/service.rs
@@ -124,6 +124,7 @@ impl InventoryLocker for RedisLocker {
 }
 
 pub struct InventoryService {
+    redis_client: Option<redis::Client>,
     locker: Box<dyn InventoryLocker>,
 }
 
@@ -150,12 +151,12 @@ pub struct CommitResult {
 
 impl InventoryService {
     pub fn new(redis_client: Option<redis::Client>) -> Self {
-        let locker: Box<dyn InventoryLocker> = if let Some(client) = redis_client {
-            Box::new(RedisLocker::new(client))
+        let locker: Box<dyn InventoryLocker> = if let Some(ref client) = redis_client {
+            Box::new(RedisLocker::new(client.clone()))
         } else {
             Box::new(MemoryLocker::new())
         };
-        Self { locker }
+        Self { locker, redis_client }
     }
 
     // Redis Redlock pattern for distributed lock
@@ -292,21 +293,22 @@ impl InventoryService {
                     let _ = tx.commit().await;
 
                     // Publish to Redis Pub/Sub for Real-Time Sync
-                    if false {
-
-
-                // Also emit cache invalidation event for storefront
-                let _invalidation_topic = "cache_invalidation_events";
-                let _invalidation_payload = serde_json::json!({
-                    "event": "inventory.updated",
-                    "tags": [
-                        format!("tenant-id:{}", tenant_id),
-                        format!("entity:product:{}", product_id)
-                    ]
-                }).to_string();
+                    if let Some(client) = self.redis_client.as_ref() {
+                        if let Ok(mut conn) = client.get_multiplexed_async_connection().await {
+                            // Also emit cache invalidation event for storefront
+                            let invalidation_topic = "cache_invalidation_events";
+                            let invalidation_payload = serde_json::json!({
+                                "event": "inventory.updated",
+                                "tags": [
+                                    format!("tenant-id:{}", tenant_id),
+                                    format!("entity:product:{}", product_id)
+                                ]
+                            }).to_string();
+                            let _: Result<(), _> = redis::cmd("PUBLISH").arg(invalidation_topic).arg(invalidation_payload).query_async(&mut conn).await;
+                        }
                     }
                 } else {
-            self.locker.clear(&lock_key).await;
+                    self.locker.clear(&lock_key).await;
                     return Ok(ReserveResult {
                         success: false,
                         lock_id: "".to_string(),
@@ -545,20 +547,20 @@ impl InventoryService {
         tx.commit().await.map_err(|e| e.to_string())?;
 
         // Publish to Redis Pub/Sub for Real-Time Sync
-        if false {
-            if false {
+        if let Some(client) = self.redis_client.as_ref() {
+            if let Ok(mut conn) = client.get_multiplexed_async_connection().await {
 
-
-                // Also emit cache invalidation event for storefront
-                let _invalidation_topic = "cache_invalidation_events";
-                let _invalidation_payload = serde_json::json!({
-                    "event": "inventory.updated",
-                    "tags": [
-                        format!("tenant-id:{}", tenant_id),
-                        format!("entity:product:{}", product_id)
-                    ]
-                }).to_string();
-            }
+                    // Also emit cache invalidation event for storefront
+                    let invalidation_topic = "cache_invalidation_events";
+                    let invalidation_payload = serde_json::json!({
+                        "event": "inventory.updated",
+                        "tags": [
+                            format!("tenant-id:{}", tenant_id),
+                            format!("entity:product:{}", product_id)
+                        ]
+                    }).to_string();
+                    let _: Result<(), _> = redis::cmd("PUBLISH").arg(invalidation_topic).arg(invalidation_payload).query_async(&mut conn).await;
+                }
         }
 
         Ok(CommitResult {


### PR DESCRIPTION
Resolves #31662

This PR addresses the issue of Edge Cache invalidation for storefronts when inventory changes. It updates `InventoryService` in `src/server/services/inventory/service.rs` to correctly utilize its optional Redis client for publishing cache invalidation events to the `cache_invalidation_events` topic when `reserve_inventory` or `commit_inventory` occurs. Additionally, a compiler error regarding an implicit-borrow pattern match in `src/server/lib.rs` was resolved. All relevant E2E tests have been verified to pass via `bazel`.

---
*PR created automatically by Jules for task [7394171596817208865](https://jules.google.com/task/7394171596817208865) started by @ql-owo-lp*