### PR TITLE
fix(observability): redact PII before JSON marshaling in Teammate Mesh broadcasts

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -2779,7 +2779,9 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
 
     let tm_mesh = handoff_mesh.clone();
     hub.task_manager().set_broadcaster(std::sync::Arc::new(move |task, event_type| {
-        let payload = match serde_json::to_string(&task) {
+        let task_value = serde_json::to_value(&task).unwrap_or(serde_json::Value::Null);
+        let redacted_task = ::server_telemetry::redact_interface_pii(task_value);
+        let payload = match serde_json::to_string(&redacted_task) {
             Ok(p) => p,
             Err(e) => {
                 ::server_telemetry::record_error_signal("[bug] Failed to serialize task");


### PR DESCRIPTION
The OHC codebase enforces strict PII redaction across the multi-tenant architecture. However, during Teammate Mesh task broadcasting, tasks were serialized directly to JSON strings without going through the PII scrubbing logic. 

This commit addresses the gap by explicitly calling `redact_interface_pii` before generating the payload for `TeammateMeshEvent`. This ensures that tasks containing sensitive PII won't leak to event logs or persistence when published to the broadcast queue.

---
*PR created automatically by Jules for task [9520604105877624818](https://jules.google.com/task/9520604105877624818) started by @ql-owo-lp*