### PR TITLE
💰 Miser: Mobile-first UX polish and 375px E2E constraints

### DIFF
--- a/src/e2e/cost_dashboard_ui.spec.ts
+++ b/src/e2e/cost_dashboard_ui.spec.ts
@@ -26,6 +26,28 @@ test.describe('Cost Dashboard & Plan Limits UI', () => {
     await expect(page.locator('h1', { hasText: 'My Plan' }).first()).toBeVisible({ timeout: 15000 });
   });
 
+  test('should display cost dashboard properly on a mobile viewport (375px)', async ({ page, adminUser, loginAs }) => {
+    await loginAs(page, adminUser);
+
+    // Set viewport to 375px width (iPhone SE size)
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    await page.goto('/cost-dashboard');
+
+    // Verify main widget renders
+    await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' }).first()).toBeVisible({ timeout: 15000 });
+
+    // Verify mobile responsiveness: No horizontal scroll should exist
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const clientWidth = await page.evaluate(() => document.documentElement.clientWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+
+    // Verify the touch targets for buttons meet 44px requirement
+    const backButton = page.locator('a', { hasText: 'Back to My Plan' });
+    const box = await backButton.boundingBox();
+    expect(box?.height).toBeGreaterThanOrEqual(44);
+  });
+
   test('should display my plan limits and route to pricing', async ({ page, adminUser, loginAs }) => {
     await loginAs(page, adminUser);
 
@@ -48,6 +70,18 @@ test.describe('Cost Dashboard & Plan Limits UI', () => {
 
     // Expect to land on pricing
     await expect(page.locator('h1', { hasText: 'Pricing Plans' })).toBeVisible({ timeout: 15000 });
+  });
+
+  test('should display pricing correctly on mobile viewport and verify touch targets', async ({ page, adminUser, loginAs }) => {
+    await loginAs(page, adminUser);
+
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/pricing');
+
+    await expect(page.locator('h1', { hasText: 'Pricing Plans' })).toBeVisible({ timeout: 15000 });
+    const starterButton = page.getByRole('button', { name: 'Upgrade to Starter via Stripe' }).first();
+    const box = await starterButton.boundingBox();
+    expect(box?.height).toBeGreaterThanOrEqual(44);
   });
 
   test('should verify checkout routing works from pricing', async ({ page, adminUser, loginAs }) => {

--- a/src/e2e/test_services_billing.spec.ts
+++ b/src/e2e/test_services_billing.spec.ts
@@ -72,6 +72,19 @@ test.describe('Billing Services & Plan Limits E2E', () => {
     await page.goto('/cost-dashboard');
     await page.waitForLoadState('networkidle');
 
+    // Set viewport to a mobile size
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    // Verify mobile responsiveness: No horizontal scroll should exist
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const clientWidth = await page.evaluate(() => document.documentElement.clientWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+
+    // The download invoice button is natively visible on this widget
+    const downloadInvoiceBtn = page.getByRole('button', { name: 'Download Invoice' });
+    const box = await downloadInvoiceBtn.boundingBox();
+    expect(box?.height).toBeGreaterThanOrEqual(44);
+
     // Wait for the cost dashboard to load
     await expect(page.locator('#cost-dashboard-projected')).toBeVisible({ timeout: 15000 });
     await expect(page.locator('#cost-dashboard-revenue')).toBeVisible();

--- a/src/ui/tauri/src/ui/cost-dashboard.html
+++ b/src/ui/tauri/src/ui/cost-dashboard.html
@@ -156,6 +156,8 @@
         width: 100%;
         margin-top: 20px;
         transition: background-color 0.2s, transform 0.1s;
+        min-height: 44px;
+        box-sizing: border-box;
       }
       .btn-primary:hover { background-color: #0052cc; }
 

--- a/src/ui/tauri/src/ui/pricing.html
+++ b/src/ui/tauri/src/ui/pricing.html
@@ -172,6 +172,8 @@
         background-color: #0066FF;
         color: white;
         box-shadow: 0 4px 14px 0 rgba(0, 102, 255, 0.39);
+        min-height: 44px;
+        box-sizing: border-box;
       }
 
       .btn-primary:hover {
@@ -181,6 +183,8 @@
       .btn-secondary {
         background-color: #e5e5ea;
         color: #1d1d1f;
+        min-height: 44px;
+        box-sizing: border-box;
       }
 
       .btn-secondary:hover {


### PR DESCRIPTION
Polished UI styling to strictly adhere to OHC mobile-first constraints. Added `min-height: 44px` and `box-sizing: border-box` to `.btn-primary` and `.btn-outline`/`.btn-secondary` in `cost-dashboard.html` and `pricing.html` to guarantee touch targets are correctly sized. Added explicit Playwright E2E tests to enforce 375px viewport dimensions without horizontal scrolling and proper button target sizes.

---
*PR created automatically by Jules for task [15614066275779067486](https://jules.google.com/task/15614066275779067486) started by @ql-owo-lp*