### PR TITLE
Fix tenant isolation bug in `revoke_token`

### DIFF
--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -412,8 +412,6 @@ impl UserRepository for PgUserRepository {
 
     async fn revoke_token(&self, jti: String, exp: DateTime<Utc>, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
@@ -433,11 +431,7 @@ impl UserRepository for PgUserRepository {
 
 
         let now = chrono::Utc::now();
-        let _ = if should_bypass {
-            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1").bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = current_setting('app.current_tenant')::text").bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?
-        };
+        sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = current_setting('app.current_tenant')::text").bind(now).execute(&mut *tx).await.map_err(|e| e.to_string())?;
 
         tx.commit().await.map_err(|e| e.to_string())?;
 

--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -334,8 +334,6 @@ impl UserRepository for SqliteUserRepository {
 
     async fn revoke_token(&self, jti: String, exp: DateTime<Utc>, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = (!is_multitenant) && org_id.eq_ignore_ascii_case("system");
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
 
@@ -354,11 +352,7 @@ impl UserRepository for SqliteUserRepository {
 
 
         let now = chrono::Utc::now();
-        if should_bypass {
-            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1").bind(now).execute(&mut *tx).await.map_err(|e: sqlx::Error| e.to_string())?;
-        } else {
-            sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = $2").bind(now).bind(org_id).execute(&mut *tx).await.map_err(|e: sqlx::Error| e.to_string())?;
-        }
+        sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < $1 AND tenant_id = $2").bind(now).bind(org_id).execute(&mut *tx).await.map_err(|e: sqlx::Error| e.to_string())?;
 
         tx.commit().await.map_err(|e| e.to_string())?;
 


### PR DESCRIPTION
In `revoke_token` methods in both PostgreSQL and SQLite stores, the code was conditionally bypassing tenant filtering and deleting all expired tokens across all tenants when the caller was acting as the system organization in standalone mode. 

This change ensures that `DELETE FROM revoked_tokens` strictly uses the appropriate `tenant_id` context filtering (using `current_setting('app.current_tenant')::text` for PostgreSQL and explicit parameter binding for SQLite). Dead code logic related to checking `should_bypass` within `revoke_token` has been cleanly removed to eliminate compiler warnings.

---
*PR created automatically by Jules for task [13367665106043010034](https://jules.google.com/task/13367665106043010034) started by @ql-owo-lp*