### PR TITLE
fix: deduplicate triage feed items on dashboard

### DIFF
--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1732,8 +1732,7 @@
 
           const data = await res.json();
           // Adjust logic to match new ui triage shape if necessary
-          agentFeedItems = [...(data.triage || []), ...(data.pending_approvals || []), ...(data.agent_feed || []), ...(data.approvals || []), ...(data.items || [])];
-          if (agentFeedItems.length === 0) { agentFeedItems = (Array.isArray(data) ? data : (data.items || [])); }
+          agentFeedItems = data.triage || (Array.isArray(data) ? data : (data.items || []));
           if (agentFeedItems.length === 0) {
             triageQueue.innerHTML = `
               <div class="triage-item glassmorphism" data-testid="onboarding-welcome-card" style="background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(30px) saturate(210%); border-radius: 16px; padding: 20px; border: 1px solid rgba(0, 102, 255, 0.2); box-shadow: 0 4px 16px rgba(0, 102, 255, 0.1);">


### PR DESCRIPTION
Resolves #32000

The UI dashboard incorrectly concatenated the unified triage array with the separate subset arrays when loading the Agent Feed. This commit updates `loadUnifiedFeed` in `dashboard.html` to properly use the pre-unified `data.triage` payload returned by the backend, ensuring zero duplicates and delivering on the single pane of glass experience.

---
*PR created automatically by Jules for task [5333838952469099749](https://jules.google.com/task/5333838952469099749) started by @ql-owo-lp*