### PR TITLE
Enhance AgentProtocol status mapping and ToolExecutionEngine logging

### DIFF
--- a/src/agents/builtin/agent_protocol.rs
+++ b/src/agents/builtin/agent_protocol.rs
@@ -57,6 +57,7 @@ pub enum StepStatus {
     Created,
     Running,
     Completed,
+    Failed, // Added Failed status according to AutoGPT / agentprotocol.ai spec
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -297,7 +298,7 @@ impl AgentProtocolServer {
                     task_id: task_id.to_string(),
                     step_id: uuid::Uuid::new_v4().to_string(),
                     name: None,
-                    status: StepStatus::Completed, // Spec does not define Failed, using Completed for now
+                    status: StepStatus::Failed, // Using standard Failed status for errors
                     output: Some(format!("Error: {}", e)),
                     additional_output: None,
                     is_last: true,
@@ -539,7 +540,7 @@ mod tests {
         let resp_json = server.execute_step("task-123", req_json).await;
 
         let err_resp: Step = serde_json::from_value(resp_json).unwrap();
-        assert_eq!(err_resp.status, StepStatus::Completed);
+        assert_eq!(err_resp.status, StepStatus::Failed);
         assert!(err_resp.output.unwrap().contains("LLM execution failed"));
     }
 }

--- a/src/agents/builtin/tool_executor_engine.rs
+++ b/src/agents/builtin/tool_executor_engine.rs
@@ -42,11 +42,12 @@ impl ToolExecutionEngine {
                         let jitter = rand::thread_rng().gen_range(0..100);
                         let backoff = Duration::from_millis((base_backoff as u64) + jitter);
                         warn!(
-                            "Transient error executing '{}', retrying {}/{} after {}ms...",
+                            "Transient error executing '{}', retrying {}/{} after {}ms... Error details: {}",
                             tool.name,
                             retry_count,
                             max_retries,
-                            backoff.as_millis()
+                            backoff.as_millis(),
+                            msg
                         );
                         tokio::time::sleep(backoff).await;
                         continue;


### PR DESCRIPTION
- Adds `StepStatus::Failed` to `AgentProtocolServer` to match the actual AgentProtocol spec, returning a Failed status instead of defaulting to Completed on error.
- Enhances transient error logs inside `ToolExecutionEngine` to output the exact failure `msg` alongside the standard logging output.
- Both updates fulfill `Master Catalog` requirements around deterministic reporting and logging.

---
*PR created automatically by Jules for task [10985548043338494046](https://jules.google.com/task/10985548043338494046) started by @ql-owo-lp*