### PR TITLE
⚙️ Consolidator: Fix memory pruning logic and optimize consolidation flow

### DIFF
--- a/src/agents/builtin/consolidation_worker.rs
+++ b/src/agents/builtin/consolidation_worker.rs
@@ -29,6 +29,18 @@ impl ConsolidationWorker {
 
     /// Run a single consolidation pass manually. Useful for testing.
     pub async fn run_once(&self) -> Result<(usize, bool), String> {
+        let threshold_date = Utc::now() - chrono::Duration::days(self.pruning_threshold_days);
+        let pruning_success = match self.repository.prune_stale(threshold_date).await {
+            Ok(_) => true,
+            Err(e) => {
+                tracing::error!("Consolidation Worker: Failed to prune stale context: {}", e);
+                if let Some(ref cb) = self.telemetry_error_callback {
+                    cb("Consolidation Worker: Failed to prune stale context", &e);
+                }
+                return Err(e);
+            }
+        };
+
         let conflicts_resolved = match self.repository.auto_resolve_conflicts().await {
             Ok(count) => count,
             Err(e) => {
@@ -41,18 +53,6 @@ impl ConsolidationWorker {
                         "Consolidation Worker: Failed to resolve memory conflicts",
                         &e,
                     );
-                }
-                return Err(e);
-            }
-        };
-
-        let threshold_date = Utc::now() - chrono::Duration::days(self.pruning_threshold_days);
-        let pruning_success = match self.repository.prune_stale(threshold_date).await {
-            Ok(_) => true,
-            Err(e) => {
-                tracing::error!("Consolidation Worker: Failed to prune stale context: {}", e);
-                if let Some(ref cb) = self.telemetry_error_callback {
-                    cb("Consolidation Worker: Failed to prune stale context", &e);
                 }
                 return Err(e);
             }

--- a/src/agents/builtin/memory_exhaustive_tests.rs
+++ b/src/agents/builtin/memory_exhaustive_tests.rs
@@ -3905,7 +3905,7 @@ mod tests_added_for_coverage {
             .unwrap();
         let ids: Vec<String> = results.iter().map(|r| r.id.clone()).collect();
 
-        assert!(!ids.contains(&"rec_prune_1".to_string())); // pruned due to low reliability
+        assert!(ids.contains(&"rec_prune_1".to_string())); // NOT pruned anymore (reliability check removed)
         assert!(ids.contains(&"rec_prune_2".to_string())); // kept due to owner override
         assert!(!ids.contains(&"rec_prune_3".to_string())); // pruned due to being stale TASK_SUMMARY
     }

--- a/src/agents/builtin/memory_store.rs
+++ b/src/agents/builtin/memory_store.rs
@@ -499,14 +499,14 @@ impl VectorRepository {
     pub async fn prune_stale(&self, older_than: DateTime<Utc>) -> Result<(), String> {
         match &self.store {
             VectorMemoryStore::Postgres(pool) => {
-                sqlx::query("DELETE FROM consolidated_memory WHERE (last_referenced_at < $1 AND owner_override = FALSE AND reference_count < 5 AND source_type = 'TASK_SUMMARY') OR (reliability_score < 20 AND owner_override = FALSE)")
+                sqlx::query("DELETE FROM consolidated_memory WHERE last_referenced_at < $1 AND owner_override = FALSE AND reference_count < 5 AND source_type = 'TASK_SUMMARY'")
                     .bind(older_than)
                     .execute(pool)
                     .await
                     .map_err(|e| e.to_string())?;
             }
             VectorMemoryStore::Sqlite(pool) => {
-                sqlx::query("DELETE FROM consolidated_memory WHERE (last_referenced_at < ? AND owner_override = FALSE AND reference_count < 5 AND source_type = 'TASK_SUMMARY') OR (reliability_score < 20 AND owner_override = FALSE)")
+                sqlx::query("DELETE FROM consolidated_memory WHERE last_referenced_at < ? AND owner_override = FALSE AND reference_count < 5 AND source_type = 'TASK_SUMMARY'")
                     .bind(older_than)
                     .execute(pool)
                     .await
@@ -4004,8 +4004,8 @@ mod get_and_delete_tests {
             "Should have pruned stale task summary"
         );
         assert!(
-            repo.get_by_id("prune_unreliable").await.unwrap().is_none(),
-            "Should have pruned unreliable record"
+            repo.get_by_id("prune_unreliable").await.unwrap().is_some(),
+            "Should NOT have pruned unreliable record anymore"
         );
 
         assert!(


### PR DESCRIPTION
The `ConsolidationWorker` and the `prune_stale` logic in the memory store were updated according to the architecture design requirements for conservative pruning.

**Changes:**
1. **Removed the undocumented `reliability_score < 20` pruning condition.** The design requires pruning only when `last_referenced_at` is older than the threshold, `owner_override = FALSE`, `reference_count < 5`, and `source_type = 'TASK_SUMMARY'`. The additional condition for pruning any record with `reliability_score < 20` was removed from both PostgreSQL and SQLite implementations in `memory_store.rs`.
2. **Re-ordered `run_once` operations in `ConsolidationWorker`.** Pruning stale records is now executed *before* `auto_resolve_conflicts`. This is more efficient as it reduces the number of records that need conflict resolution.
3. **Updated exhaustive tests** (`src/agents/builtin/memory_exhaustive_tests.rs` and `memory_store.rs`) to verify that records with low reliability scores are no longer incorrectly pruned.

**Verified:** Tests are successfully passing across both the builtin agent unit tests and e2e Playwright.

---
*PR created automatically by Jules for task [11492065827827627087](https://jules.google.com/task/11492065827827627087) started by @ql-owo-lp*