### PR TITLE
Fix unused variable warning in inventory service

### DIFF
--- a/src/server/services/inventory/service.rs
+++ b/src/server/services/inventory/service.rs
@@ -378,11 +378,10 @@ impl InventoryService {
     ) -> Result<CommitResult, String> {
         let mut all_match = true;
         let mut valid_indices = Vec::new();
-        let mut lock_id_base = "";
 
         let parts: Vec<&str> = lock_id.split(':').collect();
         if parts.len() == 2 {
-            lock_id_base = parts[0];
+            let lock_id_base = parts[0];
             let indices: Vec<&str> = parts[1].split(',').collect();
             for idx in indices {
                 let lock_key = format!("{}:{}", Self::get_lock_key(tenant_id, product_id), idx);


### PR DESCRIPTION
Addressed an unused variable `lock_id_base` warning in `src/server/services/inventory/service.rs` to ensure a clean build and adhere to the strict `ALL warnings MUST be fixed` directive.

---
*PR created automatically by Jules for task [526939843231918504](https://jules.google.com/task/526939843231918504) started by @ql-owo-lp*