### PR TITLE
🧙 Wizard: setup wizard inputs border-radius

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -185,12 +185,12 @@
           0 4px 6px -1px rgba(0, 0, 0, 0.1),
           0 2px 4px -1px rgba(0, 0, 0, 0.06);
       }
-      textarea.glassmorphism, input.glassmorphism {
+      textarea.glassmorphism, input.glassmorphism, select.glassmorphism {
         background: rgba(255, 255, 255, 0.65);
         backdrop-filter: blur(30px) saturate(210%);
         -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
-        border-radius: 16px;
+        border-radius: 8px !important;
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
       }
       @media (prefers-color-scheme: dark) {

--- a/src/ui/tauri/src/ui/setup.html.rej
+++ b/src/ui/tauri/src/ui/setup.html.rej
@@ -1,0 +1,18 @@
+--- setup.html
++++ setup.html
+@@ -185,9 +185,13 @@
+           0 4px 6px -1px rgba(0, 0, 0, 0.1),
+           0 2px 4px -1px rgba(0, 0, 0, 0.06);
+       }
+-      input.glassmorphism, select.glassmorphism, textarea.glassmorphism {
++      textarea.glassmorphism, input.glassmorphism {
++        background: rgba(255, 255, 255, 0.65);
++        backdrop-filter: blur(30px) saturate(210%);
++        -webkit-backdrop-filter: blur(30px) saturate(210%);
++        border: 1px solid rgba(255, 255, 255, 0.4);
+         border-radius: 8px !important;
+-        box-shadow: none !important;
++        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+       }
+       @media (prefers-color-scheme: dark) {
+         .glassmorphism {


### PR DESCRIPTION
Fix the styling of input forms in the setup wizard (`setup.html`) to apply a uniform 16px border-radius to glassmorphism containers, but keep inputs at 8px, aligning with the OHC Premium Glassmorphism mandate.

---
*PR created automatically by Jules for task [6100614322952827761](https://jules.google.com/task/6100614322952827761) started by @ql-owo-lp*