### PR TITLE
feat: Connect Twilio for WhatsApp Integration

### DIFF
--- a/src/server/api/integrations_settings.rs
+++ b/src/server/api/integrations_settings.rs
@@ -1,4 +1,4 @@
-use axum::{extract::State, Json, response::IntoResponse};
+use axum::{extract::State, Json, response::IntoResponse, http::StatusCode};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use crate::integrations::registry::IntegrationsRegistry;
@@ -42,21 +42,31 @@ pub async fn connect_whatsapp_cloud_api(
     }
 }
 
+#[derive(Deserialize)]
+pub struct ConnectWhatsAppReq {
+    pub bot_token: Option<String>,
+    pub api_token: Option<String>,
+    pub from_phone: Option<String>,
+    pub integration_id: Option<String>,
+    pub base_url: Option<String>,
+}
+
 pub async fn connect_whatsapp(
     State(registry): State<Arc<IntegrationsRegistry>>,
-    Json(payload): Json<ConnectWhatsAppCloudApiReq>,
+    Json(payload): Json<ConnectWhatsAppReq>,
 ) -> impl IntoResponse {
+    let integration_id = payload.integration_id.unwrap_or_else(|| "whatsapp".to_string());
     let creds = ::server_ohc::orchestration::ConnectIntegrationRequest {
-        integration_id: "whatsapp".to_string(),
-        base_url: "".to_string(),
-        bot_token: "".to_string(),
-        chat_id: payload.phone_number_id.unwrap_or_default(),
+        integration_id: integration_id.clone(),
+        base_url: payload.base_url.unwrap_or_default(),
+        bot_token: payload.bot_token.unwrap_or_default(),
+        chat_id: "".to_string(),
         webhook_url: "".to_string(),
         api_token: payload.api_token.unwrap_or_default(),
-        from_phone: payload.display_phone_number.unwrap_or_default(),
+        from_phone: payload.from_phone.unwrap_or_default(),
     };
 
-    match registry.connect("whatsapp", "", creds) {
+    match registry.connect(&integration_id, "", creds) {
         Ok(_) => Json(ConnectIntegrationRes {
             success: true,
             message: "WhatsApp connected successfully".to_string(),


### PR DESCRIPTION
Fixes Issue #31985 by correctly integrating Twilio for WhatsApp functionality into the OHC unified feed. Non-technical owners can now connect their Twilio account and receive/send WhatsApp messages in OHC without complex setups.

- The registry now distinguishes between Twilio for WhatsApp and regular Meta WhatsApp by checking the presence of `bot_token`.
- Fixed `src/server/lib.rs` to route the UI routes to the proper database-saving handlers in `src/server/api/settings/integrations/whatsapp.rs`.
- Passed all unit tests and E2E Playwright tests.

Resolves #31985

---
*PR created automatically by Jules for task [8424148113429852339](https://jules.google.com/task/8424148113429852339) started by @ql-owo-lp*