### PR TITLE
Fix triage action payload structure in UI

### DIFF
--- a/src/ui/tauri/src/ui/triage.html
+++ b/src/ui/tauri/src/ui/triage.html
@@ -558,12 +558,12 @@
         try {
           // If approved is false, status should be DISMISSED
           const action_status = approved ? "APPROVED" : "DISMISSED";
-          let payload = { action_status };
+          let payload = { triage_item_id: id, approved: approved };
           if (approved && editValue !== null) {
              payload.edited_payload = editValue;
           }
 
-          const res = await fetch(`/api/ui/triage/action?tenant_id=${encodeURIComponent(tenantId())}&id=${encodeURIComponent(id)}`, {
+          const res = await fetch(`/api/ui/triage/action?tenant_id=${encodeURIComponent(tenantId())}`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)


### PR DESCRIPTION
This PR fixes the triage action payload bug as requested in the task description. The backend route `/api/ui/triage/action` expected `TriageActionPayload` with `triage_item_id` and `approved`, but the UI in `src/ui/tauri/src/ui/triage.html` was sending `action_status` and putting `id` in the URL. This has been updated to match the backend expectation.

Resolves #32015

No superpowers were explicitly loaded but this resolves the reported UI-to-API discrepancy and enables tests. E2E UI verification was skipped because this is purely an API contract alignment fix.

---
*PR created automatically by Jules for task [5241126287579462409](https://jules.google.com/task/5241126287579462409) started by @ql-owo-lp*