### PR TITLE
test(e2e): fix race condition in triage action feed tests

### DIFF
--- a/src/ui/next/src/e2e/triage-action-feed.spec.ts
+++ b/src/ui/next/src/e2e/triage-action-feed.spec.ts
@@ -65,8 +65,13 @@ test.describe('Triage Action Feed UI', () => {
     while (count > 0) {
       const firstCard = listItems.nth(0);
       const testId = await firstCard.getAttribute('data-testid');
-      const approveBtn = firstCard.locator('button', { hasText: /Approve|Yes, draft it!/i }).first();
-      const dismissBtn = firstCard.locator('button', { hasText: /Dismiss|Deny/i }).first();
+      const approveBtn = firstCard.locator('button[data-testid="approve-triage-btn"]').first();
+      const dismissBtn = firstCard.locator('button[data-testid="dismiss-triage-btn"]').first();
+
+      // We will wait for the API response after clicking
+      const responsePromise = page.waitForResponse(response =>
+        response.url().includes('/api/triage/action') && response.status() === 200
+      );
 
       if (await approveBtn.isVisible()) {
         await approveBtn.click();
@@ -75,6 +80,8 @@ test.describe('Triage Action Feed UI', () => {
       } else {
         break;
       }
+
+      await responsePromise;
 
       // 5. Verify the card disappears (Optimistic UI + backend update)
       if (testId) {


### PR DESCRIPTION
Resolves #31835

This PR focuses on fixing the flaky Playwright test `triage-action-feed.spec.ts` for the "Intelligent Owner Triage Inbox" task. 

The previous test implementation suffered from a race condition where the script clicked "Approve/Dismiss" and immediately moved to verify UI state or process the next item. Because the backend (`/api/triage/action`) had not finished processing and Next.js SWR/React state hadn't settled, the items sometimes reappeared when the test expected the empty state, failing the test.

**Fixes:**
1. Upgraded fragile text-based locators (`hasText: /Approve/`) to standard `data-testid` attributes.
2. Implemented `page.waitForResponse` to guarantee the test waits for the API success (status 200) before continuing the `while` loop.

All Bazel tests and Playwright spec coverage tests now pass reliably locally without timeouts or retry flakiness.

---
*PR created automatically by Jules for task [11049256887273811395](https://jules.google.com/task/11049256887273811395) started by @ql-owo-lp*