### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Prevent multi-tenant bypass via string padding

### DIFF
--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -687,7 +687,7 @@ impl Store {
                     if ::server_config::get().multitenant && claims.organization_id.clone().unwrap_or_default().trim().is_empty() {
                         return Err("Invalid token: organization_id is required in cloud mode".to_string());
                     }
-                    if ::server_config::get().multitenant && claims.organization_id.as_deref() .map(|s| s.eq_ignore_ascii_case("system")).unwrap_or(false) {
+                    if ::server_config::get().multitenant && claims.organization_id.as_deref().map(|s| s.trim().eq_ignore_ascii_case("system")).unwrap_or(false) {
                         return Err("Invalid token: 'system' organization cannot be used in multitenant mode".to_string());
                     }
                     if self.is_revoked(&claims.jti, &claims.organization_id.clone().unwrap_or_default()).await {
@@ -713,7 +713,7 @@ impl Store {
                     if ::server_config::get().multitenant && data.claims.organization_id.clone().unwrap_or_default().trim().is_empty() {
                         return Err("Invalid token: organization_id is required in cloud mode".to_string());
                     }
-                    if ::server_config::get().multitenant && data.claims.organization_id.as_deref() .map(|s| s.eq_ignore_ascii_case("system")).unwrap_or(false) {
+                    if ::server_config::get().multitenant && data.claims.organization_id.as_deref().map(|s| s.trim().eq_ignore_ascii_case("system")).unwrap_or(false) {
                         return Err("Invalid token: 'system' organization cannot be used in multitenant mode".to_string());
                     }
                     if self.is_revoked(&data.claims.jti, &data.claims.organization_id.clone().unwrap_or_default()).await {
@@ -737,7 +737,7 @@ impl Store {
                         if ::server_config::get().multitenant && claims.organization_id.clone().unwrap_or_default().trim().is_empty() {
                             return Err("Invalid token: organization_id is required in cloud mode".to_string());
                         }
-                        if ::server_config::get().multitenant && claims.organization_id.as_deref() .map(|s| s.eq_ignore_ascii_case("system")).unwrap_or(false) {
+                        if ::server_config::get().multitenant && claims.organization_id.as_deref().map(|s| s.trim().eq_ignore_ascii_case("system")).unwrap_or(false) {
                             return Err("Invalid token: 'system' organization cannot be used in multitenant mode".to_string());
                         }
                         if self.is_revoked(&claims.jti, &claims.organization_id.clone().unwrap_or_default()).await {

--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -49,7 +49,7 @@ impl UserRepository for PgUserRepository {
         validate_org_id!(org_id);
         let roles_json = serde_json::to_string(&user.roles).unwrap_or_default();
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
@@ -102,7 +102,7 @@ impl UserRepository for PgUserRepository {
         validate_org_id!(org_id);
 
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1"
@@ -148,7 +148,7 @@ impl UserRepository for PgUserRepository {
         validate_org_id!(org_id);
 
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE username = $1"
@@ -193,7 +193,7 @@ impl UserRepository for PgUserRepository {
         validate_org_id!(org_id);
 
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1"
@@ -238,7 +238,7 @@ impl UserRepository for PgUserRepository {
         validate_org_id!(org_id);
 
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1"
@@ -282,7 +282,7 @@ impl UserRepository for PgUserRepository {
     async fn list_users(&self, org_id: &str) -> Result<Vec<User>, String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users ORDER BY created_at"
         } else {
@@ -326,7 +326,7 @@ impl UserRepository for PgUserRepository {
         validate_org_id!(org_id);
         let roles_json = serde_json::to_string(&user.roles).unwrap_or_default();
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         let query = if should_bypass {
             r#"
@@ -385,7 +385,7 @@ impl UserRepository for PgUserRepository {
     async fn delete_user(&self, id: &str, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
         let query = if should_bypass {
             "DELETE FROM users WHERE id = $1 RETURNING id"
         } else {
@@ -413,7 +413,7 @@ impl UserRepository for PgUserRepository {
     async fn revoke_token(&self, jti: String, exp: DateTime<Utc>, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
@@ -447,7 +447,7 @@ impl UserRepository for PgUserRepository {
     async fn is_revoked(&self, jti: &str, org_id: &str) -> Result<bool, String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
@@ -523,7 +523,7 @@ mod security_tests {
         let old_val = std::env::var("OHC_MULTITENANT").ok();
         unsafe { std::env::set_var("OHC_MULTITENANT", "true"); }
         let is_multitenant = is_multitenant_mode();
-        let org_id = "system"; let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let org_id = "system"; let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         // Ensure the condition strictly evaluates to false when multitenant is true.
         assert!(!should_bypass, "Cloud mode should NEVER bypass tenant filters when org_id is 'system'");

--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -74,7 +74,7 @@ impl UserRepository for SqliteUserRepository {
     async fn get_by_id(&self, id: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1"
         } else {
@@ -111,7 +111,7 @@ impl UserRepository for SqliteUserRepository {
     async fn get_by_username(&self, username: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE username = $1"
         } else {
@@ -148,7 +148,7 @@ impl UserRepository for SqliteUserRepository {
     async fn get_by_email(&self, email: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1"
         } else {
@@ -185,7 +185,7 @@ impl UserRepository for SqliteUserRepository {
     async fn get_by_oidc_subject(&self, sub: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1"
         } else {
@@ -222,7 +222,7 @@ impl UserRepository for SqliteUserRepository {
     async fn list_users(&self, org_id: &str) -> Result<Vec<User>, String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
         let query = if should_bypass {
             "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users ORDER BY created_at"
         } else {
@@ -259,7 +259,7 @@ impl UserRepository for SqliteUserRepository {
         validate_org_id!(org_id);
         let roles_json = serde_json::to_string(&user.roles).unwrap_or_default();
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         let query = if should_bypass {
             r#"
@@ -314,7 +314,7 @@ impl UserRepository for SqliteUserRepository {
     async fn delete_user(&self, id: &str, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
         let query = if should_bypass {
             "DELETE FROM users WHERE id = $1 RETURNING id"
         } else {
@@ -335,7 +335,7 @@ impl UserRepository for SqliteUserRepository {
     async fn revoke_token(&self, jti: String, exp: DateTime<Utc>, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
 
@@ -368,7 +368,7 @@ impl UserRepository for SqliteUserRepository {
     async fn is_revoked(&self, jti: &str, org_id: &str) -> Result<bool, String> {
         validate_org_id!(org_id);
         let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+        let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
 
         let row = if should_bypass {
             sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $2")
@@ -518,7 +518,7 @@ mod tests {
         let repo = SqliteUserRepository::new(_pool.clone());
         temp_env::async_with_vars([("OHC_MULTITENANT", Some("true"))], async {
             let is_multitenant = is_multitenant_mode();
-            let org_id = "system"; let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
+            let org_id = "system"; let should_bypass = (!is_multitenant) && org_id.trim().eq_ignore_ascii_case("system");
             assert!(!should_bypass || is_multitenant == false, "Cloud mode should NEVER bypass tenant filters when org_id is 'system'");
 
             let res = repo.get_by_id("dummy_id", "system").await;


### PR DESCRIPTION
Fixes a vulnerability where users can bypass tenant-specific isolation using whitespace padded `" system "` strings in the `organization_id` claim. Added trimming on the claims before strictly checking for the system bypass ID. All Bazel tests for `server_auth` are passing successfully.

---
*PR created automatically by Jules for task [2178037185294285413](https://jules.google.com/task/2178037185294285413) started by @ql-owo-lp*