### PR TITLE
fix(e2e): update zero-click onboarding tests to match new setup.html UI

### DIFF
--- a/src/e2e/playwright/zero_click_onboarding.spec.ts
+++ b/src/e2e/playwright/zero_click_onboarding.spec.ts
@@ -5,17 +5,17 @@ test.describe('Zero-Click Onboarding Flow', () => {
 
   test('should complete the zero-click onboarding flow on mobile', async ({ page }) => {
     // Navigate to onboarding page
-    await page.goto('/onboarding/zero-click');
+    await page.goto('/setup.html');
     await expect(page).toHaveTitle(/OneHumanCorp|OHC/);
 
     // Initial Screen
-    await expect(page.locator('h1', { hasText: 'Zero-Click Business Generator' })).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('h1', { hasText: 'OneHumanCorp' })).toBeVisible({ timeout: 15000 });
 
     // Check if the chat assistant loaded
-    await expect(page.getByText('OHC Setup Assistant')).toBeVisible();
+    await expect(page.getByText('Setup Assistant')).toBeVisible();
 
     // The user input should be visible
-    const input = page.getByPlaceholder('e.g. I am a home baker in Austin selling custom vegan cakes.');
+    const input = page.getByPlaceholder('e.g. I am a home baker');
     await expect(input).toBeVisible();
 
     // Type into the input

--- a/src/e2e/tests/zero_click_onboarding.spec.ts
+++ b/src/e2e/tests/zero_click_onboarding.spec.ts
@@ -3,13 +3,13 @@ import { test, expect } from '@playwright/test';
 test.describe('Zero-Click Onboarding to Agent Feed', () => {
   test('User completes chat onboarding and sees welcome card on feed', async ({ page }) => {
     // Navigate to the setup route
-    await page.goto('/onboarding/zero-click');
+    await page.goto('/setup.html');
 
     // Make sure we're on a mobile viewport
     await page.setViewportSize({ width: 375, height: 812 });
 
     // Click Conversational Setup
-    const conversationalSetupBtn = page.locator('text=Zero-Click Business Generator').first();
+    const conversationalSetupBtn = page.locator('text=Conversational Setup').first();
     await expect(conversationalSetupBtn).toBeVisible();
     await conversationalSetupBtn.click();
 
@@ -35,10 +35,10 @@ test.describe('Zero-Click Onboarding to Agent Feed', () => {
   });
 
   test('Conversational Setup prevents empty submissions', async ({ page }) => {
-    await page.goto('/onboarding/zero-click');
+    await page.goto('/setup.html');
 
     // Click Conversational Setup
-    const conversationalSetupBtn = page.locator('text=Zero-Click Business Generator').first();
+    const conversationalSetupBtn = page.locator('text=Conversational Setup').first();
     await expect(conversationalSetupBtn).toBeVisible();
     await conversationalSetupBtn.click();
 
@@ -54,10 +54,10 @@ test.describe('Zero-Click Onboarding to Agent Feed', () => {
   });
 
   test('Conversational Setup opens image upload input when toggled', async ({ page }) => {
-    await page.goto('/onboarding/zero-click');
+    await page.goto('/setup.html');
 
     // Click Conversational Setup
-    const conversationalSetupBtn = page.locator('text=Zero-Click Business Generator').first();
+    const conversationalSetupBtn = page.locator('text=Conversational Setup').first();
     await expect(conversationalSetupBtn).toBeVisible();
     await conversationalSetupBtn.click();
 
@@ -74,10 +74,10 @@ test.describe('Zero-Click Onboarding to Agent Feed', () => {
   });
 
   test('Conversational Setup maintains history after reload', async ({ page }) => {
-    await page.goto('/onboarding/zero-click');
+    await page.goto('/setup.html');
 
     // Start conversational flow
-    const conversationalSetupBtn = page.locator('text=Zero-Click Business Generator').first();
+    const conversationalSetupBtn = page.locator('text=Conversational Setup').first();
     await expect(conversationalSetupBtn).toBeVisible();
     await conversationalSetupBtn.click();
 
@@ -103,10 +103,10 @@ test.describe('Zero-Click Onboarding to Agent Feed', () => {
   });
 
   test('Conversational Setup renders user messages correctly', async ({ page }) => {
-    await page.goto('/onboarding/zero-click');
+    await page.goto('/setup.html');
 
     // Start conversational flow
-    const conversationalSetupBtn = page.locator('text=Zero-Click Business Generator').first();
+    const conversationalSetupBtn = page.locator('text=Conversational Setup').first();
     await expect(conversationalSetupBtn).toBeVisible();
     await conversationalSetupBtn.click();
 


### PR DESCRIPTION
The `setup.html` was updated to reflect a new design and messaging, but the `zero_click_onboarding.spec.ts` tests in both `src/e2e/tests` and `src/e2e/playwright` directories were not updated. This corrects the UI text matchers, placeholder matchers, and routes in both files.

E2E test suite correctly passes with this change under Bazel.

---
*PR created automatically by Jules for task [2996654460520423279](https://jules.google.com/task/2996654460520423279) started by @ql-owo-lp*