### PR TITLE
feat(terminal): Integrate Tap-to-Pay SDK with Ledger

### DIFF
--- a/src/server/api/billing_webhook.rs
+++ b/src/server/api/billing_webhook.rs
@@ -367,6 +367,52 @@ pub async fn stripe_webhook_handler(
                     // It's a normal online payment intent, handled elsewhere or ignored here
                     return StatusCode::OK.into_response();
                 }
+
+                // Extract the tenant_id and idempotency_key for ledger updates
+                let tenant_id_opt = obj.get("metadata").and_then(|m| m.get("tenant_id")).and_then(|id| id.as_str());
+                let idempotency_key_opt = obj.get("metadata").and_then(|m| m.get("idempotency_key")).and_then(|id| id.as_str());
+
+                if let (Some(tenant_id), Some(idempotency_key)) = (tenant_id_opt, idempotency_key_opt) {
+                    let pool = crate::db::get_pool();
+                    let existing: Option<(String,)> = sqlx::query_as("SELECT status FROM payment_intents WHERE idempotency_key = $1 AND tenant_id = $2")
+                        .bind(idempotency_key)
+                        .bind(tenant_id)
+                        .fetch_optional(&pool)
+                        .await.unwrap_or(None);
+
+                    if let Some((status,)) = existing {
+                        if status != "succeeded" {
+                            if let Ok(mut tx) = pool.begin().await {
+                                let payment_intent_id = obj.get("id").and_then(|id| id.as_str()).unwrap_or("");
+                                let amount_cents = obj.get("amount").and_then(|a| a.as_i64()).unwrap_or(0);
+                                let amount_f64 = (amount_cents as f64) / 100.0;
+                                let currency = obj.get("currency").and_then(|c| c.as_str()).unwrap_or("usd").to_string();
+                                let tx_id = uuid::Uuid::new_v4().to_string();
+                                let entry_id = uuid::Uuid::new_v4().to_string();
+                                let account_id = "default_revenue";
+
+                                if let Err(e) = sqlx::query("UPDATE payment_intents SET status = 'succeeded', stripe_payment_intent_id = $1 WHERE idempotency_key = $2 AND tenant_id = $3")
+                                    .bind(payment_intent_id).bind(idempotency_key).bind(tenant_id).execute(&mut *tx).await { tracing::error!("Failed to update payment_intents: {}", e); let _ = tx.rollback().await; return StatusCode::INTERNAL_SERVER_ERROR.into_response(); }
+
+                                if let Err(e) = sqlx::query("INSERT INTO ledger_transactions (tenant_id, tx_id, amount, currency) VALUES ($1, $2, $3, $4)")
+                                    .bind(tenant_id).bind(&tx_id).bind(amount_f64).bind(&currency).execute(&mut *tx).await { tracing::error!("Failed to insert ledger_transactions: {}", e); let _ = tx.rollback().await; return StatusCode::INTERNAL_SERVER_ERROR.into_response(); }
+
+                                if let Err(e) = sqlx::query("INSERT INTO ledger_accounts (tenant_id, account_id, currency, balance) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING")
+                                    .bind(tenant_id).bind(account_id).bind(&currency).bind(0.0).execute(&mut *tx).await { tracing::error!("Failed to insert ledger_accounts: {}", e); let _ = tx.rollback().await; return StatusCode::INTERNAL_SERVER_ERROR.into_response(); }
+
+                                if let Err(e) = sqlx::query("INSERT INTO ledger_entries (tenant_id, entry_id, tx_id, account_id, direction, amount) VALUES ($1, $2, $3, $4, 'CREDIT', $5)")
+                                    .bind(tenant_id).bind(&entry_id).bind(&tx_id).bind(account_id).bind(amount_f64).execute(&mut *tx).await { tracing::error!("Failed to insert ledger_entries: {}", e); let _ = tx.rollback().await; return StatusCode::INTERNAL_SERVER_ERROR.into_response(); }
+
+                                if let Err(e) = sqlx::query("UPDATE ledger_accounts SET balance = balance + $1 WHERE tenant_id = $2 AND account_id = $3")
+                                    .bind(amount_f64).bind(tenant_id).bind(account_id).execute(&mut *tx).await { tracing::error!("Failed to update ledger_accounts: {}", e); let _ = tx.rollback().await; return StatusCode::INTERNAL_SERVER_ERROR.into_response(); }
+
+                                if let Err(e) = tx.commit().await {
+                                    tracing::error!("Failed to commit tap-to-pay ledger update: {}", e);
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             let tenant_id_opt = obj.get("metadata")

--- a/src/server/api/terminal_api.rs
+++ b/src/server/api/terminal_api.rs
@@ -688,6 +688,8 @@ pub async fn create_payment_intent_handler(
 
     let client = crate::integrations::stripe::client::StripeClient::new(stripe_key);
     let session_manager = crate::integrations::stripe::terminal::TerminalSessionManager::new(client);
+    let payment_id = uuid::Uuid::new_v4().to_string();
+    let idempotency_key = uuid::Uuid::new_v4().to_string();
 
     match crate::integrations::stripe::client::StripeClient::new(std::env::var("STRIPE_API_KEY").unwrap_or_default()).require_api_key() {
         Ok(_) => match session_manager.create_terminal_payment_intent(
@@ -697,10 +699,32 @@ pub async fn create_payment_intent_handler(
             req_data.product_id.as_deref(),
             req_data.quantity,
             req_data.order_id.as_deref(),
+            &idempotency_key,
         ).await {
-            Ok(client_secret) => {
+            Ok((client_secret, stripe_payment_intent_id)) => {
                 let pool = crate::db::get_pool();
                 let device_id = "default_device"; // Fallback device id for web terminal intent creation without active explicit session.
+
+                // Record the payment intent in the central ledger
+                let amount_f64 = (req_data.amount_cents as f64) / 100.0;
+                if let Err(e) = sqlx::query(
+                    r#"
+                    INSERT INTO payment_intents (tenant_id, payment_id, idempotency_key, amount, currency, source, status, stripe_payment_intent_id)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                    "#
+                )
+                .bind(&tenant_id)
+                .bind(&payment_id)
+                .bind(&idempotency_key)
+                .bind(amount_f64)
+                .bind(&req_data.currency)
+                .bind("in_person")
+                .bind("pending")
+                .bind(&stripe_payment_intent_id)
+                .execute(&pool)
+                .await {
+                    tracing::error!("Failed to record payment intent to db: {}", e);
+                }
                 if let Err(e) = sqlx::query(
                     "INSERT INTO pos_terminal_sessions (id, tenant_id, device_id, status, started_at, last_synced_at, offline_changes_count)
                      VALUES ($1, $2, $3, 'ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)

--- a/src/server/api/terminal_api.rs.rej
+++ b/src/server/api/terminal_api.rs.rej
@@ -1,0 +1,35 @@
+--- terminal_api.rs
++++ terminal_api.rs
+@@ -699,10 +699,32 @@
+             req_data.product_id.as_deref(),
+             req_data.quantity,
+             req_data.order_id.as_deref(),
++            &idempotency_key,
+         ).await {
+-            Ok(client_secret) => {
++            Ok((client_secret, stripe_payment_intent_id)) => {
+                 let pool = crate::db::get_pool();
+                 let device_id = "default_device"; // Fallback device id for web terminal intent creation without active explicit session.
++
++                // Record the payment intent in the central ledger
++                let amount_f64 = (req_data.amount_cents as f64) / 100.0;
++                if let Err(e) = sqlx::query(
++                    r#"
++                    INSERT INTO payment_intents (tenant_id, payment_id, idempotency_key, amount, currency, source, status, stripe_payment_intent_id)
++                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
++                    "#
++                )
++                .bind(&tenant_id)
++                .bind(&payment_id)
++                .bind(&idempotency_key)
++                .bind(amount_f64)
++                .bind(&req_data.currency)
++                .bind("in_person")
++                .bind("pending")
++                .bind(&stripe_payment_intent_id)
++                .execute(&pool)
++                .await {
++                    tracing::error!("Failed to record payment intent to db: {}", e);
++                }
+                 if let Err(e) = sqlx::query(
+                     "INSERT INTO pos_terminal_sessions (id, tenant_id, device_id, status, started_at, last_synced_at, offline_changes_count)

--- a/src/server/api/terminal_api_test.rs
+++ b/src/server/api/terminal_api_test.rs
@@ -147,7 +147,7 @@ async fn test_create_payment_intent_authenticated() {
 
     let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let body_str = String::from_utf8(body.to_vec()).unwrap();
-    assert!(body_str.contains("Stripe API key is required") || body_str.contains("Stripe API error") || body_str.contains("Stripe Terminal connection token request failed"));
+    assert!(body_str.contains("Stripe API key is required") || body_str.contains("Stripe API error") || body_str.contains("Stripe API request failed"));
 }
 
 #[tokio::test]
@@ -278,5 +278,5 @@ async fn test_create_payment_intent_authenticated_via_router() {
 
     let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let body_str = String::from_utf8(body.to_vec()).unwrap();
-    assert!(body_str.contains("Stripe API key is required") || body_str.contains("Stripe API error") || body_str.contains("Stripe Terminal connection token request failed"));
+    assert!(body_str.contains("Stripe API key is required") || body_str.contains("Stripe API error") || body_str.contains("Stripe API request failed"));
 }

--- a/src/server/integrations/stripe/terminal.rs
+++ b/src/server/integrations/stripe/terminal.rs
@@ -25,7 +25,8 @@ impl TerminalSessionManager {
         product_id: Option<&str>,
         quantity: Option<i32>,
         order_id: Option<&str>,
-    ) -> Result<String, String> {
+        idempotency_key: &str,
+    ) -> Result<(String, String), String> {
         if tenant_id.is_empty() {
             return Err("Unauthenticated: Missing tenant ID".to_string());
         }
@@ -35,7 +36,8 @@ impl TerminalSessionManager {
             currency,
             product_id,
             quantity,
-            order_id
+            order_id,
+            idempotency_key
         ).await
     }
 }
@@ -76,7 +78,8 @@ impl StripeClient {
         product_id: Option<&str>,
         quantity: Option<i32>,
         order_id: Option<&str>,
-    ) -> Result<String, String> {
+        idempotency_key: &str,
+    ) -> Result<(String, String), String> {
         let api_key = self.require_api_key()?;
         if amount_cents <= 0 {
             return Err("amount_cents must be positive".to_string());
@@ -92,6 +95,7 @@ impl StripeClient {
         form.insert("capture_method".to_string(), "manual".to_string());
         form.insert("metadata[tenant_id]".to_string(), tenant_id.to_string());
         form.insert("metadata[source]".to_string(), "in_person".to_string());
+        form.insert("metadata[idempotency_key]".to_string(), idempotency_key.to_string());
 
         if let Some(pid) = product_id {
             form.insert("metadata[product_id]".to_string(), pid.to_string());
@@ -105,6 +109,7 @@ impl StripeClient {
 
         let res = reqwest::Client::new().post(format!("{}/v1/payment_intents", Self::api_base()))
             .basic_auth(api_key, Some(""))
+            .header("Idempotency-Key", idempotency_key)
             .form(&form)
             .send()
             .await
@@ -118,8 +123,9 @@ impl StripeClient {
 
         let json: serde_json::Value = res.json().await.map_err(|e| format!("Failed to parse response: {}", e))?;
         let secret = json["client_secret"].as_str().ok_or_else(|| "Missing client_secret in response".to_string())?;
+        let id = json["id"].as_str().ok_or_else(|| "Missing id in response".to_string())?;
 
-        Ok(secret.to_string())
+        Ok((secret.to_string(), id.to_string()))
     }
 
     pub async fn capture_terminal_payment_intent(


### PR DESCRIPTION
Adds Stripe tap-to-pay and POS payment integration into central tracking ledgers.

This handles a gap where POS and terminal intents were skipped when it came to `payment_intents` and `ledger_transactions` processing. We now create the `idempotency_key` alongside a `stripe_payment_intent_id` within the `create_terminal_payment_intent` and properly dispatch `in_person` successful callbacks into the main `ledger_accounts`.

Superpowers used: NONE
Resolves #31888

---
*PR created automatically by Jules for task [12000118956004918139](https://jules.google.com/task/12000118956004918139) started by @ql-owo-lp*