### PR TITLE
feat: AI Voice Ordering for Small Business

### DIFF
--- a/src/server/api/twilio_voice.rs
+++ b/src/server/api/twilio_voice.rs
@@ -140,11 +140,21 @@ pub async fn twilio_voice_status_handler(
         let session_actions: Vec<_> = actions.iter().filter(|a| a.session_id == call_sid).collect();
         let has_booking_intent = session_actions.iter().any(|a| a.intent_type == "BOOK_APPOINTMENT");
 
+        let has_order_food_intent = session_actions.iter().any(|a| a.intent_type == "ORDER_FOOD");
+
         let deposit_link = session_actions.iter()
             .find(|a| a.intent_type == "BOOK_APPOINTMENT")
             .and_then(|a| a.details.get("deposit_link").and_then(|v| v.as_str()))
             .unwrap_or("https://pay.ohc.com/deposit/voice")
             .to_string();
+
+        let link_to_send = if has_booking_intent {
+            deposit_link.clone()
+        } else if has_order_food_intent {
+            "https://pay.ohc.com/order/voice".to_string()
+        } else {
+            "".to_string()
+        };
         drop(actions);
 
         let transcripts = state.voice_engine.transcripts.lock().await;
@@ -222,21 +232,22 @@ pub async fn twilio_voice_status_handler(
                 tracing::error!("Failed to insert voice call transcript into omni_inbox_messages: {}", e);
             }
 
-            if has_booking_intent {
+            if has_booking_intent || has_order_food_intent {
                 let task_manager = crate::tasks::TaskManager::with_db(state.db.clone());
                 let mission_id = uuid::Uuid::new_v4().to_string();
 
-                let title = format!("Voice Booking Request from {}", clean_caller);
+                let title = if has_booking_intent { format!("Voice Booking Request from {}", clean_caller) } else { format!("Voice Order Handled for {}", clean_caller) };
                 let priority = "P1".to_string(); // Requires approval
 
                 if let Ok(mut task) = task_manager.create_task(tenant_id.clone(), mission_id, title, summary.clone(), priority) {
-                    task.approval_status = Some("PENDING".to_string());
+                    task.approval_status = if has_booking_intent { Some("PENDING".to_string()) } else { None };
+                    task.status = if has_order_food_intent { "COMPLETED".to_string() } else { "PENDING".to_string() };
 
                     let proposed_content = serde_json::json!({
-                        "feature_type": "booking_draft",
+                        "feature_type": if has_booking_intent { "booking_draft" } else { "order_food" },
                         "summary": summary,
                         "caller_phone": clean_caller,
-                        "deposit_link": deposit_link,
+                        "link_sent": link_to_send,
                     });
                     task.proposed_content = Some(proposed_content.to_string());
 

--- a/src/server/voice/router.rs
+++ b/src/server/voice/router.rs
@@ -31,7 +31,7 @@ pub struct LlmVoiceTurnPlanner;
 impl VoiceTurnPlanner for LlmVoiceTurnPlanner {
     async fn plan_turn(&self, session_id: &str, user_text: &str) -> Result<VoiceTurnPlan, String> {
         let prompt = format!(
-            "You are the OneHumanCorp voice receptionist planner. Return strict JSON with keys intent_type, ai_response, and sms_body. intent_type must be CHECK_AVAILABILITY, BOOK_APPOINTMENT, or GENERAL_HELP. Use sms_body only when the caller explicitly confirms a booking and a secure confirmation/deposit link should be sent. Do not invent exact appointment availability; ask a concise follow-up when calendar data is not present. Session: {session_id}. Caller said: {user_text}"
+            "You are the OneHumanCorp voice receptionist planner. Return strict JSON with keys intent_type, ai_response, and sms_body. intent_type must be CHECK_AVAILABILITY, BOOK_APPOINTMENT, ORDER_FOOD, GENERAL_INQUIRY, or GENERAL_HELP. Use sms_body only when the caller explicitly confirms a booking and a secure confirmation/deposit link should be sent, or when the intent is ORDER_FOOD (use 'https://pay.ohc.com/order/voice' as the link). If the intent is ORDER_FOOD, explicitly respond with: 'Absolutely. I am an automated assistant. I'm texting you a link to our online menu right now so you can place your order. Please check your messages!' (translated into the caller's detected language). Detect the caller's language and always respond in the same language. Do not invent exact appointment availability; ask a concise follow-up when calendar data is not present. Session: {session_id}. Caller said: {user_text}"
         );
 
         let provider = std::env::var("OHC_VOICE_LLM_PROVIDER")
@@ -196,6 +196,15 @@ mod tests {
         assert_eq!(plan.intent_type.as_deref(), Some("BOOK_APPOINTMENT"));
         assert_eq!(plan.ai_response, "I sent the confirmation link.");
         assert_eq!(plan.sms_body.as_deref(), Some("Confirm here: https://ohc.example/confirm"));
+
+        let plan2 = parse_voice_turn_plan(
+            r#"{"intent_type":"ORDER_FOOD","ai_response":"Absolutely. I am an automated assistant. I'm texting you a link to our online menu right now so you can place your order. Please check your messages!","sms_body":"https://pay.ohc.com/order/voice"}"#,
+        )
+        .unwrap();
+        assert_eq!(plan2.intent_type.as_deref(), Some("ORDER_FOOD"));
+        assert_eq!(plan2.ai_response, "Absolutely. I am an automated assistant. I'm texting you a link to our online menu right now so you can place your order. Please check your messages!");
+        assert_eq!(plan2.sms_body.as_deref(), Some("https://pay.ohc.com/order/voice"));
+
     }
 
     #[tokio::test]
@@ -236,5 +245,42 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert_eq!(actions[0].intent_type, "CHECK_AVAILABILITY");
         assert_eq!(actions[1].intent_type, "BOOK_APPOINTMENT");
+    }
+
+    #[tokio::test]
+    async fn test_voice_context_router_order_food_flow() {
+        let engine = Arc::new(VoiceAIEdgeEngine::new());
+        let sent = Arc::new(AtomicUsize::new(0));
+        let mock_twilio = Arc::new(TwilioProvider::with_client(Arc::new(MockTwilioClient { sent_messages: sent.clone() })));
+        let planner = Arc::new(ScriptedVoiceTurnPlanner {
+            plans: tokio::sync::Mutex::new(vec![
+                VoiceTurnPlan {
+                    intent_type: Some("GENERAL_INQUIRY".to_string()),
+                    ai_response: "Hello, how can I help?".to_string(),
+                    sms_body: None,
+                },
+                VoiceTurnPlan {
+                    intent_type: Some("ORDER_FOOD".to_string()),
+                    ai_response: "Absolutely. I am an automated assistant. I'm texting you a link to our online menu right now so you can place your order. Please check your messages!".to_string(),
+                    sms_body: Some("https://pay.ohc.com/order/voice".to_string()),
+                },
+            ]),
+        });
+
+        let router = VoiceContextRouter::with_planner(engine.clone(), mock_twilio, planner);
+
+        let session_id = engine.handle_incoming_call("merchant_123", "+1234567890").await;
+
+        let response1 = router.process_user_input(&session_id, "Hi there", "+0987654321").await;
+        assert!(response1.contains("how can I help"));
+
+        let response2 = router.process_user_input(&session_id, "I'd like to place an order for pickup", "+0987654321").await;
+        assert!(response2.contains("automated assistant"));
+
+        assert_eq!(sent.load(Ordering::SeqCst), 1);
+
+        let actions = engine.actions.lock().await;
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[1].intent_type, "ORDER_FOOD");
     }
 }


### PR DESCRIPTION
Resolves #31789

Implements the Voice-to-SMS Ordering Handoff for SMBs by adding `ORDER_FOOD` and `GENERAL_INQUIRY` intents to the AI voice receptionist. It replies with a confirmation and dispatches an SMS link to order food, and logs the task as completed in the agent feed.

---
*PR created automatically by Jules for task [16018427678836205356](https://jules.google.com/task/16018427678836205356) started by @ql-owo-lp*