### PR TITLE
chore(helm): tune VPA updateMode based on HPA

### DIFF
--- a/deploy/helm/ohc/templates/vpa.yaml
+++ b/deploy/helm/ohc/templates/vpa.yaml
@@ -11,7 +11,11 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-backend
   updatePolicy:
+    {{- if .Values.backend.autoscaling.enabled }}
+    updateMode: "Off"
+    {{- else }}
     updateMode: "Auto"
+    {{- end }}
   resourcePolicy:
     containerPolicies:
       - containerName: backend
@@ -32,7 +36,11 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-core
   updatePolicy:
+    {{- if .Values.ohcCore.autoscaling.enabled }}
+    updateMode: "Off"
+    {{- else }}
     updateMode: "Auto"
+    {{- end }}
   resourcePolicy:
     containerPolicies:
       - containerName: ohc-core
@@ -53,7 +61,11 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-chatwoot
   updatePolicy:
+    {{- if .Values.chatwoot.autoscaling.enabled }}
+    updateMode: "Off"
+    {{- else }}
     updateMode: "Auto"
+    {{- end }}
   resourcePolicy:
     containerPolicies:
       - containerName: chatwoot
@@ -74,7 +86,11 @@ spec:
     kind: Deployment
     name: {{ include "ohc.fullname" . }}-powersync
   updatePolicy:
+    {{- if .Values.powersync.autoscaling.enabled }}
+    updateMode: "Off"
+    {{- else }}
     updateMode: "Auto"
+    {{- end }}
   resourcePolicy:
     containerPolicies:
       - containerName: powersync


### PR DESCRIPTION
Modifies `deploy/helm/ohc/templates/vpa.yaml` to set `updateMode: "Off"` when `autoscaling.enabled` is true, allowing VPA to act as a recommender instead of overriding HPA. The PodCrashLooping alert in `prometheusrule.yaml` was verified to already be correct. Tests were skipped according to instructions due to timeout issues.

---
*PR created automatically by Jules for task [12637603949187461215](https://jules.google.com/task/12637603949187461215) started by @ql-owo-lp*