### PR TITLE
feat: implement viral trial extension growth loop on pricing page

### DIFF
--- a/src/e2e/viral_trial_extension.spec.ts
+++ b/src/e2e/viral_trial_extension.spec.ts
@@ -72,4 +72,32 @@ test.describe('Viral Trial Extension Loop', () => {
 
     await expect(page).toHaveURL(/.*\/dashboard/);
   });
+  test('should display the trial extension widget on the Pricing page and handle share', async ({ page, adminUser, loginAs }) => {
+    // Navigate to pricing
+    await loginAs(page, adminUser);
+    await page.goto('/pricing');
+
+    // Wait for the Pricing screen to load
+    await expect(page.locator('h1:has-text("Pricing Plans")')).toBeVisible();
+
+    // Verify the widget text
+    await expect(page.getByText('Want 7 Extra Days of Pro?')).toBeVisible();
+    await expect(page.getByText('Share on X (Twitter) to unlock a free week of advanced features.')).toBeVisible();
+
+    // The share button should be present inside the widget
+    const shareButton = page.getByRole('button', { name: /Share to Unlock/i });
+    await expect(shareButton).toBeVisible();
+    await expect(shareButton).toBeEnabled();
+
+    // Mock window.open to prevent popup
+    await page.evaluate(() => {
+      window.open = function() { return null; };
+    });
+
+    await shareButton.click();
+
+    // Verify it transitions to success state
+    await expect(page.getByText('Trial Extended!')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText("You've unlocked 7 days of Pro for free.")).toBeVisible();
+  });
 });

--- a/src/ui/next/src/app/components/ViralTrialExtensionWidget.tsx
+++ b/src/ui/next/src/app/components/ViralTrialExtensionWidget.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import React, { useState } from 'react';
+
+export function ViralTrialExtensionWidget() {
+  const [isClaiming, setIsClaiming] = useState(false);
+  const [hasClaimed, setHasClaimed] = useState(false);
+
+  const handleShareAndClaim = async () => {
+    setIsClaiming(true);
+
+    const message = "I just set up my AI-powered storefront using OneHumanCorp! 🚀 Get your own assistant-led business hub today. #OneHumanCorp #SmallBiz";
+    const shareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(message)}`;
+
+    // Open the share window
+    window.open(shareUrl, '_blank');
+
+    try {
+      const response = await fetch('/api/v1/growth/trial-extension/claim', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      });
+
+      if (response.ok) {
+        setHasClaimed(true);
+      } else {
+        console.error('Failed to claim trial extension');
+        alert("Failed to claim trial extension. Please try again.");
+      }
+    } catch (error) {
+      console.error('Error claiming trial extension:', error);
+      alert("Error claiming trial extension. Please try again.");
+    } finally {
+      setIsClaiming(false);
+    }
+  };
+
+  if (hasClaimed) {
+    return (
+      <div className="mt-4 p-4 bg-green-50 rounded-xl border border-green-100 text-center animate-fade-in">
+        <div className="text-green-600 text-2xl mb-2">🎉</div>
+        <h4 className="font-bold text-gray-900 text-sm mb-1 font-outfit">Trial Extended!</h4>
+        <p className="text-xs text-gray-600">You've unlocked 7 days of Pro for free.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 p-4 bg-indigo-50/50 rounded-xl border border-indigo-100 relative overflow-hidden group">
+      <div className="absolute top-0 right-0 w-16 h-16 bg-indigo-100 rounded-bl-full -z-10 group-hover:scale-110 transition-transform"></div>
+      <h4 className="font-bold text-gray-900 text-sm mb-2 font-outfit flex items-center gap-2">
+        <span className="text-indigo-600">🚀</span> Want 7 Extra Days of Pro?
+      </h4>
+      <p className="text-xs text-gray-600 mb-3">
+        Share on X (Twitter) to unlock a free week of advanced features.
+      </p>
+      <button
+        onClick={handleShareAndClaim}
+        disabled={isClaiming}
+        className={`w-full py-2 bg-indigo-600 text-white rounded-lg text-xs font-semibold hover:bg-indigo-700 transition-colors flex items-center justify-center gap-2 ${isClaiming ? 'opacity-70 cursor-wait' : ''}`}
+      >
+        {isClaiming ? (
+           <>
+             <svg className="animate-spin h-3 w-3 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+             </svg>
+             Verifying...
+           </>
+        ) : (
+          "Share to Unlock"
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/ui/next/src/app/pricing/page.test.tsx
+++ b/src/ui/next/src/app/pricing/page.test.tsx
@@ -16,6 +16,10 @@ vi.mock('../components/PoweredByOHC', () => ({
   PoweredByOHC: () => <div data-testid="powered-by-ohc" />,
 }));
 
+vi.mock('../components/ViralTrialExtensionWidget', () => ({
+  ViralTrialExtensionWidget: () => <div data-testid="viral-trial-extension-widget" />,
+}));
+
 describe('PricingPage', () => {
   const mockPush = vi.fn();
 
@@ -146,6 +150,13 @@ describe('PricingPage', () => {
       render(<PricingPage />);
     });
     expect(screen.getByTestId('powered-by-ohc')).toBeDefined();
+  });
+
+  it('renders the ViralTrialExtensionWidget when plan is Free', async () => {
+    await act(async () => {
+      render(<PricingPage />);
+    });
+    expect(screen.getByTestId('viral-trial-extension-widget')).toBeDefined();
   });
 
   it('renders the FAQ section with Stripe Billing integration info', async () => {

--- a/src/ui/next/src/app/pricing/page.tsx
+++ b/src/ui/next/src/app/pricing/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { WithTooltip } from '../../components/TooltipRegistry';
 import { PoweredByOHC } from '../components/PoweredByOHC';
+import { ViralTrialExtensionWidget } from '../components/ViralTrialExtensionWidget';
 
 export default function PricingPage() {
   const router = useRouter();
@@ -164,6 +165,9 @@ export default function PricingPage() {
               <button onClick={handleManageBilling} className="w-full min-h-[44px] px-4 py-2 bg-gray-200 text-gray-800 rounded-xl font-medium flex items-center justify-center hover:bg-gray-300 transition-colors">
                 Downgrade to Free
               </button>
+            )}
+            {(!loading && (currentPlan === 'Free' || !currentPlan)) && (
+              <ViralTrialExtensionWidget />
             )}
           </div>
 


### PR DESCRIPTION
**Motivation**
To rapidly acquire new owners/operators and convert users into advocates, this PR implements the Viral Trial Extension growth loop on the pricing page. When Free tier users navigate to upgrade, they are presented with an interactive widget that grants them a 7-day Pro extension in exchange for a promotional share on X, satisfying the growth goal of utilizing interactive trial extensions.

**Changes**
* Created `ViralTrialExtensionWidget.tsx` component implementing the share-to-unlock UX.
* Updated `PricingPage` (`page.tsx`) to conditionally render the widget for users on the `Free` plan.
* Modified the E2E test `viral_trial_extension.spec.ts` to assert that the trial extension flow is present and functional directly from the Pricing view.
* Updated `page.test.tsx` for Pricing page to mock and test the new widget inclusion.

**Testing**
* Tested with Playwright E2E UI verification against live dashboard routing for trial extension.
* Verified backend `/api/v1/growth/trial-extension/claim` capabilities matched our fetch call format.

---
*PR created automatically by Jules for task [2280647471878736513](https://jules.google.com/task/2280647471878736513) started by @ql-owo-lp*