### PR TITLE
style: apply aesthetic mandate injector to all grafana dashboards

### DIFF
--- a/deploy/docker/grafana/provisioning/dashboards/grafana-dashboard.json
+++ b/deploy/docker/grafana/provisioning/dashboards/grafana-dashboard.json
@@ -26,20 +26,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
-      "id": 4,
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 728404,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": "Prometheus",

--- a/deploy/docker/grafana/provisioning/dashboards/hybrid_swarm_cost_analytics.json
+++ b/deploy/docker/grafana/provisioning/dashboards/hybrid_swarm_cost_analytics.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 611848,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/docker/grafana/provisioning/dashboards/hybrid_swarm_health.json
+++ b/deploy/docker/grafana/provisioning/dashboards/hybrid_swarm_health.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 800882,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/docker/grafana/provisioning/dashboards/llm_provider_health.json
+++ b/deploy/docker/grafana/provisioning/dashboards/llm_provider_health.json
@@ -15,6 +15,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19582,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/docker/grafana/provisioning/dashboards/ohc-agent-audit.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-agent-audit.json
@@ -53,19 +53,20 @@
   "liveNow": true,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 281482,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "title": "Agent Violations Feed",

--- a/deploy/docker/grafana/provisioning/dashboards/ohc-database.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-database.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 513770,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/docker/grafana/provisioning/dashboards/ohc-harness-efficiency.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-harness-efficiency.json
@@ -23,6 +23,22 @@
   "liveNow": false,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 554727,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/docker/grafana/provisioning/dashboards/ohc-hybrid-dashboard.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-hybrid-dashboard.json
@@ -11,7 +11,7 @@
   "panels": [
     {
       "type": "text",
-      "title": "OHC Aesthetics",
+      "title": "Aesthetic Mandate Injector",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -20,25 +20,9 @@
       },
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
       "transparent": true
-    },
-    {
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 100,
-      "options": {
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry",
-        "mode": "html"
-      },
-      "title": "Aesthetic Mandate Injector",
-      "transparent": true,
-      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/docker/grafana/provisioning/dashboards/ohc-hybrid-telemetry.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-hybrid-telemetry.json
@@ -24,7 +24,7 @@
   "panels": [
     {
       "type": "text",
-      "title": "OHC Aesthetics",
+      "title": "Aesthetic Mandate Injector",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -33,25 +33,9 @@
       },
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
       "transparent": true
-    },
-    {
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry",
-        "mode": "html"
-      },
-      "title": "Aesthetic Mandate Injector",
-      "transparent": true,
-      "type": "text"
     },
     {
       "id": 51,

--- a/deploy/docker/grafana/provisioning/dashboards/ohc-infra-observability.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-infra-observability.json
@@ -44,19 +44,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 789107,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/docker/grafana/provisioning/dashboards/ohc-infra.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-infra.json
@@ -44,19 +44,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 713578,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/docker/grafana/provisioning/dashboards/ohc-kairos-hybrid.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-kairos-hybrid.json
@@ -23,6 +23,22 @@
   "liveNow": false,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 986407,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/docker/grafana/provisioning/dashboards/ohc-kairos.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-kairos.json
@@ -64,6 +64,22 @@
   "version": 1,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 720989,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/docker/grafana/provisioning/dashboards/ohc-tenant-cost-miser.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-tenant-cost-miser.json
@@ -9,19 +9,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 852685,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/docker/grafana/provisioning/dashboards/ohc-token-forecast.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-token-forecast.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 276186,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/docker/grafana/provisioning/dashboards/standalone_swarm_health.json
+++ b/deploy/docker/grafana/provisioning/dashboards/standalone_swarm_health.json
@@ -28,19 +28,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 532870,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/docker/grafana/provisioning/dashboards/tenant-cost.json
+++ b/deploy/docker/grafana/provisioning/dashboards/tenant-cost.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 235614,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/docker/grafana/provisioning/dashboards/tenant_cost_efficiency.json
+++ b/deploy/docker/grafana/provisioning/dashboards/tenant_cost_efficiency.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 662358,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/docker/grafana/provisioning/dashboards/tenant_costs.json
+++ b/deploy/docker/grafana/provisioning/dashboards/tenant_costs.json
@@ -25,19 +25,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 984873,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -329,7 +330,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Tenant Cost Visibility (\ud83d\udcb0 Miser)",
+  "title": "Tenant Cost Visibility (💰 Miser)",
   "uid": "tenant_costs",
   "version": 1,
   "weekStart": ""

--- a/deploy/docker/grafana/provisioning/dashboards/token_forecast.json
+++ b/deploy/docker/grafana/provisioning/dashboards/token_forecast.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 192430,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/grafana/dashboards/grafana-dashboard.json
+++ b/deploy/grafana/dashboards/grafana-dashboard.json
@@ -26,20 +26,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
-      "id": 4,
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 728404,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": "Prometheus",

--- a/deploy/grafana/dashboards/hybrid_swarm_cost_analytics.json
+++ b/deploy/grafana/dashboards/hybrid_swarm_cost_analytics.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 611848,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/grafana/dashboards/hybrid_swarm_health.json
+++ b/deploy/grafana/dashboards/hybrid_swarm_health.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 800882,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/grafana/dashboards/llm_provider_health.json
+++ b/deploy/grafana/dashboards/llm_provider_health.json
@@ -15,6 +15,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19582,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/grafana/dashboards/ohc-agent-audit.json
+++ b/deploy/grafana/dashboards/ohc-agent-audit.json
@@ -53,19 +53,20 @@
   "liveNow": true,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 281482,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "title": "Agent Violations Feed",

--- a/deploy/grafana/dashboards/ohc-database.json
+++ b/deploy/grafana/dashboards/ohc-database.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 513770,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/grafana/dashboards/ohc-harness-efficiency.json
+++ b/deploy/grafana/dashboards/ohc-harness-efficiency.json
@@ -23,6 +23,22 @@
   "liveNow": false,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 554727,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/grafana/dashboards/ohc-hybrid-dashboard.json
+++ b/deploy/grafana/dashboards/ohc-hybrid-dashboard.json
@@ -11,7 +11,7 @@
   "panels": [
     {
       "type": "text",
-      "title": "OHC Aesthetics",
+      "title": "Aesthetic Mandate Injector",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -20,25 +20,9 @@
       },
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
       "transparent": true
-    },
-    {
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 100,
-      "options": {
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry",
-        "mode": "html"
-      },
-      "title": "Aesthetic Mandate Injector",
-      "transparent": true,
-      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/grafana/dashboards/ohc-hybrid-telemetry.json
+++ b/deploy/grafana/dashboards/ohc-hybrid-telemetry.json
@@ -24,7 +24,7 @@
   "panels": [
     {
       "type": "text",
-      "title": "OHC Aesthetics",
+      "title": "Aesthetic Mandate Injector",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -33,25 +33,9 @@
       },
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
       "transparent": true
-    },
-    {
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry",
-        "mode": "html"
-      },
-      "title": "Aesthetic Mandate Injector",
-      "transparent": true,
-      "type": "text"
     },
     {
       "id": 51,

--- a/deploy/grafana/dashboards/ohc-infra-observability.json
+++ b/deploy/grafana/dashboards/ohc-infra-observability.json
@@ -44,19 +44,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 789107,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/grafana/dashboards/ohc-infra.json
+++ b/deploy/grafana/dashboards/ohc-infra.json
@@ -44,19 +44,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 713578,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/grafana/dashboards/ohc-kairos-hybrid.json
+++ b/deploy/grafana/dashboards/ohc-kairos-hybrid.json
@@ -23,6 +23,22 @@
   "liveNow": false,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 986407,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/grafana/dashboards/ohc-kairos.json
+++ b/deploy/grafana/dashboards/ohc-kairos.json
@@ -64,6 +64,22 @@
   "version": 1,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 720989,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/grafana/dashboards/ohc-tenant-cost-miser.json
+++ b/deploy/grafana/dashboards/ohc-tenant-cost-miser.json
@@ -9,19 +9,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 852685,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/grafana/dashboards/ohc-token-forecast.json
+++ b/deploy/grafana/dashboards/ohc-token-forecast.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 276186,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/grafana/dashboards/standalone_swarm_health.json
+++ b/deploy/grafana/dashboards/standalone_swarm_health.json
@@ -28,19 +28,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 532870,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/grafana/dashboards/tenant-cost.json
+++ b/deploy/grafana/dashboards/tenant-cost.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 235614,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/grafana/dashboards/tenant_cost_efficiency.json
+++ b/deploy/grafana/dashboards/tenant_cost_efficiency.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 662358,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/grafana/dashboards/tenant_costs.json
+++ b/deploy/grafana/dashboards/tenant_costs.json
@@ -25,19 +25,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 984873,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -329,7 +330,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Tenant Cost Visibility (\ud83d\udcb0 Miser)",
+  "title": "Tenant Cost Visibility (💰 Miser)",
   "uid": "tenant_costs",
   "version": 1,
   "weekStart": ""

--- a/deploy/grafana/dashboards/token_forecast.json
+++ b/deploy/grafana/dashboards/token_forecast.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 192430,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/helm/ohc/dashboards/grafana-dashboard.json
+++ b/deploy/helm/ohc/dashboards/grafana-dashboard.json
@@ -26,20 +26,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
-      "id": 4,
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 728404,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": "Prometheus",

--- a/deploy/helm/ohc/dashboards/hybrid_swarm_cost_analytics.json
+++ b/deploy/helm/ohc/dashboards/hybrid_swarm_cost_analytics.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 611848,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/helm/ohc/dashboards/hybrid_swarm_health.json
+++ b/deploy/helm/ohc/dashboards/hybrid_swarm_health.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 800882,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/helm/ohc/dashboards/llm_provider_health.json
+++ b/deploy/helm/ohc/dashboards/llm_provider_health.json
@@ -15,6 +15,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19582,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/helm/ohc/dashboards/ohc-agent-audit.json
+++ b/deploy/helm/ohc/dashboards/ohc-agent-audit.json
@@ -53,19 +53,20 @@
   "liveNow": true,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 281482,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "title": "Agent Violations Feed",

--- a/deploy/helm/ohc/dashboards/ohc-database.json
+++ b/deploy/helm/ohc/dashboards/ohc-database.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 513770,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/helm/ohc/dashboards/ohc-harness-efficiency.json
+++ b/deploy/helm/ohc/dashboards/ohc-harness-efficiency.json
@@ -23,6 +23,22 @@
   "liveNow": false,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 554727,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/helm/ohc/dashboards/ohc-hybrid-dashboard.json
+++ b/deploy/helm/ohc/dashboards/ohc-hybrid-dashboard.json
@@ -11,7 +11,7 @@
   "panels": [
     {
       "type": "text",
-      "title": "OHC Aesthetics",
+      "title": "Aesthetic Mandate Injector",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -20,25 +20,9 @@
       },
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
       "transparent": true
-    },
-    {
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 100,
-      "options": {
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry",
-        "mode": "html"
-      },
-      "title": "Aesthetic Mandate Injector",
-      "transparent": true,
-      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/helm/ohc/dashboards/ohc-hybrid-telemetry.json
+++ b/deploy/helm/ohc/dashboards/ohc-hybrid-telemetry.json
@@ -24,7 +24,7 @@
   "panels": [
     {
       "type": "text",
-      "title": "OHC Aesthetics",
+      "title": "Aesthetic Mandate Injector",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -33,25 +33,9 @@
       },
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
       "transparent": true
-    },
-    {
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry",
-        "mode": "html"
-      },
-      "title": "Aesthetic Mandate Injector",
-      "transparent": true,
-      "type": "text"
     },
     {
       "id": 51,

--- a/deploy/helm/ohc/dashboards/ohc-infra-observability.json
+++ b/deploy/helm/ohc/dashboards/ohc-infra-observability.json
@@ -44,19 +44,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 789107,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/helm/ohc/dashboards/ohc-infra.json
+++ b/deploy/helm/ohc/dashboards/ohc-infra.json
@@ -44,19 +44,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 713578,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/helm/ohc/dashboards/ohc-kairos-hybrid.json
+++ b/deploy/helm/ohc/dashboards/ohc-kairos-hybrid.json
@@ -23,6 +23,22 @@
   "liveNow": false,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 986407,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/helm/ohc/dashboards/ohc-kairos.json
+++ b/deploy/helm/ohc/dashboards/ohc-kairos.json
@@ -64,6 +64,22 @@
   "version": 1,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 720989,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/helm/ohc/dashboards/ohc-tenant-cost-miser.json
+++ b/deploy/helm/ohc/dashboards/ohc-tenant-cost-miser.json
@@ -9,19 +9,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 852685,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/helm/ohc/dashboards/ohc-token-forecast.json
+++ b/deploy/helm/ohc/dashboards/ohc-token-forecast.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 276186,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/helm/ohc/dashboards/standalone_swarm_health.json
+++ b/deploy/helm/ohc/dashboards/standalone_swarm_health.json
@@ -28,19 +28,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 532870,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/helm/ohc/dashboards/tenant-cost.json
+++ b/deploy/helm/ohc/dashboards/tenant-cost.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 235614,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/deploy/helm/ohc/dashboards/tenant_cost_efficiency.json
+++ b/deploy/helm/ohc/dashboards/tenant_cost_efficiency.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 662358,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/deploy/helm/ohc/dashboards/tenant_costs.json
+++ b/deploy/helm/ohc/dashboards/tenant_costs.json
@@ -25,19 +25,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 984873,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -329,7 +330,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Tenant Cost Visibility (\ud83d\udcb0 Miser)",
+  "title": "Tenant Cost Visibility (💰 Miser)",
   "uid": "tenant_costs",
   "version": 1,
   "weekStart": ""

--- a/deploy/helm/ohc/dashboards/token_forecast.json
+++ b/deploy/helm/ohc/dashboards/token_forecast.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 192430,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/src/server/monitoring/dashboards/grafana-dashboard.json
+++ b/src/server/monitoring/dashboards/grafana-dashboard.json
@@ -26,20 +26,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
-      "id": 4,
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 728404,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": "Prometheus",

--- a/src/server/monitoring/dashboards/hybrid_swarm_cost_analytics.json
+++ b/src/server/monitoring/dashboards/hybrid_swarm_cost_analytics.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 611848,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/src/server/monitoring/dashboards/hybrid_swarm_health.json
+++ b/src/server/monitoring/dashboards/hybrid_swarm_health.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 800882,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/src/server/monitoring/dashboards/llm_provider_health.json
+++ b/src/server/monitoring/dashboards/llm_provider_health.json
@@ -15,6 +15,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19582,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/src/server/monitoring/dashboards/ohc-agent-audit.json
+++ b/src/server/monitoring/dashboards/ohc-agent-audit.json
@@ -53,19 +53,20 @@
   "liveNow": true,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 281482,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "title": "Agent Violations Feed",

--- a/src/server/monitoring/dashboards/ohc-database.json
+++ b/src/server/monitoring/dashboards/ohc-database.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 513770,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/src/server/monitoring/dashboards/ohc-harness-efficiency.json
+++ b/src/server/monitoring/dashboards/ohc-harness-efficiency.json
@@ -23,6 +23,22 @@
   "liveNow": false,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 554727,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/src/server/monitoring/dashboards/ohc-hybrid-dashboard.json
+++ b/src/server/monitoring/dashboards/ohc-hybrid-dashboard.json
@@ -11,7 +11,7 @@
   "panels": [
     {
       "type": "text",
-      "title": "OHC Aesthetics",
+      "title": "Aesthetic Mandate Injector",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -20,25 +20,9 @@
       },
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
       "transparent": true
-    },
-    {
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 100,
-      "options": {
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry",
-        "mode": "html"
-      },
-      "title": "Aesthetic Mandate Injector",
-      "transparent": true,
-      "type": "text"
     },
     {
       "datasource": {

--- a/src/server/monitoring/dashboards/ohc-hybrid-telemetry.json
+++ b/src/server/monitoring/dashboards/ohc-hybrid-telemetry.json
@@ -24,7 +24,7 @@
   "panels": [
     {
       "type": "text",
-      "title": "OHC Aesthetics",
+      "title": "Aesthetic Mandate Injector",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -33,25 +33,9 @@
       },
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
       "transparent": true
-    },
-    {
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry",
-        "mode": "html"
-      },
-      "title": "Aesthetic Mandate Injector",
-      "transparent": true,
-      "type": "text"
     },
     {
       "id": 51,

--- a/src/server/monitoring/dashboards/ohc-infra-observability.json
+++ b/src/server/monitoring/dashboards/ohc-infra-observability.json
@@ -44,19 +44,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 789107,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/src/server/monitoring/dashboards/ohc-infra.json
+++ b/src/server/monitoring/dashboards/ohc-infra.json
@@ -44,19 +44,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 713578,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/src/server/monitoring/dashboards/ohc-kairos-hybrid.json
+++ b/src/server/monitoring/dashboards/ohc-kairos-hybrid.json
@@ -23,6 +23,22 @@
   "liveNow": false,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 986407,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/src/server/monitoring/dashboards/ohc-kairos.json
+++ b/src/server/monitoring/dashboards/ohc-kairos.json
@@ -64,6 +64,22 @@
   "version": 1,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 720989,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/src/server/monitoring/dashboards/ohc-tenant-cost-miser.json
+++ b/src/server/monitoring/dashboards/ohc-tenant-cost-miser.json
@@ -9,19 +9,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 852685,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/src/server/monitoring/dashboards/ohc-token-forecast.json
+++ b/src/server/monitoring/dashboards/ohc-token-forecast.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 276186,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/src/server/monitoring/dashboards/standalone_swarm_health.json
+++ b/src/server/monitoring/dashboards/standalone_swarm_health.json
@@ -28,19 +28,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 532870,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/src/server/monitoring/dashboards/tenant-cost.json
+++ b/src/server/monitoring/dashboards/tenant-cost.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 235614,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {

--- a/src/server/monitoring/dashboards/tenant_cost_efficiency.json
+++ b/src/server/monitoring/dashboards/tenant_cost_efficiency.json
@@ -14,6 +14,22 @@
   },
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 662358,
+      "options": {
+        "mode": "html",
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
+      },
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "type": "text",
       "title": "OHC Aesthetic Injector",
       "gridPos": {

--- a/src/server/monitoring/dashboards/tenant_costs.json
+++ b/src/server/monitoring/dashboards/tenant_costs.json
@@ -25,19 +25,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 984873,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -329,7 +330,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Tenant Cost Visibility (\ud83d\udcb0 Miser)",
+  "title": "Tenant Cost Visibility (💰 Miser)",
   "uid": "tenant_costs",
   "version": 1,
   "weekStart": ""

--- a/src/server/monitoring/dashboards/token_forecast.json
+++ b/src/server/monitoring/dashboards/token_forecast.json
@@ -10,19 +10,20 @@
   "liveNow": false,
   "panels": [
     {
-      "type": "text",
-      "title": "OHC Aesthetics",
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 192430,
       "options": {
         "mode": "html",
-        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">"
+        "content": "<link rel=\"stylesheet\" href=\"/public/css/custom.css\">\nOHC Premium Telemetry"
       },
-      "transparent": true
+      "title": "Aesthetic Mandate Injector",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {


### PR DESCRIPTION
Added the `Aesthetic Mandate Injector` to all Grafana dashboards to load the `custom.css` containing the OHC visual aesthetic styles (translucent glass components, clean Apple/Ubiquiti-style design). This ensures all monitoring instances align with the design guidelines. Also synchronized the generated updates across all dashboard copies in `deploy/`. Validated changes by ensuring all `bazel test //...` and `e2e` scripts pass.

---
*PR created automatically by Jules for task [5781357675518365083](https://jules.google.com/task/5781357675518365083) started by @ql-owo-lp*