### PR TITLE
feat: Implement E2E test for viral share to unlock loop

### DIFF
--- a/src/e2e/viral_share_to_unlock.spec.ts
+++ b/src/e2e/viral_share_to_unlock.spec.ts
@@ -1,10 +1,82 @@
 import { test, expect } from './fixtures';
-import { currentAppSmoke } from './current_app_smoke';
 
 test.describe('Viral Share to Unlock Loop', () => {
-  test('Dashboard shows soft paywall and allows unlock via share', async ({ page, request, loginAs, adminUser }) => {
-    // Rely on currentAppSmoke to do the smoke testing which has fallback protections
+  test('Dashboard allows owner to create share-to-unlock campaign and user to unlock it', async ({ page, context, loginAs, adminUser }) => {
     await loginAs(page, adminUser);
-    await currentAppSmoke(page, request, 'viral_share_to_unlock');
+
+    // 1. Navigate to dashboard
+    await page.goto('/dashboard');
+
+    // 2. Find and click the Share-to-Unlock Generator link
+    // Wait for the dashboard to load fully
+    await expect(page.locator('h1', { hasText: 'Dashboard' }).first()).toBeVisible({ timeout: 15000 });
+
+    const generatorLink = page.locator('a[href="share-to-unlock-generator.html"]');
+    await expect(generatorLink).toBeVisible();
+    await generatorLink.click();
+
+    // Verify generator page content
+    await expect(page.getByRole('heading', { name: 'Share-to-Unlock Generator' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Campaign Settings' })).toBeVisible();
+
+    // 3. Fill out the configuration
+    const titleInput = page.getByLabel('Campaign Title');
+    await titleInput.fill('');
+    await titleInput.pressSequentially('Epic Summer Sale');
+
+    const rewardInput = page.getByLabel('Reward Description');
+    await rewardInput.fill('');
+    await rewardInput.pressSequentially('50% Off Select Items');
+
+    const codeInput = page.getByLabel('Hidden Discount Code');
+    await codeInput.fill('');
+    await codeInput.pressSequentially('SUMMER50');
+
+    // 4. Click generate link
+    const generateBtn = page.getByRole('button', { name: 'Generate Link' });
+    await expect(generateBtn).toBeEnabled();
+    await generateBtn.click();
+
+    // 5. Capture the URL
+    await expect(page.getByText('Your Share-to-Unlock Link is Ready!')).toBeVisible();
+    const linkInput = page.locator('#generated-url');
+    const generatedUrl = await linkInput.inputValue();
+    expect(generatedUrl).toContain('/share-to-unlock/index.html');
+    expect(generatedUrl).toContain('SUMMER50');
+    expect(generatedUrl).toContain('Epic+Summer+Sale');
+
+    // 6. Navigate to the generated public URL in a new context
+    const publicPage = await context.newPage();
+    await publicPage.goto(generatedUrl);
+
+    // Verify the public entry page content
+    await expect(publicPage.getByRole('heading', { name: 'Epic Summer Sale' })).toBeVisible();
+    await expect(publicPage.getByText('50% Off Select Items')).toBeVisible();
+
+    // Code is locked initially
+    const codeBox = publicPage.locator('#discount-code');
+    await expect(codeBox).toHaveClass(/locked-code-box/);
+    await expect(codeBox).not.toHaveClass(/unlocked/);
+    await expect(publicPage.locator('#locked-badge')).toBeVisible();
+    await expect(publicPage.locator('#share-actions')).toBeVisible();
+    await expect(publicPage.locator('#unlocked-actions')).not.toBeVisible();
+
+    // Mock window.open so the test doesn't actually open a new tab and block
+    await publicPage.evaluate(() => {
+        window.open = function() { return null; };
+    });
+
+    // 7. Click share to unlock
+    const shareBtn = publicPage.locator('#share-x-btn');
+    await expect(shareBtn).toBeVisible();
+    await shareBtn.click();
+
+    // 8. Verify it unlocks
+    await expect(codeBox).toHaveClass(/unlocked/);
+    await expect(publicPage.locator('#share-actions')).not.toBeVisible();
+    await expect(publicPage.locator('#unlocked-actions')).toBeVisible();
+    await expect(publicPage.locator('#copy-code-btn')).toBeVisible();
+
+    await publicPage.close();
   });
 });

--- a/src/ui/next/next-env.d.ts
+++ b/src/ui/next/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
- Replace the generic `currentAppSmoke` call in `src/e2e/viral_share_to_unlock.spec.ts` with a specific test flow.
- The test flow correctly verifies the `share-to-unlock-generator.html` and `share-to-unlock/index.html` pages.
- It covers creating a campaign, generating the link, visiting the public URL, clicking the share button, and verifying the unlock action.

---
*PR created automatically by Jules for task [8240251068532480905](https://jules.google.com/task/8240251068532480905) started by @ql-owo-lp*