### PR TITLE
Fix onboarding redirect and LLM flake

### DIFF
--- a/src/server/orchestration/minimax_swarm.rs
+++ b/src/server/orchestration/minimax_swarm.rs
@@ -164,7 +164,7 @@ fn agent_prompt(
     let handoff_json = serde_json::to_string(&template.handoff_to).map_err(|err| err.to_string())?;
 
     Ok(format!(
-        "You are an OHC agent in a five-agent workspace. Agent id: {agent_id}. Role: {role}. Mission: {mission}. Task: {task}. Prior agent transcript JSON: {prior_json}. You must collaborate with the prior agents and hand off to exactly these next agents: {handoff_json}. Return strict JSON only with keys agent_id, role, contribution, handoff_to, confidence. contribution must mention at least one prior agent when prior transcript is non-empty, and must be concise but specific.",
+        "You are an OHC agent in a five-agent workspace. Agent id: {agent_id}. Role: {role}. Mission: {mission}. Task: {task}. Prior agent transcript JSON: {prior_json}. You must collaborate with the prior agents and hand off to exactly these next agents: {handoff_json} (do not include any other agents or omit any, ensure the list is exactly as provided). Return strict JSON only with keys agent_id, role, contribution, handoff_to, confidence. contribution must mention at least one prior agent when prior transcript is non-empty, and must be concise but specific.",
         agent_id = template.id,
         role = template.role,
         mission = template.mission,

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -3908,7 +3908,7 @@
               localStorage.removeItem("onboardingState");
               localStorage.setItem("has_onboarded", "true");
 
-              window.location.href = "dashboard.html";
+              window.location.href = "success.html";
               return;
             }
 
@@ -3952,7 +3952,7 @@
               localStorage.removeItem("onboardingState");
               localStorage.setItem("has_onboarded", "true");
 
-              window.location.href = "dashboard.html";
+              window.location.href = "success.html";
             } else {
               const errData = await response.json().catch(() => ({}));
               throw new Error(
@@ -4259,7 +4259,7 @@
                   localStorage.removeItem("onboardingState");
                   localStorage.setItem("has_onboarded", "true");
 
-                  window.location.href = "dashboard.html";
+                  window.location.href = "success.html";
                 })
                 .catch((err) => {
                   console.error(err);
@@ -4301,7 +4301,7 @@
                     }
                     localStorage.removeItem("onboardingState");
                     localStorage.setItem("has_onboarded", "true");
-                    window.location.href = "dashboard.html";
+                    window.location.href = "success.html";
                   } else {
                     const errData = await response.json().catch(() => ({}));
                     throw new Error(


### PR DESCRIPTION
This fixes an issue in the visual flow where users completing the onboarding wizard skipped the success.html confirmation. It also updates the server orchestration test suite that expected exact matching of the minimax agent task array

---
*PR created automatically by Jules for task [14824507478886317153](https://jules.google.com/task/14824507478886317153) started by @ql-owo-lp*