### PR TITLE
chore: align glassmorphism styling across ui components

### DIFF
--- a/src/ui/next/src/app/agents/page.tsx
+++ b/src/ui/next/src/app/agents/page.tsx
@@ -240,7 +240,7 @@ export default function AgentsPage() {
   }
   return (
     <div className="min-h-screen bg-stone-50 dark:bg-zinc-950 text-zinc-950 dark:text-zinc-50 transition-colors duration-200">
-      <header className="border-b border-zinc-200 dark:border-zinc-850 bg-white/70 dark:bg-zinc-900/70 backdrop-blur-[30px] sticky top-0 z-30">
+      <header className="border-b border-zinc-200 dark:border-zinc-850 bg-white/70 dark:bg-zinc-900/70 backdrop-blur-[30px] saturate-[210%] sticky top-0 z-30">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-5 sm:px-6 lg:px-8">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
@@ -482,7 +482,7 @@ function CatalogPanel({
   return (
     <>
       {/* Featured Scenarios Carousel */}
-      <div className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-6 shadow-sm">
+      <div className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-6 shadow-sm">
         <h3 className="text-lg font-bold text-zinc-900 dark:text-white mb-4">Featured Scenarios</h3>
         <div className="flex gap-4 overflow-x-auto pb-2 scrollbar-thin scrollbar-thumb-zinc-350 dark:scrollbar-thumb-zinc-700 scrollbar-track-transparent snap-x">
           {featuredScenarios.map((scenario) => (
@@ -514,7 +514,7 @@ function CatalogPanel({
       </div>
 
       {/* Search Filter Panel */}
-      <div className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+      <div className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
         <SectionHeader
           title={panel === 'teams' ? 'Expert Teams' : 'Browse experts'}
           detail="Search by job, pick a single expert or a coordinated team, then summon it into the task composer."
@@ -696,7 +696,7 @@ function ComposerPanel({
   startTask: () => void;
 }) {
   return (
-    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
       <div className="flex items-center justify-between gap-3 mb-4">
         <div>
           <h2 className="text-base font-bold text-zinc-900 dark:text-white">Task Composer</h2>
@@ -993,7 +993,7 @@ function SkillsPanel({
   setEnabledSkills: React.Dispatch<React.SetStateAction<string[]>>;
 }) {
   return (
-    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
       <SectionHeader title="Skill Market" detail="Install, disable, search, upload, or create natural-language skills for experts." />
       <div className="mb-4 flex flex-wrap gap-2">
         <button className="rounded-full bg-teal-600 hover:bg-teal-700 text-white px-4 py-2 text-xs font-bold transition-colors" type="button">Find skill</button>
@@ -1045,7 +1045,7 @@ function ConnectorsPanel({
   setEnabledConnectors: React.Dispatch<React.SetStateAction<string[]>>;
 }) {
   return (
-    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
       <SectionHeader title="Connector Center" detail="Connect external data and service actions for expert tasks." />
       <div className="mb-4 grid gap-3 md:grid-cols-3">
         {['Create custom connector', 'MCP endpoint', 'Notification channel'].map((label) => (
@@ -1102,7 +1102,7 @@ function AutomationsPanel() {
   ];
 
   return (
-    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
       <SectionHeader title="Scheduled Tasks" detail="Configure recurring expert runs with prompt, workspace, model, skills, connectors, and notifications." />
       
       <div className="mb-4 grid gap-3 md:grid-cols-3">
@@ -1193,7 +1193,7 @@ function MemoryPanel() {
   };
 
   return (
-    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
       <SectionHeader title="Consolidated Memory" detail="Review and override what AI agents remember about your business." />
 
       {loading ? (
@@ -1228,7 +1228,7 @@ function MemoryPanel() {
 }
 function ExplorePanel({ summon }: { summon: (item: ExpertCatalogItem) => void }) {
   return (
-    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
       <SectionHeader title="Explore Templates" detail="Curated templates prefill prompt, expert, skills, and connector choices." />
       <div className="grid gap-3 md:grid-cols-2">
         {exploreTemplates.map((template, index) => (
@@ -1248,7 +1248,7 @@ function ExplorePanel({ summon }: { summon: (item: ExpertCatalogItem) => void })
 }
 function RemotePanel() {
   return (
-    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
       <SectionHeader title="Remote Assistant Control" detail="Summon experts and receive notifications from business chat tools." />
       <div className="mb-4 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-950/30 p-3 text-xs font-bold text-teal-700 dark:text-teal-400 font-mono">
         /summon Growth Strategist
@@ -1266,7 +1266,7 @@ function RemotePanel() {
 }
 function DataPanel() {
   return (
-    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
       <SectionHeader title="Data Management" detail="Manage shared files, task archives, generated outputs, and workspace history." />
       <div className="grid gap-3 md:grid-cols-3">
         {['Shared files', 'Archived tasks', 'Generated outputs', 'Workspace history', 'Download center', 'Unshare queue'].map((item) => (
@@ -1280,7 +1280,7 @@ function DataPanel() {
 }
 function OperationsPanel() {
   return (
-    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
       <SectionHeader title="AI Departments" detail="Operational agents stay visible for backwards-compatible business management." />
       <div className="grid gap-3 md:grid-cols-2">
         {departments.map((department) => (
@@ -1371,7 +1371,7 @@ function WorkflowsPanel({ workflows, setWorkflows }: { workflows: WorkflowRecord
 }
 function FeedPanel({ feed }: { feed: ApprovalItem[] }) {
   return (
-    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
       <SectionHeader title="Activity Feed" detail="Realtime expert and department activity." />
       {feed.length === 0 ? (
         <p className="rounded-xl border border-dashed border-zinc-350 dark:border-zinc-750 p-4 text-xs text-zinc-500 dark:text-zinc-400">No activity yet.</p>
@@ -1396,7 +1396,7 @@ function ApprovalsPanel({
   decideApproval: (id: string, approved: boolean) => void;
 }) {
   return (
-    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
+    <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] saturate-[210%] p-5 shadow-sm">
       <SectionHeader title="Needs Approval" detail="Review high-risk drafts before experts execute or send." />
       {approvals.length === 0 ? (
         <div className="rounded-xl border border-dashed border-zinc-350 dark:border-zinc-750 p-5 text-center">

--- a/src/ui/next/src/app/anthropic-guardrails/page.tsx
+++ b/src/ui/next/src/app/anthropic-guardrails/page.tsx
@@ -52,7 +52,7 @@ export default function AnthropicGuardrailsPage() {
         Trust establishment, Session permissions, and High-risk user confirmation.
       </p>
 
-      <div className="space-y-6 bg-white/65 backdrop-blur-[30px] p-6 shadow-sm border border-white/40">
+      <div className="space-y-6 bg-white/65 backdrop-blur-[30px] saturate-[210%] p-6 shadow-sm border border-white/40">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-2">
             Tool to Execute

--- a/src/ui/next/src/app/booking-widget/page.tsx
+++ b/src/ui/next/src/app/booking-widget/page.tsx
@@ -66,14 +66,14 @@ export default function BookingWidgetBuilder() {
                         <button
                             aria-pressed={theme === 'light'}
                             onClick={() => setTheme('light')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Light
                         </button>
                         <button
                             aria-pressed={theme === 'dark'}
                             onClick={() => setTheme('dark')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Dark
                         </button>

--- a/src/ui/next/src/app/builder/components.tsx
+++ b/src/ui/next/src/app/builder/components.tsx
@@ -129,7 +129,7 @@ export function SmartBlock({ type, props }: { type: string; props: any }) {
           className="absolute inset-0 bg-cover bg-center opacity-90"
           style={{ backgroundImage: `url(${props.image})` }}
         >
-          <div className="absolute inset-0 bg-black/40 backdrop-blur-[2px]" />
+          <div className="absolute inset-0 bg-black/40 backdrop-blur-[30px] saturate-[210%]" />
         </div>
         <div className="relative z-10 p-6 flex flex-col items-center justify-center min-h-[300px] text-center text-white m-4 glassmorphism shadow-lg">
           <h1 className="text-3xl font-bold font-outfit mb-3 tracking-tight">{props.headline}</h1>

--- a/src/ui/next/src/app/changelog/page.tsx
+++ b/src/ui/next/src/app/changelog/page.tsx
@@ -38,14 +38,14 @@ export default function ChangelogPage() {
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#0071E3]"></div>
             </div>
           ) : sections.length === 0 ? (
-            <p className="text-center text-gray-500 font-medium py-8 backdrop-blur-[40px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.08)] rounded-3xl">
+            <p className="text-center text-gray-500 font-medium py-8 backdrop-blur-[30px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.08)] rounded-3xl">
               No changelog available.
             </p>
           ) : (
             sections.map((section, idx) => (
               <div
                 key={idx}
-                className="backdrop-blur-[40px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-6 sm:p-8 rounded-3xl transition-all hover:-translate-y-1 hover:shadow-[0_12px_40px_rgba(0,0,0,0.12)] hover:border-blue-300 dark:hover:border-blue-700"
+                className="backdrop-blur-[30px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-6 sm:p-8 rounded-3xl transition-all hover:-translate-y-1 hover:shadow-[0_12px_40px_rgba(0,0,0,0.12)] hover:border-blue-300 dark:hover:border-blue-700"
               >
                 <h2 className="text-xl sm:text-2xl font-bold text-[#0071E3] dark:text-blue-400 mb-4 font-outfit">
                   {section.version}
@@ -93,7 +93,7 @@ export default function ChangelogPage() {
               href="https://onehumancorp.com/changelog"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-[#0071E3] dark:text-blue-400 font-bold hover:text-blue-700 dark:hover:text-blue-300 bg-blue-50/80 dark:bg-blue-900/20 px-8 py-4 rounded-full border border-blue-100 dark:border-blue-800/50 inline-block shadow-sm backdrop-blur-xl saturate-[210%] transition-all hover:shadow-md hover:-translate-y-0.5"
+              className="text-[#0071E3] dark:text-blue-400 font-bold hover:text-blue-700 dark:hover:text-blue-300 bg-blue-50/80 dark:bg-blue-900/20 px-8 py-4 rounded-full border border-blue-100 dark:border-blue-800/50 inline-block shadow-sm backdrop-blur-[30px] saturate-[210%] transition-all hover:shadow-md hover:-translate-y-0.5"
             >
               Read the full technical changelog on our website →
             </a>

--- a/src/ui/next/src/app/chaos-report/page.tsx
+++ b/src/ui/next/src/app/chaos-report/page.tsx
@@ -94,7 +94,7 @@ export default function ChaosReportPage() {
                   className={`w-full rounded-t-md transition-all duration-500 ${isDarkMode ? 'bg-[#0066FF]/80' : 'bg-[#0066FF]/60'} group-hover:bg-blue-400 relative`}
                   style={{ height: `${Math.max(5, Math.min(100, val / 10))}%` }}
                 >
-                  <div className={`absolute -top-8 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity text-xs font-bold px-2 py-1 rounded ${isDarkMode ? 'bg-gray-800 text-white' : 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm text-gray-900'}`}>
+                  <div className={`absolute -top-8 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity text-xs font-bold px-2 py-1 rounded ${isDarkMode ? 'bg-gray-800 text-white' : 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm text-gray-900'}`}>
                     {val}ms
                   </div>
                 </div>

--- a/src/ui/next/src/app/checkout/page.tsx
+++ b/src/ui/next/src/app/checkout/page.tsx
@@ -203,7 +203,7 @@ function CheckoutContent() {
       >
         {isSuccess ? (
           <div className="flex flex-col gap-6">
-            <div className="p-8 flex flex-col justify-center items-center bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-lg rounded-[24px] text-center">
+            <div className="p-8 flex flex-col justify-center items-center bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-lg rounded-[24px] text-center">
               <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mb-4">
                 <svg
                   className="w-8 h-8 text-green-600"
@@ -240,7 +240,7 @@ function CheckoutContent() {
             />
           </div>
         ) : tier ? (
-          <div className="p-6 md:p-8 flex flex-col justify-between bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-lg rounded-[24px]">
+          <div className="p-6 md:p-8 flex flex-col justify-between bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-lg rounded-[24px]">
             <div className="mb-6">
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">
                 OHC {tier} Plan
@@ -502,7 +502,7 @@ function CheckoutContent() {
                 </p>
               )}
               {checkoutStatus === "Oops! Item just sold out." && (
-                <div className="fixed bottom-0 left-0 right-0 p-6 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] z-[100] shadow-2xl rounded-t-[24px]">
+                <div className="fixed bottom-0 left-0 right-0 p-6 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] z-[100] shadow-2xl rounded-t-[24px]">
                   <div className="flex items-start gap-4 max-w-lg mx-auto">
                     <div className="w-12 h-12 bg-red-100 rounded-full flex-shrink-0 flex items-center justify-center text-xl text-red-600">
                       <svg

--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -146,7 +146,7 @@ export default function CostDashboardPage() {
     >
       <div className="flex-1 max-w-4xl mx-auto w-full flex flex-col gap-6 font-inter">
         <section className="app-panel glass-panel hover:shadow-xl transition-shadow duration-300">
-            <div className="app-panel-header backdrop-blur-md bg-white/70 px-6 py-4">
+            <div className="app-panel-header backdrop-blur-[30px] saturate-[210%] bg-white/70 px-6 py-4">
                 <h2 className="app-panel-title text-xl font-bold font-outfit text-gray-900 dark:text-white">Advisory Summary</h2>
             </div>
             <div className="app-panel-body p-6">
@@ -158,7 +158,7 @@ export default function CostDashboardPage() {
 
         {/* My Plan Section */}
         <section id="my-plan-section" className="app-panel glass-panel">
-          <div className="app-panel-header backdrop-blur-md bg-white/70 px-6 py-4 flex justify-between items-center">
+          <div className="app-panel-header backdrop-blur-[30px] saturate-[210%] bg-white/70 px-6 py-4 flex justify-between items-center">
              <h2 className="app-panel-title text-xl font-bold font-outfit text-gray-900 dark:text-white">My Plan</h2>
              <button
                onClick={() => router.push('/pricing')}
@@ -221,26 +221,26 @@ export default function CostDashboardPage() {
 
         {/* Overview Section */}
         <section className="app-panel glass-panel hover:shadow-xl transition-shadow duration-300">
-            <div className="app-panel-header backdrop-blur-md bg-white/70 px-6 py-4">
+            <div className="app-panel-header backdrop-blur-[30px] saturate-[210%] bg-white/70 px-6 py-4">
                <h2 className="app-panel-title text-xl font-bold font-outfit text-gray-900 dark:text-white">Cost Transparency Dashboard</h2>
                <span id="cost-dashboard-period" className="text-sm text-gray-500 font-medium">Period: {data?.period_start} to {data?.period_end}</span>
             </div>
 
             <div className="app-panel-body p-6">
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                    <div className="app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl group">
+                    <div className="app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl group">
                         <h2 className="text-sm font-medium text-gray-500 mb-1">Total Costs</h2>
                         <p id="cost-dashboard-total-costs" className="text-3xl font-bold font-outfit text-gray-900 dark:text-white">{formatCurrency(data?.total_costs || 0)}</p>
                     </div>
-                    <div className="app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl group">
+                    <div className="app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl group">
                         <h2 className="text-sm font-medium text-gray-500 mb-1">Projected Monthly Cost</h2>
                         <p id="cost-dashboard-projected" className="text-3xl font-bold font-outfit text-[#0f766e] dark:text-[#6ac5bd]">{formatCurrency(data?.projected_monthly_cost || 0)}</p>
                     </div>
-                    <div className="app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl group">
+                    <div className="app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl group">
                         <h2 className="text-sm font-medium text-gray-500 mb-1">Total Revenue</h2>
                         <p id="cost-dashboard-revenue" className="text-3xl font-bold font-outfit text-green-600">{formatCurrency(data?.total_revenue || 0)}</p>
                     </div>
-                    <div className="app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl group">
+                    <div className="app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl group">
                         <h2 className="text-sm font-medium text-green-700 mb-1">Network & Storage Savings</h2>
                         <p id="cost-dashboard-total-savings" className="text-3xl font-bold font-outfit text-green-700">{formatCurrency((data?.bandwidth_savings || 0))}</p>
                         <p className="text-xs text-green-600 mt-2">Saved via auto-compression</p>
@@ -264,12 +264,12 @@ export default function CostDashboardPage() {
 
         {/* Breakdown Section */}
         <section className="app-panel glass-panel hover:shadow-xl transition-shadow duration-300">
-            <div className="app-panel-header backdrop-blur-md bg-white/70 px-6 py-4">
+            <div className="app-panel-header backdrop-blur-[30px] saturate-[210%] bg-white/70 px-6 py-4">
                 <h2 className="app-panel-title text-xl font-bold font-outfit text-gray-900 dark:text-white">Cost Breakdown</h2>
             </div>
 
             <div className="app-panel-body p-6 space-y-4">
-                <div className="flex flex-col app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
+                <div className="flex flex-col app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
                     <h3 className="font-medium text-gray-950 dark:text-white mb-4">7-Day Trend</h3>
                     {data?.trend && data.trend.length > 0 ? (
                         <div className="flex items-end h-32 gap-2 mt-4" id="cost-dashboard-trend">
@@ -294,7 +294,7 @@ export default function CostDashboardPage() {
                     )}
                 </div>
 
-                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
                     <div>
                         <span className="font-medium text-gray-900 dark:text-white flex items-center gap-2">
                             LLM Usage
@@ -316,7 +316,7 @@ export default function CostDashboardPage() {
                 </div>
 
                 {/* Per-Agent / Per-Feature Costs */}
-                <div className="flex flex-col app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
+                <div className="flex flex-col app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
                     <h3 className="font-medium text-gray-900 dark:text-white mb-2">Agent & Feature Costs</h3>
                     {data?.agent_costs && data.agent_costs.length > 0 ? (
                         <ul id="cost-dashboard-agent-costs" className="space-y-2">
@@ -332,7 +332,7 @@ export default function CostDashboardPage() {
                     )}
                 </div>
 
-                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
                     <div>
                         <span className="font-medium text-gray-900 dark:text-white">Storage</span>
                         <p className="text-sm text-gray-500 mt-1">Cost of cloud storage and file hosting.</p>
@@ -340,7 +340,7 @@ export default function CostDashboardPage() {
                     <span id="cost-dashboard-storage" className="text-lg font-semibold text-gray-900 dark:text-white">{formatCurrency(data?.storage_cost || 0)}</span>
                 </div>
 
-                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
                     <div>
                         <span className="font-medium text-gray-900 dark:text-white">Payment Fees</span>
                         <p className="text-sm text-gray-500 mt-1">Stripe transaction fees on processed revenue.</p>
@@ -348,7 +348,7 @@ export default function CostDashboardPage() {
                     <span id="cost-dashboard-payment-fees" className="text-lg font-semibold text-gray-900 dark:text-white">{formatCurrency(data?.payment_fees || 0)}</span>
                 </div>
 
-                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
                     <div>
                         <span className="font-medium text-gray-900 dark:text-white">Compute Usage</span>
                         <p className="text-sm text-gray-500 mt-1">Cost of container execution and background processing.</p>
@@ -356,7 +356,7 @@ export default function CostDashboardPage() {
                     <span id="cost-dashboard-compute" className="text-lg font-semibold text-gray-900 dark:text-white">{formatCurrency(data?.compute_cost || 0)}</span>
                 </div>
 
-                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
                     <div>
                         <span className="font-medium text-gray-900 dark:text-white">Network & Bandwidth</span>
                         <p className="text-sm text-gray-500 mt-1">Cost of CDN delivery and outbound traffic.</p>
@@ -364,7 +364,7 @@ export default function CostDashboardPage() {
                     <span id="cost-dashboard-network" className="text-lg font-semibold text-gray-900 dark:text-white">{formatCurrency(data?.network_cost || 0)}</span>
                 </div>
 
-                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
                     <div>
                         <span className="font-medium text-gray-900 dark:text-white">Email Sends</span>
                         <p className="text-sm text-gray-500 mt-1">Cost of transactional and marketing email delivery.</p>
@@ -372,7 +372,7 @@ export default function CostDashboardPage() {
                     <span id="cost-dashboard-email" className="text-lg font-semibold text-gray-900 dark:text-white">{formatCurrency(data?.email_cost || 0)}</span>
                 </div>
 
-                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
                     <div>
                         <span className="font-medium text-gray-900 dark:text-white">Outbound API Calls</span>
                         <p className="text-sm text-gray-500 mt-1">Cost of third-party integration usage.</p>
@@ -380,7 +380,7 @@ export default function CostDashboardPage() {
                     <span id="cost-dashboard-api" className="text-lg font-semibold text-gray-900 dark:text-white">{formatCurrency(data?.api_cost || 0)}</span>
                 </div>
 
-                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 rounded-2xl">
                     <div>
                         <span className="font-medium text-green-700">Network & Storage Savings</span>
                         <p className="text-sm text-green-600 mt-1">Savings from automated WebP compression and minification.</p>
@@ -390,7 +390,7 @@ export default function CostDashboardPage() {
             </div>
         </section>
 
-        <section className="app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg rounded-2xl hover:shadow-2xl transition-shadow duration-300 p-6 md:p-8">
+        <section className="app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg rounded-2xl hover:shadow-2xl transition-shadow duration-300 p-6 md:p-8">
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-6">
                 <h2 className="text-xl font-bold font-outfit text-gray-900 dark:text-white">Department Tier Usage</h2>
                 <span className="text-sm text-gray-500 font-medium">

--- a/src/ui/next/src/app/customer/memory-graph/page.tsx
+++ b/src/ui/next/src/app/customer/memory-graph/page.tsx
@@ -72,7 +72,7 @@ function CustomerMemoryGraphContent() {
     <div className="flex flex-col h-screen w-full bg-gray-50 dark:bg-gray-900 text-[#1D1D1F] dark:text-[#F5F5F7]">
       <div className="flex-1 overflow-y-auto p-4 max-w-2xl mx-auto w-full space-y-6 pt-8 pb-20">
 
-        <div className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-6 shadow-sm">
+        <div className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-6 shadow-sm">
           <div className="flex items-center gap-4 mb-4">
              <div className="w-16 h-16 rounded-full bg-indigo-100 dark:bg-indigo-900/50 flex items-center justify-center text-2xl font-bold text-[#0066FF]">
                {customerName.charAt(0)}
@@ -101,7 +101,7 @@ function CustomerMemoryGraphContent() {
                   <div className="flex items-center justify-center w-10 h-10 rounded-full border-2 border-white dark:border-gray-900 bg-white dark:bg-gray-800 text-gray-500 shadow shrink-0 md:order-1 md:group-odd:-translate-x-1/2 md:group-even:translate-x-1/2 z-10">
                      {getIcon(interaction.channel || interaction.type)}
                   </div>
-                  <div className="w-[calc(100%-4rem)] md:w-[calc(50%-2.5rem)] bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-4 shadow-sm">
+                  <div className="w-[calc(100%-4rem)] md:w-[calc(50%-2.5rem)] bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-4 shadow-sm">
                      <div className="flex items-center justify-between mb-1">
                         <span className="font-bold text-sm">{interaction.channel || (interaction.type === 'agent_reply' ? 'OHC Agent' : 'Customer')}</span>
                         <time className="text-xs text-gray-500">{interaction.date || (interaction.created_at ? new Date(interaction.created_at).toLocaleString() : '')}</time>

--- a/src/ui/next/src/app/dashboard/MorningBriefingCard.test.tsx
+++ b/src/ui/next/src/app/dashboard/MorningBriefingCard.test.tsx
@@ -49,7 +49,7 @@ describe('MorningBriefingCard', () => {
     // Visual styles check
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper).toHaveClass('backdrop-blur-[30px]');
-    expect(wrapper).toHaveClass('backdrop-saturate-[2.1]');
+    expect(wrapper).toHaveClass('saturate-[210%]');
     expect(wrapper).toHaveClass('bg-white/65');
   });
 

--- a/src/ui/next/src/app/dashboard/MorningBriefingCard.tsx
+++ b/src/ui/next/src/app/dashboard/MorningBriefingCard.tsx
@@ -103,7 +103,7 @@ try {
   };
 
   return (
-    <div className="p-6 mb-6 shadow-sm w-full relative overflow-hidden group bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] border border-white/40 dark:bg-[#16161a]/70 dark:backdrop-blur-[30px] dark:backdrop-saturate-[2.1] dark:border-white/10">
+    <div className="p-6 mb-6 shadow-sm w-full relative overflow-hidden group bg-white/65 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:bg-[#16161a]/70 dark:backdrop-blur-[30px] dark:saturate-[210%] dark:border-white/10">
       <div className="absolute top-0 right-0 w-24 h-24 bg-white/40 rounded-bl-full -z-10 group-hover:scale-110 transition-transform"></div>
 
       <div className="flex flex-col gap-4">

--- a/src/ui/next/src/app/dashboard/NeighborhoodPulseCard.test.tsx
+++ b/src/ui/next/src/app/dashboard/NeighborhoodPulseCard.test.tsx
@@ -62,7 +62,7 @@ describe('NeighborhoodPulseCard', () => {
 
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper).toHaveClass('backdrop-blur-[30px]');
-    expect(wrapper).toHaveClass('backdrop-saturate-[2.1]');
+    expect(wrapper).toHaveClass('saturate-[210%]');
     expect(wrapper).toHaveClass('bg-white/65');
   });
 

--- a/src/ui/next/src/app/dashboard/NeighborhoodPulseCard.tsx
+++ b/src/ui/next/src/app/dashboard/NeighborhoodPulseCard.tsx
@@ -51,7 +51,7 @@ export const NeighborhoodPulseCard = ({ tenant }: { tenant: string }) => {
 
   return (
     <div
-      className="p-6 rounded-2xl mb-6 shadow-xl relative overflow-hidden text-black dark:text-white bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] border border-white/40 dark:bg-[#16161a]/70 dark:backdrop-blur-[30px] dark:backdrop-saturate-[2.1] dark:border-white/10"
+      className="p-6 rounded-2xl mb-6 shadow-xl relative overflow-hidden text-black dark:text-white bg-white/65 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:bg-[#16161a]/70 dark:backdrop-blur-[30px] dark:saturate-[210%] dark:border-white/10"
     >
       {/* Decorative pulse element */}
       <div className="absolute top-0 right-0 w-64 h-64 bg-white opacity-10 rounded-full blur-3xl -mr-10 -mt-10 animate-pulse"></div>

--- a/src/ui/next/src/app/dashboard/ShiftReassignmentCard.tsx
+++ b/src/ui/next/src/app/dashboard/ShiftReassignmentCard.tsx
@@ -54,7 +54,7 @@ export const ShiftReassignmentCard: React.FC<ShiftReassignmentCardProps> = ({
   return (
     <div
       data-testid="shift-reassignment-card"
-      className="bg-[rgba(255,255,255,0.7)] dark:bg-[rgba(22,22,26,0.75)] backdrop-blur-[40px] backdrop-saturate-[200%] border border-[rgba(0,0,0,0.1)] dark:border-[rgba(255,255,255,0.1)] p-5 rounded-[24px] shadow-[0_8px_30px_rgb(0,0,0,0.04)] dark:shadow-[0_8px_30px_rgb(0,0,0,0.12)] flex flex-col gap-4 relative overflow-hidden transition-all duration-300"
+      className="bg-[rgba(255,255,255,0.7)] dark:bg-[rgba(22,22,26,0.75)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(0,0,0,0.1)] dark:border-[rgba(255,255,255,0.1)] p-5 rounded-[24px] shadow-[0_8px_30px_rgb(0,0,0,0.04)] dark:shadow-[0_8px_30px_rgb(0,0,0,0.12)] flex flex-col gap-4 relative overflow-hidden transition-all duration-300"
     >
       {/* Decorative gradient orb */}
       <div className="absolute top-0 right-0 w-32 h-32 bg-gradient-to-br from-[#FF9500]/20 to-[#FF2D55]/20 rounded-full blur-3xl -mr-10 -mt-10 pointer-events-none" />
@@ -72,7 +72,7 @@ export const ShiftReassignmentCard: React.FC<ShiftReassignmentCardProps> = ({
         </div>
       </div>
 
-      <div className="z-10 mt-2 bg-[#F5F5F7]/80 dark:bg-[#1C1C1E]/80 backdrop-blur-md p-4 rounded-xl border border-[rgba(0,0,0,0.05)] dark:border-[rgba(255,255,255,0.05)]">
+      <div className="z-10 mt-2 bg-[#F5F5F7]/80 dark:bg-[#1C1C1E]/80 backdrop-blur-[30px] saturate-[210%] p-4 rounded-xl border border-[rgba(0,0,0,0.05)] dark:border-[rgba(255,255,255,0.05)]">
          <span className="font-semibold text-sm text-[#1D1D1F] dark:text-[#F5F5F7] block mb-2">AI Proposal:</span>
          <p className="text-base text-[#1D1D1F] dark:text-[#F5F5F7]">
             {proposalText}

--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -691,7 +691,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
 
   if (error) {
     return (
-      <div className="w-full mb-6 p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[#FF3B30] text-[#FF3B30] text-center">
+      <div className="w-full mb-6 p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[#FF3B30] text-[#FF3B30] text-center">
         {error}
       </div>
     );
@@ -743,7 +743,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
         {activeTab === "proposals" && (
           <>
             {loading && (
-              <div className="w-full p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] text-center text-[#1D1D1F] dark:text-[#F5F5F7]">
+              <div className="w-full p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] text-center text-[#1D1D1F] dark:text-[#F5F5F7]">
                 Loading Agent Proposals...
               </div>
             )}
@@ -810,12 +810,12 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
         {activeTab === "activity" && (
           <>
             {activityLoading && (
-              <div className="w-full p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] text-center text-[#1D1D1F] dark:text-[#F5F5F7]">
+              <div className="w-full p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] text-center text-[#1D1D1F] dark:text-[#F5F5F7]">
                 Loading Activity Feed...
               </div>
             )}
             {!activityLoading && activities.length === 0 && (
-              <div className="w-full p-6 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] text-center">
+              <div className="w-full p-6 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] text-center">
                 <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 break-words">
                   No recent activity found.
                 </p>
@@ -825,7 +825,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
               {activities.map((activity) => (
                 <div
                   key={activity.id}
-                  className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-5 shadow-sm flex flex-col gap-3 opacity-90 min-h-[44px]"
+                  className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-5 shadow-sm flex flex-col gap-3 opacity-90 min-h-[44px]"
                 >
                   <div className="flex items-center justify-between">
                     <span className="text-xs font-bold font-outfit uppercase tracking-wider text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 px-2 py-1 rounded-[8px]">

--- a/src/ui/next/src/app/dashboard/WrappedWidget.tsx
+++ b/src/ui/next/src/app/dashboard/WrappedWidget.tsx
@@ -62,7 +62,7 @@ export function WrappedWidget() {
     <section
         id="wrapped-summary"
         data-testid="wrapped-widget"
-        className="mb-6 relative overflow-hidden rounded-[24px] border border-white/40 dark:border-white/10 shadow-xl bg-gradient-to-br from-pink-500/90 via-purple-500/90 to-indigo-600/90 dark:from-pink-900/80 dark:via-purple-900/80 dark:to-indigo-950/80 backdrop-blur-[40px] backdrop-saturate-[2] p-6 text-white group transform transition-all hover:scale-[1.01]"
+        className="mb-6 relative overflow-hidden rounded-[24px] border border-white/40 dark:border-white/10 shadow-xl bg-gradient-to-br from-pink-500/90 via-purple-500/90 to-indigo-600/90 dark:from-pink-900/80 dark:via-purple-900/80 dark:to-indigo-950/80 backdrop-blur-[30px] saturate-[210%] p-6 text-white group transform transition-all hover:scale-[1.01]"
     >
       {/* Decorative blurred blobs */}
       <div className="absolute -top-20 -right-20 w-64 h-64 bg-yellow-400/30 rounded-full blur-[80px] pointer-events-none"></div>

--- a/src/ui/next/src/app/dashboard/ledger/page.tsx
+++ b/src/ui/next/src/app/dashboard/ledger/page.tsx
@@ -45,7 +45,7 @@ export default function LedgerPage() {
         description="Recent financial activity"
       />
 
-      <div className="bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm border border-white/40-sm border border-slate-200 mt-6 p-6">
+      <div className="bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm border border-white/40-sm border border-slate-200 mt-6 p-6">
         {loading && <p className="text-slate-500">Loading ledger entries...</p>}
         {error && <ErrorState title="Error" message={error} />}
         {!loading && !error && entries.length === 0 && (

--- a/src/ui/next/src/app/digital-business-card/view/page.tsx
+++ b/src/ui/next/src/app/digital-business-card/view/page.tsx
@@ -130,7 +130,7 @@ function VCardContent() {
           <div className="px-6 space-y-4">
             {phone && (
               <a href={`tel:${phone.replace(/[^\d+]/g, '')}`} className="bg-gray-50 hover:bg-gray-100 p-4 rounded-2xl border border-gray-100 flex items-center gap-4 transition-colors group">
-                <div className="w-12 h-12 rounded-full bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform" style={{ color: themeColor }}>
+                <div className="w-12 h-12 rounded-full bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform" style={{ color: themeColor }}>
                   📱
                 </div>
                 <div className="overflow-hidden">
@@ -142,7 +142,7 @@ function VCardContent() {
 
             {email && (
               <a href={`mailto:${email}`} className="bg-gray-50 hover:bg-gray-100 p-4 rounded-2xl border border-gray-100 flex items-center gap-4 transition-colors group">
-                <div className="w-12 h-12 rounded-full bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform" style={{ color: themeColor }}>
+                <div className="w-12 h-12 rounded-full bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform" style={{ color: themeColor }}>
                   ✉️
                 </div>
                 <div className="overflow-hidden">
@@ -154,7 +154,7 @@ function VCardContent() {
 
             {website && (
               <a href={website.startsWith('http') ? website : `https://${website}`} target="_blank" rel="noopener noreferrer" className="bg-gray-50 hover:bg-gray-100 p-4 rounded-2xl border border-gray-100 flex items-center gap-4 transition-colors group">
-                <div className="w-12 h-12 rounded-full bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform" style={{ color: themeColor }}>
+                <div className="w-12 h-12 rounded-full bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform" style={{ color: themeColor }}>
                   🌐
                 </div>
                 <div className="overflow-hidden">
@@ -166,7 +166,7 @@ function VCardContent() {
 
             {linkedin && (
               <a href={linkedin.startsWith('http') ? linkedin : `https://${linkedin}`} target="_blank" rel="noopener noreferrer" className="bg-gray-50 hover:bg-gray-100 p-4 rounded-2xl border border-gray-100 flex items-center gap-4 transition-colors group">
-                <div className="w-12 h-12 rounded-full bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform" style={{ color: themeColor }}>
+                <div className="w-12 h-12 rounded-full bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform" style={{ color: themeColor }}>
                   💼
                 </div>
                 <div className="overflow-hidden">

--- a/src/ui/next/src/app/feed/page.tsx
+++ b/src/ui/next/src/app/feed/page.tsx
@@ -242,14 +242,14 @@ export default function FeedPage() {
         )}
 
         {error && (
-          <div className="glassmorphism p-4 text-center backdrop-blur-[30px] backdrop-saturate-[210%]">
+          <div className="glassmorphism p-4 text-center backdrop-blur-[30px] saturate-[210%]">
             <p className="text-[#FF3B30] dark:text-[#DE1B1B] font-medium mb-2">We couldn't load your feed.</p>
             <p className="text-sm text-gray-500">{error}</p>
           </div>
         )}
 
         {!loading && !error && items.length === 0 && (
-          <div className="glassmorphism flex flex-col items-center justify-center p-12 text-center backdrop-blur-[30px] backdrop-saturate-[210%]" data-testid="agent-feed-empty">
+          <div className="glassmorphism flex flex-col items-center justify-center p-12 text-center backdrop-blur-[30px] saturate-[210%]" data-testid="agent-feed-empty">
             <div className="w-16 h-16 bg-[#e8f7ef] dark:bg-[rgba(23,166,106,0.2)] rounded-full flex items-center justify-center mb-4">
               <svg className="w-8 h-8 text-[#17a66a]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7"></path>
@@ -275,7 +275,7 @@ export default function FeedPage() {
             return (
               <div
                 key={item.id}
-                className={`glassmorphism p-5 relative overflow-hidden break-words whitespace-normal transition-all duration-300 backdrop-blur-[30px] backdrop-saturate-[210%] ${isProcessing ? 'opacity-50 scale-[0.98]' : 'animate-fade-in'}`}
+                className={`glassmorphism p-5 relative overflow-hidden break-words whitespace-normal transition-all duration-300 backdrop-blur-[30px] saturate-[210%] ${isProcessing ? 'opacity-50 scale-[0.98]' : 'animate-fade-in'}`}
                 data-testid="agent-feed-card"
               >
                 <div className="flex justify-between items-start mb-3">

--- a/src/ui/next/src/app/field-ops/jobs/page.tsx
+++ b/src/ui/next/src/app/field-ops/jobs/page.tsx
@@ -370,7 +370,7 @@ function FieldOpsJobsPageContent() {
         {jobs.map((job) => (
           <div
             key={job.id}
-            className="bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm border border-white/40 overflow-hidden"
+            className="bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm border border-white/40 overflow-hidden"
           >
             <div className="p-5 border-b border-gray-100 bg-gray-50/50">
               <div className="flex justify-between items-start mb-2">
@@ -512,7 +512,7 @@ function FieldOpsJobsPageContent() {
 
       {/* Voice-to-Quote Modal */}
       {voiceQuoteJobId && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm">
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-[30px] saturate-[210%]">
           <div className="bg-white/80 dark:bg-[#16161A]/80 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10 rounded-[24px] shadow-2xl p-6 w-full max-w-md flex flex-col">
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-bold font-outfit text-gray-900 dark:text-white flex items-center gap-2">

--- a/src/ui/next/src/app/flash-sale-generator/page.tsx
+++ b/src/ui/next/src/app/flash-sale-generator/page.tsx
@@ -121,14 +121,14 @@ export default function FlashSaleGeneratorPage() {
                         <button
                             aria-pressed={theme === 'light'}
                             onClick={() => setTheme('light')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Light
                         </button>
                         <button
                             aria-pressed={theme === 'dark'}
                             onClick={() => setTheme('dark')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Dark
                         </button>

--- a/src/ui/next/src/app/fulfillment-hub/page.tsx
+++ b/src/ui/next/src/app/fulfillment-hub/page.tsx
@@ -67,7 +67,7 @@ export default function FulfillmentHub() {
     <div className="min-h-screen bg-gray-50 flex justify-center">
       <div className="w-full max-w-[375px] bg-white relative pb-20 shadow-xl overflow-hidden">
         {/* App Bar (Translucent Glass) */}
-        <div className="sticky top-0 z-50 bg-[rgba(255,255,255,0.65)] backdrop-blur-[30px] backdrop-saturate-[210%] border-b border-[rgba(255,255,255,0.4)] dark:bg-[rgba(22,22,26,0.7)] dark:border-[rgba(255,255,255,0.1)] px-4 py-3 flex items-center justify-between">
+        <div className="sticky top-0 z-50 bg-[rgba(255,255,255,0.65)] backdrop-blur-[30px] saturate-[210%] border-b border-[rgba(255,255,255,0.4)] dark:bg-[rgba(22,22,26,0.7)] dark:border-[rgba(255,255,255,0.1)] px-4 py-3 flex items-center justify-between">
           <h1 className="text-xl font-bold text-gray-900 tracking-tight">Fulfillment Hub</h1>
           <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center text-[#0071E3] font-bold text-sm">
             OHC

--- a/src/ui/next/src/app/gift-cards/page.tsx
+++ b/src/ui/next/src/app/gift-cards/page.tsx
@@ -58,7 +58,7 @@ export default function GiftCardsPage() {
                     type="number"
                     value={value}
                     onChange={(e) => setValue(e.target.value)}
-                    className="w-full pl-8 pr-4 py-2 rounded-xl border border-gray-300 bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all font-semibold"
+                    className="w-full pl-8 pr-4 py-2 rounded-xl border border-gray-300 bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all font-semibold"
                     min="5"
                     max="1000"
                   />
@@ -125,7 +125,7 @@ export default function GiftCardsPage() {
 
            {/* Share Modal */}
            {showShareModal && (
-             <div className="mt-4 p-6 rounded-2xl bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-lg border border-gray-100 flex flex-col gap-4 animate-in slide-in-from-bottom-4">
+             <div className="mt-4 p-6 rounded-2xl bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-lg border border-gray-100 flex flex-col gap-4 animate-in slide-in-from-bottom-4">
                 <h3 className="text-lg font-bold font-outfit text-gray-900">Share Your Gift Card</h3>
                 <p className="text-sm text-gray-600">Send this link directly to your customer. They can claim it securely online.</p>
 

--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -104,7 +104,7 @@ export default function HelpCenterPage() {
             </p>
             <WithTooltip id="ask-ai-tooltip" defaultText="Open AI Help Chat to get answers instantly.">
             <button
-              className="mt-6 px-6 py-3 bg-blue-600/95 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg backdrop-blur-md saturate-[210%] transition-all min-h-[44px] hover:scale-105 active:scale-95"
+              className="mt-6 px-6 py-3 bg-blue-600/95 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg backdrop-blur-[30px] saturate-[210%] transition-all min-h-[44px] hover:scale-105 active:scale-95"
               onClick={() => {
                 const event = new CustomEvent('open-help-chat');
                 window.dispatchEvent(event);

--- a/src/ui/next/src/app/interactive-demo/page.tsx
+++ b/src/ui/next/src/app/interactive-demo/page.tsx
@@ -155,7 +155,7 @@ ${removeBranding ? '' : `  <div style="text-align: center; margin-top: 16px;">
                 />
                 <button
                   onClick={() => navigator.clipboard.writeText(embedCode)}
-                  className="absolute top-2 right-2 px-3 py-1 bg-white/10 hover:bg-white/20 text-white rounded text-xs font-medium transition-colors backdrop-blur-sm"
+                  className="absolute top-2 right-2 px-3 py-1 bg-white/10 hover:bg-white/20 text-white rounded text-xs font-medium transition-colors backdrop-blur-[30px] saturate-[210%]"
                 >
                   Copy
                 </button>
@@ -193,7 +193,7 @@ ${removeBranding ? '' : `  <div style="text-align: center; margin-top: 16px;">
 
       {/* Soft Paywall Modal */}
       {showSoftPaywall && (
-        <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4 backdrop-blur-sm">
+        <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4 backdrop-blur-[30px] saturate-[210%]">
           <div className="bg-white w-full max-w-md rounded-2xl p-8 shadow-2xl relative overflow-hidden text-center">
             <div className="absolute top-0 right-0 w-32 h-32 bg-blue-50 rounded-bl-full -z-10"></div>
 

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -680,7 +680,7 @@ Image provided: ${instantImageUrl}`;
 
   return (
     <div className="setup-page min-h-screen w-full bg-[#F5F5F7] dark:bg-[#16161a] flex items-center justify-center sm:p-4 font-inter overflow-x-hidden">
-      <div id="setup-screen" className="w-full max-w-[375px] sm:max-w-md lg:max-w-lg xl:max-w-2xl mx-auto overflow-hidden flex flex-col min-h-[100vh] sm:min-h-[812px] relative bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border-0 sm:border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-none sm:shadow-[0_18px_44px_rgba(15,23,42,0.12)] glassmorphism">
+      <div id="setup-screen" className="w-full max-w-[375px] sm:max-w-md lg:max-w-lg xl:max-w-2xl mx-auto overflow-hidden flex flex-col min-h-[100vh] sm:min-h-[812px] relative bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border-0 sm:border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-none sm:shadow-[0_18px_44px_rgba(15,23,42,0.12)] glassmorphism">
         <div className="px-6 pt-5 text-center">
           <div className="setup-header-main">
             {showIntroBack ? (
@@ -708,7 +708,7 @@ Image provided: ${instantImageUrl}`;
         </div>
 
         {error && (
-          <div className="mx-6 mt-4 z-10 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[#FF3B30]/50 text-[#FF3B30] p-3 rounded-[8px] text-sm font-semibold shadow-lg flex items-center gap-2 animate-shake">
+          <div className="mx-6 mt-4 z-10 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[#FF3B30]/50 text-[#FF3B30] p-3 rounded-[8px] text-sm font-semibold shadow-lg flex items-center gap-2 animate-shake">
             <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
             <p className="flex-1">{error}</p>
           </div>
@@ -736,14 +736,14 @@ Image provided: ${instantImageUrl}`;
                 </button>
                 <button
                   type="button"
-                  className="flex items-center justify-center w-full bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] p-4 font-semibold hover:border-gray-400 dark:hover:border-gray-500 transition-all min-h-[44px]"
+                  className="flex items-center justify-center w-full bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] p-4 font-semibold hover:border-gray-400 dark:hover:border-gray-500 transition-all min-h-[44px]"
                   onClick={() => { updateState({ step: -1 }); syncStateToBackend({ step: -1 }); }}
                 >
                   <span className="flex items-center gap-2"><SetupIcon name="sparkles" /> Instant Build</span>
                 </button>
                 <button
                   type="button"
-                  className="w-full bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] p-4 font-semibold hover:border-gray-400 dark:hover:border-gray-500 transition-all min-h-[44px]"
+                  className="w-full bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] p-4 font-semibold hover:border-gray-400 dark:hover:border-gray-500 transition-all min-h-[44px]"
                   onClick={() => { updateState({ step: 0 }); syncStateToBackend({ step: 0 }); }}
                 >
                   Conversational Setup
@@ -753,7 +753,7 @@ Image provided: ${instantImageUrl}`;
           )}
 
           {step === 0 && (
-            <div className="flex flex-col flex-1 animate-fade-in w-full h-full max-h-full backdrop-blur-[40px] backdrop-saturate-[250%] bg-[rgba(255,255,255,0.7)] dark:bg-[rgba(22,22,26,0.8)] shadow-[0_8px_32px_0_rgba(31,38,135,0.07)] rounded-2xl border border-white/20 p-4">
+            <div className="flex flex-col flex-1 animate-fade-in w-full h-full max-h-full backdrop-blur-[30px] saturate-[210%] bg-[rgba(255,255,255,0.7)] dark:bg-[rgba(22,22,26,0.8)] shadow-[0_8px_32px_0_rgba(31,38,135,0.07)] rounded-2xl border border-white/20 p-4">
               <button onClick={() => { updateState({ step: -2 }); syncStateToBackend({ step: -2 }); }} className="self-start text-[#0066FF] text-sm font-semibold mb-4 flex items-center gap-1 min-h-[44px] min-w-[44px] p-2">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg> Back
               </button>
@@ -763,7 +763,7 @@ Image provided: ${instantImageUrl}`;
               </p>
 
               <div className="flex flex-col flex-1 gap-4 overflow-hidden w-full max-w-full">
-                <div id="chat-messages" className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] flex-1 overflow-y-auto p-4 text-[#1D1D1F] dark:text-[#F5F5F7] text-left space-y-4">
+                <div id="chat-messages" className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] flex-1 overflow-y-auto p-4 text-[#1D1D1F] dark:text-[#F5F5F7] text-left space-y-4">
                   {chatMessages.length === 0 && (
                     <div className="mb-2"><strong>Assistant:</strong> What do you do? (e.g. I bake custom vegan cakes in Austin)</div>
                   )}
@@ -792,7 +792,7 @@ Image provided: ${instantImageUrl}`;
                     id="chat-image-url"
                     value={chatImageUrl}
                     onChange={(e) => setChatImageUrl(e.target.value)}
-                    className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] w-full p-3 text-[#1D1D1F] dark:text-[#F5F5F7] outline-none transition-all duration-[250ms] border border-white/20 focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20 min-h-[44px]"
+                    className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] w-full p-3 text-[#1D1D1F] dark:text-[#F5F5F7] outline-none transition-all duration-[250ms] border border-white/20 focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20 min-h-[44px]"
                     placeholder="Image URL (Optional)"
                     inputMode="url"
                     autoComplete="url"
@@ -801,7 +801,7 @@ Image provided: ${instantImageUrl}`;
                   <div className="flex gap-2 w-full">
                     <button
                       id="chat-upload-btn"
-                      className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] min-w-[44px] min-h-[44px] flex items-center justify-center text-[#1D1D1F] dark:text-[#F5F5F7] hover:border-gray-400 dark:hover:border-gray-500 transition-all duration-[250ms] active:scale-[0.98]"
+                      className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] min-w-[44px] min-h-[44px] flex items-center justify-center text-[#1D1D1F] dark:text-[#F5F5F7] hover:border-gray-400 dark:hover:border-gray-500 transition-all duration-[250ms] active:scale-[0.98]"
                       onClick={() => {
                         const url = prompt("Enter image URL");
                         if (url) setChatImageUrl(url);
@@ -823,7 +823,7 @@ Image provided: ${instantImageUrl}`;
                       onKeyDown={(e) => {
                          if (e.key === 'Enter') handleSendChatMessage();
                       }}
-                      className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] w-full p-3 text-[#1D1D1F] dark:text-[#F5F5F7] outline-none flex-1 transition-all duration-[250ms] border border-white/20 focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20 min-h-[44px]"
+                      className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] w-full p-3 text-[#1D1D1F] dark:text-[#F5F5F7] outline-none flex-1 transition-all duration-[250ms] border border-white/20 focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20 min-h-[44px]"
                       placeholder="Type a message..."
                       enterKeyHint="send"
                     />
@@ -855,7 +855,7 @@ Image provided: ${instantImageUrl}`;
                 <textarea
                   id="instant-bio"
                   data-testid="instant-bio"
-                  className={`bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] w-full p-4 text-[#1D1D1F] dark:text-[#F5F5F7] outline-none transition-all duration-[250ms] ${error === "Please tell us about your business." || error ? "border border-[#FF3B30]" : "border border-white/20 focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20"}`}
+                  className={`bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] w-full p-4 text-[#1D1D1F] dark:text-[#F5F5F7] outline-none transition-all duration-[250ms] ${error === "Please tell us about your business." || error ? "border border-[#FF3B30]" : "border border-white/20 focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20"}`}
                   placeholder="e.g. I run a local bakery that sells custom vegan cakes..."
                   rows={6}
                   style={{ resize: 'none' }}
@@ -870,7 +870,7 @@ Image provided: ${instantImageUrl}`;
                   id="instant-image-url"
                   data-testid="instant-image-url"
                   type="url"
-                  className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] min-h-[44px]"
+                  className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] min-h-[44px]"
                   placeholder="Image URL (Optional)"
                   value={instantImageUrl}
                   onChange={(e) => updateState({ instantImageUrl: e.target.value })}
@@ -947,7 +947,7 @@ Image provided: ${instantImageUrl}`;
                           }
                         }}
                         placeholder="e.g. Maya's Custom Cakes"
-                        className={`w-full p-3 sm:p-4 border outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] text-lg transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] shadow-inner ${validationError === 'Business Name must be at least 3 characters.' ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} min-h-[44px]`}
+                        className={`w-full p-3 sm:p-4 border outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] text-lg transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] shadow-inner ${validationError === 'Business Name must be at least 3 characters.' ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} min-h-[44px]`}
                         inputMode="text"
                         enterKeyHint="next"
                       />
@@ -1019,7 +1019,7 @@ Image provided: ${instantImageUrl}`;
                           }
                         }}
                         placeholder="e.g. I bake custom vegan cakes"
-                        className={`w-full p-3 sm:p-4 border outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] h-32 resize-none transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] shadow-inner ${validationError === 'Please tell us what you sell.' ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20 focus:ring-2 focus:ring-[#0066FF]/30'}`}
+                        className={`w-full p-3 sm:p-4 border outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] h-32 resize-none transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] shadow-inner ${validationError === 'Please tell us what you sell.' ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20 focus:ring-2 focus:ring-[#0066FF]/30'}`}
                       />
                     </div>
                   </div>
@@ -1086,7 +1086,7 @@ Image provided: ${instantImageUrl}`;
                           }
                         }}
                         placeholder="e.g. Portland, OR"
-                        className={`w-full p-3 sm:p-4 border outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] text-lg transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] shadow-inner ${validationError === 'Please tell us your location.' ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} min-h-[44px]`}
+                        className={`w-full p-3 sm:p-4 border outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] text-lg transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] shadow-inner ${validationError === 'Please tell us your location.' ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} min-h-[44px]`}
                       />
                     </div>
                   </div>
@@ -1153,7 +1153,7 @@ Image provided: ${instantImageUrl}`;
                           }
                         }}
                         placeholder="e.g. Local families, Tech startups"
-                        className={`w-full p-3 sm:p-4 border outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] text-lg transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] shadow-inner ${validationError === 'Please tell us your target audience.' ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} min-h-[44px]`}
+                        className={`w-full p-3 sm:p-4 border outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] text-lg transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] shadow-inner ${validationError === 'Please tell us your target audience.' ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} min-h-[44px]`}
                       />
                     </div>
                   </div>
@@ -1221,7 +1221,7 @@ Image provided: ${instantImageUrl}`;
                       updateState({ businessName: e.target.value });
                       setValidationErrors(prev => { const { businessName, ...rest } = prev; return rest; });
                     }}
-                    className={`w-full p-3 sm:p-4 border ${validationErrors.businessName ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
+                    className={`w-full p-3 sm:p-4 border ${validationErrors.businessName ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
                   />
                   {validationErrors.businessName && <p className="text-[#FF3B30] text-xs mt-1">{validationErrors.businessName}</p>}
                 </div>
@@ -1236,7 +1236,7 @@ Image provided: ${instantImageUrl}`;
                       updateState({ businessType: e.target.value });
                       setValidationErrors(prev => { const { businessType, ...rest } = prev; return rest; });
                     }}
-                    className={`w-full p-3 sm:p-4 border ${validationErrors.businessType ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
+                    className={`w-full p-3 sm:p-4 border ${validationErrors.businessType ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
                   />
                   {validationErrors.businessType && <p className="text-[#FF3B30] text-xs mt-1">{validationErrors.businessType}</p>}
                 </div>
@@ -1248,7 +1248,7 @@ Image provided: ${instantImageUrl}`;
                     autoCapitalize="words"
                     value={categories.join(', ')}
                     onChange={(e) => updateState({ categories: e.target.value.split(',').map(c => c.trim()) })}
-                    className="w-full p-3 sm:p-4 border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20 outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]"
+                    className="w-full p-3 sm:p-4 border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20 outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]"
                   />
                 </div>
                 <div className="grid grid-cols-2 gap-2">
@@ -1260,7 +1260,7 @@ Image provided: ${instantImageUrl}`;
                         autoCapitalize="words"
                         value={firstProductName}
                         onChange={(e) => updateState({ firstProductName: e.target.value })}
-                        className="w-full p-3 sm:p-4 border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20 outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]"
+                        className="w-full p-3 sm:p-4 border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20 outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]"
                       />
                    </div>
                    <div>
@@ -1277,7 +1277,7 @@ Image provided: ${instantImageUrl}`;
                               setValidationErrors(prev => { const { firstProductPrice, ...rest } = prev; return rest; });
                            }
                         }}
-                        className={`w-full p-3 sm:p-4 border ${validationErrors.firstProductPrice ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
+                        className={`w-full p-3 sm:p-4 border ${validationErrors.firstProductPrice ? 'border-[#FF3B30]' : 'border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20'} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
                       />
                       {validationErrors.firstProductPrice && <p className="text-[#FF3B30] text-xs mt-1">{validationErrors.firstProductPrice}</p>}
                    </div>
@@ -1348,7 +1348,7 @@ Image provided: ${instantImageUrl}`;
                       <div
                         key={template}
                         onClick={() => updateState({ websiteTemplate: template })}
-                        className={`p-3 border cursor-pointer transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] ${websiteTemplate === template ? 'border-[#0066FF] bg-[#0066FF]/10 text-[#0066FF]' : 'border-white/50 dark:border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] hover:border-gray-400 dark:hover:border-gray-500 text-[#1D1D1F] dark:text-white'}`}
+                        className={`p-3 border cursor-pointer transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] ${websiteTemplate === template ? 'border-[#0066FF] bg-[#0066FF]/10 text-[#0066FF]' : 'border-white/50 dark:border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] hover:border-gray-400 dark:hover:border-gray-500 text-[#1D1D1F] dark:text-white'}`}
                       >
                         <div className="font-semibold text-sm">{template}</div>
                       </div>
@@ -1361,14 +1361,14 @@ Image provided: ${instantImageUrl}`;
                   <div className="grid grid-cols-2 gap-3 mb-2">
                     <div
                       onClick={() => updateState({ domainChoice: 'subdomain' })}
-                      className={`p-3 border cursor-pointer transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] flex flex-col items-center justify-center text-center ${domainChoice === 'subdomain' ? 'border-[#0066FF] bg-[#0066FF]/10 text-[#0066FF]' : 'border-white/50 dark:border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-white hover:border-gray-400 dark:hover:border-gray-500'}`}
+                      className={`p-3 border cursor-pointer transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] flex flex-col items-center justify-center text-center ${domainChoice === 'subdomain' ? 'border-[#0066FF] bg-[#0066FF]/10 text-[#0066FF]' : 'border-white/50 dark:border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-white hover:border-gray-400 dark:hover:border-gray-500'}`}
                     >
                       <span className="font-semibold text-sm mb-1">Free Subdomain</span>
                       <span className="text-[10px] opacity-70">your-name.ohc.app</span>
                     </div>
                     <div
                       onClick={() => updateState({ domainChoice: 'custom' })}
-                      className={`p-3 border cursor-pointer transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] flex flex-col items-center justify-center text-center ${domainChoice === 'custom' ? 'border-[#0066FF] bg-[#0066FF]/10 text-[#0066FF]' : 'border-white/50 dark:border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-white hover:border-gray-400 dark:hover:border-gray-500'}`}
+                      className={`p-3 border cursor-pointer transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] flex flex-col items-center justify-center text-center ${domainChoice === 'custom' ? 'border-[#0066FF] bg-[#0066FF]/10 text-[#0066FF]' : 'border-white/50 dark:border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-white hover:border-gray-400 dark:hover:border-gray-500'}`}
                     >
                       <span className="font-semibold text-sm mb-1">Custom Domain</span>
                       <span className="text-[10px] opacity-70">your-name.com</span>
@@ -1397,7 +1397,7 @@ Image provided: ${instantImageUrl}`;
                           }
                         }}
                         placeholder="e.g. Maya Smith"
-                        className={`w-full p-3 sm:p-4 border ${validationErrors.adminName ? "border-[#FF3B30]" : "border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20"} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
+                        className={`w-full p-3 sm:p-4 border ${validationErrors.adminName ? "border-[#FF3B30]" : "border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20"} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
                         inputMode="text"
                         enterKeyHint="next"
                       />
@@ -1424,7 +1424,7 @@ Image provided: ${instantImageUrl}`;
                       }
                     }}
                     placeholder="you@example.com"
-                    className={`w-full p-3 sm:p-4 border ${validationErrors.adminEmail ? "border-[#FF3B30]" : "border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20"} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
+                    className={`w-full p-3 sm:p-4 border ${validationErrors.adminEmail ? "border-[#FF3B30]" : "border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20"} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
                   />
                       {validationErrors.adminEmail && <p className="text-[#FF3B30] text-xs mt-1">{validationErrors.adminEmail}</p>}
                     </div>
@@ -1447,7 +1447,7 @@ Image provided: ${instantImageUrl}`;
                           }
                         }}
                         placeholder="••••••••"
-                        className={`w-full p-3 sm:p-4 border ${validationErrors.adminPassword ? "border-[#FF3B30]" : "border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20"} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
+                        className={`w-full p-3 sm:p-4 border ${validationErrors.adminPassword ? "border-[#FF3B30]" : "border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] focus:border-[#0066FF] focus:ring-4 focus:ring-[#0066FF]/20"} outline-none bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px]`}
                       />
                       {validationErrors.adminPassword && <p className="text-[#FF3B30] text-xs mt-1">{validationErrors.adminPassword}</p>}
                     </div>
@@ -1473,7 +1473,7 @@ Image provided: ${instantImageUrl}`;
                 </div>
 
                 <div className="pt-2">
-                  <label className="flex items-center justify-between cursor-pointer p-3 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-white">
+                  <label className="flex items-center justify-between cursor-pointer p-3 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-white">
                     <span className="font-semibold text-sm">Allow AI to Auto-Respond</span>
                     <input
                       type="checkbox"
@@ -1563,13 +1563,13 @@ Image provided: ${instantImageUrl}`;
 
                 <a
                   href="/assistant"
-                  className="flex w-full items-center justify-center bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] p-4 font-bold shadow-md hover:border-gray-400 dark:hover:border-gray-500 active:scale-[0.98] transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)]"
+                  className="flex w-full items-center justify-center bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] p-4 font-bold shadow-md hover:border-gray-400 dark:hover:border-gray-500 active:scale-[0.98] transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)]"
                 >
                   <IconLabel icon="sparkles">Open Assistant</IconLabel>
                 </a>
                 <a
                   href="/builder"
-                  className="flex w-full items-center justify-center bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] p-4 font-bold shadow-sm active:scale-[0.98] transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)]"
+                  className="flex w-full items-center justify-center bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[8px] text-[#1D1D1F] dark:text-[#F5F5F7] p-4 font-bold shadow-sm active:scale-[0.98] transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)]"
                 >
                   <IconLabel icon="eye">Preview Storefront</IconLabel>
                 </a>

--- a/src/ui/next/src/app/onboarding/zero-click/components/OnboardingChatAgent.tsx
+++ b/src/ui/next/src/app/onboarding/zero-click/components/OnboardingChatAgent.tsx
@@ -146,7 +146,7 @@ export function OnboardingChatAgent({ onComplete }: OnboardingChatAgentProps) {
   ];
 
   return (
-    <div className="flex flex-col h-full bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] overflow-hidden shadow-xl w-full max-w-2xl mx-auto">
+    <div className="flex flex-col h-full bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] overflow-hidden shadow-xl w-full max-w-2xl mx-auto">
       {/* Header */}
       <div className="p-4 border-b border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] flex items-center gap-3 bg-transparent">
         <div className="w-10 h-10 rounded-full bg-indigo-100 dark:bg-indigo-900/50 flex items-center justify-center text-xl">
@@ -174,7 +174,7 @@ export function OnboardingChatAgent({ onComplete }: OnboardingChatAgentProps) {
 
         {isLoading && (
           <div className="flex justify-start">
-            <div className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] rounded-2xl rounded-bl-sm px-4 py-3 border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] flex gap-1 items-center">
+            <div className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] rounded-2xl rounded-bl-sm px-4 py-3 border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] flex gap-1 items-center">
               <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce"></div>
               <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }}></div>
               <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.4s' }}></div>
@@ -187,7 +187,7 @@ export function OnboardingChatAgent({ onComplete }: OnboardingChatAgentProps) {
 
       {/* Provisioning Overlay */}
       {isProvisioning && (
-        <div className="absolute inset-0 z-10 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[10px] flex flex-col items-center justify-center rounded-2xl">
+        <div className="absolute inset-0 z-10 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] flex flex-col items-center justify-center rounded-2xl">
           <div className="w-16 h-16 border-4 border-[#0066FF]/20 border-t-[#0066FF] rounded-full animate-spin mb-6"></div>
           <h3 className="text-xl font-bold text-[#1D1D1F] dark:text-[#F5F5F7] mb-2 animate-pulse">
             Building Your Business...

--- a/src/ui/next/src/app/onboarding/zero-click/page.tsx
+++ b/src/ui/next/src/app/onboarding/zero-click/page.tsx
@@ -60,7 +60,7 @@ export default function ZeroClickBuilderPage() {
             </div>
 
             <div className="space-y-6">
-              <div className="w-full h-[500px] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] overflow-hidden relative bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%]">
+              <div className="w-full h-[500px] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] overflow-hidden relative bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%]">
                 <iframe
                   src={`/builder?tenant=${generatedStore.organization_id}&preview=true`}
                   className="w-full h-full border-none"

--- a/src/ui/next/src/app/plan/page.tsx
+++ b/src/ui/next/src/app/plan/page.tsx
@@ -84,7 +84,7 @@ export default function MyPlanPage() {
   if (loading) {
     return (
       <div className="flex flex-col min-h-screen font-inter bg-gradient-to-br from-indigo-50 via-white to-purple-50 justify-center items-center p-4">
-        <div className="flex flex-col items-center justify-center p-8 app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg rounded-2xl w-full max-w-sm animate-pulse">
+        <div className="flex flex-col items-center justify-center p-8 app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg rounded-2xl w-full max-w-sm animate-pulse">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
           <p className="mt-6 text-gray-600 font-medium">Loading your plan data...</p>
         </div>
@@ -94,9 +94,9 @@ export default function MyPlanPage() {
 
   return (
     <div className="flex flex-col min-h-screen font-inter bg-gradient-to-br from-indigo-50 via-white to-purple-50 text-gray-900 w-full overflow-x-hidden max-w-[100vw]">
-      <header className="px-4 py-4 flex items-center justify-between sticky top-0 z-50 app-panel-header backdrop-blur-md bg-white/70 shadow-sm w-full glass-panel">
+      <header className="px-4 py-4 flex items-center justify-between sticky top-0 z-50 app-panel-header backdrop-blur-[30px] saturate-[210%] bg-white/70 shadow-sm w-full glass-panel">
         <div className="flex items-center gap-3">
-          <button onClick={() => router.push('/dashboard')} className="min-w-[44px] min-h-[44px] px-3 py-2 glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-sm rounded-xl text-sm font-medium text-gray-800 hover:-translate-y-0.5 hover:shadow-md transition-all duration-300 flex items-center justify-center">
+          <button onClick={() => router.push('/dashboard')} className="min-w-[44px] min-h-[44px] px-3 py-2 glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-sm rounded-xl text-sm font-medium text-gray-800 hover:-translate-y-0.5 hover:shadow-md transition-all duration-300 flex items-center justify-center">
             Back
           </button>
           <WithTooltip id="my-plan-tooltip" defaultText="View and manage your subscription plan and usage.">
@@ -108,7 +108,7 @@ export default function MyPlanPage() {
       <main className="p-4 md:p-8 flex-1 max-w-4xl mx-auto w-full flex flex-col gap-6">
 
         {/* Status Snapshot */}
-        <section className="app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:shadow-2xl transition-all duration-300 p-6 rounded-2xl">
+        <section className="app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:shadow-2xl transition-all duration-300 p-6 rounded-2xl">
             <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
                 <div>
                     <h2 className="text-2xl font-bold font-outfit text-gray-900 flex items-center gap-2">
@@ -136,15 +136,15 @@ export default function MyPlanPage() {
                 </button>
                 <button
                     onClick={() => router.push('/cost-dashboard')}
-                    className="w-full sm:w-auto px-6 py-3 glass-card backdrop-blur-xl bg-white/60 hover:bg-white/80 text-gray-700 border border-white/40 rounded-xl font-medium transition-all shadow-sm hover:shadow-md hover:-translate-y-0.5 duration-300 text-center">
+                    className="w-full sm:w-auto px-6 py-3 glass-card backdrop-blur-[30px] saturate-[210%] bg-white/60 hover:bg-white/80 text-gray-700 border border-white/40 rounded-xl font-medium transition-all shadow-sm hover:shadow-md hover:-translate-y-0.5 duration-300 text-center">
                     View Detailed Costs
                 </button>
             </div>
         </section>
 
         {/* Current Usage Section */}
-        <section className="app-card ohc-growth-card glass-panel backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:shadow-2xl transition-all duration-300 mt-4 rounded-2xl overflow-hidden">
-          <div className="app-panel-header backdrop-blur-md bg-white/70 px-6 py-4 border-b border-white/40 bg-transparent">
+        <section className="app-card ohc-growth-card glass-panel backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg hover:shadow-2xl transition-all duration-300 mt-4 rounded-2xl overflow-hidden">
+          <div className="app-panel-header backdrop-blur-[30px] saturate-[210%] bg-white/70 px-6 py-4 border-b border-white/40 bg-transparent">
              <h2 className="app-panel-title text-xl font-bold font-outfit text-gray-900">Your Current Usage</h2>
           </div>
           <div className="app-panel-body p-6">

--- a/src/ui/next/src/app/pos/kds/page.tsx
+++ b/src/ui/next/src/app/pos/kds/page.tsx
@@ -98,7 +98,7 @@ export default function KDSPage() {
       <div className="w-[375px] max-w-[375px] mx-auto h-[812px] bg-gradient-to-br from-white/40 to-white/10 backdrop-blur-[30px] saturate-[210%] shadow-2xl overflow-hidden flex flex-col relative border-x border-gray-200">
 
         {/* Header */}
-        <div className="pt-12 pb-4 px-6 bg-white/65 backdrop-blur-[30px] shadow-sm border-b border-gray-200 sticky top-0 z-10 flex justify-between items-center">
+        <div className="pt-12 pb-4 px-6 bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm border-b border-gray-200 sticky top-0 z-10 flex justify-between items-center">
           <div>
             <h1 className="text-xl font-bold text-gray-900">{texts.kds}</h1>
             {isOffline && <span className="text-[#FF3B30] font-bold text-sm bg-red-100 px-2 py-1 rounded-md">{texts.offline}</span>}
@@ -119,7 +119,7 @@ export default function KDSPage() {
           <h2 className="text-lg font-bold text-gray-800 mb-3">{texts.orders}</h2>
           <div className="flex flex-col gap-4 mb-6">
             {orders.map(order => (
-              <div key={order.id} className="app-card backdrop-blur-[30px] rounded-2xl p-4 shadow-sm border border-gray-100">
+              <div key={order.id} className="app-card backdrop-blur-[30px] saturate-[210%] rounded-2xl p-4 shadow-sm border border-gray-100">
                 <div className="flex justify-between items-start mb-2">
                   <h3 className="font-bold text-lg text-gray-900">#{order.id} - {order.customer_name}</h3>
                   <span className={`px-2 py-1 rounded text-xs font-bold ${
@@ -175,7 +175,7 @@ export default function KDSPage() {
           <h2 className="text-lg font-bold text-gray-800 mb-3">{texts.inventory}</h2>
           <div className="flex flex-col gap-3">
              {inventory.map(item => (
-                <div key={item.id} className="app-card backdrop-blur-[30px] rounded-xl p-4 shadow-sm border border-gray-100 flex justify-between items-center">
+                <div key={item.id} className="app-card backdrop-blur-[30px] saturate-[210%] rounded-xl p-4 shadow-sm border border-gray-100 flex justify-between items-center">
                    <span className="font-bold text-gray-800 text-lg">{language === 'en' ? item.name_en : item.name_ar}</span>
                    <button
                      id={`sold-out-toggle-${item.id}`}

--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -387,13 +387,13 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
   };
 
   return (
-    <div id="pos-keypad" className="p-6 rounded-3xl shadow-2xl mt-6 relative overflow-hidden bg-white/70 backdrop-blur-[32px] saturate-[200%] border border-white/50">
+    <div id="pos-keypad" className="p-6 rounded-3xl shadow-2xl mt-6 relative overflow-hidden bg-white/70 backdrop-blur-[30px] saturate-[210%] border border-white/50">
       <h2 className="text-lg font-bold font-outfit text-gray-900 mb-2">Tap to Pay via Terminal</h2>
       <p className={`text-sm mb-6 font-medium p-3 rounded-xl border ${status?.toLowerCase()?.includes('fail') || status?.toLowerCase()?.includes('error') || status?.toLowerCase()?.includes('sold out') ? 'bg-red-50/80 backdrop-blur-[30px] saturate-[210%] text-red-800 border-red-200' : 'text-gray-600 border-transparent'}`}>Status: {status}</p>
 
       {pendingReconciliation.length > 0 && (
         <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 backdrop-blur-[30px] saturate-[210%] p-4">
-           <div className="bg-white/85 backdrop-blur-[40px] saturate-[210%] border border-white/50 rounded-3xl p-6 shadow-2xl max-w-sm w-full text-center">
+           <div className="bg-white/85 backdrop-blur-[30px] saturate-[210%] border border-white/50 rounded-3xl p-6 shadow-2xl max-w-sm w-full text-center">
              <h2 className="text-xl font-bold font-outfit text-gray-900 mb-4">Inventory Conflict Detected</h2>
              <p className="text-sm text-gray-600 mb-6">Some offline sales conflicted with online inventory. The Operations Agent has drafted an alternative offer for the online customer.</p>
              <ul className="space-y-2 mb-6">

--- a/src/ui/next/src/app/pos/terminal/page.tsx
+++ b/src/ui/next/src/app/pos/terminal/page.tsx
@@ -332,7 +332,7 @@ export default function POSTerminal() {
       <div className="w-full max-w-[375px] mx-auto min-h-[100dvh] md:h-[812px] md:min-h-0 bg-white md:shadow-2xl overflow-hidden flex flex-col relative border-x border-gray-200 mobile-pos-container">
 
         {/* Header */}
-        <div className="pt-12 pb-6 px-6 bg-white/65 backdrop-blur-[30px] border-b border-gray-200 sticky top-0 z-10 flex justify-between items-center">
+        <div className="pt-12 pb-6 px-6 bg-white/65 backdrop-blur-[30px] saturate-[210%] border-b border-gray-200 sticky top-0 z-10 flex justify-between items-center">
           <div>
             <h1 className="text-2xl font-bold font-outfit text-gray-900 tracking-tight">{activeStaff?.name}</h1>
             <p className="text-[#0071E3] font-medium text-sm mt-1">{t(activeStaff?.role)}</p>
@@ -356,7 +356,7 @@ export default function POSTerminal() {
         {/* Content */}
         <div className="flex-1 overflow-y-auto px-4 py-6 bg-[#F5F5F7]">
 
-           <div className="app-card rounded-2xl p-6 shadow-lg mb-6 text-center bg-white/70 backdrop-blur-[32px] saturate-[200%] border border-white/50">
+           <div className="app-card rounded-2xl p-6 shadow-lg mb-6 text-center bg-white/70 backdrop-blur-[30px] saturate-[210%] border border-white/50">
              <div className={`w-16 h-16 mx-auto rounded-full flex items-center justify-center mb-4 ${clockedIn ? 'bg-green-100 text-green-600' : 'bg-gray-100 text-gray-400'}`}>
                 <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -392,7 +392,7 @@ export default function POSTerminal() {
              <button
                 onClick={handleQuickCharge}
                 disabled={reserving}
-                className={`charge-btn min-h-[44px] min-w-[44px] p-4 rounded-[8px] text-left shadow-lg bg-white/70 backdrop-blur-[32px] saturate-[200%] border border-white/50 ${reserving ? 'opacity-50' : 'active:scale-[0.98]'}`}
+                className={`charge-btn min-h-[44px] min-w-[44px] p-4 rounded-[8px] text-left shadow-lg bg-white/70 backdrop-blur-[30px] saturate-[210%] border border-white/50 ${reserving ? 'opacity-50' : 'active:scale-[0.98]'}`}
              >
                <div className="text-[#0066FF] mb-2">
                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
@@ -400,7 +400,7 @@ export default function POSTerminal() {
                <span className="font-medium text-gray-900">{t('Quick Charge $50')}</span>
              </button>
 
-             <button className="min-h-[44px] min-w-[44px] p-4 rounded-[8px] text-left shadow-lg active:scale-[0.98] bg-white/70 backdrop-blur-[32px] saturate-[200%] border border-white/50">
+             <button className="min-h-[44px] min-w-[44px] p-4 rounded-[8px] text-left shadow-lg active:scale-[0.98] bg-white/70 backdrop-blur-[30px] saturate-[210%] border border-white/50">
                <div className="text-[#FF9500] mb-2">
                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z" /></svg>
                </div>
@@ -434,7 +434,7 @@ export default function POSTerminal() {
 
            {/* Bottom Bar */}
            {cartItemCount > 0 && !checkoutComplete && (
-             <div className="fixed bottom-0 left-0 right-0 p-4 bg-white/80 backdrop-blur-[30px] border-t border-gray-200 z-40 pb-safe pb-8">
+             <div className="fixed bottom-0 left-0 right-0 p-4 bg-white/80 backdrop-blur-[30px] saturate-[210%] border-t border-gray-200 z-40 pb-safe pb-8">
                <button
                  onClick={() => setIsCartOpen(true)}
                  className="w-full bg-[#0066FF] text-white rounded-xl min-h-[60px] text-lg font-bold flex justify-between items-center px-6 shadow-lg active:scale-[0.98]"
@@ -449,7 +449,7 @@ export default function POSTerminal() {
            {isCartOpen && !checkoutComplete && (
              <div className="fixed inset-0 z-50 flex flex-col justify-end">
                <div className="absolute inset-0 bg-black/40 backdrop-blur-[30px] saturate-[210%]" onClick={() => setIsCartOpen(false)}></div>
-               <div className="relative bg-white/85 backdrop-blur-[40px] saturate-[210%] border-t border-white/50 rounded-t-3xl p-6 shadow-2xl animate-in slide-in-from-bottom max-h-[90vh] overflow-y-auto">
+               <div className="relative bg-white/85 backdrop-blur-[30px] saturate-[210%] border-t border-white/50 rounded-t-3xl p-6 shadow-2xl animate-in slide-in-from-bottom max-h-[90vh] overflow-y-auto">
                  <div className="flex justify-between items-center mb-6">
                    <h2 className="text-xl font-bold font-outfit text-gray-900">Current Order</h2>
                    <button onClick={() => setIsCartOpen(false)} className="p-2 bg-gray-100 rounded-full text-gray-500 hover:bg-gray-200">

--- a/src/ui/next/src/app/pricing/page.tsx
+++ b/src/ui/next/src/app/pricing/page.tsx
@@ -102,7 +102,7 @@ export default function PricingPage() {
         </div>
 
         {/* My Plan Section */}
-        <div className="mb-8 p-6 app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-indigo-200/50 shadow-xl rounded-2xl w-full">
+        <div className="mb-8 p-6 app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-indigo-200/50 shadow-xl rounded-2xl w-full">
             <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
                 <div>
                     <h2 className="text-2xl font-bold font-outfit text-gray-900">My Plan: {currentPlan || 'Free'}</h2>
@@ -141,7 +141,7 @@ export default function PricingPage() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 w-full">
           {/* Free Tier */}
-          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
+          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Free</h3>
               <p className="text-xl font-semibold mb-4 text-gray-900">$0 <span className="text-sm font-normal text-gray-500">/ month</span></p>
@@ -168,7 +168,7 @@ export default function PricingPage() {
           </div>
 
           {/* Starter Tier */}
-          <div className="p-6 flex flex-col justify-between relative app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-xl rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
+          <div className="p-6 flex flex-col justify-between relative app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-xl rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
             <div className="absolute top-0 right-0 bg-indigo-600 text-white text-xs font-bold px-3 py-1 rounded-bl-xl rounded-tr-2xl">Recommended</div>
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Starter</h3>
@@ -197,7 +197,7 @@ export default function PricingPage() {
           </div>
 
           {/* Pro Tier */}
-          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
+          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Pro</h3>
               <p className="text-xl font-semibold mb-4 text-gray-900">$79 <span className="text-sm font-normal text-gray-500">/ month</span></p>
@@ -224,7 +224,7 @@ export default function PricingPage() {
           </div>
 
           {/* Business Tier */}
-          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
+          <div className="p-6 flex flex-col justify-between app-card ohc-growth-card glass-card backdrop-blur-[30px] saturate-[210%] bg-white/40 border border-white/20 shadow-lg rounded-2xl hover:-translate-y-1 hover:shadow-2xl transition-all duration-300 w-full">
             <div>
               <h3 className="text-2xl font-bold font-outfit mb-2 text-gray-900">Business</h3>
               <p className="text-xl font-semibold mb-4 text-gray-900">$299 <span className="text-sm font-normal text-gray-500">/ month</span></p>

--- a/src/ui/next/src/app/products/new/page.tsx
+++ b/src/ui/next/src/app/products/new/page.tsx
@@ -255,7 +255,7 @@ function AutoCatalogContent() {
           >
             Subscription Box
           </button>
-          <label className="w-full aspect-square border-2 border-dashed border-gray-300 rounded-2xl flex flex-col items-center justify-center bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm cursor-pointer hover:bg-gray-50 transition-colors">
+          <label className="w-full aspect-square border-2 border-dashed border-gray-300 rounded-2xl flex flex-col items-center justify-center bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm cursor-pointer hover:bg-gray-50 transition-colors">
             <div className="text-4xl mb-2">📷</div>
             <span className="font-semibold text-gray-800">Take a photo or upload</span>
             <input type="file" accept="image/*" className="hidden" onChange={handleFileUpload} />

--- a/src/ui/next/src/app/proposals/new/page.tsx
+++ b/src/ui/next/src/app/proposals/new/page.tsx
@@ -53,7 +53,7 @@ export default function NewProposalPage() {
       </button>
 
       {proposal && (
-        <div className="mt-12 p-6 border border-gray-200 rounded bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm">
+        <div className="mt-12 p-6 border border-gray-200 rounded bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm">
           <h2 className="text-xl font-semibold mb-4">Generated Draft</h2>
           <div className="whitespace-pre-wrap font-serif leading-relaxed text-gray-800">
             {proposal}

--- a/src/ui/next/src/app/pydantic-validation/page.tsx
+++ b/src/ui/next/src/app/pydantic-validation/page.tsx
@@ -57,7 +57,7 @@ export default function PydanticValidationPage() {
         Test how the system validates tool payloads and generates recoverable errors.
       </p>
 
-      <div className="space-y-6 bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] p-6 shadow-sm border border-white/40 border border-gray-200">
+      <div className="space-y-6 bg-white/65 backdrop-blur-[30px] saturate-[210%] p-6 shadow-sm border border-white/40 border border-gray-200">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-2">
             Tool Name

--- a/src/ui/next/src/app/qr-code-generator/page.tsx
+++ b/src/ui/next/src/app/qr-code-generator/page.tsx
@@ -122,7 +122,7 @@ export default function QRCodeGeneratorPage() {
 
              <div className="text-center flex flex-col items-center">
                  <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-widest mb-6">Scan to test</h3>
-                 <div className="p-4 bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm border border-white/40-sm border border-gray-100 inline-block mb-6">
+                 <div className="p-4 bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm border border-white/40-sm border border-gray-100 inline-block mb-6">
                     {/* Fallback svg while loading image from api */}
                     <img src={qrImageUrl} alt="QR Code" width={256} height={256} className="mx-auto" style={{ width: '256px', height: '256px' }} />
                  </div>

--- a/src/ui/next/src/app/quoting/page.tsx
+++ b/src/ui/next/src/app/quoting/page.tsx
@@ -123,7 +123,7 @@ function QuotingContent() {
 
   return (
     <div className="flex flex-col min-h-screen bg-gray-50 font-inter">
-      <header className="px-6 py-4 bg-white/65 backdrop-blur-3xl saturate-200 border-b border-white/40 sticky top-0 z-10 flex items-center justify-between shadow-sm">
+      <header className="px-6 py-4 bg-white/65 backdrop-blur-[30px] saturate-[210%] saturate-200 border-b border-white/40 sticky top-0 z-10 flex items-center justify-between shadow-sm">
         <h1 className="text-xl font-bold font-outfit text-[#1D1D1F]">Project Proposal</h1>
         <div className="text-sm px-3 py-1 bg-[#0066FF]/10 text-[#0066FF] rounded-full font-medium">
           {accepted ? 'Accepted' : quote.status}
@@ -131,7 +131,7 @@ function QuotingContent() {
       </header>
 
       <main className="p-4 md:p-10 flex-1 max-w-3xl mx-auto w-full">
-        <div className="bg-white/65 backdrop-blur-3xl saturate-200 shadow-sm border border-white/40 overflow-hidden">
+        <div className="bg-white/65 backdrop-blur-[30px] saturate-[210%] saturate-200 shadow-sm border border-white/40 overflow-hidden">
           <div className="p-6 md:p-8 border-b border-gray-100">
             <h2 className="text-2xl font-bold font-outfit text-[#1D1D1F] mb-2">Quote Summary</h2>
             <p className="text-gray-600">Review the scope and pricing below. You can adjust the quantity and price if needed.</p>

--- a/src/ui/next/src/app/referral-fab-builder/page.tsx
+++ b/src/ui/next/src/app/referral-fab-builder/page.tsx
@@ -75,7 +75,7 @@ export default function ReferralFabBuilder() {
 
         {/* Editor Section */}
         <div className="space-y-6">
-          <div className="bg-white/80 backdrop-blur-xl border border-gray-100 rounded-3xl p-8 shadow-sm">
+          <div className="bg-white/80 backdrop-blur-[30px] saturate-[210%] border border-gray-100 rounded-3xl p-8 shadow-sm">
             <h2 className="text-xl font-semibold mb-6">Customize Your Floating Action Button</h2>
 
             <div className="space-y-5">
@@ -150,7 +150,7 @@ export default function ReferralFabBuilder() {
         </div>
 
         {/* Preview Section */}
-        <div className="bg-white/50 backdrop-blur-3xl rounded-[40px] border-[8px] border-white/60 shadow-2xl overflow-hidden relative flex flex-col h-[600px] lg:h-auto min-h-[600px]">
+        <div className="bg-white/50 backdrop-blur-[30px] saturate-[210%] rounded-[40px] border-[8px] border-white/60 shadow-2xl overflow-hidden relative flex flex-col h-[600px] lg:h-auto min-h-[600px]">
            {/* Mock Website Background */}
            <div className="bg-gray-100 h-12 flex items-center px-4 gap-2 border-b border-gray-200">
              <div className="w-3 h-3 rounded-full bg-red-400"></div>
@@ -202,7 +202,7 @@ export default function ReferralFabBuilder() {
 
       {/* Paywall Modal */}
       {showPaywall && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm">
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/40 backdrop-blur-[30px] saturate-[210%]">
           <div className="bg-white rounded-3xl p-8 max-w-sm w-full shadow-2xl relative">
             <button
               onClick={() => setShowPaywall(false)}

--- a/src/ui/next/src/app/share-to-unlock-generator/page.tsx
+++ b/src/ui/next/src/app/share-to-unlock-generator/page.tsx
@@ -102,7 +102,7 @@ export default function ShareToUnlockGeneratorPage() {
                     <div className="flex gap-2 border p-1 min-h-[44px] min-w-[44px] bg-gray-50 border-gray-200">
                         <button
                             onClick={() => setTheme('light')}
-                            className={`flex-1 py-1 px-3 rounded text-sm font-medium transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-1 px-3 rounded text-sm font-medium transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Light
                         </button>

--- a/src/ui/next/src/app/smart-pricing/page.tsx
+++ b/src/ui/next/src/app/smart-pricing/page.tsx
@@ -59,7 +59,7 @@ export default function SmartPricingPage() {
 
   return (
     <div className="flex flex-col min-h-screen font-inter bg-[#F5F5F7]">
-      <header className="px-6 py-4 flex items-center justify-between border-b border-white/40 dark:border-white/10 sticky top-0 z-50 bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] backdrop-saturate-[2.1]">
+      <header className="px-6 py-4 flex items-center justify-between border-b border-white/40 dark:border-white/10 sticky top-0 z-50 bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%]">
         <h1 className="text-2xl font-bold font-outfit text-[#1D1D1F] tracking-[-0.02em]">
           Smart Pricing
         </h1>
@@ -81,7 +81,7 @@ export default function SmartPricingPage() {
           </p>
         </div>
 
-        <div className="p-6 shadow-sm flex items-center justify-between bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)]">
+        <div className="p-6 shadow-sm flex items-center justify-between bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)]">
           <div>
             <h3 className="text-lg font-semibold font-outfit text-[#1D1D1F]">
               Enable Smart Pricing
@@ -106,7 +106,7 @@ export default function SmartPricingPage() {
         </div>
 
         {enabled && (
-          <div className="p-6 shadow-sm flex flex-col gap-6 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)]">
+          <div className="p-6 shadow-sm flex flex-col gap-6 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)]">
             <h3 className="text-lg font-semibold font-outfit border-b pb-2 text-[#1D1D1F] border-black/10">
               Configuration
             </h3>

--- a/src/ui/next/src/app/storefront-widget/page.tsx
+++ b/src/ui/next/src/app/storefront-widget/page.tsx
@@ -66,14 +66,14 @@ export default function StorefrontWidgetPage() {
                         <button
                             aria-pressed={theme === 'light'}
                             onClick={() => setTheme('light')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Light
                         </button>
                         <button
                             aria-pressed={theme === 'dark'}
                             onClick={() => setTheme('dark')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Dark
                         </button>

--- a/src/ui/next/src/app/team/chat/page.tsx
+++ b/src/ui/next/src/app/team/chat/page.tsx
@@ -129,7 +129,7 @@ export default function TeamChatPage() {
       <div className="w-[375px] min-h-[812px] glassmorphism shadow-2xl overflow-hidden flex flex-col relative border-x border-gray-200">
 
         {/* Header */}
-        <div className="pt-12 pb-4 px-6 bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] border-b border-white/40 sticky top-0 z-10 flex items-center gap-4">
+        <div className="pt-12 pb-4 px-6 bg-white/65 backdrop-blur-[30px] saturate-[210%] border-b border-white/40 sticky top-0 z-10 flex items-center gap-4">
           <button aria-label="Back to Team" onClick={() => router.push('/team')} className="text-gray-500">
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg>
           </button>
@@ -184,7 +184,7 @@ export default function TeamChatPage() {
 
                 {/* Action Card if present */}
                 {msg.card && (
-                  <div className="app-card bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] border border-white/40 p-4 shadow-sm relative overflow-hidden" data-testid="action-card">
+                  <div className="app-card bg-white/65 backdrop-blur-[30px] saturate-[210%] border border-white/40 p-4 shadow-sm relative overflow-hidden" data-testid="action-card">
                     <div className={`absolute top-0 left-0 w-full h-1 ${msg.card.status === 'approved' ? 'bg-[#34C759]' : 'bg-gradient-to-r from-blue-400 to-indigo-500'}`}></div>
                     <div className="flex items-center gap-2 mb-2">
                       {msg.card.status === 'pending' ? (
@@ -242,7 +242,7 @@ export default function TeamChatPage() {
         </div>
 
         {/* Input */}
-        <div className="p-4 bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] border-t border-white/40 sticky bottom-0 z-10">
+        <div className="p-4 bg-white/65 backdrop-blur-[30px] saturate-[210%] border-t border-white/40 sticky bottom-0 z-10">
           <div className="flex items-center bg-gray-50 rounded-full border border-gray-200 px-4 py-2">
             <input
               type="text"

--- a/src/ui/next/src/app/team/components/ApprovalInbox.tsx
+++ b/src/ui/next/src/app/team/components/ApprovalInbox.tsx
@@ -60,10 +60,10 @@ export default function ApprovalInbox({
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50 font-inter py-10">
       <div className="w-full sm:w-[375px] max-w-[375px] min-h-[812px] bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-2xl overflow-hidden flex flex-col relative border border-white/40 rounded-3xl glassmorphism">
         {/* Header */}
-        <div className="pt-12 pb-6 px-6 bg-white/65 backdrop-blur-[30px] border-b border-white/40 sticky top-0 z-10 flex items-center gap-4">
+        <div className="pt-12 pb-6 px-6 bg-white/65 backdrop-blur-[30px] saturate-[210%] border-b border-white/40 sticky top-0 z-10 flex items-center gap-4">
           <button
             onClick={onBack}
-            className="w-[44px] h-[44px] flex items-center justify-center rounded-full bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm border border-gray-100 text-gray-500 hover:text-gray-900 transition-colors"
+            className="w-[44px] h-[44px] flex items-center justify-center rounded-full bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm border border-gray-100 text-gray-500 hover:text-gray-900 transition-colors"
           >
             <svg
               className="w-5 h-5"

--- a/src/ui/next/src/app/team/page.tsx
+++ b/src/ui/next/src/app/team/page.tsx
@@ -119,7 +119,7 @@ export default function TeamPage() {
       <div className="w-[375px] max-w-[375px] min-h-[812px] bg-gradient-to-br from-gray-50 to-gray-100 shadow-2xl overflow-hidden flex flex-col relative border-x border-gray-200">
 
         {/* Header */}
-        <div className="pt-12 pb-6 px-6 bg-white/65 backdrop-blur-[30px] border-b border-white/40 sticky top-0 z-10 flex justify-between items-center">
+        <div className="pt-12 pb-6 px-6 bg-white/65 backdrop-blur-[30px] saturate-[210%] border-b border-white/40 sticky top-0 z-10 flex justify-between items-center">
           <div>
             <h1 className="text-3xl font-bold font-outfit text-gray-900 tracking-tight">Your Team</h1>
             <p className="text-gray-500 text-sm mt-1">Invisible specialized AI teams</p>

--- a/src/ui/next/src/app/testimonial-widget/page.tsx
+++ b/src/ui/next/src/app/testimonial-widget/page.tsx
@@ -99,14 +99,14 @@ export default function TestimonialWidgetGenerator() {
                         <button
                             aria-pressed={theme === 'light'}
                             onClick={() => setTheme('light')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Light
                         </button>
                         <button
                             aria-pressed={theme === 'dark'}
                             onClick={() => setTheme('dark')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Dark
                         </button>

--- a/src/ui/next/src/app/tip-jar/page.tsx
+++ b/src/ui/next/src/app/tip-jar/page.tsx
@@ -101,14 +101,14 @@ export default function TipJarWidgetGenerator() {
                         <button
                             aria-pressed={theme === 'light'}
                             onClick={() => setTheme('light')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Light
                         </button>
                         <button
                             aria-pressed={theme === 'dark'}
                             onClick={() => setTheme('dark')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Dark
                         </button>

--- a/src/ui/next/src/app/triage/page.tsx
+++ b/src/ui/next/src/app/triage/page.tsx
@@ -251,10 +251,10 @@ export default function TriagePage() {
               <div
                 key={item.id}
                 data-testid={`triage-card-${item.id}`}
-                className="ohc-card w-full glassmorphism bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[24px] shadow-sm flex flex-col mb-4 overflow-hidden transition-all duration-300"
+                className="ohc-card w-full glassmorphism bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] rounded-[24px] shadow-sm flex flex-col mb-4 overflow-hidden transition-all duration-300"
               >
                 {/* Header Context */}
-                <div className="p-5 border-b border-[rgba(255,255,255,0.2)] bg-[rgba(255,255,255,0.4)] dark:bg-[rgba(22,22,26,0.5)] backdrop-blur-[30px] backdrop-saturate-[210%]">
+                <div className="p-5 border-b border-[rgba(255,255,255,0.2)] bg-[rgba(255,255,255,0.4)] dark:bg-[rgba(22,22,26,0.5)] backdrop-blur-[30px] saturate-[210%]">
                   <div className="flex justify-between items-start mb-3">
                     <div className="flex items-center gap-2">
                       <span className="text-xl">{getSourceIcon(item.source || "")}</span>

--- a/src/ui/next/src/app/viral-powered-by-ohc-widget/page.tsx
+++ b/src/ui/next/src/app/viral-powered-by-ohc-widget/page.tsx
@@ -43,7 +43,7 @@ export default function ViralPoweredByOHCWidgetPage() {
 
   return (
     <div className="flex flex-col min-h-screen font-inter bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50 items-center justify-center py-10 px-4">
-      <div className="w-full max-w-4xl bg-white/80 backdrop-blur-xl rounded-[24px] shadow-sm border border-gray-100 flex flex-col md:flex-row gap-8">
+      <div className="w-full max-w-4xl bg-white/80 backdrop-blur-[30px] saturate-[210%] rounded-[24px] shadow-sm border border-gray-100 flex flex-col md:flex-row gap-8">
         <div className="flex-1 p-8">
           <h1 className="text-3xl font-bold font-outfit text-gray-900 mb-6">Viral Widget Builder</h1>
           <div className="space-y-4">

--- a/src/ui/next/src/app/visual-workflow/page.tsx
+++ b/src/ui/next/src/app/visual-workflow/page.tsx
@@ -72,7 +72,7 @@ export default function VisualWorkflowPage() {
         <div className="flex flex-wrap gap-3">
           <WalkthroughTarget id="vw-add-node">
             <button
-              className="bg-[#0071E3]/90 backdrop-blur-md hover:bg-[#005bb5]/90 text-white px-4 py-2.5 rounded-lg shadow-sm transition-all min-h-[44px] font-medium"
+              className="bg-[#0071E3]/90 backdrop-blur-[30px] saturate-[210%] hover:bg-[#005bb5]/90 text-white px-4 py-2.5 rounded-lg shadow-sm transition-all min-h-[44px] font-medium"
               onClick={() => addNode("Input")}
             >
               + Add Input Node
@@ -107,7 +107,7 @@ export default function VisualWorkflowPage() {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 md:gap-8">
-        <div className="border border-white/20 rounded-2xl p-6 min-h-[400px] bg-white/40 backdrop-blur-2xl shadow-[0_8px_32px_rgba(0,0,0,0.05)]">
+        <div className="border border-white/20 rounded-2xl p-6 min-h-[400px] bg-white/40 backdrop-blur-[30px] saturate-[210%] shadow-[0_8px_32px_rgba(0,0,0,0.05)]">
           <h2 className="text-xl font-semibold mb-4 text-[#1D1D1F]">Workspace Canvas</h2>
 
           {nodes.length === 0 && (
@@ -118,7 +118,7 @@ export default function VisualWorkflowPage() {
 
           <div className="space-y-4">
             {nodes.map((n, i) => (
-              <div key={n.id} className="bg-white/80 backdrop-blur-md p-4 shadow-sm border border-gray-200/60 rounded-xl flex items-center justify-between transition-all hover:shadow-md">
+              <div key={n.id} className="bg-white/80 backdrop-blur-[30px] saturate-[210%] p-4 shadow-sm border border-gray-200/60 rounded-xl flex items-center justify-between transition-all hover:shadow-md">
                 <div className="flex items-center">
                   <span className="inline-flex items-center justify-center px-2.5 py-1 bg-gray-100/80 text-xs font-mono rounded-md mr-3 text-gray-600 min-w-[3rem]">{n.id}</span>
                   <span className="font-semibold text-gray-800">{n.type}</span>
@@ -150,7 +150,7 @@ export default function VisualWorkflowPage() {
           )}
         </div>
 
-        <div className="border border-white/10 rounded-2xl p-6 bg-[#16161A]/60 backdrop-blur-3xl saturate-[180%] text-[#F5F5F7] shadow-xl overflow-auto h-[400px] lg:h-[500px]">
+        <div className="border border-white/10 rounded-2xl p-6 bg-[#16161A]/60 backdrop-blur-[30px] saturate-[210%] text-[#F5F5F7] shadow-xl overflow-auto h-[400px] lg:h-[500px]">
           <h2 className="text-xl font-semibold mb-4 text-white">Execution Result</h2>
           {result ? (
             <pre className="text-sm font-mono whitespace-pre-wrap break-all text-gray-300 bg-black/20 p-4 rounded-xl border border-white/5">{result}</pre>

--- a/src/ui/next/src/app/whatsapp-link-generator/page.tsx
+++ b/src/ui/next/src/app/whatsapp-link-generator/page.tsx
@@ -145,7 +145,7 @@ export default function WhatsAppLinkGeneratorPage() {
                             aria-label="Light theme"
                             aria-pressed={theme === 'light'}
                             onClick={() => setTheme('light')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Light
                         </button>
@@ -153,7 +153,7 @@ export default function WhatsAppLinkGeneratorPage() {
                             aria-label="Dark theme"
                             aria-pressed={theme === 'dark'}
                             onClick={() => setTheme('dark')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Dark
                         </button>

--- a/src/ui/next/src/app/work-intake-widget/page.tsx
+++ b/src/ui/next/src/app/work-intake-widget/page.tsx
@@ -96,14 +96,14 @@ export default function WorkIntakeWidgetPage() {
                         <button
                             aria-pressed={theme === 'light'}
                             onClick={() => setTheme('light')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'light' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Light
                         </button>
                         <button
                             aria-pressed={theme === 'dark'}
                             onClick={() => setTheme('dark')}
-                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] backdrop-saturate-[2.1] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                            className={`flex-1 py-2 text-sm font-medium min-h-[44px] min-w-[44px] transition-all ${theme === 'dark' ? 'bg-white/65 backdrop-blur-[30px] saturate-[210%] shadow-sm-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
                         >
                             Dark
                         </button>

--- a/src/ui/next/src/components/HelpChat.tsx
+++ b/src/ui/next/src/components/HelpChat.tsx
@@ -176,7 +176,7 @@ export function HelpChat() {
             <button
               id="ai-chat-trigger-btn"
               onClick={() => setIsOpen(true)}
-              className="bg-blue-600/95 text-white p-4 min-h-[44px] rounded-full shadow-2xl hover:shadow-xl hover:scale-105 transition-all flex items-center justify-center gap-2 group backdrop-blur-xl saturate-[210%]"
+              className="bg-blue-600/95 text-white p-4 min-h-[44px] rounded-full shadow-2xl hover:shadow-xl hover:scale-105 transition-all flex items-center justify-center gap-2 group backdrop-blur-[30px] saturate-[210%]"
               aria-label="Open help chat"
               aria-expanded={isOpen}
               aria-controls="ai-chat-interface"
@@ -196,7 +196,7 @@ export function HelpChat() {
           {/* Header */}
           <div
             id="ai-chat-header"
-            className="bg-blue-600/95 text-white p-4 flex justify-between items-center backdrop-blur-md"
+            className="bg-blue-600/95 text-white p-4 flex justify-between items-center backdrop-blur-[30px] saturate-[210%]"
           >
             <div className="flex items-center gap-2">
               <span className="text-xl drop-shadow-md">✨</span>
@@ -254,8 +254,8 @@ export function HelpChat() {
                 <div
                   className={`px-4 py-3 rounded-2xl max-w-[85%] leading-relaxed shadow-sm saturate-[210%] ${
                     msg.sender === "user"
-                      ? "bg-blue-600/80 backdrop-blur-xl text-white rounded-br-sm border border-white/20"
-                      : "bg-white/80 dark:bg-black/50 backdrop-blur-md border border-white/50 dark:border-white/20 text-gray-900 dark:text-gray-100 rounded-bl-sm"
+                      ? "bg-blue-600/80 backdrop-blur-[30px] saturate-[210%] text-white rounded-br-sm border border-white/20"
+                      : "bg-white/80 dark:bg-black/50 backdrop-blur-[30px] saturate-[210%] border border-white/50 dark:border-white/20 text-gray-900 dark:text-gray-100 rounded-bl-sm"
                   }`}
                   dangerouslySetInnerHTML={{
                     __html: DOMPurify.sanitize(msg.text),
@@ -264,7 +264,7 @@ export function HelpChat() {
                 {msg.link && (
                   <a
                     href={msg.link.url}
-                    className="mt-2 ml-1 text-blue-600 hover:text-blue-800 text-xs font-bold hover:underline bg-blue-50/90 backdrop-blur-[30px] px-3.5 py-1.5 rounded-full border border-blue-100 flex items-center shadow-sm transition-all hover:bg-blue-100/90"
+                    className="mt-2 ml-1 text-blue-600 hover:text-blue-800 text-xs font-bold hover:underline bg-blue-50/90 backdrop-blur-[30px] saturate-[210%] px-3.5 py-1.5 rounded-full border border-blue-100 flex items-center shadow-sm transition-all hover:bg-blue-100/90"
                   >
                     Read the full article →
                   </a>
@@ -304,12 +304,12 @@ export function HelpChat() {
               onChange={(e) => setInputValue(e.target.value)}
               placeholder="Ask anything..."
               disabled={isLoading}
-              className="flex-1 bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] border border-white/40 dark:border-white/10 rounded-[24px] px-4 py-3 text-base min-h-[44px] focus:outline-none focus:ring-2 focus:ring-blue-500/50 font-inter shadow-inner disabled:opacity-70 disabled:bg-gray-100/70 text-gray-900 dark:text-gray-100"
+              className="flex-1 bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10 rounded-[24px] px-4 py-3 text-base min-h-[44px] focus:outline-none focus:ring-2 focus:ring-blue-500/50 font-inter shadow-inner disabled:opacity-70 disabled:bg-gray-100/70 text-gray-900 dark:text-gray-100"
             />
             <button
               type="submit"
               disabled={!inputValue.trim() || isLoading}
-              className="bg-blue-600/95 backdrop-blur-md text-white p-2.5 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-2xl disabled:opacity-50 disabled:cursor-not-allowed hover:bg-blue-700/95 transition-all shadow-md active:scale-95"
+              className="bg-blue-600/95 backdrop-blur-[30px] saturate-[210%] text-white p-2.5 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-2xl disabled:opacity-50 disabled:cursor-not-allowed hover:bg-blue-700/95 transition-all shadow-md active:scale-95"
               aria-label="Send message"
             >
               {isLoading ? (

--- a/src/ui/next/src/components/RateLimitWarning.tsx
+++ b/src/ui/next/src/components/RateLimitWarning.tsx
@@ -60,7 +60,7 @@ export function RateLimitWarningProvider({ children }: { children: ReactNode }) 
       {children}
       {warningMessage && (
         <div
-          className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 text-amber-800 dark:text-amber-100 px-6 py-4 rounded-xl shadow-lg z-[9999] flex items-start gap-3 max-w-md w-full backdrop-blur-[30px] backdrop-saturate-[2.1]"
+          className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 text-amber-800 dark:text-amber-100 px-6 py-4 rounded-xl shadow-lg z-[9999] flex items-start gap-3 max-w-md w-full backdrop-blur-[30px] saturate-[210%]"
           role="alert"
           aria-live="polite"
         >

--- a/src/ui/next/src/components/TooltipRegistry.tsx
+++ b/src/ui/next/src/components/TooltipRegistry.tsx
@@ -81,7 +81,7 @@ export function TooltipProvider({ children }: { children: ReactNode }) {
       {children}
       {activeTooltip && tooltipRect && (
         <div
-          className="fixed z-[100] backdrop-blur-[30px] backdrop-saturate-[2.1] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 !rounded-[8px] text-gray-900 dark:text-gray-100 text-sm font-inter p-3 shadow-[0_12px_40px_rgba(0,0,0,0.2)] pointer-events-none w-64 max-w-[calc(100vw-32px)] mx-4 text-center leading-relaxed animate-fade-in-up"
+          className="fixed z-[100] backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 !rounded-[8px] text-gray-900 dark:text-gray-100 text-sm font-inter p-3 shadow-[0_12px_40px_rgba(0,0,0,0.2)] pointer-events-none w-64 max-w-[calc(100vw-32px)] mx-4 text-center leading-relaxed animate-fade-in-up"
           style={{
             top: tooltipRect.top - 10,
             left: Math.max(144, Math.min(windowWidth - 144, tooltipRect.left + tooltipRect.width / 2)),
@@ -89,7 +89,7 @@ export function TooltipProvider({ children }: { children: ReactNode }) {
           }}
         >
           {tooltipText}
-          <div className="absolute top-full left-1/2 transform -translate-x-1/2 border-solid border-t-white/90 dark:border-t-black/80 border-t-8 border-x-transparent border-x-8 border-b-0 backdrop-blur-[30px] backdrop-saturate-[2.1] bg-white/65 dark:bg-[#16161a]/70"></div>
+          <div className="absolute top-full left-1/2 transform -translate-x-1/2 border-solid border-t-white/90 dark:border-t-black/80 border-t-8 border-x-transparent border-x-8 border-b-0 backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70"></div>
         </div>
       )}
       <style dangerouslySetInnerHTML={{__html: `

--- a/src/ui/next/src/components/VideoTutorialList.tsx
+++ b/src/ui/next/src/components/VideoTutorialList.tsx
@@ -79,7 +79,7 @@ export function VideoTutorialList({
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredVideos.map(video => (
-            <div key={video.id} onClick={() => setActiveVideo(video)} className="backdrop-blur-[30px] bg-white/80 dark:bg-black/40 saturate-[250%] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.08)] border border-white/80 dark:border-white/20 overflow-hidden group hover:shadow-lg transition-all cursor-pointer flex flex-col hover:-translate-y-1">
+            <div key={video.id} onClick={() => setActiveVideo(video)} className="backdrop-blur-[30px] bg-white/80 dark:bg-black/40 saturate-[210%] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.08)] border border-white/80 dark:border-white/20 overflow-hidden group hover:shadow-lg transition-all cursor-pointer flex flex-col hover:-translate-y-1">
             {/* Mock video player area (portrait optimized 9:16 approx for mobile shorts feel, or standard 16:9) */}
             <div className="w-full aspect-[9/16] sm:aspect-video bg-gray-900 relative flex items-center justify-center">
               {/* Play button overlay */}
@@ -107,8 +107,8 @@ export function VideoTutorialList({
       )}
       {/* Video Player Modal */}
       {activeVideo && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-gray-900/80 backdrop-blur-[20px] saturate-200 p-4 animate-fade-in">
-          <div className="bg-black backdrop-blur-[30px] rounded-3xl shadow-2xl flex flex-col overflow-hidden border border-white/20 w-full max-w-[375px] mx-auto aspect-[9/16] relative animate-pop-in">
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-gray-900/80 backdrop-blur-[30px] saturate-[210%] saturate-200 p-4 animate-fade-in">
+          <div className="bg-black backdrop-blur-[30px] saturate-[210%] rounded-3xl shadow-2xl flex flex-col overflow-hidden border border-white/20 w-full max-w-[375px] mx-auto aspect-[9/16] relative animate-pop-in">
             {/* Header */}
             <div className="absolute top-0 left-0 right-0 p-4 bg-gradient-to-b from-black/90 to-transparent z-10 flex justify-between items-start pt-6">
               <h3 className="text-white font-bold font-outfit text-base pr-4 line-clamp-2 drop-shadow-md leading-tight">{activeVideo.title}</h3>

--- a/src/ui/next/src/components/Walkthrough.tsx
+++ b/src/ui/next/src/components/Walkthrough.tsx
@@ -130,7 +130,7 @@ export function InteractiveWalkthrough({ steps, isOpen, onClose, onComplete }: W
       {/* Target Highlight Overlay (using box-shadow to punch a hole) */}
       {targetRect && (
         <div
-          className="ohc-walkthrough-overlay fixed pointer-events-none transition-all duration-300 ease-in-out ring-4 ring-blue-500/50 rounded-2xl shadow-[0_0_0_9999px_rgba(0,0,0,0.6)] backdrop-blur-[2px]"
+          className="ohc-walkthrough-overlay fixed pointer-events-none transition-all duration-300 ease-in-out ring-4 ring-blue-500/50 rounded-2xl shadow-[0_0_0_9999px_rgba(0,0,0,0.6)] backdrop-blur-[30px] saturate-[210%]"
           style={{
             zIndex: 9999,
             top: targetRect.top - 4,
@@ -169,7 +169,7 @@ export function InteractiveWalkthrough({ steps, isOpen, onClose, onComplete }: W
           <button
             id="wt-next"
             onClick={handleNext}
-            className="bg-blue-600/95 hover:bg-blue-700 text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-lg backdrop-blur-md saturate-[210%] active:scale-95 transition-all"
+            className="bg-blue-600/95 hover:bg-blue-700 text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-lg backdrop-blur-[30px] saturate-[210%] active:scale-95 transition-all"
           >
             {isLastStep ? 'Finish' : 'Next'}
           </button>

--- a/src/ui/next/src/components/chat/ContextCard.tsx
+++ b/src/ui/next/src/components/chat/ContextCard.tsx
@@ -36,7 +36,7 @@ export const ContextCard: React.FC<ContextCardProps> = ({ tenantId, customerId }
 
   if (loading) {
     return (
-      <div className="w-full h-11 min-h-[44px] backdrop-blur-[30px] backdrop-saturate-[2.1] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 shadow-[0_4px_24px_rgba(0,0,0,0.04)] rounded-lg flex items-center justify-center animate-pulse">
+      <div className="w-full h-11 min-h-[44px] backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 shadow-[0_4px_24px_rgba(0,0,0,0.04)] rounded-lg flex items-center justify-center animate-pulse">
         <span className="text-sm text-gray-500">Loading context...</span>
       </div>
     );
@@ -47,7 +47,7 @@ export const ContextCard: React.FC<ContextCardProps> = ({ tenantId, customerId }
   }
 
   return (
-    <div className="w-full min-h-[44px] p-3 backdrop-blur-[30px] backdrop-saturate-[2.1] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 shadow-[0_4px_24px_rgba(0,0,0,0.04)] rounded-xl mb-4 transition-all duration-300">
+    <div className="w-full min-h-[44px] p-3 backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 shadow-[0_4px_24px_rgba(0,0,0,0.04)] rounded-xl mb-4 transition-all duration-300">
       <div className="flex flex-col space-y-1">
         <div className="text-xs font-semibold text-gray-700 flex flex-wrap gap-1">
           {profile.segments.map((segment, idx) => (

--- a/src/ui/next/src/components/feed/AgentActionCard.tsx
+++ b/src/ui/next/src/components/feed/AgentActionCard.tsx
@@ -86,7 +86,7 @@ export const AgentActionCard: React.FC<AgentActionCardProps> = ({
   return (
     <div
       key={approval.id}
-      className={`glassmorphism app-list-item bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-5 shadow-sm flex flex-col gap-4 transition-all duration-300 overflow-hidden break-words whitespace-normal ${approval.event_source?.includes("marketing") ? "!border-t-[4px] !border-t-pink-500" : approval.event_source?.includes("operations") ? "!border-t-[4px] !border-t-blue-500" : approval.event_source?.includes("sales") || approval.event_source?.includes("triage") ? "!border-t-[4px] !border-t-green-500" : ""}`}
+      className={`glassmorphism app-list-item bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-5 shadow-sm flex flex-col gap-4 transition-all duration-300 overflow-hidden break-words whitespace-normal ${approval.event_source?.includes("marketing") ? "!border-t-[4px] !border-t-pink-500" : approval.event_source?.includes("operations") ? "!border-t-[4px] !border-t-blue-500" : approval.event_source?.includes("sales") || approval.event_source?.includes("triage") ? "!border-t-[4px] !border-t-green-500" : ""}`}
       data-testid={`triage-card-${approval.id}`}
     >
       <div className="flex flex-col gap-1">
@@ -176,7 +176,7 @@ export const AgentActionCard: React.FC<AgentActionCardProps> = ({
             {(approval.proposed_action || approval.context_payload)
               ?.feature_type === "onboarding_welcome" && (
               <div
-                className="mb-4 p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] flex flex-col gap-3"
+                className="mb-4 p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] flex flex-col gap-3"
                 data-testid="onboarding-welcome-card"
               >
                 <div className="flex items-center gap-2 text-[#0066FF] font-semibold text-sm">
@@ -438,7 +438,7 @@ export const AgentActionCard: React.FC<AgentActionCardProps> = ({
             {(approval.proposed_action || approval.context_payload)
               ?.feature_type === "autonomous_booking_quote" && (
               <div
-                className="mb-4 p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] flex flex-col gap-3"
+                className="mb-4 p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] flex flex-col gap-3"
                 data-testid="autonomous-booking-quote-card"
               >
                 <div className="flex items-center gap-2 text-[#0066FF] font-semibold text-sm">
@@ -595,7 +595,7 @@ export const AgentActionCard: React.FC<AgentActionCardProps> = ({
             {(approval.proposed_action || approval.context_payload)
               ?.feature_type === "quote_draft" && (
               <div
-                className="mb-4 p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] flex flex-col gap-3"
+                className="mb-4 p-4 bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] flex flex-col gap-3"
                 data-testid="quote-draft-card"
               >
                 <div className="flex items-center gap-2 text-[#0066FF] font-semibold text-sm">
@@ -623,7 +623,7 @@ export const AgentActionCard: React.FC<AgentActionCardProps> = ({
                       .customer_inquiry
                   }
                 </div>
-                <div className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-3 rounded-[8px] relative mt-2">
+                <div className="bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-3 rounded-[8px] relative mt-2">
                   <div className="text-[10px] uppercase font-bold text-gray-500 mb-2">
                     AI Proposed Quote
                   </div>
@@ -1264,7 +1264,7 @@ export const AgentActionCard: React.FC<AgentActionCardProps> = ({
             </div>
           ) : (
             <>
-              <div className="p-3 bg-white/50 dark:bg-gray-800/50 rounded-lg mb-3 border border-gray-200 dark:border-gray-700 backdrop-blur-[10px]">
+              <div className="p-3 bg-white/50 dark:bg-gray-800/50 rounded-lg mb-3 border border-gray-200 dark:border-gray-700 backdrop-blur-[30px] saturate-[210%]">
                 <p className="text-sm font-medium text-gray-900 dark:text-white mb-1">
                   Audio Summary
                 </p>

--- a/src/ui/next/src/components/feed/GroupedAgentActionCard.tsx
+++ b/src/ui/next/src/components/feed/GroupedAgentActionCard.tsx
@@ -26,7 +26,7 @@ export const GroupedAgentActionCard = ({
 
   return (
     <div
-      className="glassmorphism bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-5 shadow-sm flex flex-col gap-4 transition-all duration-300 overflow-hidden break-words whitespace-normal"
+      className="glassmorphism bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] saturate-[210%] border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] p-5 shadow-sm flex flex-col gap-4 transition-all duration-300 overflow-hidden break-words whitespace-normal"
       data-testid={`grouped-triage-card-${groupKey}`}
     >
       <div className="flex flex-col gap-1">

--- a/src/ui/next/src/components/help.tsx
+++ b/src/ui/next/src/components/help.tsx
@@ -218,7 +218,7 @@ export function HelpWidget() {
           <button
             id="ohc-floating-help-btn"
             onClick={() => setOpen(!open)}
-            className="w-14 h-14 bg-blue-600/90 backdrop-blur-[20px] saturate-200 text-white rounded-full shadow-[0_8px_32px_rgba(37,99,235,0.3)] flex items-center justify-center hover:bg-blue-700/90 active:scale-95 transition-all min-h-[44px] min-w-[44px]"
+            className="w-14 h-14 bg-blue-600/90 backdrop-blur-[30px] saturate-[210%] saturate-200 text-white rounded-full shadow-[0_8px_32px_rgba(37,99,235,0.3)] flex items-center justify-center hover:bg-blue-700/90 active:scale-95 transition-all min-h-[44px] min-w-[44px]"
             aria-label="Help"
           >
             <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -229,7 +229,7 @@ export function HelpWidget() {
       </div>
 
       {open && (
-        <div id="ohc-floating-help-widget" data-ui-overlay="true" className="fixed bottom-24 right-4 sm:right-6 w-[calc(100vw-32px)] sm:w-[380px] h-[75vh] sm:h-[550px] max-h-[700px] backdrop-blur-[40px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 rounded-3xl shadow-[0_8px_32px_rgba(0,0,0,0.12)] flex flex-col overflow-hidden z-[90] border border-white/60 transition-all font-inter">
+        <div id="ohc-floating-help-widget" data-ui-overlay="true" className="fixed bottom-24 right-4 sm:right-6 w-[calc(100vw-32px)] sm:w-[380px] h-[75vh] sm:h-[550px] max-h-[700px] backdrop-blur-[30px] saturate-[210%] bg-white/70 dark:bg-[#1C1C1E]/70 rounded-3xl shadow-[0_8px_32px_rgba(0,0,0,0.12)] flex flex-col overflow-hidden z-[90] border border-white/60 transition-all font-inter">
           <div className="flex border-b border-white/30 bg-white/40 backdrop-blur-[30px] saturate-[210%] overflow-x-auto scrollbar-hide relative pr-12">
             {helpTabs.map((t) => (
               <button
@@ -257,7 +257,7 @@ export function HelpWidget() {
             {tab === "center" && (
               <div>
                 <h3 className="font-bold font-outfit text-gray-900 mb-4 text-xl">In-App Help Center</h3>
-                <input type="text" placeholder="Search for help..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} className="w-full p-4 border border-white/50 rounded-2xl mb-6 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-sm bg-white/60 backdrop-blur-[20px] saturate-200 min-h-[44px]" />
+                <input type="text" placeholder="Search for help..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} className="w-full p-4 border border-white/50 rounded-2xl mb-6 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-sm bg-white/60 backdrop-blur-[30px] saturate-[210%] saturate-200 min-h-[44px]" />
                 <div className="space-y-6 mb-8">
                   {Array.from(
                     filteredArticles.reduce((acc, article) => {
@@ -288,17 +288,17 @@ export function HelpWidget() {
                                 <h3 className="font-bold font-outfit text-gray-900 mb-4 text-lg">Interactive Tours</h3>
                 <div className="space-y-3">
                   <WithTooltip id="walkthrough-btn-tooltip" defaultText="Start an interactive guide to learn how to use OHC.">
-                  <button onClick={() => { setOpen(false); fetch("/api/walkthrough/store-setup").then(res => res.json()).then(data => data && data.length > 0 ? startWalkthrough(data) : startWalkthrough([{ targetId: "bio-input-tooltip", title: "Business Description", content: "Enter your business description." }, { targetId: "generate-btn-tooltip", title: "Generate", content: "Click to generate!" }])); }} className="w-full text-left bg-blue-50/80 backdrop-blur-[20px] saturate-200 p-4 rounded-2xl shadow-sm border border-blue-100 hover:bg-blue-100/90 hover:shadow-md transition-all min-h-[44px]">
+                  <button onClick={() => { setOpen(false); fetch("/api/walkthrough/store-setup").then(res => res.json()).then(data => data && data.length > 0 ? startWalkthrough(data) : startWalkthrough([{ targetId: "bio-input-tooltip", title: "Business Description", content: "Enter your business description." }, { targetId: "generate-btn-tooltip", title: "Generate", content: "Click to generate!" }])); }} className="w-full text-left bg-blue-50/80 backdrop-blur-[30px] saturate-[210%] saturate-200 p-4 rounded-2xl shadow-sm border border-blue-100 hover:bg-blue-100/90 hover:shadow-md transition-all min-h-[44px]">
                     <span className="font-bold font-outfit text-blue-800 text-base block">Tour: Set up your store</span>
                   </button>
                   </WithTooltip>
-                  <button onClick={() => { setOpen(false); fetch("/api/walkthrough/pos").then(res => res.json()).then(data => data && data.length > 0 ? startWalkthrough(data) : startWalkthrough([{ targetId: "pos-keypad", title: "Enter Amount", content: "Type in the total sale amount using the keypad." }, { targetId: "charge-btn", title: "Charge Customer", content: "Tap here to process the payment. It's that easy!" }])); }} className="w-full text-left bg-blue-50/80 backdrop-blur-[20px] saturate-200 p-4 rounded-2xl shadow-sm border border-blue-100 hover:bg-blue-100/90 hover:shadow-md transition-all min-h-[44px]">
+                  <button onClick={() => { setOpen(false); fetch("/api/walkthrough/pos").then(res => res.json()).then(data => data && data.length > 0 ? startWalkthrough(data) : startWalkthrough([{ targetId: "pos-keypad", title: "Enter Amount", content: "Type in the total sale amount using the keypad." }, { targetId: "charge-btn", title: "Charge Customer", content: "Tap here to process the payment. It's that easy!" }])); }} className="w-full text-left bg-blue-50/80 backdrop-blur-[30px] saturate-[210%] saturate-200 p-4 rounded-2xl shadow-sm border border-blue-100 hover:bg-blue-100/90 hover:shadow-md transition-all min-h-[44px]">
                     <span className="font-bold font-outfit text-blue-800 text-base block">Tour: Accept your first payment</span>
                   </button>
-                  <button onClick={() => { setOpen(false); fetch("/api/walkthrough/assistant").then(res => res.json()).then(data => data && data.length > 0 ? startWalkthrough(data) : startWalkthrough([{ targetId: "ai-chat-trigger", title: "Open Assistant", content: "Click here to open your AI Support Agent." }, { targetId: "ohc-help-input-area", title: "Ask Anything", content: "Type your request here and the agent will handle it while you sleep." }])); }} className="w-full text-left bg-blue-50/80 backdrop-blur-[20px] saturate-200 p-4 rounded-2xl shadow-sm border border-blue-100 hover:bg-blue-100/90 hover:shadow-md transition-all min-h-[44px]">
+                  <button onClick={() => { setOpen(false); fetch("/api/walkthrough/assistant").then(res => res.json()).then(data => data && data.length > 0 ? startWalkthrough(data) : startWalkthrough([{ targetId: "ai-chat-trigger", title: "Open Assistant", content: "Click here to open your AI Support Agent." }, { targetId: "ohc-help-input-area", title: "Ask Anything", content: "Type your request here and the agent will handle it while you sleep." }])); }} className="w-full text-left bg-blue-50/80 backdrop-blur-[30px] saturate-[210%] saturate-200 p-4 rounded-2xl shadow-sm border border-blue-100 hover:bg-blue-100/90 hover:shadow-md transition-all min-h-[44px]">
                     <span className="font-bold font-outfit text-blue-800 text-base block">Tour: Activate your AI Support Agent</span>
                   </button>
-                  <button onClick={() => { setOpen(false); fetch("/api/walkthrough/meeting-room").then(res => res.json()).then(data => data && data.length > 0 ? startWalkthrough(data) : startWalkthrough([{ targetId: "help-widget-container", title: "Virtual Meeting Room", content: "Agents join the Virtual Meeting Room to debate and plan before executing tasks." }, { targetId: "help-widget-container", title: "UltraPlan Protocol", content: "Phase 1: Brainstorming. Phase 2: Refinement. Phase 3: Consensus (UltraPlan protocol)." }])); }} className="w-full text-left bg-blue-50/80 backdrop-blur-[20px] saturate-200 p-4 rounded-2xl shadow-sm border border-blue-100 hover:bg-blue-100/90 hover:shadow-md transition-all min-h-[44px]">
+                  <button onClick={() => { setOpen(false); fetch("/api/walkthrough/meeting-room").then(res => res.json()).then(data => data && data.length > 0 ? startWalkthrough(data) : startWalkthrough([{ targetId: "help-widget-container", title: "Virtual Meeting Room", content: "Agents join the Virtual Meeting Room to debate and plan before executing tasks." }, { targetId: "help-widget-container", title: "UltraPlan Protocol", content: "Phase 1: Brainstorming. Phase 2: Refinement. Phase 3: Consensus (UltraPlan protocol)." }])); }} className="w-full text-left bg-blue-50/80 backdrop-blur-[30px] saturate-[210%] saturate-200 p-4 rounded-2xl shadow-sm border border-blue-100 hover:bg-blue-100/90 hover:shadow-md transition-all min-h-[44px]">
                     <span className="font-bold font-outfit text-blue-800 text-base block">Tour: Virtual Meeting Room & UltraPlan</span>
                   </button>
                   <button
@@ -307,7 +307,7 @@ export function HelpWidget() {
                       setOpen(false);
                       router.push("/kairos?walkthrough=true");
                     }}
-                    className="w-full text-left bg-indigo-50/80 backdrop-blur-[20px] saturate-200 p-4 rounded-2xl shadow-sm border border-indigo-100 hover:bg-indigo-100/90 hover:shadow-md transition-all min-h-[44px]"
+                    className="w-full text-left bg-indigo-50/80 backdrop-blur-[30px] saturate-[210%] saturate-200 p-4 rounded-2xl shadow-sm border border-indigo-100 hover:bg-indigo-100/90 hover:shadow-md transition-all min-h-[44px]"
                   >
                     <span className="font-bold font-outfit text-indigo-800 text-base block">Tour: KAIROS AI OS Orchestration</span>
                   </button>
@@ -316,7 +316,7 @@ export function HelpWidget() {
             )}
 
             {tab === "chat" && (
-              <div className="flex flex-col h-full bg-white/30 backdrop-blur-[20px] saturate-200 rounded-xl p-2">
+              <div className="flex flex-col h-full bg-white/30 backdrop-blur-[30px] saturate-[210%] saturate-200 rounded-xl p-2">
                 <div className="flex-1 space-y-4 overflow-y-auto pr-2 pb-2">
                   {chatMessages.map((msg) => {
                     const className = `p-3 rounded-2xl text-sm w-4/5 ${
@@ -360,7 +360,7 @@ export function HelpWidget() {
                   {videos.map((v) => (
                     <div key={v.id} onClick={() => setActiveVideo(v)} className="aspect-[9/16] bg-gray-200 rounded-2xl flex items-center justify-center relative overflow-hidden group cursor-pointer shadow-sm border border-white/30">
                       <div className="absolute inset-0 bg-black/30 group-hover:bg-black/20 transition-all"></div>
-                        <div className="w-10 h-10 bg-white/90 backdrop-blur-3xl saturate-[210%] rounded-full flex items-center justify-center shadow-lg z-10 group-hover:scale-110 transition-transform">
+                        <div className="w-10 h-10 bg-white/90 backdrop-blur-[30px] saturate-[210%] rounded-full flex items-center justify-center shadow-lg z-10 group-hover:scale-110 transition-transform">
                         <svg className="w-5 h-5 text-blue-600 ml-1" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clipRule="evenodd" /></svg>
                       </div>
                       <div className="absolute bottom-2 left-2 right-2 z-10">
@@ -401,12 +401,12 @@ export function HelpWidget() {
 
       {/* Video Player Modal */}
       {activeVideo && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-gray-900/80 backdrop-blur-md saturate-200 p-4 animate-fade-in">
-          <div className="bg-black backdrop-blur-3xl rounded-3xl shadow-[0_12px_40px_rgba(0,0,0,0.5)] flex flex-col overflow-hidden border border-white/20 w-full max-w-[375px] mx-auto aspect-[9/16] relative animate-pop-in">
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-gray-900/80 backdrop-blur-[30px] saturate-[210%] saturate-200 p-4 animate-fade-in">
+          <div className="bg-black backdrop-blur-[30px] saturate-[210%] rounded-3xl shadow-[0_12px_40px_rgba(0,0,0,0.5)] flex flex-col overflow-hidden border border-white/20 w-full max-w-[375px] mx-auto aspect-[9/16] relative animate-pop-in">
             {/* Header */}
             <div className="absolute top-0 left-0 right-0 p-4 bg-gradient-to-b from-black/90 to-transparent z-10 flex justify-between items-start pt-6">
               <h3 className="text-white font-bold font-outfit text-base pr-4 line-clamp-2 drop-shadow-md leading-tight">{activeVideo.title}</h3>
-              <button onClick={() => setActiveVideo(null)} className="text-white/80 hover:text-white bg-white/20 hover:bg-white/30 backdrop-blur-3xl saturate-[210%] border border-white/20 rounded-full p-2 transition-all min-h-[44px] min-w-[44px] flex items-center justify-center flex-shrink-0" aria-label="Close video">
+              <button onClick={() => setActiveVideo(null)} className="text-white/80 hover:text-white bg-white/20 hover:bg-white/30 backdrop-blur-[30px] saturate-[210%] border border-white/20 rounded-full p-2 transition-all min-h-[44px] min-w-[44px] flex items-center justify-center flex-shrink-0" aria-label="Close video">
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
               </button>
             </div>

--- a/src/ui/next/src/components/layout/ErrorState.test.tsx
+++ b/src/ui/next/src/components/layout/ErrorState.test.tsx
@@ -19,7 +19,7 @@ describe('ErrorState', () => {
     const { container } = render(<ErrorState message="Check styles" />);
     const divElement = container.firstChild as HTMLElement;
     expect(divElement).toHaveClass('backdrop-blur-[30px]');
-    expect(divElement).toHaveClass('backdrop-saturate-[2.1]');
+    expect(divElement).toHaveClass('saturate-[210%]');
     expect(divElement).toHaveClass('bg-white/65');
   });
 });

--- a/src/ui/next/src/components/layout/ErrorState.tsx
+++ b/src/ui/next/src/components/layout/ErrorState.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const ErrorState = ({ title, message }: { title?: string; message: string }) => (
-  <div className="p-4 rounded-xl text-red-700 dark:text-red-400 backdrop-blur-[30px] backdrop-saturate-[2.1] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 shadow-[0_4px_24px_rgba(0,0,0,0.04)]">
+  <div className="p-4 rounded-xl text-red-700 dark:text-red-400 backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 shadow-[0_4px_24px_rgba(0,0,0,0.04)]">
     {title && <h3 className="font-semibold mb-1">{title}</h3>}
     <p className="text-sm font-medium">{message}</p>
   </div>

--- a/src/ui/next/src/components/layout/PageHeader.test.tsx
+++ b/src/ui/next/src/components/layout/PageHeader.test.tsx
@@ -20,7 +20,7 @@ describe('PageHeader', () => {
     const { container } = render(<PageHeader title="Style Check" />);
     const divElement = container.firstChild as HTMLElement;
     expect(divElement).toHaveClass('backdrop-blur-[30px]');
-    expect(divElement).toHaveClass('backdrop-saturate-[2.1]');
+    expect(divElement).toHaveClass('saturate-[210%]');
     expect(divElement).toHaveClass('bg-white/65');
   });
 });

--- a/src/ui/next/src/components/layout/PageHeader.tsx
+++ b/src/ui/next/src/components/layout/PageHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const PageHeader = ({ title, description }: { title: string; description?: string }) => (
-  <div className="mb-6 p-4 rounded-xl backdrop-blur-[30px] backdrop-saturate-[2.1] bg-white/65 dark:bg-[#16161a]/70 shadow-[0_4px_24px_rgba(0,0,0,0.04)] border border-white/40 dark:border-white/10 sticky top-0 z-10">
+  <div className="mb-6 p-4 rounded-xl backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 shadow-[0_4px_24px_rgba(0,0,0,0.04)] border border-white/40 dark:border-white/10 sticky top-0 z-10">
     <h1 className="text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100 drop-shadow-sm">{title}</h1>
     {description && <p className="mt-1 text-sm text-gray-600/90 dark:text-gray-400 font-medium">{description}</p>}
   </div>


### PR DESCRIPTION
This PR aligns all glassmorphism occurrences to use the mandated Apple/Ubiquiti-style Translucent Glass UI token classes: `backdrop-blur-[30px]` and `saturate-[210%]`.

Many files inconsistently used incorrect values like `saturate-[2.1]`, `backdrop-blur-md`, `backdrop-blur-[10px]`, or `backdrop-saturate-[2.1]`. This PR programmatically targets these values and replaces them with strict adherence to the visual mandate. 

Corresponding Next.js UI unit tests have been updated to check for `saturate-[210%]` instead of `backdrop-saturate-[2.1]`. All tests are now fully green (`//src/ui/next:next_vitest` and `//src/e2e:playwright`).

---
*PR created automatically by Jules for task [3265201299377808209](https://jules.google.com/task/3265201299377808209) started by @ql-owo-lp*