### PR TITLE
Fix offline Tap-to-Pay and update POS offline indicator

### DIFF
--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -269,49 +269,12 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
   const processPayment = async () => {
     if (!terminal || !connectedReader) return;
 
-    setReserving(true);
-
     if (!navigator.onLine) {
-       setStatus('Processing offline payment...');
-       onOptimisticReserve?.();
-       // Mock the terminal process for offline
-       setTimeout(async () => {
-          const transactionId = `tx_offline_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
-          const tx = {
-             id: transactionId,
-             type: 'tap_to_pay',
-             client_id: 'terminal_1',
-             amount_cents: amount,
-             amount: amount,
-             currency: 'usd',
-             product_id: cart ? cart[0].product.id : productId,
-             quantity: cart ? cart[0].quantity : 1,
-             payload: JSON.stringify((cart || [{product: {id: productId}, quantity: 1}]).map(c => ({ product_id: c.product.id, quantity: c.quantity }))),
-             timestamp: new Date().toISOString()
-          };
-
-          for (const item of (cart || [{product: {id: productId}, quantity: 1}])) {
-            const crdtTx = {
-              id: `crdt_${transactionId}_${item.product.id}`,
-              type: 'CRDT_MUTATION',
-              timestamp: new Date().toISOString(),
-              payload: {
-                 entity_id: item.product.id,
-                 data: {
-                    pn_counter_n_increment: -item.quantity
-                 }
-              }
-            };
-            await SyncManager.getInstance().enqueue(crdtTx);
-          }
-          await SyncManager.getInstance().enqueue(tx);
-
-          setStatus('Payment saved offline. Will sync when network is restored.');
-          setTimeout(() => setStatus('Terminal ready.'), 3000);
-          setReserving(false);
-       }, 1500);
+       setStatus('Tap-to-Pay requires an active internet connection. Please use Cash Sale instead.');
        return;
     }
+
+    setReserving(true);
 
     setStatus('Reserving inventory...');
     onOptimisticReserve?.();
@@ -460,6 +423,10 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
         <div className="mt-4">
           <button id="tap-to-pay-btn" onClick={async () => {
             if (!terminal) return;
+            if (typeof window !== 'undefined' && !navigator.onLine) {
+              setStatus('Tap-to-Pay requires an active internet connection. Please use Cash Sale instead.');
+              return;
+            }
             setReserving(true);
             setStatus('Initializing Tap to Pay...');
 
@@ -568,7 +535,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
             } finally {
               setReserving(false);
             }
-          }} disabled={reserving} className={`w-full bg-gradient-to-b from-[#000000] to-[#333333] text-white px-4 py-4 min-h-[56px] rounded-xl font-bold text-lg hover:bg-gray-800 transition-colors shadow-xl shadow-gray-500/20 active:scale-[0.98] ${reserving ? 'opacity-50' : ''}`}>
+          }} disabled={reserving || (typeof window !== 'undefined' && !navigator.onLine)} className={`w-full bg-gradient-to-b from-[#000000] to-[#333333] text-white px-4 py-4 min-h-[56px] rounded-xl font-bold text-lg transition-colors shadow-xl shadow-gray-500/20 active:scale-[0.98] ${reserving || (typeof window !== 'undefined' && !navigator.onLine) ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-800'}`}>
             {reserving ? 'Processing...' : 'Tap to Pay'}
           </button>
         </div>
@@ -576,7 +543,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
 
       {!connectedReader && (
         <div className="mb-4">
-          <button onClick={discoverReaders} className="w-full bg-[#0066FF] text-white px-4 py-3 min-h-[44px] rounded-xl font-bold hover:bg-blue-700 transition-colors shadow-md shadow-blue-500/20 active:scale-[0.98]">
+          <button onClick={discoverReaders} disabled={typeof window !== 'undefined' && !navigator.onLine} className={`w-full bg-[#0066FF] text-white px-4 py-3 min-h-[44px] rounded-xl font-bold shadow-md shadow-blue-500/20 active:scale-[0.98] transition-colors ${(typeof window !== 'undefined' && !navigator.onLine) ? 'opacity-50 cursor-not-allowed' : 'hover:bg-blue-700'}`}>
             Discover Readers
           </button>
           <ul className="mt-4 space-y-2">
@@ -594,7 +561,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
 
       {connectedReader ? (
         <div className="flex gap-2 mt-4">
-          <button id="charge-btn" onClick={processPayment} disabled={reserving} className={`flex-1 bg-gradient-to-b from-[#0066FF] to-[#0052CC] text-white px-6 py-4 min-h-[56px] rounded-2xl font-bold text-lg shadow-xl shadow-blue-500/30 transition-all charge-btn ${reserving ? 'opacity-50' : 'hover:shadow-blue-500/40 hover:scale-[1.02] active:scale-[0.98]'}`}>
+          <button id="charge-btn" onClick={processPayment} disabled={reserving || typeof window !== 'undefined' && !navigator.onLine} className={`flex-1 bg-gradient-to-b from-[#0066FF] to-[#0052CC] text-white px-6 py-4 min-h-[56px] rounded-2xl font-bold text-lg shadow-xl shadow-blue-500/30 transition-all charge-btn ${reserving || (typeof window !== 'undefined' && !navigator.onLine) ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-blue-500/40 hover:scale-[1.02] active:scale-[0.98]'}`}>
             {reserving ? 'Processing...' : `Charge $${(amount / 100).toFixed(2)}`}
           </button>
           <button id="cash-btn" onClick={processCashSale} disabled={reserving} className={`flex-1 bg-gradient-to-b from-[#34C759] to-[#28A745] text-white px-6 py-4 min-h-[56px] rounded-2xl font-bold text-lg shadow-xl shadow-green-500/30 transition-all cash-btn ${reserving ? 'opacity-50' : 'hover:shadow-green-500/40 hover:scale-[1.02] active:scale-[0.98]'}`}>

--- a/src/ui/next/src/app/pos/terminal/page.tsx
+++ b/src/ui/next/src/app/pos/terminal/page.tsx
@@ -339,7 +339,7 @@ export default function POSTerminal() {
             {isOffline ? (
               <div className="inline-flex items-center gap-1.5 mt-1 text-yellow-800 font-bold text-xs bg-yellow-100 px-2 py-1 rounded border border-yellow-200 shadow-sm">
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-                {t('Offline - Changes will sync later')}
+                {t('Offline - Syncing later')}
               </div>
             ) : (
               <span className="inline-block mt-1 text-green-800 font-bold text-xs bg-green-100 px-2 py-1 rounded border border-green-200 shadow-sm">{t('Online')}</span>

--- a/src/ui/next/src/e2e/pos-inventory-sync-optimistic.spec.ts
+++ b/src/ui/next/src/e2e/pos-inventory-sync-optimistic.spec.ts
@@ -238,7 +238,7 @@ test.describe('POS Inventory Sync - Optimistic UI', () => {
       await page.context().setOffline(true);
 
       // Verify offline mode indicator
-      await expect(page.getByText('Offline - Changes will sync later')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText('Offline - Syncing later')).toBeVisible({ timeout: 5000 });
 
       // Click the "Charge" button to open cart drawer
       const collectBtn = page.locator('button', { hasText: /Charge/i }).first();


### PR DESCRIPTION
Resolves #31828

Implemented constraints on the offline-first POS functionality:
1. Tap-to-Pay now properly requires an active internet connection to authorize, safely displaying an error if attempted while offline, rather than failing gracefully or falsely queueing the transaction.
2. Disabled the "Tap to Pay", "Charge", and "Discover Readers" buttons dynamically while the terminal is offline.
3. Updated the offline indicator text to explicitly match the "Offline - Syncing later" requirement from the design doc.
4. Cash sales remain fully functional and correctly queue offline mutations via CRDTs.
5. Adjusted Playwright E2E testing to expect the correct offline indicator string.

---
*PR created automatically by Jules for task [6437068336209260475](https://jules.google.com/task/6437068336209260475) started by @ql-owo-lp*