### PR TITLE
feat(docs): polish visual/UX interfaces of documentation pages to premium translucent glass standards

### DIFF
--- a/src/ui/next/src/app/changelog/page.tsx
+++ b/src/ui/next/src/app/changelog/page.tsx
@@ -38,14 +38,14 @@ export default function ChangelogPage() {
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#0071E3]"></div>
             </div>
           ) : sections.length === 0 ? (
-            <p className="text-center text-gray-500 font-medium py-8 bg-white/80 dark:bg-black/50 backdrop-blur-xl saturate-[210%] border border-white/50 dark:border-white/20 shadow-xl rounded-3xl">
+            <p className="text-center text-gray-500 font-medium py-8 backdrop-blur-[40px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.08)] rounded-3xl">
               No changelog available.
             </p>
           ) : (
             sections.map((section, idx) => (
               <div
                 key={idx}
-                className="bg-white/80 dark:bg-black/50 backdrop-blur-xl saturate-[210%] border border-white/50 dark:border-white/20 p-6 sm:p-8 rounded-3xl shadow-xl transition-all hover:-translate-y-1 hover:shadow-2xl hover:border-blue-300 dark:hover:border-blue-700"
+                className="backdrop-blur-[40px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-6 sm:p-8 rounded-3xl transition-all hover:-translate-y-1 hover:shadow-[0_12px_40px_rgba(0,0,0,0.12)] hover:border-blue-300 dark:hover:border-blue-700"
               >
                 <h2 className="text-xl sm:text-2xl font-bold text-[#0071E3] dark:text-blue-400 mb-4 font-outfit">
                   {section.version}

--- a/src/ui/next/src/app/help/page.test.tsx
+++ b/src/ui/next/src/app/help/page.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-vi.mock("next/link", () => ({ default: (props: any) => <a href={props.href}>{props.children}</a> }));
+vi.mock("next/link", () => ({ default: (props: any) => React.createElement("a", { href: props.href }, props.children) }));
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import HelpCenterPage from './page';
 import { TooltipProvider } from '../../components/TooltipRegistry';

--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -60,14 +60,14 @@ export default function HelpCenterPage() {
                 placeholder="Search for help articles and videos..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full p-4 focus:outline-none focus:ring-2 focus:ring-blue-600 shadow-2xl text-gray-900 bg-white/80 dark:bg-black/50 backdrop-blur-xl saturate-[210%] border border-white/50 dark:border-white/20 hover:bg-white/90 min-h-[50px] text-base placeholder:text-gray-500 transition-all rounded-[24px]"
+                className="w-full p-4 focus:outline-none focus:ring-2 focus:ring-blue-600 text-gray-900 backdrop-blur-[40px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.08)] hover:bg-white/90 min-h-[50px] text-base placeholder:text-gray-500 transition-all rounded-[24px]"
               />
             </WithTooltip>
           </div>
         </div>
 
         {filteredArticles.length === 0 && filteredVideos.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 px-4 backdrop-blur-xl saturate-[210%] bg-white/80 dark:bg-black/50 border border-white/50 dark:border-white/20 shadow-2xl rounded-3xl min-h-[300px] w-full max-w-[400px] mx-auto transition-all">
+          <div className="flex flex-col items-center justify-center py-16 px-4 backdrop-blur-[40px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.08)] rounded-3xl min-h-[300px] w-full max-w-[400px] mx-auto transition-all">
             <svg className="w-16 h-16 max-w-[64px] max-h-[64px] text-gray-400 mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
@@ -102,7 +102,7 @@ export default function HelpCenterPage() {
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 flex-col">
                       {filteredArticles.filter(a => (a.category || "General") === category).map((article, idx) => (
                         <Link key={idx} href={article.link} className="block group">
-                          <div className="backdrop-blur-xl saturate-[210%] bg-white/80 dark:bg-black/50 border border-white/50 dark:border-white/20 p-5 sm:p-6 rounded-3xl shadow-xl group-hover:border-blue-400 group-hover:shadow-2xl group-hover:-translate-y-1 hover:bg-white/90 transition-all duration-300 cursor-pointer h-full flex flex-col min-h-[120px] sm:min-h-[140px]">
+                          <div className="backdrop-blur-[40px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 border border-white/40 dark:border-white/10 p-5 sm:p-6 rounded-[24px] shadow-[0_8px_32px_rgba(0,0,0,0.08)] group-hover:border-blue-300 group-hover:shadow-[0_0_15px_rgba(59,130,246,0.5)] group-hover:-translate-y-1 hover:bg-white/90 transition-all duration-300 cursor-pointer h-full flex flex-col min-h-[120px] sm:min-h-[140px]">
                             <h3 className="text-lg sm:text-xl font-bold font-outfit text-blue-600 mb-2 sm:mb-3 group-hover:text-blue-700">{article.title}</h3>
                             <p className="text-sm sm:text-base text-gray-600 leading-relaxed flex-grow">{article.desc}</p>
                           </div>

--- a/src/ui/next/src/components/Walkthrough.tsx
+++ b/src/ui/next/src/components/Walkthrough.tsx
@@ -146,7 +146,7 @@ export function InteractiveWalkthrough({ steps, isOpen, onClose, onComplete }: W
         role="dialog"
         aria-label={`${currentStep.title} walkthrough step`}
         id="walkthrough-bubble"
-        className="ohc-walkthrough-bubble fixed z-[10000] glassmorphism shadow-[0_8px_32px_rgba(0,0,0,0.15)] p-6 w-[300px] max-w-[calc(100vw-32px)] font-inter animate-pop-in"
+        className="ohc-walkthrough-bubble fixed z-[10000] backdrop-blur-[40px] saturate-[210%] bg-white/90 dark:bg-[#1C1C1E]/90 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.15)] p-6 w-[300px] max-w-[calc(100vw-32px)] font-inter animate-pop-in"
         style={bubbleStyle}
       >
         {targetRect && (


### PR DESCRIPTION
As part of continuous codebase optimization, I audited the repository to fulfill the task and realized that the main features were already fully implemented (Help Center, Tooltips, Interactive Walkthroughs, AI-Powered Help Chat, Video Tutorials, API Documentation, Release Notes). Therefore, I've chosen to fulfill the prompt's instruction to polish the visual UI interfaces. I replaced some older CSS and inline glassmorphism styles with explicit Tailwind CSS utility classes aligned with the OHC premium tokens to ensure consistent Apple/Ubiquiti-style translucent glass styling across the documentation pages:

- Replaced CSS in `HelpCenterPage` (`src/ui/next/src/app/help/page.tsx`) with proper translucent glass standards (`backdrop-blur-[40px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.08)]`).
- Upgraded container elements on the `ChangelogPage` (`src/ui/next/src/app/changelog/page.tsx`) with the same uniform styling.
- Refactored `Walkthrough.tsx` to remove generic `glassmorphism` CSS class and instead leverage consistent Tailwind utilities.
- Fixed an existing Vitest JS parsing issue (`src/ui/next/src/app/help/page.test.tsx`) by substituting JSX in `vi.mock` with `React.createElement`.

---
*PR created automatically by Jules for task [15641573693113000070](https://jules.google.com/task/15641573693113000070) started by @ql-owo-lp*