### PR TITLE
fix: handle network errors gracefully in viral loyalty widget

### DIFF
--- a/src/ui/tauri/src/ui/viral-loyalty-widget.html
+++ b/src/ui/tauri/src/ui/viral-loyalty-widget.html
@@ -245,17 +245,24 @@
 
       try {
         const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'e2e-tenant';
+        let refId = tenantId;
 
-        // This simulates generating a program
-        const res = await fetch('/api/v1/growth/referrals/generate', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'x-spiffe-id': 'spiffe://onehumancorp.io/' + tenantId + '/agent1'
-            }
-        });
-        const data = await res.json();
-        const refId = data.referral_link ? data.referral_link.split('/').pop() : tenantId;
+        try {
+          // This simulates generating a program
+          const res = await fetch('/api/v1/growth/referrals/generate', {
+              method: 'POST',
+              headers: {
+                  'Content-Type': 'application/json',
+                  'x-spiffe-id': 'spiffe://onehumancorp.io/' + tenantId + '/agent1'
+              }
+          });
+          const data = await res.json();
+          if (data.referral_link) {
+              refId = data.referral_link.split('/').pop();
+          }
+        } catch (fetchErr) {
+            console.error("Error calling generate API, using fallback", fetchErr);
+        }
 
         // Show result
         const baseUrl = window.location.origin;


### PR DESCRIPTION
Wrapped the `/api/v1/growth/referrals/generate` fetch in `src/ui/tauri/src/ui/viral-loyalty-widget.html` within its own try/catch block. This prevents the widget from breaking if the backend is down or the JSON response is invalid, allowing the UI to gracefully fall back and complete its animation.

---
*PR created automatically by Jules for task [16571584870431914629](https://jules.google.com/task/16571584870431914629) started by @ql-owo-lp*