### PR TITLE
🛡️ Sentry: [reliability fix] Resolve IDOR multitenant system bypass prevention test fragility

### DIFF
--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -516,25 +516,15 @@ mod security_tests {
 
         let repo = PgUserRepository::new(pool.clone());
 
-        // Since we can't reliably override the global `is_multitenant_mode()` inline here
-        // without unsafe/mocking because it returns a reference to a static OnceLock, we simulate the query generation logic.
+        temp_env::async_with_vars([("OHC_MULTITENANT", Some("true"))], async {
+            let is_multitenant = is_multitenant_mode();
+            let org_id = "system"; let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+            assert!(!should_bypass, "Cloud mode should NEVER bypass tenant filters when org_id is 'system'");
 
-        // Cloud multitenant mode should NOT allow bypassing.
-        let old_val = std::env::var("OHC_MULTITENANT").ok();
-        unsafe { std::env::set_var("OHC_MULTITENANT", "true"); }
-        let is_multitenant = is_multitenant_mode();
-        let org_id = "system"; let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-
-        // Ensure the condition strictly evaluates to false when multitenant is true.
-        assert!(!should_bypass, "Cloud mode should NEVER bypass tenant filters when org_id is 'system'");
-
-        let res = repo.get_by_id("dummy_id", "system").await;
-        assert!(res.is_err(), "Must reject system id");
-        if let Some(ref val) = old_val {
-            unsafe { std::env::set_var("OHC_MULTITENANT", val); }
-        } else {
-            unsafe { std::env::remove_var("OHC_MULTITENANT"); }
-        }
+            let res = repo.get_by_id("dummy_id", "system").await;
+            assert!(res.is_err(), "Must reject system id in multitenant mode");
+            assert_eq!(res.unwrap_err(), "tenant_id 'system' cannot be queried in multi-tenant mode".to_string());
+        }).await;
     }
 
     #[tokio::test]

--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -519,13 +519,11 @@ mod tests {
         temp_env::async_with_vars([("OHC_MULTITENANT", Some("true"))], async {
             let is_multitenant = is_multitenant_mode();
             let org_id = "system"; let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
-            assert!(!should_bypass || is_multitenant == false, "Cloud mode should NEVER bypass tenant filters when org_id is 'system'");
+            assert!(!should_bypass, "Cloud mode should NEVER bypass tenant filters when org_id is 'system'");
 
             let res = repo.get_by_id("dummy_id", "system").await;
-            if is_multitenant {
-                assert!(res.is_err(), "Must reject system id in multitenant mode");
-                assert_eq!(res.unwrap_err(), "tenant_id 'system' cannot be queried in multi-tenant mode");
-            }
+            assert!(res.is_err(), "Must reject system id in multitenant mode");
+            assert_eq!(res.unwrap_err(), "tenant_id 'system' cannot be queried in multi-tenant mode");
         }).await;
     }
 


### PR DESCRIPTION
This PR replaces the `unsafe` environment variable mutators within the `postgres_store.rs` test suite, which introduced data races and flaky test failures during `bazel test //...` across `server_auth_unit_test`.

**Changes Made:**
1. Replaced `std::env::set_var` with `temp_env::async_with_vars` which is designed for hermetic thread-safe environment scoping.
2. Hardened parity in `sqlite_store.rs` and `postgres_store.rs` ensuring IDOR system test correctly asserts that bypassing NEVER occurs during `OHC_MULTITENANT=true` context.

**Verification:**
Superpower skills loaded and instructions followed.
Ran `bazel test //src/server/auth/...` and ensured full test suite parity passed locally.

---
*PR created automatically by Jules for task [3893267182993026020](https://jules.google.com/task/3893267182993026020) started by @ql-owo-lp*