### PR TITLE
✍️ Scribe: [Refactor Help Center & Tooltips]

### DIFF
--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -5,6 +5,31 @@ import { WithTooltip } from '../../components/TooltipRegistry';
 import Link from 'next/link';
 import { VideoTutorialList } from '../../components/VideoTutorialList';
 
+function ArticleSections({ articles, hoverBg }: { articles: { category: string, title: string, desc: string, link: string }[], hoverBg: string }) {
+  return (
+    <div className="space-y-10 sm:space-y-12 flex flex-col">
+      {Array.from(new Set(articles.map(a => a.category || "General"))).map((category) => (
+        <section key={category} className="flex flex-col">
+          <div className="flex items-center mb-4 sm:mb-6">
+            <h2 className="text-xl sm:text-2xl font-bold font-outfit text-gray-900">{category}</h2>
+            <div className="ml-4 flex-grow border-t border-gray-200/50"></div>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 flex-col">
+            {articles.filter(a => (a.category || "General") === category).map((article, idx) => (
+              <Link key={idx} href={article.link} className="block group">
+                <div className={`backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 p-5 sm:p-6 rounded-[24px] shadow-[0_8px_32px_rgba(0,0,0,0.08)] group-hover:border-blue-300 group-hover:shadow-[0_0_15px_rgba(59,130,246,0.5)] group-hover:-translate-y-1 transition-all duration-300 cursor-pointer h-full flex flex-col min-h-[120px] sm:min-h-[140px] ${hoverBg}`}>
+                  <h3 className="text-lg sm:text-xl font-bold font-outfit text-blue-600 mb-2 sm:mb-3 group-hover:text-blue-700">{article.title}</h3>
+                  <p className="text-sm sm:text-base text-gray-600 leading-relaxed flex-grow">{article.desc}</p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
 export default function HelpCenterPage() {
   const [articles, setArticles] = useState<{category: string, title: string, desc: string, link: string}[]>([]);
   const [videos, setVideos] = useState<{id: number, title: string, duration: string, video_url: string}[]>([]);
@@ -92,26 +117,7 @@ export default function HelpCenterPage() {
         ) : (
           <div className="space-y-10 sm:space-y-12">
             {filteredArticles.length > 0 && (
-              <div className="space-y-10 sm:space-y-12 flex flex-col">
-                {Array.from(new Set(filteredArticles.map(a => a.category || "General"))).map((category) => (
-                  <section key={category} className="flex flex-col">
-                    <div className="flex items-center mb-4 sm:mb-6">
-                      <h2 className="text-xl sm:text-2xl font-bold font-outfit text-gray-900">{category}</h2>
-                      <div className="ml-4 flex-grow border-t border-gray-200/50"></div>
-                    </div>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 flex-col">
-                      {filteredArticles.filter(a => (a.category || "General") === category).map((article, idx) => (
-                        <Link key={idx} href={article.link} className="block group">
-                          <div className="backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 p-5 sm:p-6 rounded-[24px] shadow-[0_8px_32px_rgba(0,0,0,0.08)] group-hover:border-blue-300 group-hover:shadow-[0_0_15px_rgba(59,130,246,0.5)] group-hover:-translate-y-1 hover:bg-white/90 transition-all duration-300 cursor-pointer h-full flex flex-col min-h-[120px] sm:min-h-[140px]">
-                            <h3 className="text-lg sm:text-xl font-bold font-outfit text-blue-600 mb-2 sm:mb-3 group-hover:text-blue-700">{article.title}</h3>
-                            <p className="text-sm sm:text-base text-gray-600 leading-relaxed flex-grow">{article.desc}</p>
-                          </div>
-                        </Link>
-                      ))}
-                    </div>
-                  </section>
-                ))}
-              </div>
+              <ArticleSections articles={filteredArticles} hoverBg="hover:bg-white/90" />
             )}
 
             {filteredVideos.length > 0 && (
@@ -121,25 +127,8 @@ export default function HelpCenterPage() {
             )}
 
             {advancedArticles.length > 0 && (
-              <div className="space-y-10 sm:space-y-12 flex flex-col pt-8">
-                {Array.from(new Set(advancedArticles.map(a => a.category || "General"))).map((category) => (
-                  <section key={category} className="flex flex-col">
-                    <div className="flex items-center mb-4 sm:mb-6">
-                      <h2 className="text-xl sm:text-2xl font-bold font-outfit text-gray-900">{category}</h2>
-                      <div className="ml-4 flex-grow border-t border-gray-200/50"></div>
-                    </div>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 flex-col">
-                      {advancedArticles.filter(a => (a.category || "General") === category).map((article, idx) => (
-                        <Link key={idx} href={article.link} className="block group">
-                          <div className="backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 p-5 sm:p-6 rounded-[24px] shadow-[0_8px_32px_rgba(0,0,0,0.08)] group-hover:border-blue-300 group-hover:shadow-[0_0_15px_rgba(59,130,246,0.5)] group-hover:-translate-y-1 hover:bg-white/80 transition-all duration-300 cursor-pointer h-full flex flex-col min-h-[120px] sm:min-h-[140px]">
-                            <h3 className="text-lg sm:text-xl font-bold font-outfit text-blue-600 mb-2 sm:mb-3 group-hover:text-blue-700">{article.title}</h3>
-                            <p className="text-sm sm:text-base text-gray-600 leading-relaxed flex-grow">{article.desc}</p>
-                          </div>
-                        </Link>
-                      ))}
-                    </div>
-                  </section>
-                ))}
+              <div className="pt-8">
+                <ArticleSections articles={advancedArticles} hoverBg="hover:bg-white/80" />
               </div>
             )}
           </div>

--- a/src/ui/next/src/components/TooltipRegistry.tsx
+++ b/src/ui/next/src/components/TooltipRegistry.tsx
@@ -84,7 +84,7 @@ export function TooltipProvider({ children }: { children: ReactNode }) {
           className="fixed z-[100] backdrop-blur-[30px] backdrop-saturate-[2.1] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 !rounded-[8px] text-gray-900 dark:text-gray-100 text-sm font-inter p-3 shadow-[0_12px_40px_rgba(0,0,0,0.2)] pointer-events-none w-64 max-w-[calc(100vw-32px)] mx-4 text-center leading-relaxed animate-fade-in-up"
           style={{
             top: tooltipRect.top - 10,
-            left: Math.max(128, Math.min(windowWidth - 128, tooltipRect.left + tooltipRect.width / 2)),
+            left: Math.max(144, Math.min(windowWidth - 144, tooltipRect.left + tooltipRect.width / 2)),
             transform: 'translate(-50%, -100%)'
           }}
         >


### PR DESCRIPTION
Extracted reusable `ArticleSections` component to reduce code duplication in `HelpCenterPage`. Adjusted tooltip positioning bounds from 128px to 144px for better responsive alignment on mobile screens. Tested all affected functionality.

---
*PR created automatically by Jules for task [7589811149422168849](https://jules.google.com/task/7589811149422168849) started by @ql-owo-lp*