### PR TITLE
🤖 Implementer: Harness Upgrade - Output Parsing: Schema-constrained responses with Pydantic fallback

### DIFF
--- a/src/agents/builtin/tools/superpowers_tool.rs
+++ b/src/agents/builtin/tools/superpowers_tool.rs
@@ -1,25 +1,27 @@
 use ohc_builtin_agent_core::types::ToolError;
-use serde_json::{json, Value};
+use serde_json::json;
 
 use std::sync::Arc;
 
-use super::{Tool, ToolExecutor};
+use super::Tool;
 
+use serde::Deserialize;
+use super::pydantic::{PydanticToolExecutor, PydanticAdapter};
+
+#[derive(Deserialize)]
+struct SuperpowersArgs {
+    skill_name: String,
+    #[serde(default)]
+    context: Option<String>,
+}
 
 struct SuperpowersSkillExecutor {}
 
 #[async_trait::async_trait]
-impl ToolExecutor for SuperpowersSkillExecutor {
-    async fn execute(&self, args: Value) -> Result<String, ToolError> {
-        let skill_name = args
-            .get("skill_name")
-            .and_then(Value::as_str)
-            .ok_or_else(|| ToolError::LlmRecoverable("skill_name is required".to_string()))?;
-
-        let context = args
-            .get("context")
-            .and_then(Value::as_str)
-            .unwrap_or_default();
+impl PydanticToolExecutor<SuperpowersArgs> for SuperpowersSkillExecutor {
+    async fn execute_typed(&self, args: SuperpowersArgs) -> Result<String, ToolError> {
+        let skill_name = args.skill_name;
+        let context = args.context.unwrap_or_default();
 
         Ok(format!(
             "Superpowers skill '{}' executed with context: {}. Please follow the instructions injected in your prompt for this skill.",
@@ -47,6 +49,6 @@ pub fn superpowers_skill_tool() -> Tool {
             },
             "required": ["skill_name"]
         }),
-        execute: Arc::new(SuperpowersSkillExecutor {}),
+        execute: Arc::new(PydanticAdapter::new(SuperpowersSkillExecutor {})),
     }
 }


### PR DESCRIPTION
🤖 Implementer: Harness Upgrade - Output Parsing: Schema-constrained responses with Pydantic fallback

**Master Catalog Implementation:**
This PR upgrades the `superpowers_skill_tool` in our Rust microservice to the "Pydantic-first tool schema validation" mechanic from the **Master Catalog B.6. Output Parsing** list.

**Implementation Details:**
- Defined a strongly-typed `SuperpowersArgs` struct.
- Changed `SuperpowersSkillExecutor` to implement `PydanticToolExecutor<SuperpowersArgs>` rather than `ToolExecutor`.
- Wrapped the executor instance with `PydanticAdapter::new()` when creating the tool definition.
- This ensures any tool argument errors (like missing fields or mismatched types) are now robustly caught via serde and returned to the LLM as `ToolError::LlmRecoverable` messages for self-correction rather than causing manual parse crashes or less descriptive errors.

**Testing/Verification:**
- Ran the full test suite (`bazelisk test //...`), and everything compiles and passes smoothly.
- UI/E2E tests (`bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"`) ran and passed successfully.
- Code review gave a "Correct".
- Superpowers skills injected into the prompt will correctly process via the upgraded harness mechanism.

---
*PR created automatically by Jules for task [2600697898896468494](https://jules.google.com/task/2600697898896468494) started by @ql-owo-lp*