### PR TITLE
✍️ Scribe: Fix Playwright E2E Tests for Walkthroughs and Help Center

### DIFF
--- a/src/e2e/documentation_features.spec.ts
+++ b/src/e2e/documentation_features.spec.ts
@@ -129,7 +129,7 @@ test.describe('AppShell Help Button', () => {
     await loginAs(page, unlimitedAdminUser);
     await page.goto('/api/ui/dashboard.html');
 
-    const helpButton = page.getByRole('link', { name: 'In-App Help Center' });
+    const helpButton = page.locator('#help-center-nav-btn');
     await expect(helpButton).toBeVisible();
 
     await Promise.all([

--- a/src/ui/tauri/src/ui/assistant.html
+++ b/src/ui/tauri/src/ui/assistant.html
@@ -262,7 +262,7 @@
       <div class="top-actions">
         <a href="workflow-builder.html" aria-label="Automations">Automations</a>
         <a href="agent-profile.html" aria-label="Expert Center">Expert Center</a>
-        <button id="assistant-walkthrough-btn" data-tooltip="assistant-walkthrough-btn" style="background: none; border: none; font-size: 14px; font-weight: 600; color: #0066FF; cursor: pointer; padding: 0 8px;" onclick="window.startWalkthrough([{selector: '#ohc-help-input-area', title: 'Activate your AI Support Agent', text: 'Chat here to activate your AI agent.'}])">Walkthrough</button>
+        <button id="assistant-walkthrough-btn" data-tooltip="assistant-walkthrough-btn" style="background: none; border: none; font-size: 14px; font-weight: 600; color: #0066FF; cursor: pointer; padding: 0 8px;" onclick="window.startWalkthrough([{selector: '.composer-input', title: 'Activate your AI Support Agent', text: 'Chat here to activate your AI agent.'}])">Walkthrough</button>
         <button id="help-center-nav-btn" data-tooltip="help-center-nav-btn" style="background: none; border: none; font-size: 18px; font-weight: 600; color: #1d1d1f; cursor: pointer; padding: 0 8px;" onclick="window.location.href='help.html'">?</button>
       </div>
     </header>


### PR DESCRIPTION
This PR fixes failing E2E tests related to documentation and help features.

- The `AppShell Help Button` test now targets the correct `#help-center-nav-btn` button instead of a link.
- The `Assistant walkthrough` in `src/ui/tauri/src/ui/assistant.html` now correctly targets `.composer-input` to show the walkthrough bubble since `#ohc-help-input-area` was not present in the DOM.

These fixes address the test failures reported by Playwright while ensuring the feature remains functional.

---
*PR created automatically by Jules for task [15245447096033777514](https://jules.google.com/task/15245447096033777514) started by @ql-owo-lp*