### PR TITLE
feat: implement multi-tenant tap-to-pay terminal sdk backend

### DIFF
--- a/src/e2e/terminal_pos.spec.ts
+++ b/src/e2e/terminal_pos.spec.ts
@@ -54,6 +54,19 @@ test.describe('Terminal POS - Mobile First & Inventory Sync', () => {
     // Connect to a reader (the first one)
     await page.getByRole('button', { name: 'Connect' }).first().click();
 
+    // Mock API
+    await page.route('/api/v1/payments/terminal/token', async route => {
+       await route.fulfill({ json: { secret: 'mock_token' } });
+    });
+
+    await page.route('/api/v1/payments/terminal/intent', async route => {
+       await route.fulfill({ json: { client_secret: 'pi_test_secret_test' } });
+    });
+
+    await page.route('/api/v1/payments/terminal/intent/capture', async route => {
+       await route.fulfill({ json: { success: true, status: 'succeeded' } });
+    });
+
     // Wait for the token request to occur and assert it was successful
     const tokenRequest = await tokenPromise;
     expect(tokenRequest).toBeTruthy();

--- a/src/server/api/billing_webhook.rs
+++ b/src/server/api/billing_webhook.rs
@@ -377,16 +377,82 @@ pub async fn stripe_webhook_handler(
                 .and_then(|m| m.get("product_id"))
                 .and_then(|id| id.as_str());
 
-            if let (Some(tenant_id), Some(product_id)) = (tenant_id_opt, product_id_opt) {
-                let quantity = obj.get("metadata")
-                    .and_then(|m| m.get("quantity"))
-                    .and_then(|q| q.as_str())
-                    .and_then(|q| q.parse::<i32>().ok())
-                    .unwrap_or(1);
+            if let Some(tenant_id) = tenant_id_opt {
+                if let Some(payment_intent_id) = obj.get("id").and_then(|id| id.as_str()) {
+                    let mut tx = webhook_state.db.pool.begin().await.unwrap();
+                    let update_res = sqlx::query("UPDATE payment_intents SET status = 'succeeded' WHERE stripe_payment_intent_id = $1 AND tenant_id = $2")
+                        .bind(payment_intent_id)
+                        .bind(tenant_id)
+                        .execute(&mut *tx)
+                        .await;
 
-                let inventory_service = crate::services::inventory::InventoryService::new(None);
+                    if update_res.is_ok() {
+                        let payment_info: Option<(f64, String)> = sqlx::query_as("SELECT amount, currency FROM payment_intents WHERE stripe_payment_intent_id = $1")
+                            .bind(payment_intent_id)
+                            .fetch_optional(&mut *tx)
+                            .await.unwrap_or(None);
 
-                let _ = inventory_service.commit_inventory(tenant_id, product_id, quantity, "").await;
+                        if let Some((amount, currency)) = payment_info {
+                            let tx_id = uuid::Uuid::new_v4().to_string();
+                            if let Err(e) = sqlx::query("INSERT INTO ledger_transactions (tenant_id, tx_id, amount, currency) VALUES ($1, $2, $3, $4)")
+                                .bind(tenant_id)
+                                .bind(&tx_id)
+                                .bind(amount)
+                                .bind(&currency)
+                                .execute(&mut *tx)
+                                .await {
+                                tracing::error!("Failed to insert ledger_transactions: {}", e);
+                            } else {
+                                let account_id = "default_revenue";
+                                if let Err(e) = sqlx::query("INSERT INTO ledger_accounts (tenant_id, account_id, currency, balance) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING")
+                                    .bind(tenant_id)
+                                    .bind(account_id)
+                                    .bind(&currency)
+                                    .bind(0.0)
+                                    .execute(&mut *tx)
+                                    .await {
+                                    tracing::error!("Failed to insert ledger_accounts: {}", e);
+                                } else {
+                                    let entry_id = uuid::Uuid::new_v4().to_string();
+                                    if let Err(e) = sqlx::query("INSERT INTO ledger_entries (tenant_id, entry_id, tx_id, account_id, direction, amount) VALUES ($1, $2, $3, $4, 'CREDIT', $5)")
+                                        .bind(tenant_id)
+                                        .bind(&entry_id)
+                                        .bind(&tx_id)
+                                        .bind(account_id)
+                                        .bind(amount)
+                                        .execute(&mut *tx)
+                                        .await {
+                                        tracing::error!("Failed to insert ledger_entries: {}", e);
+                                    } else {
+                                        if let Err(e) = sqlx::query("UPDATE ledger_accounts SET balance = balance + $1 WHERE tenant_id = $2 AND account_id = $3")
+                                            .bind(amount)
+                                            .bind(tenant_id)
+                                            .bind(account_id)
+                                            .execute(&mut *tx)
+                                            .await {
+                                            tracing::error!("Failed to update ledger_accounts balance: {}", e);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if let Err(e) = tx.commit().await {
+                        tracing::error!("Failed to commit transaction: {}", e);
+                    }
+                }
+
+                if let Some(product_id) = product_id_opt {
+                    let quantity = obj.get("metadata")
+                        .and_then(|m| m.get("quantity"))
+                        .and_then(|q| q.as_str())
+                        .and_then(|q| q.parse::<i32>().ok())
+                        .unwrap_or(1);
+
+                    let inventory_service = crate::services::inventory::InventoryService::new(None);
+
+                    let _ = inventory_service.commit_inventory(tenant_id, product_id, quantity, "").await;
+                }
 
                 // Notify KAIROS Orchestrator for Sales and Operations AI agents
                 let orch = webhook_state.orchestrator.clone();
@@ -395,11 +461,20 @@ pub async fn stripe_webhook_handler(
                 tokio::spawn(async move {
                     let evt = crate::orchestration::departments::types::DepartmentEvent {
                         id: uuid::Uuid::new_v4().to_string(),
-                        tenant_id: tenant_id_val,
+                        tenant_id: tenant_id_val.clone(),
                         event_type: "POS_SALE_COMPLETED".to_string(),
-                        payload: payload_val,
+                        payload: payload_val.clone(),
                     };
                     let _ = orch.dispatch_event(evt).await;
+
+                    // Dispatch event for customer success agent to send a receipt
+                    let receipt_evt = crate::orchestration::departments::types::DepartmentEvent {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        tenant_id: tenant_id_val,
+                        event_type: "CUSTOMER_SUCCESS_RECEIPT".to_string(),
+                        payload: payload_val,
+                    };
+                    let _ = orch.dispatch_event(receipt_evt).await;
                 });
             }
 

--- a/src/server/api/terminal_api.rs
+++ b/src/server/api/terminal_api.rs
@@ -713,6 +713,26 @@ pub async fn create_payment_intent_handler(
                 .await {
                     tracing::warn!("Failed to update pos terminal session for generic intent: {}", e);
                 }
+
+                let payment_intent_id = client_secret.split("_secret_").next().unwrap_or("").to_string();
+                let payment_id = uuid::Uuid::new_v4().to_string();
+                let idempotency_key = uuid::Uuid::new_v4().to_string();
+
+                if let Err(e) = sqlx::query(
+                    "INSERT INTO payment_intents (tenant_id, payment_id, idempotency_key, amount, currency, status, source, stripe_payment_intent_id)
+                     VALUES ($1, $2, $3, $4, $5, 'pending', 'in_person', $6)"
+                )
+                .bind(&tenant_id)
+                .bind(&payment_id)
+                .bind(&idempotency_key)
+                .bind(req_data.amount_cents as f64 / 100.0)
+                .bind(&req_data.currency)
+                .bind(&payment_intent_id)
+                .execute(&pool)
+                .await {
+                    tracing::warn!("Failed to create payment_intent record for terminal: {}", e);
+                }
+
                 Json(Ok(PaymentIntentResponse { client_secret, lock_id: lock_id_out }))
             },
             Err(e) => {


### PR DESCRIPTION
This PR fulfills issue #31888 by adding backend integration and database updates for the multi-tenant Tap-to-Pay terminal POS flows.

Specifically:
- Registers new POS terminal intents inside the local `payment_intents` table via `create_payment_intent_handler`.
- Enhances the `payment_intent.succeeded` webhook for `in_person` payments to officially transition `payment_intents` to `succeeded` and reconciles the paid amount using multi-tenant table inserts (into `ledger_transactions`, `ledger_accounts`, `ledger_entries`).
- Broadcasts the `CUSTOMER_SUCCESS_RECEIPT` KAIROS orchestration event, triggering subsequent Customer Success Agent operations as required.
- Implements test mocks across `terminal_pos.spec.ts` matching official Stripe interactions in Playwright.

Superpowers Skill Loaded: `backend-auth-flow`, `e2e-playwright-mocks`

---
*PR created automatically by Jules for task [6708407945225993763](https://jules.google.com/task/6708407945225993763) started by @ql-owo-lp*

Resolves #31888