### PR TITLE
Fix reference count inflation during memory conflict resolution

### DIFF
--- a/src/agents/builtin/consolidation_worker.rs
+++ b/src/agents/builtin/consolidation_worker.rs
@@ -251,9 +251,9 @@ mod tests {
         let ref_count: i32 = rows[0].try_get("reference_count").unwrap();
 
         assert_eq!(id, "conflict_winner", "The winner must be preserved");
-        // Loser has 1, winner has 2, logic increments winner by loser + 1 -> 2 + 1 + 1 = 4.
+        // Loser has 1, winner has 2, logic increments winner by loser -> 2 + 1 = 3.
         assert_eq!(
-            ref_count, 4,
+            ref_count, 3,
             "The winner should inherit the loser's reference count"
         );
         handle.abort();

--- a/src/agents/builtin/memory_store.rs
+++ b/src/agents/builtin/memory_store.rs
@@ -602,7 +602,7 @@ impl VectorRepository {
     ) -> Result<(), String> {
         self.delete(&loser.id).await?;
         let mut updated_winner = winner.clone();
-        updated_winner.reference_count += loser.reference_count + 1;
+        updated_winner.reference_count += loser.reference_count;
         updated_winner.last_referenced_at = chrono::Utc::now();
         updated_winner.reliability_score =
             std::cmp::max(winner.reliability_score, loser.reliability_score);
@@ -1640,7 +1640,7 @@ mod get_conflicts_tests {
         let ref_count: i32 = rows[0].get("reference_count");
 
         assert_eq!(id, "winner");
-        assert_eq!(ref_count, 2 + 5 + 1); // winner.ref_count + loser.ref_count + 1
+        assert_eq!(ref_count, 2 + 5); // winner.ref_count + loser.ref_count
     }
 
     #[tokio::test]
@@ -1787,9 +1787,9 @@ mod get_conflicts_tests {
         }
 
         assert_eq!(results.len(), 3);
-        assert_eq!(results.get("rec1_b"), Some(&4));
-        assert_eq!(results.get("rec2_a"), Some(&9));
-        assert_eq!(results.get("rec3_b"), Some(&2));
+        assert_eq!(results.get("rec1_b"), Some(&3));
+        assert_eq!(results.get("rec2_a"), Some(&8));
+        assert_eq!(results.get("rec3_b"), Some(&1));
     }
 
     #[tokio::test]
@@ -1994,8 +1994,8 @@ mod get_conflicts_tests {
 
         // It will pick `r1` as winner arbitrarily (since a=r1, b=r2, and we return (&a, &b))
         assert_eq!(id, "rec4_a");
-        // new ref count = r1.reference_count (1) + r2.reference_count (2) + 1 = 4
-        assert_eq!(ref_count, 4);
+        // new ref count = r1.reference_count (1) + r2.reference_count (2) = 3
+        assert_eq!(ref_count, 3);
     }
 
     #[tokio::test]
@@ -3184,8 +3184,8 @@ mod e2e_consolidation_tests {
         );
         assert_eq!(
             results[0].reference_count,
-            2 + 1 + 1,
-            "reference count should be sum + 1"
+            2 + 1,
+            "reference count should be sum"
         );
     }
 


### PR DESCRIPTION
Fix reference count inflation during memory conflict resolution.

- Corrected the `resolve_conflict` method in `memory_store.rs` to correctly increment reference counts when consolidating.
- Fixed associated assertions in unit tests.

---
*PR created automatically by Jules for task [15159681094255701763](https://jules.google.com/task/15159681094255701763) started by @ql-owo-lp*