### PR TITLE
✍️ Scribe: Polish UI for Translucent Glass standards

### DIFF
--- a/src/ui/next/src/app/api-docs/page.tsx
+++ b/src/ui/next/src/app/api-docs/page.tsx
@@ -51,7 +51,7 @@ export default function ApiDocsPage() {
         </div>
       )}
       {mounted && !loading && spec && (
-        <div className="w-full max-w-6xl flex flex-col h-full bg-white/40 backdrop-blur-[60px] saturate-[250%] rounded-2xl p-4 sm:p-6 overflow-x-hidden shadow-[0_12px_40px_rgba(0,0,0,0.15)] border border-white/60 transition-all">
+        <div className="w-full max-w-6xl flex flex-col h-full backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 rounded-2xl p-4 sm:p-6 overflow-x-hidden shadow-[0_12px_40px_rgba(0,0,0,0.15)] transition-all">
           <div className="overflow-x-auto w-full max-w-[calc(100vw-32px)] sm:max-w-none">
             <MemoizedSwaggerUI spec={spec} />
           </div>

--- a/src/ui/next/src/app/help/[articleId]/page.tsx
+++ b/src/ui/next/src/app/help/[articleId]/page.tsx
@@ -54,7 +54,7 @@ export default function HelpArticlePage() {
             </Link>
         </div>
 
-        <article className="app-card backdrop-blur-xl saturate-[210%] bg-white/80 dark:bg-black/50 shadow-2xl border border-white/50 dark:border-white/20 rounded-[32px] p-8 sm:p-12">
+        <article className="app-card backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 shadow-2xl rounded-[32px] p-8 sm:p-12">
             <h1 className="text-3xl sm:text-4xl font-extrabold font-outfit text-gray-900 dark:text-gray-100 mb-8 tracking-tight">{article.title}</h1>
             <div
                 className="prose prose-lg prose-blue max-w-none prose-headings:font-outfit prose-headings:font-bold prose-headings:text-gray-800 dark:prose-headings:text-gray-200 prose-p:text-gray-700 dark:prose-p:text-gray-300 prose-p:leading-relaxed"

--- a/src/ui/next/src/app/help/getting-started-1/page.tsx
+++ b/src/ui/next/src/app/help/getting-started-1/page.tsx
@@ -9,7 +9,7 @@ export default function GettingStartedArticle() {
   return (
     <div className="min-h-screen bg-[#F5F5F7] py-12 px-4 sm:px-6 lg:px-8 font-inter">
       <div className="max-w-4xl mx-auto">
-        <div className="app-card backdrop-blur-[20px] saturate-200 p-8 sm:p-12 rounded-3xl shadow-[0_8px_32px_rgba(0,0,0,0.04)] border border-white/50">
+        <div className="app-card backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 p-8 sm:p-12 rounded-3xl shadow-[0_8px_32px_rgba(0,0,0,0.04)]">
           <h1 className="text-3xl sm:text-4xl font-extrabold font-outfit text-[#1D1D1F] mb-6 tracking-tight">
             Getting Started with Your Store
           </h1>


### PR DESCRIPTION
Since the main tasks for the In-App Help Center were already implemented, I proactively polished the UI for the Translucent Glass standards as requested in the instructions.

- Used `backdrop-blur-[30px]` and `saturate-[210%]` for the "Glass" effect.
- Updated `src/ui/next/src/app/help/getting-started-1/page.tsx`
- Updated `src/ui/next/src/app/api-docs/page.tsx`
- Updated `src/ui/next/src/app/help/[articleId]/page.tsx`

Verified that all unit and E2E tests pass.

---
*PR created automatically by Jules for task [3434372469614844408](https://jules.google.com/task/3434372469614844408) started by @ql-owo-lp*