### PR TITLE
🎥 Lens Audit: fix missing rounded-[16px] token on field ops cards

### DIFF
--- a/src/ui/next/src/app/field-ops/jobs/page.test.tsx
+++ b/src/ui/next/src/app/field-ops/jobs/page.test.tsx
@@ -14,6 +14,12 @@ vi.mock('../../../lib/powersync/PowerSyncProvider', () => ({
   PowerSyncProvider: ({ children }: any) => <div data-testid="powersync-provider">{children}</div>,
   isPowerSyncSupportedForLocation: () => true
 }));
+vi.mock('../../../lib/powersync/db', () => ({
+  getPowerSyncDB: vi.fn(() => Promise.resolve({
+    execute: vi.fn()
+  }))
+}));
+
 vi.mock('@powersync/react', () => ({
   useQuery: vi.fn(() => ({ data: [] })),
   PowerSyncContext: { Provider: ({ children }: any) => <div>{children}</div> }

--- a/src/ui/next/src/app/field-ops/jobs/page.tsx
+++ b/src/ui/next/src/app/field-ops/jobs/page.tsx
@@ -370,7 +370,7 @@ function FieldOpsJobsPageContent() {
         {jobs.map((job) => (
           <div
             key={job.id}
-            className="bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm border border-white/40 overflow-hidden"
+            className="bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm border border-white/40 overflow-hidden rounded-[16px]"
           >
             <div className="p-5 border-b border-gray-100 bg-gray-50/50">
               <div className="flex justify-between items-start mb-2">

--- a/src/ui/next/vitest.setup.ts
+++ b/src/ui/next/vitest.setup.ts
@@ -197,3 +197,28 @@ console.error = (...args: any[]) => {
 
 // Set IS_REACT_ACT_ENVIRONMENT
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+// Mock Worker
+class Worker {
+  constructor(stringUrl: string) {}
+  onmessage: (this: Worker, ev: MessageEvent) => any = () => {};
+  postMessage(message: any): void {}
+  terminate(): void {}
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  dispatchEvent(): boolean { return false; }
+}
+global.Worker = Worker as any;
+
+// Mock navigator.locks
+if (typeof navigator !== 'undefined') {
+  Object.defineProperty(navigator, 'locks', {
+    value: {
+      request: vi.fn(),
+      query: vi.fn()
+    },
+    writable: true
+  });
+}
+if (typeof navigator !== 'undefined' && navigator.locks) {
+  navigator.locks.request = vi.fn().mockImplementation(async (name, cb) => cb());
+}

--- a/src/ui/next/vitest.setup.ts
+++ b/src/ui/next/vitest.setup.ts
@@ -197,6 +197,7 @@ console.error = (...args: any[]) => {
 
 // Set IS_REACT_ACT_ENVIRONMENT
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
 // Mock Worker
 class Worker {
   constructor(stringUrl: string) {}
@@ -220,5 +221,9 @@ if (typeof navigator !== 'undefined') {
   });
 }
 if (typeof navigator !== 'undefined' && navigator.locks) {
-  navigator.locks.request = vi.fn().mockImplementation(async (name, cb) => cb());
+  navigator.locks.request = vi.fn().mockImplementation(async (name, cb) => {
+    if (typeof cb === 'function') {
+      return cb();
+    }
+  });
 }


### PR DESCRIPTION
This PR fixes a missing design token on the field ops jobs page where a `rounded-[16px]` border radius was missing from the job card container according to the OHC Premium Design Standard.
It also fixes broken vitest tests by providing correct mocks for `Worker` and `navigator.locks` required by `@powersync/web`, and explicitly mocks `getPowerSyncDB` in the specific test.

Tests have been run and a Playwright verification snippet confirmed visual UI state.

---
*PR created automatically by Jules for task [11921805644601004839](https://jules.google.com/task/11921805644601004839) started by @ql-owo-lp*