### PR TITLE
Add UI feedback toast notifications to Tooltip Registry

### DIFF
--- a/src/e2e/tooltip_registry.spec.ts
+++ b/src/e2e/tooltip_registry.spec.ts
@@ -10,9 +10,20 @@ test.describe('Tooltip Registry', () => {
     await page.fill('#new-text', 'My test tooltip text');
     await page.click('#add-btn');
 
+    // Wait for the UI to show the success toast
+    await expect(page.locator('.ohc-toast')).toHaveText('Tooltip added successfully');
+
     // Wait for the UI to update the table
     await page.waitForTimeout(1000); // UI may take a bit to fetch again
 
     await expect(page.locator('input#input-test-dynamic-id')).toHaveValue('My test tooltip text');
+
+    // Test updating
+    await page.fill('input#input-test-dynamic-id', 'Updated test tooltip text');
+    const row = page.locator('tr').filter({ hasText: 'test-dynamic-id' });
+    await row.locator('button', { hasText: 'Save' }).click();
+
+    // Wait for the UI to show the success toast for update
+    await expect(page.locator('.ohc-toast').last()).toHaveText('Tooltip updated successfully');
   });
 });

--- a/src/ui/tauri/src/ui/tooltip-registry.html
+++ b/src/ui/tauri/src/ui/tooltip-registry.html
@@ -34,6 +34,18 @@
       .glassmorphism-input {
         border-radius: 8px;
       }
+
+        .ohc-toast { position: fixed; bottom: 20px; right: 20px; padding: 12px 20px; border-radius: 8px; color: white; font-weight: 500; font-size: 14px; z-index: 10000; opacity: 0; transform: translateY(20px); transition: opacity 0.3s, transform 0.3s; box-shadow: 0 4px 12px rgba(0,0,0,0.15); pointer-events: none; }
+        .ohc-toast.show { opacity: 1; transform: translateY(0); }
+        .ohc-toast.success { background-color: rgba(34, 197, 94, 0.9); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: 1px solid rgba(255,255,255,0.2); }
+        .ohc-toast.error { background-color: rgba(239, 68, 68, 0.9); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: 1px solid rgba(255,255,255,0.2); }
+
+
+        .ohc-toast { position: fixed; bottom: 20px; right: 20px; padding: 12px 20px; border-radius: 8px; color: white; font-weight: 500; font-size: 14px; z-index: 10000; opacity: 0; transform: translateY(20px); transition: opacity 0.3s, transform 0.3s; box-shadow: 0 4px 12px rgba(0,0,0,0.15); pointer-events: none; }
+        .ohc-toast.show { opacity: 1; transform: translateY(0); }
+        .ohc-toast.success { background-color: rgba(34, 197, 94, 0.9); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: 1px solid rgba(255,255,255,0.2); }
+        .ohc-toast.error { background-color: rgba(239, 68, 68, 0.9); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: 1px solid rgba(255,255,255,0.2); }
+
     </style>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -58,6 +70,12 @@
             h1 { font-size: 24px; }
             input { font-size: 14px; padding: 12px; }
         }
+
+        .ohc-toast { position: fixed; bottom: 20px; right: 20px; padding: 12px 20px; border-radius: 8px; color: white; font-weight: 500; font-size: 14px; z-index: 10000; opacity: 0; transform: translateY(20px); transition: opacity 0.3s, transform 0.3s; box-shadow: 0 4px 12px rgba(0,0,0,0.15); pointer-events: none; }
+        .ohc-toast.show { opacity: 1; transform: translateY(0); }
+        .ohc-toast.success { background-color: rgba(34, 197, 94, 0.9); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: 1px solid rgba(255,255,255,0.2); }
+        .ohc-toast.error { background-color: rgba(239, 68, 68, 0.9); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: 1px solid rgba(255,255,255,0.2); }
+
     </style>
 </head>
 <body>
@@ -78,10 +96,28 @@
         </div>
     </div>
     <script>
+
+        function showToast(message, isError = false) {
+            const toast = document.createElement('div');
+            toast.className = `ohc-toast ${isError ? 'error' : 'success'}`;
+            toast.innerText = message;
+            document.body.appendChild(toast);
+
+            // Trigger reflow
+            void toast.offsetWidth;
+
+            toast.classList.add('show');
+
+            setTimeout(() => {
+                toast.classList.remove('show');
+                setTimeout(() => toast.remove(), 300);
+            }, 3000);
+        }
+
         async function loadTooltips() {
             try {
                 const res = await fetch('/api/tooltips');
-                if (!res.ok) return;
+                if (!res.ok) throw new Error('Network error');
                 const data = await res.json();
                 const tbody = document.getElementById('registry-body');
                 tbody.innerHTML = '';
@@ -89,42 +125,76 @@
                     tbody.innerHTML += `<tr>
                         <td>${id}</td>
                         <td><input type="text" id="input-${id}" value="${text.replace(/"/g, '&quot;')}" /></td>
-                        <td><button onclick="update('${id}')">Save</button></td>
+                        <td><button onclick="update('${id}', event)">Save</button></td>
                     </tr>`;
                 }
             } catch (e) {
                 console.error('Failed to load tooltips', e);
+                showToast("Failed to load tooltips", true);
             }
         }
-        window.update = async function(id) {
+        window.update = async function(id, event) {
             const text = document.getElementById('input-' + id).value;
+            const btn = event ? event.target : null;
+            let originalText = '';
+            if (btn) {
+                originalText = btn.innerText;
+                btn.innerText = 'Saving...';
+                btn.disabled = true;
+            }
             try {
-                await fetch('/api/tooltips', {
+                const res = await fetch('/api/tooltips', {
                     method: 'POST', headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ id, text })
                 });
-                loadTooltips();
+                if (!res.ok) throw new Error('Failed to save');
+                showToast("Tooltip updated successfully");
+                await loadTooltips();
             } catch (e) {
                 console.error('Failed to update tooltip', e);
+                showToast("Failed to update tooltip", true);
+            } finally {
+                if (btn) {
+                    btn.innerText = originalText;
+                    btn.disabled = false;
+                }
             }
         };
-        document.getElementById('add-btn').onclick = async () => {
+        document.getElementById('add-btn').onclick = async (event) => {
             const id = document.getElementById('new-id').value;
             const text = document.getElementById('new-text').value;
             if (!id || !text) return;
+
+            const btn = event ? event.target : null;
+            let originalText = '';
+            if (btn) {
+                originalText = btn.innerText;
+                btn.innerText = 'Adding...';
+                btn.disabled = true;
+            }
+
             try {
-                await fetch('/api/tooltips', {
+                const res = await fetch('/api/tooltips', {
                     method: 'POST', headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ id, text })
                 });
+                if (!res.ok) throw new Error('Failed to save');
                 document.getElementById('new-id').value = '';
                 document.getElementById('new-text').value = '';
-                loadTooltips();
+                showToast("Tooltip added successfully");
+                await loadTooltips();
             } catch (e) {
                 console.error('Failed to add tooltip', e);
+                showToast("Failed to add tooltip", true);
+            } finally {
+                if (btn) {
+                    btn.innerText = originalText;
+                    btn.disabled = false;
+                }
             }
         };
         loadTooltips();
+
     </script>
 </body>
 </html>


### PR DESCRIPTION
Added visual toast notifications (success and error) and button loading states when updating/adding tooltips in `tooltip-registry.html` so the UI has proper feedback instead of silent console errors. Added assertions to `src/e2e/tooltip_registry.spec.ts` for E2E coverage of this feature.

---
*PR created automatically by Jules for task [12032896075033547127](https://jules.google.com/task/12032896075033547127) started by @ql-owo-lp*