### PR TITLE
feat(docs): implement interactive walkthrough target and optimize help center empty state

### DIFF
--- a/src/ui/next/src/app/dashboard/WrappedWidget.tsx
+++ b/src/ui/next/src/app/dashboard/WrappedWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { WalkthroughTarget } from "../../components/Walkthrough";
 
 type WrappedStats = {
   totalSales: string;
@@ -59,8 +60,8 @@ export function WrappedWidget() {
   };
 
   return (
+    <WalkthroughTarget id="wrapped-summary">
     <section
-        id="wrapped-summary"
         data-testid="wrapped-widget"
         className="mb-6 relative overflow-hidden rounded-[24px] border border-white/40 dark:border-white/10 shadow-xl bg-gradient-to-br from-pink-500/90 via-purple-500/90 to-indigo-600/90 dark:from-pink-900/80 dark:via-purple-900/80 dark:to-indigo-950/80 backdrop-blur-[40px] backdrop-saturate-[2] p-6 text-white group transform transition-all hover:scale-[1.01]"
     >
@@ -142,5 +143,6 @@ export function WrappedWidget() {
         </div>
       </div>
     </section>
+    </WalkthroughTarget>
   );
 }

--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -92,19 +92,19 @@ export default function HelpCenterPage() {
         </div>
 
         {filteredArticles.length === 0 && filteredVideos.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 px-4 backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.08)] rounded-3xl min-h-[300px] w-full max-w-[400px] mx-auto transition-all">
-            <svg className="w-16 h-16 max-w-[64px] max-h-[64px] text-gray-400 mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="flex flex-col items-center justify-center py-24 px-8 backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.08)] rounded-3xl min-h-[400px] w-full max-w-2xl mx-auto transition-all">
+            <svg className="w-20 h-20 max-w-[80px] max-h-[80px] text-gray-400 mb-6 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-            <p className="text-center text-gray-600 font-medium text-lg">
-              No results found matching <span className="text-gray-900 font-semibold">"{searchQuery}"</span>
+            <p className="text-center text-gray-700 dark:text-gray-300 font-medium text-xl md:text-2xl mb-2">
+              No results found matching <span className="text-gray-900 dark:text-gray-100 font-semibold">"{searchQuery}"</span>
             </p>
-            <p className="text-center text-gray-500 mt-2 text-sm">
+            <p className="text-center text-gray-500 dark:text-gray-400 text-base md:text-lg mb-8 max-w-md">
               Try adjusting your search terms or ask our AI assistant for help.
             </p>
             <WithTooltip id="ask-ai-tooltip" defaultText="Open AI Help Chat to get answers instantly.">
             <button
-              className="mt-6 px-6 py-3 bg-blue-600/95 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg backdrop-blur-md saturate-[210%] transition-all min-h-[44px] hover:scale-105 active:scale-95"
+              className="px-8 py-4 bg-[#0071E3] hover:bg-[#0077ED] text-white font-semibold rounded-full shadow-lg backdrop-blur-md saturate-[210%] transition-all min-h-[44px] hover:-translate-y-1 active:scale-95 text-lg"
               onClick={() => {
                 const event = new CustomEvent('open-help-chat');
                 window.dispatchEvent(event);


### PR DESCRIPTION
This PR addresses two specific gaps regarding the in-app documentation and onboarding flow:

1. **Dashboard Interactive Walkthrough Fix:** Added a `WalkthroughTarget` component around `WrappedWidget.tsx`. Previously, the dashboard tests verified the presence of the tutorial walkthrough text `"Welcome to your dashboard! This is your control center."`, but the UI was missing the required target bindings to anchor the bubbles accurately.
2. **Help Center Responsive Layout Polish:** Optimized the `src/ui/next/src/app/help/page.tsx` empty-state UI component. Widened the maximum width constraints to a `max-w-2xl` scale, updated text sizes, and adjusted padding for a cleaner visual representation on varied screen sizes, adhering to the repository’s continuous UI refinement directives.

All associated NextJS vitest suites and overall project bazelisk tests pass properly. The front-end view of the empty-state adjustments has also been visually verified.

---
*PR created automatically by Jules for task [1195898115154024384](https://jules.google.com/task/1195898115154024384) started by @ql-owo-lp*