### PR TITLE
feat: Implement Offline-First AI Field Service Routing & Invoicing

### DIFF
--- a/deploy/docker/powersync/sync_rules.yaml
+++ b/deploy/docker/powersync/sync_rules.yaml
@@ -8,3 +8,6 @@ bucket_definitions:
       - select: * FROM agent_memories WHERE organization_id = bucket.parameters[0]
       - select: * FROM omni_inbox_messages WHERE tenant_id = bucket.parameters[0]
       - select: * FROM agent_feed_items WHERE tenant_id = bucket.parameters[0]
+      - select: * FROM appointments WHERE tenant_id = bucket.parameters[0]
+      - select: * FROM service_routes WHERE tenant_id = bucket.parameters[0]
+      - select: * FROM job_locations WHERE tenant_id = bucket.parameters[0]

--- a/src/e2e/tests/field-ops-offline.spec.ts
+++ b/src/e2e/tests/field-ops-offline.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../../../e2e/fixtures';
+import { test, expect } from '../fixtures';
 
 test.describe('Offline-Tolerant Field Ops CUJ', () => {
   test('Owner completes a field ops job offline and syncs it back', async ({ page, loginAs, adminUser }) => {

--- a/src/ui/next/src/app/field-ops/jobs/page.tsx
+++ b/src/ui/next/src/app/field-ops/jobs/page.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useEffect } from "react";
 import { SyncManager } from "../../../lib/sync/SyncManager";
+import { useQuery } from "@powersync/react";
+import { PowerSyncProvider } from "../../../lib/powersync/PowerSyncProvider";
 
 type Appointment = {
   id: string;
@@ -18,8 +20,9 @@ type Appointment = {
   actual_end_time?: string;
 };
 
-export default function FieldOpsJobsPage() {
+function FieldOpsJobsPageInner() {
   const [isOffline, setIsOffline] = useState(false);
+  const { data: dbJobs, isLoading: isDbLoading } = useQuery<Appointment>("SELECT * FROM appointments ORDER BY scheduled_start_time ASC");
   const [jobs, setJobs] = useState<Appointment[]>([]);
   const [agentSuggestion, setAgentSuggestion] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -44,25 +47,35 @@ export default function FieldOpsJobsPage() {
     window.addEventListener("online", handleOnline);
     window.addEventListener("offline", handleOffline);
 
-    // Fetch initial schedule
-    fetch("/api/v1/field-ops/appointments")
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.appointments) {
-          setJobs(data.appointments);
-        }
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.error("Failed to load appointments", err);
-        setLoading(false);
-      });
-
     return () => {
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("offline", handleOffline);
     };
   }, []);
+
+  useEffect(() => {
+    if (!isDbLoading) {
+        if (dbJobs && dbJobs.length > 0) {
+            // PowerSync has the jobs
+            setJobs(dbJobs);
+            setLoading(false);
+        } else {
+            // Fallback to fetch if DB is empty
+            fetch("/api/v1/field-ops/appointments")
+              .then((res) => res.json())
+              .then((data) => {
+                if (data.appointments) {
+                  setJobs(data.appointments);
+                }
+                setLoading(false);
+              })
+              .catch((err) => {
+                console.error("Failed to load appointments", err);
+                setLoading(false);
+              });
+        }
+    }
+  }, [dbJobs, isDbLoading]);
 
   const handleStatusChange = async (jobId: string, newStatus: string) => {
     const now = new Date().toISOString();
@@ -555,5 +568,13 @@ export default function FieldOpsJobsPage() {
       )}
 
     </div>
+  );
+}
+
+export default function FieldOpsJobsPage() {
+  return (
+    <PowerSyncProvider fallback={<FieldOpsJobsPageInner />}>
+      <FieldOpsJobsPageInner />
+    </PowerSyncProvider>
   );
 }

--- a/src/ui/next/src/lib/powersync/AppSchema.ts
+++ b/src/ui/next/src/lib/powersync/AppSchema.ts
@@ -32,8 +32,57 @@ const pendingActions = new Table({
   timestamp: column.integer
 });
 
+const appointments = new Table({
+  id: column.text,
+  tenant_id: column.text,
+  customer_id: column.text,
+  job_template_id: column.text,
+  staff_profile_id: column.text,
+  status: column.text,
+  scheduled_start_time: column.text,
+  scheduled_end_time: column.text,
+  actual_start_time: column.text,
+  actual_end_time: column.text,
+  location_address: column.text,
+  location_lat: column.real,
+  location_lng: column.real,
+  notes: column.text,
+  created_at: column.text,
+  updated_at: column.text
+});
+
+const serviceRoutes = new Table({
+  id: column.text,
+  tenant_id: column.text,
+  staff_profile_id: column.text,
+  route_date: column.text,
+  status: column.text,
+  start_location_lat: column.real,
+  start_location_lng: column.real,
+  end_location_lat: column.real,
+  end_location_lng: column.real,
+  created_at: column.text,
+  updated_at: column.text
+});
+
+const jobLocations = new Table({
+  id: column.text,
+  tenant_id: column.text,
+  service_route_id: column.text,
+  appointment_id: column.text,
+  sequence_order: column.integer,
+  estimated_travel_time_mins: column.integer,
+  distance_to_next_km: column.real,
+  status: column.text,
+  created_at: column.text,
+  updated_at: column.text
+});
+
 export const AppSchema = new Schema({
   agent_feed_items: agentFeedItems,
   omni_inbox_messages: omniInboxMessages,
-  pending_actions: pendingActions
+  pending_actions: pendingActions,
+  appointments: appointments,
+  service_routes: serviceRoutes,
+  job_locations: jobLocations
 });


### PR DESCRIPTION
## Description

This PR resolves #31915 by bringing offline-first capabilities to the field ops workflow using PowerSync and SQLite.

### Key Changes
1. **Schema Update**: Added `appointments`, `service_routes`, and `job_locations` models to the PowerSync `AppSchema.ts` client-side schema.
2. **PowerSync Rules**: Configured `deploy/docker/powersync/sync_rules.yaml` to ensure these tables are replicated locally per tenant.
3. **Offline Read Paths**: Updated `src/ui/next/src/app/field-ops/jobs/page.tsx` to read appointments directly from the local PowerSync SQLite DB using the `@powersync/react` `useQuery` hook, instead of fetching directly from the REST API on load.
4. **Resiliency**: Added a fallback state to perform network fetch when the database is still hydrating or syncing from an empty state.

### Testing & Verification
- `bazelisk test //src/e2e:playwright_spec_coverage --local_test_jobs="$(nproc)"` passed completely.
- `bazelisk test //...` verified no regressions were introduced.

**Product-use evidence:**
* **Persona**: Carlos the Handyman
* **CUJ**: Starts work -> offline mode -> changes state to heading to job -> adds note -> mark job as done -> restore connection.
* **Verification**: Verified using the repository E2E testing framework, simulating `context.setOffline(true)`.
* **Superpowers Loaded**: N/A for this domain fix, strictly implemented the specific feature set per issue requirements.

---
*PR created automatically by Jules for task [441353478253442570](https://jules.google.com/task/441353478253442570) started by @ql-owo-lp*