### PR TITLE
fix: correct tooltip-registry routing and links

### DIFF
--- a/src/e2e/tooltip_registry.spec.ts
+++ b/src/e2e/tooltip_registry.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures';
 test.describe('Tooltip Registry', () => {
   test('Persona: Admin updates dynamic tooltips', async ({ page }) => {
     // We append /api/ui/ since this is served via backend in testing
-    await page.goto('/api/ui/tooltip-registry.html');
+    await page.goto('/tooltip-registry.html');
     await expect(page.locator('h1')).toHaveText('Tooltip Registry');
 
     await page.fill('#new-id', 'test-dynamic-id');

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6915,7 +6915,7 @@ async fn create_ui_bom_item_handler(
         .route("/kairos.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/kairos.html"))
         }))
-        .route("/api/ui/tooltip-registry.html", axum::routing::get(|| async {
+        .route("/tooltip-registry.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/tooltip-registry.html"))
         }))
         .route("/api/ui/hybrid-landing.html", axum::routing::get(|| async {

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -3216,7 +3216,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 </div>
                 <div id="advanced-help-links" style="display: none;">
                     <a href="/api-docs.html" style="color: #64748b; font-size: 13px; text-decoration: none; display: block; margin-bottom: 8px;">API Reference for advanced users</a>
-                    <a href="/api/ui/tooltip-registry.html" style="color: #64748b; font-size: 13px; text-decoration: none; display: block;">Tooltip Registry</a>
+                    <a href="/tooltip-registry.html" style="color: #64748b; font-size: 13px; text-decoration: none; display: block;">Tooltip Registry</a>
                 </div>
             </div>
         </div>

--- a/src/ui/tauri/src/ui/help-widget.mjs
+++ b/src/ui/tauri/src/ui/help-widget.mjs
@@ -299,7 +299,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 </div>
                 <div id="help-widget-advanced-links" style="display: none;">
                     <a href="/api-docs.html" style="color: #64748b; font-size: 13px; text-decoration: none; display: block; margin-bottom: 8px;">API Reference for advanced users</a>
-                    <a href="/api/ui/tooltip-registry.html" style="color: #64748b; font-size: 13px; text-decoration: none; display: block;">Tooltip Registry</a>
+                    <a href="/tooltip-registry.html" style="color: #64748b; font-size: 13px; text-decoration: none; display: block;">Tooltip Registry</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes 404 when navigating to Tooltip Registry from Help Center and Dashboard advanced links.

---
*PR created automatically by Jules for task [7203129226031622758](https://jules.google.com/task/7203129226031622758) started by @ql-owo-lp*