### PR TITLE
🛡️ Sentinel: Fix TOCTOU vulnerability in standalone mode

### DIFF
--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -204,14 +204,14 @@ impl ModeEnforcer for StandaloneModeEnforcer {
                         #[cfg(unix)] builder.mode(0o700);
                         let _ = builder.create(parent);
                     }
-                match OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .create(true)
-                    .truncate(false)
-                    .mode(0o600)
-                    .open(db_path)
-                {
+                let mut opts = OpenOptions::new();
+                opts.read(true).write(true).create(true).truncate(false).mode(0o600);
+                #[cfg(target_os = "linux")]
+                opts.custom_flags(0x00020000); // O_NOFOLLOW
+                #[cfg(target_os = "macos")]
+                opts.custom_flags(0x0100); // O_NOFOLLOW
+
+                match opts.open(db_path) {
                     Ok(file) => {
                         if let Ok(metadata) = file.metadata() {
                             let mut perms = metadata.permissions();

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -287,46 +287,24 @@ impl DB {
                             }
                         }
 
-                        if !db_path.exists() {
-                            let file = OpenOptions::new()
-                                .read(true)
-                                .write(true)
-                                .create_new(true) // Prevent TOCTOU vulnerabilities
-                                .mode(0o600)
-                                .open(&db_path)?;
+                        let mut opts = OpenOptions::new();
+                        opts.read(true).write(true).create(true).mode(0o600);
+                        #[cfg(target_os = "linux")]
+                        opts.custom_flags(0x00020000); // O_NOFOLLOW
+                        #[cfg(target_os = "macos")]
+                        opts.custom_flags(0x0100); // O_NOFOLLOW
 
-                            let metadata = file.metadata()?;
-                            let mut perms = metadata.permissions();
-                            if (perms.mode() & 0o777) != 0o600 {
-                                perms.set_mode(0o600);
-                                if let Err(e) = file.set_permissions(perms) {
-                                    tracing::error!(
-                                        "Failed to securely update existing standalone database file permissions: {}",
-                                        e
-                                    );
-                                    return Err(e.into());
-                                }
-                            }
-                        } else {
-                            let mut opts = OpenOptions::new();
-                            opts.read(true).write(true);
-                            #[cfg(target_os = "linux")]
-                            opts.custom_flags(0x00020000); // O_NOFOLLOW
-                            #[cfg(target_os = "macos")]
-                            opts.custom_flags(0x0100); // O_NOFOLLOW
-
-                            let file = opts.open(&db_path)?;
-                            let metadata = file.metadata()?;
-                            let mut perms = metadata.permissions();
-                            if (perms.mode() & 0o777) != 0o600 {
-                                perms.set_mode(0o600);
-                                if let Err(e) = file.set_permissions(perms) {
-                                    tracing::error!(
-                                        "Failed to securely update existing standalone database file permissions: {}",
-                                        e
-                                    );
-                                    return Err(e.into());
-                                }
+                        let file = opts.open(&db_path)?;
+                        let metadata = file.metadata()?;
+                        let mut perms = metadata.permissions();
+                        if (perms.mode() & 0o777) != 0o600 {
+                            perms.set_mode(0o600);
+                            if let Err(e) = file.set_permissions(perms) {
+                                tracing::error!(
+                                    "Failed to securely update existing standalone database file permissions: {}",
+                                    e
+                                );
+                                return Err(e.into());
                             }
                         }
                     }


### PR DESCRIPTION
- Addressed `TOCTOU` (Time-of-check to Time-of-use) and symlink file vulnerabilities for `.ohc_jwt_secret` and `.ohc_sqlite_key`
- Enforced strict 0600 file permissions and prevented symlink resolution using `O_NOFOLLOW` exclusively in Standalone mode
- Ensured Kubernetes components which rely on `symlinks` such as `Secrets` and `ConfigMaps` are untouched by skipping `O_NOFOLLOW` flags when multitenancy is true.

---
*PR created automatically by Jules for task [11105442806815508482](https://jules.google.com/task/11105442806815508482) started by @ql-owo-lp*