### PR TITLE
feat: Implement AI Voice Ordering to SMS Handoff

### DIFF
--- a/src/server/api/twilio_voice.rs
+++ b/src/server/api/twilio_voice.rs
@@ -139,11 +139,18 @@ pub async fn twilio_voice_status_handler(
         let actions = state.voice_engine.actions.lock().await;
         let session_actions: Vec<_> = actions.iter().filter(|a| a.session_id == call_sid).collect();
         let has_booking_intent = session_actions.iter().any(|a| a.intent_type == "BOOK_APPOINTMENT");
+        let has_order_intent = session_actions.iter().any(|a| a.intent_type == "ORDER_FOOD");
 
         let deposit_link = session_actions.iter()
             .find(|a| a.intent_type == "BOOK_APPOINTMENT")
             .and_then(|a| a.details.get("deposit_link").and_then(|v| v.as_str()))
             .unwrap_or("https://pay.ohc.com/deposit/voice")
+            .to_string();
+
+        let order_link = session_actions.iter()
+            .find(|a| a.intent_type == "ORDER_FOOD")
+            .and_then(|a| a.details.get("order_link").and_then(|v| v.as_str()))
+            .unwrap_or("https://pay.ohc.com/store/voice")
             .to_string();
         drop(actions);
 
@@ -237,6 +244,28 @@ pub async fn twilio_voice_status_handler(
                         "summary": summary,
                         "caller_phone": clean_caller,
                         "deposit_link": deposit_link,
+                    });
+                    task.proposed_content = Some(proposed_content.to_string());
+
+                    let _ = task_manager.insert_task(task);
+                }
+            }
+
+            if has_order_intent {
+                let task_manager = crate::tasks::TaskManager::with_db(state.db.clone());
+                let mission_id = uuid::Uuid::new_v4().to_string();
+
+                let title = format!("Voice Order Request from {}", clean_caller);
+                let priority = "P1".to_string();
+
+                if let Ok(mut task) = task_manager.create_task(tenant_id.clone(), mission_id, title, summary.clone(), priority) {
+                    task.approval_status = Some("PENDING".to_string());
+
+                    let proposed_content = serde_json::json!({
+                        "feature_type": "order_draft",
+                        "summary": summary,
+                        "caller_phone": clean_caller,
+                        "order_link": order_link,
                     });
                     task.proposed_content = Some(proposed_content.to_string());
 

--- a/src/server/voice/router.rs
+++ b/src/server/voice/router.rs
@@ -31,7 +31,7 @@ pub struct LlmVoiceTurnPlanner;
 impl VoiceTurnPlanner for LlmVoiceTurnPlanner {
     async fn plan_turn(&self, session_id: &str, user_text: &str) -> Result<VoiceTurnPlan, String> {
         let prompt = format!(
-            "You are the OneHumanCorp voice receptionist planner. Return strict JSON with keys intent_type, ai_response, and sms_body. intent_type must be CHECK_AVAILABILITY, BOOK_APPOINTMENT, or GENERAL_HELP. Use sms_body only when the caller explicitly confirms a booking and a secure confirmation/deposit link should be sent. Do not invent exact appointment availability; ask a concise follow-up when calendar data is not present. Session: {session_id}. Caller said: {user_text}"
+            "You are the OneHumanCorp voice receptionist planner. Return strict JSON with keys intent_type, ai_response, and sms_body. intent_type must be CHECK_AVAILABILITY, BOOK_APPOINTMENT, GENERAL_HELP, ORDER_FOOD, or GENERAL_INQUIRY. Use sms_body only when the caller explicitly confirms a booking and a secure confirmation/deposit link should be sent, or if the caller wants to place an order (ORDER_FOOD), immediately offer to send them a secure ordering link via SMS and include the link (e.g., https://pay.ohc.com/store/voice) in the sms_body. Do not invent exact appointment availability; ask a concise follow-up when calendar data is not present. Session: {session_id}. Caller said: {user_text}"
         );
 
         let provider = std::env::var("OHC_VOICE_LLM_PROVIDER")
@@ -196,6 +196,14 @@ mod tests {
         assert_eq!(plan.intent_type.as_deref(), Some("BOOK_APPOINTMENT"));
         assert_eq!(plan.ai_response, "I sent the confirmation link.");
         assert_eq!(plan.sms_body.as_deref(), Some("Confirm here: https://ohc.example/confirm"));
+
+        let plan2 = parse_voice_turn_plan(
+            r#"{"intent_type":"ORDER_FOOD","ai_response":"I am an automated assistant. I'm texting you a link to our online menu right now so you can place your order. Please check your messages!","sms_body":"Order here: https://pay.ohc.com/store/voice"}"#,
+        )
+        .unwrap();
+        assert_eq!(plan2.intent_type.as_deref(), Some("ORDER_FOOD"));
+        assert_eq!(plan2.ai_response, "I am an automated assistant. I'm texting you a link to our online menu right now so you can place your order. Please check your messages!");
+        assert_eq!(plan2.sms_body.as_deref(), Some("Order here: https://pay.ohc.com/store/voice"));
     }
 
     #[tokio::test]
@@ -236,5 +244,35 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert_eq!(actions[0].intent_type, "CHECK_AVAILABILITY");
         assert_eq!(actions[1].intent_type, "BOOK_APPOINTMENT");
+    }
+
+    #[tokio::test]
+    async fn test_voice_context_router_ordering_flow() {
+        let engine = Arc::new(VoiceAIEdgeEngine::new());
+        let sent = Arc::new(AtomicUsize::new(0));
+        let mock_twilio = Arc::new(TwilioProvider::with_client(Arc::new(MockTwilioClient { sent_messages: sent.clone() })));
+        let planner = Arc::new(ScriptedVoiceTurnPlanner {
+            plans: tokio::sync::Mutex::new(vec![
+                VoiceTurnPlan {
+                    intent_type: Some("ORDER_FOOD".to_string()),
+                    ai_response: "I am an automated assistant. I'm texting you a link to our online menu right now so you can place your order. Please check your messages!".to_string(),
+                    sms_body: Some("Order here: https://pay.ohc.com/store/voice".to_string()),
+                },
+            ]),
+        });
+
+        let router = VoiceContextRouter::with_planner(engine.clone(), mock_twilio, planner);
+        let session_id = engine.handle_incoming_call("merchant_456", "+1122334455").await;
+
+        let response = router.process_user_input(&session_id, "I want to place an order for pickup", "+0987654321").await;
+        assert!(response.contains("texting you a link"));
+
+        // Ensure SMS was sent
+        assert_eq!(sent.load(Ordering::SeqCst), 1);
+
+        // Ensure intent was logged
+        let actions = engine.actions.lock().await;
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].intent_type, "ORDER_FOOD");
     }
 }


### PR DESCRIPTION
This implements the "Voice-to-SMS Handoff" flow for small businesses (specifically targeting a food cart operator persona, Fatima). When a customer calls in and wants to place an order, the system identifies the `ORDER_FOOD` intent and sends an SMS with an online ordering link instead of trying to take the complex order over the phone.

Changes:
* Modified `src/server/voice/router.rs` `LlmVoiceTurnPlanner::plan_turn` prompt to support `ORDER_FOOD` and `GENERAL_INQUIRY` intents.
* Added `test_voice_context_router_ordering_flow` to `src/server/voice/router.rs` to verify the order flow end-to-end.
* Updated `src/server/api/twilio_voice.rs` `twilio_voice_status_handler` to identify the `ORDER_FOOD` intent and extract the `order_link`.
* Created a task in `TaskManager` for the owner's Agent Feed when `ORDER_FOOD` is detected, indicating that the SMS ordering link was sent.

---
*PR created automatically by Jules for task [5710791731824425148](https://jules.google.com/task/5710791731824425148) started by @wbbsuper*

Resolves #31789