### PR TITLE
🚀 Nova: [Viral Leaderboard Generator]

### DIFF
--- a/src/e2e/BUILD.bazel
+++ b/src/e2e/BUILD.bazel
@@ -68,6 +68,7 @@ _NEXT_UI_E2E_SPECS = [
 
     "//src/ui/next:src/e2e/viral_share_to_unlock.spec.ts",
     "//src/ui/next:e2e/storefront_v2.spec.ts",
+    "//src/ui/next:src/e2e/viral_leaderboard_generator.spec.ts",
     "//src/ui/next:src/e2e/viral-post-generator.spec.ts",
 ]
 

--- a/src/ui/next/src/app/api/v1/growth/viral-leaderboard/embed/route.ts
+++ b/src/ui/next/src/app/api/v1/growth/viral-leaderboard/embed/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from 'next/server';
+
+function escapeHtml(unsafe: string) {
+    if (!unsafe) return unsafe;
+    return unsafe
+         .replace(/&/g, "&amp;")
+         .replace(/</g, "&lt;")
+         .replace(/>/g, "&gt;")
+         .replace(/"/g, "&quot;")
+         .replace(/'/g, "&#039;");
+}
+
+export async function GET(request: Request) {
+    const { searchParams } = new URL(request.url);
+    const tenant = searchParams.get('tenant') || 'demo';
+    const title = searchParams.get('title') || 'Top Referrers';
+    const metric = searchParams.get('metric') || 'referrers';
+    const theme = searchParams.get('theme') || 'light';
+    const rawBranding = searchParams.get('branding') !== 'false';
+
+    const escapedTitle = escapeHtml(title);
+    const encodedTenant = encodeURIComponent(tenant);
+    const isDark = theme === 'dark';
+
+    const bg = isDark ? '#1D1D1F' : '#ffffff';
+    const text = isDark ? '#ffffff' : '#111827';
+    const textSecondary = isDark ? '#a1a1aa' : '#6b7280';
+    const border = isDark ? '#333333' : '#e5e7eb';
+    const rowBg = isDark ? '#27272a' : '#f9fafb';
+
+    const mockData = metric === 'buyers'
+      ? [
+          { name: 'Sarah J.', score: '24 purchases', emoji: '🥇' },
+          { name: 'Michael T.', score: '18 purchases', emoji: '🥈' },
+          { name: 'Emma W.', score: '12 purchases', emoji: '🥉' }
+        ]
+      : [
+          { name: 'Alex K.', score: '15 referrals', emoji: '🥇' },
+          { name: 'Jessica L.', score: '11 referrals', emoji: '🥈' },
+          { name: 'Ryan P.', score: '8 referrals', emoji: '🥉' }
+        ];
+
+    const html = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${escapedTitle}</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 20px;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+            background: transparent;
+        }
+        .widget {
+            display: flex;
+            flex-direction: column;
+            padding: 24px;
+            background: ${bg};
+            color: ${text};
+            border: 1px solid ${border};
+            border-radius: 16px;
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+            max-width: 400px;
+            width: 100%;
+            box-sizing: border-box;
+            margin: auto;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .title {
+            font-size: 20px;
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+        .subtitle {
+            font-size: 13px;
+            color: ${textSecondary};
+        }
+        .leaderboard {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        .row {
+            display: flex;
+            align-items: center;
+            padding: 12px 16px;
+            background: ${rowBg};
+            border-radius: 12px;
+            border: 1px solid ${border};
+        }
+        .rank {
+            font-size: 20px;
+            margin-right: 12px;
+            min-width: 24px;
+            text-align: center;
+        }
+        .info {
+            flex: 1;
+        }
+        .name {
+            font-weight: 600;
+            font-size: 14px;
+            margin-bottom: 2px;
+        }
+        .score {
+            font-size: 12px;
+            color: ${textSecondary};
+        }
+        .footer {
+            text-align: center;
+            font-size: 12px;
+            margin-top: 24px;
+            padding-top: 16px;
+            border-top: 1px solid ${border};
+        }
+        .footer a {
+            color: ${textSecondary};
+            text-decoration: none;
+            font-weight: 600;
+            transition: color 0.2s;
+        }
+        .footer a:hover {
+            text-decoration: underline;
+            color: ${text};
+        }
+    </style>
+</head>
+<body>
+    <div class="widget">
+        <div class="header">
+            <div class="title">${escapedTitle}</div>
+            <div class="subtitle">Monthly Top Performers</div>
+        </div>
+        <div class="leaderboard">
+            ${mockData.map(row => `
+                <div class="row">
+                    <div class="rank">${row.emoji}</div>
+                    <div class="info">
+                        <div class="name">${escapeHtml(row.name)}</div>
+                        <div class="score">${escapeHtml(row.score)}</div>
+                    </div>
+                </div>
+            `).join('')}
+        </div>
+        ${rawBranding ? `
+        <div class="footer">
+            <a href="/api/v1/growth/referrals/click?target=/onboarding&ref=${encodedTenant}" target="_blank">⚡ Powered by OHC</a>
+        </div>
+        ` : ''}
+    </div>
+</body>
+</html>
+    `;
+
+    return new NextResponse(html, {
+        headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+            'Cache-Control': 'public, max-age=300, s-maxage=300'
+        },
+    });
+}

--- a/src/ui/next/src/app/dashboard/page.tsx
+++ b/src/ui/next/src/app/dashboard/page.tsx
@@ -946,6 +946,15 @@ export default function Dashboard() {
               <p className="text-sm text-gray-600 dark:text-gray-400">Launch a viral sweepstakes to capture emails and drive social shares.</p>
             </Link>
 
+            <Link href="/viral-leaderboard-generator" id="viral-leaderboard-link" className="block glassmorphism p-6 min-h-[44px] hover:shadow-lg transition-all hover:-translate-y-0.5 group border border-white/40 dark:border-white/10">
+              <div className="flex items-start justify-between mb-4">
+                <div className="w-12 h-12 rounded-full bg-yellow-50 dark:bg-yellow-900/30 flex items-center justify-center text-2xl group-hover:scale-110 transition-transform">🏆</div>
+                <div className="text-yellow-600 dark:text-yellow-400 font-semibold text-sm bg-yellow-50 dark:bg-yellow-900/30 px-3 py-1 rounded-full">Growth</div>
+              </div>
+              <h3 className="text-xl font-bold font-outfit text-[#1D1D1F] dark:text-[#F5F5F7] mb-2">Viral Leaderboard</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">Embed a gamified leaderboard on your storefront to encourage competition and referrals.</p>
+            </Link>
+
             <Link href="/share-and-save-widget" id="share-and-save-link" className="block glassmorphism p-6 min-h-[44px] hover:shadow-lg transition-all hover:-translate-y-0.5 group border border-white/40 dark:border-white/10">
               <div className="flex items-start justify-between mb-4">
                 <div className="w-12 h-12 rounded-full bg-indigo-50 dark:bg-indigo-900/30 flex items-center justify-center text-2xl group-hover:scale-110 transition-transform">💸</div>

--- a/src/ui/next/src/app/viral-leaderboard-generator/page.tsx
+++ b/src/ui/next/src/app/viral-leaderboard-generator/page.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function ViralLeaderboardGeneratorPage() {
+  const router = useRouter();
+  const [tenant, setTenant] = useState('my-store');
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [title, setTitle] = useState('Top Referrers');
+  const [metric, setMetric] = useState<'referrers' | 'buyers'>('referrers');
+  const [copied, setCopied] = useState(false);
+  const [hasPro, setHasPro] = useState(false);
+  const [showPaywall, setShowPaywall] = useState(false);
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+    if (typeof localStorage !== 'undefined') {
+      const storedTenant = localStorage.getItem('tenant') || 'my-store';
+      setTenant(storedTenant);
+      setHasPro(localStorage.getItem('has_pro') === 'true');
+    }
+    document.title = "Viral Leaderboard Generator | OHC";
+  }, []);
+
+  const handleRemoveBranding = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!hasPro) {
+      e.preventDefault();
+      setShowPaywall(true);
+    }
+  };
+
+  const embedUrl = `https://ohc.app/api/v1/growth/viral-leaderboard/embed?tenant=${tenant}&theme=${theme}&title=${encodeURIComponent(title)}&metric=${metric}&branding=${!hasPro}`;
+  const embedCode = `<iframe src="${embedUrl}" width="100%" height="450" frameborder="0" scrolling="no" style="border:none; overflow:hidden; border-radius:16px;"></iframe>`;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(embedCode);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (!isClient) return null;
+
+  return (
+    <div className="flex flex-col min-h-screen font-inter bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50 items-center justify-center py-10 px-4">
+      <div className="w-full max-w-5xl bg-white/80 backdrop-blur-xl rounded-[24px] shadow-sm border border-gray-100 flex flex-col md:flex-row gap-8">
+        <div className="flex-1 p-8">
+          <h1 className="text-3xl font-bold font-outfit text-gray-900 mb-6">Viral Leaderboard Generator 🏆</h1>
+          <p className="text-sm text-gray-600 mb-6">Embed a gamified leaderboard on your storefront to encourage competition and drive more referrals or sales.</p>
+
+          <div className="space-y-4">
+             <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Leaderboard Title</label>
+                <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+             </div>
+             <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Metric to Display</label>
+                <select value={metric} onChange={(e) => setMetric(e.target.value as any)} className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 bg-white">
+                  <option value="referrers">Top Referrers</option>
+                  <option value="buyers">Top Buyers</option>
+                </select>
+             </div>
+             <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Theme</label>
+                <select value={theme} onChange={(e) => setTheme(e.target.value as any)} className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 bg-white">
+                  <option value="light">Light</option>
+                  <option value="dark">Dark</option>
+                </select>
+             </div>
+             <div className="flex items-center gap-2 mt-4 pt-4 border-t border-gray-200">
+                <input
+                    type="checkbox"
+                    id="removeBranding"
+                    checked={hasPro}
+                    onChange={handleRemoveBranding}
+                    className="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                />
+                <label htmlFor="removeBranding" className="text-sm font-medium text-gray-700 flex items-center gap-2">
+                    Remove "Powered by OHC" Badge
+                    {!hasPro && <span className="bg-yellow-100 text-yellow-800 text-[10px] font-bold px-2 py-0.5 rounded uppercase tracking-wider">PRO</span>}
+                </label>
+             </div>
+          </div>
+
+          <div className="mt-8 bg-gray-900 text-gray-300 p-4 rounded-xl font-mono text-xs overflow-x-auto mb-4">
+             <pre>{embedCode}</pre>
+          </div>
+          <button
+             onClick={handleCopy}
+             className={`w-full py-3 rounded-lg text-sm font-semibold transition-all ${copied ? 'bg-green-100 text-green-700' : 'bg-indigo-600 text-white hover:bg-indigo-700'}`}
+          >
+             {copied ? 'Copied to Clipboard!' : 'Copy Embed Code'}
+          </button>
+        </div>
+
+        <div className="flex-1 flex flex-col p-8 bg-gray-50/50 rounded-r-[24px]">
+           <h2 className="text-xl font-semibold font-outfit text-gray-900 mb-4">Live Preview</h2>
+           <div className="flex-1 rounded-2xl shadow-inner border-2 border-dashed border-gray-300 relative overflow-hidden flex items-center justify-center p-2 min-h-[450px]">
+              <iframe src={`/api/v1/growth/viral-leaderboard/embed?tenant=${tenant}&theme=${theme}&title=${encodeURIComponent(title)}&metric=${metric}&branding=${!hasPro}`} className="w-full h-full border-none rounded-xl" />
+           </div>
+        </div>
+      </div>
+
+      {showPaywall && (
+        <div className="fixed inset-0 bg-black/60 z-[60] flex items-center justify-center p-4">
+          <div className="bg-white rounded-2xl max-w-md p-8 shadow-2xl relative overflow-hidden font-inter border border-blue-100 text-center">
+             <div className="absolute top-0 right-0 w-32 h-32 bg-blue-50 rounded-bl-full -z-10"></div>
+             <div className="flex justify-end mb-2">
+               <button
+                 aria-label="Close paywall"
+                 onClick={() => setShowPaywall(false)}
+                 className="text-gray-400 hover:text-gray-600 rounded-full hover:bg-gray-100 transition-colors w-8 h-8 flex items-center justify-center"
+               >
+                 <span className="text-xl leading-none">&times;</span>
+               </button>
+             </div>
+             <div className="w-16 h-16 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-2xl flex items-center justify-center text-3xl shadow-lg mx-auto mb-6 text-white font-bold">
+               PRO
+             </div>
+             <h2 className="text-2xl font-bold font-outfit text-gray-900 mb-3">Upgrade to Remove Branding</h2>
+             <p className="text-gray-600 mb-6 text-sm leading-relaxed">
+               Make the Viral Leaderboard 100% yours. Upgrade to Pro to remove the "Powered by OHC" watermark.
+             </p>
+             <button
+               onClick={() => { setShowPaywall(false); window.location.href = '/pricing'; }}
+               className="w-full py-4 rounded-xl font-bold text-white mb-4 transition-all shadow-md hover:shadow-lg hover:opacity-90"
+               style={{ background: 'linear-gradient(135deg, #0066ff 0%, #3b82f6 100%)' }}
+             >
+               Upgrade to Pro
+             </button>
+             <button
+               onClick={() => setShowPaywall(false)}
+               className="mt-2 text-gray-500 hover:text-gray-700 font-medium text-sm w-full"
+             >
+               Cancel
+             </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/next/src/e2e/viral_leaderboard_generator.spec.ts
+++ b/src/ui/next/src/e2e/viral_leaderboard_generator.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from './fixtures';
+import { currentAppSmoke } from './current_app_smoke';
+
+test('viral_leaderboard_generator_smoke', async ({ page, request, loginAs, adminUser }) => {
+  await loginAs(page, adminUser);
+  await currentAppSmoke(page, request, 'viral_leaderboard_generator_smoke');
+});
+
+test.describe('Viral Leaderboard Generator', () => {
+    test('generator page renders correctly and embed code contains branding by default', async ({ page, adminUser, loginAs }) => {
+        await loginAs(page, adminUser);
+
+        // Wait for dashboard to load then click link
+        await page.goto('/dashboard.html');
+        const link = page.locator('a[id="viral-leaderboard-link"]');
+        await expect(link).toBeVisible();
+        await link.click();
+
+        // Check the page header
+        await expect(page.locator('h1', { hasText: 'Viral Leaderboard Generator' })).toBeVisible();
+
+        // Configure the widget
+        const titleInput = page.locator('input[type="text"]').first();
+        await titleInput.fill('Top Ambassadors');
+
+        const metricSelect = page.locator('select').first();
+        await metricSelect.selectOption('buyers');
+
+        // The preview iframe should load
+        const iframe = page.locator('iframe').first();
+        await expect(iframe).toBeVisible();
+
+        // Check the generated embed code
+        const embedCode = await page.locator('pre').first().innerText();
+        expect(embedCode).toContain('title=Top%20Ambassadors');
+        expect(embedCode).toContain('metric=buyers');
+        expect(embedCode).toContain('branding=true');
+    });
+
+    test('should show soft paywall when attempting to remove branding without pro', async ({ page, adminUser, loginAs }) => {
+        await loginAs(page, adminUser);
+        await page.goto('/dashboard.html');
+        await page.evaluate(() => {
+            localStorage.setItem('tenant', 'e2e-test-store');
+            localStorage.setItem('has_pro', 'false');
+        });
+
+        const link = page.locator('a[id="viral-leaderboard-link"]');
+        await expect(link).toBeVisible();
+        await link.click();
+
+        const removeBrandingCheckbox = page.locator('#removeBranding');
+        await removeBrandingCheckbox.check();
+
+        // Soft paywall should appear
+        const paywallModal = page.locator('h2', { hasText: 'Upgrade to Remove Branding' });
+        await expect(paywallModal).toBeVisible();
+    });
+
+    test('should hide branding when pro is enabled and toggle is clicked', async ({ page, adminUser, loginAs }) => {
+        await loginAs(page, adminUser);
+        await page.goto('/dashboard.html');
+        await page.evaluate(() => {
+            localStorage.setItem('tenant', 'e2e-test-store');
+            localStorage.setItem('has_pro', 'true');
+        });
+
+        const link = page.locator('a[id="viral-leaderboard-link"]');
+        await expect(link).toBeVisible();
+        await link.click();
+
+        const removeBrandingCheckbox = page.locator('#removeBranding');
+        await removeBrandingCheckbox.check();
+
+        // Soft paywall should not appear
+        const paywallModal = page.locator('h2', { hasText: 'Upgrade to Remove Branding' });
+        await expect(paywallModal).not.toBeVisible();
+
+        // The generated link should NOT include the branding parameter as true
+        const embedCode = await page.locator('pre').first().innerText();
+        expect(embedCode).toContain('branding=false');
+    });
+});


### PR DESCRIPTION
Implement Viral Leaderboard Generator feature to encourage competition and drive referrals/sales.

This PR adds:
1. `ViralLeaderboardGeneratorPage` - A UI component to configure and preview the viral leaderboard widget.
2. `GET` route for `/api/v1/growth/viral-leaderboard/embed` - API route that serves the actual HTML/CSS leaderboard representation, displaying mock data based on the chosen metric ("buyers" vs. "referrers") and including the "Powered by OHC" branding link if applicable.
3. Link to the generator in the main dashboard's Growth & Virality section.
4. E2E tests verifying the generator page, soft paywall interactions, and default embed code.

E2E tests have been added and registered in `src/e2e/BUILD.bazel`. Tested manually using Playwright for UI correctness.

---
*PR created automatically by Jules for task [5582905482430001777](https://jules.google.com/task/5582905482430001777) started by @ql-owo-lp*