### PR TITLE
refactor(pricing): switch BudgetManager to track costs natively in cents

### DIFF
--- a/src/server/pricing/budget.rs
+++ b/src/server/pricing/budget.rs
@@ -1,8 +1,9 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, Ordering};
 
 pub struct BudgetManager {
     pub total_limit: f64,
-    current: AtomicU64,
+    pub total_limit_cents: i64,
+    current: AtomicI64,
     pub telemetry_store: Option<std::sync::Arc<::server_harness::telemetry::ViolationStore>>,
     tenant_id: Option<String>,
     pub alert_threshold_percent: f64,
@@ -10,9 +11,11 @@ pub struct BudgetManager {
 
 impl BudgetManager {
     pub fn new(limit: f64) -> Self {
+        let total_limit_cents = if limit == f64::MAX { i64::MAX } else { (limit * 100.0).round() as i64 };
         BudgetManager {
             total_limit: limit,
-            current: AtomicU64::new(0),
+            current: AtomicI64::new(0),
+            total_limit_cents,
             telemetry_store: None,
             tenant_id: None,
             alert_threshold_percent: 80.0,
@@ -31,40 +34,35 @@ impl BudgetManager {
     }
 
     pub fn record_spend(&self, amount: f64) -> Result<bool, String> {
-        if amount < 0.0 {
+        let amount_cents = (amount * 100.0).round() as i64;
+        self.record_spend_cents(amount_cents)
+    }
+
+    pub fn record_spend_cents(&self, amount_cents: i64) -> Result<bool, String> {
+        if amount_cents < 0 {
             return Err("spend amount cannot be negative".to_string());
         }
-        if amount == 0.0 {
-            return Ok(self.get_remaining() >= 0.0);
+        if amount_cents == 0 {
+            return Ok(self.get_remaining_cents() >= 0);
         }
 
         if let (Some(_store), Some(tid)) = (&self.telemetry_store, &self.tenant_id) {
             tracing::info!("💰 Miser telemetry: Recording budget spend for tenant {}", tid); // pii-safe
         }
 
-        let final_current_bits = self.current.fetch_update(
-            Ordering::SeqCst,
-            Ordering::Relaxed,
-            |bits| {
-                let current = f64::from_bits(bits);
-                let next = current + amount;
-                Some(next.to_bits())
-            }
-        ).unwrap(); // safe because the closure always returns Some
-
-        let final_current = f64::from_bits(final_current_bits) + amount;
+        let previous_current = self.current.fetch_add(amount_cents, Ordering::SeqCst);
+        let final_current = previous_current + amount_cents;
 
         if let (Some(store), Some(tid)) = (&self.telemetry_store, &self.tenant_id) {
-            let cents = (amount * 100.0).round() as u64;
-            if cents > 0 {
+            if amount_cents > 0 {
                 store.llm_cost_counter.add(
-                    cents,
+                    amount_cents as u64,
                     &[opentelemetry::KeyValue::new("tenant_id", tid.to_string())],
                 );
             }
         }
 
-        if final_current > self.total_limit {
+        if final_current > self.total_limit_cents {
             Ok(false)
         } else {
             Ok(true)
@@ -72,36 +70,29 @@ impl BudgetManager {
     }
 
     pub fn get_remaining(&self) -> f64 {
-        let current = f64::from_bits(self.current.load(Ordering::SeqCst));
-        self.total_limit - current
+        let current = self.current.load(Ordering::SeqCst);
+        (self.total_limit_cents - current) as f64 / 100.0
     }
 
     pub fn get_remaining_cents(&self) -> i64 {
-        let current = f64::from_bits(self.current.load(Ordering::SeqCst));
-        ((self.total_limit - current) * 100.0).round() as i64
-    }
-
-    pub fn record_spend_cents(&self, amount_cents: i64) -> Result<bool, String> {
-        if amount_cents == 0 {
-            return Ok(self.get_remaining() >= 0.0);
-        }
-        self.record_spend((amount_cents as f64) / 100.0)
+        let current = self.current.load(Ordering::SeqCst);
+        self.total_limit_cents - current
     }
 
     pub fn check_alert_threshold(&self) -> bool {
-        if self.total_limit <= 0.0 {
+        if self.total_limit_cents <= 0 {
             return false;
         }
-        let current = f64::from_bits(self.current.load(Ordering::SeqCst));
-        let usage_percent = (current / self.total_limit) * 100.0;
+        let current = self.current.load(Ordering::SeqCst);
+        let usage_percent = (current as f64 / self.total_limit_cents as f64) * 100.0;
         usage_percent >= self.alert_threshold_percent
     }
 
     pub fn is_projected_cost_over_threshold(&self, projected_cost_cents: i64) -> bool {
-        if self.total_limit <= 0.0 {
+        if self.total_limit_cents <= 0 {
             return projected_cost_cents > 0;
         }
-        let limit_threshold_cents = ((self.total_limit * 100.0) * (self.alert_threshold_percent / 100.0)).round() as i64;
+        let limit_threshold_cents = ((self.total_limit_cents as f64) * (self.alert_threshold_percent / 100.0)).round() as i64;
         projected_cost_cents >= limit_threshold_cents
     }
 
@@ -109,10 +100,9 @@ impl BudgetManager {
         if total_limit_cents <= 0 {
             return false;
         }
-        let current = f64::from_bits(self.current.load(Ordering::SeqCst));
-        let current_cents = (current * 100.0).round() as i64;
+        let current = self.current.load(Ordering::SeqCst);
         let limit_threshold_cents = ((total_limit_cents as f64) * (self.alert_threshold_percent / 100.0)).round() as i64;
-        current_cents >= limit_threshold_cents
+        current >= limit_threshold_cents
     }
 }
 


### PR DESCRIPTION
Updates `BudgetManager` in `src/server/pricing/budget.rs` to track budget usage internally in cents.
- Replaces `AtomicU64` with `AtomicI64`.
- Replaces `f64::from_bits` / `f64::to_bits` with standard `i64` arithmetic.
- Maintains `f64` APIs for backward compatibility.

---
*PR created automatically by Jules for task [12616290424194197486](https://jules.google.com/task/12616290424194197486) started by @ql-owo-lp*