### PR TITLE
🎨 Canvas: [Architecture] Edge-Caching Dynamic Storefronts (CDN & Instant Loading)

### DIFF
--- a/src/e2e/global_edge_storefront.spec.ts
+++ b/src/e2e/global_edge_storefront.spec.ts
@@ -21,19 +21,30 @@ test.describe('Global Edge-Cached Dynamic Storefronts E2E', () => {
     const tenantId = '11111111-1111-1111-1111-111111111111';
     const productId = '22222222-2222-2222-2222-222222222222';
 
+    // 1. Initial hit should result in a cache miss from our local edge caching middleware
     let res = await request.get(`http://127.0.0.1:18789/api/v1/storefront/${tenantId}/${productId}`);
     expect(res.status()).toBe(200);
+    expect(res.headers()['x-cache']).toBe('MISS');
 
-    // Perform an inventory invalidation trigger via webhook (simulating backend ops)
+    // 2. Second hit should be a cache hit
+    let hitRes = await request.get(`http://127.0.0.1:18789/api/v1/storefront/${tenantId}/${productId}`);
+    expect(hitRes.status()).toBe(200);
+    expect(hitRes.headers()['x-cache']).toBe('HIT');
+
+    // 3. Perform an inventory invalidation trigger via webhook (simulating backend ops)
+    // The pos handler invokes cdn cache invalidation asynchronously.
     const invalidateRes = await request.post('http://127.0.0.1:18789/api/v1/storefront/webhook/invalidate', {
       data: { tags: [`entity:product:${productId}`] }
     });
     expect(invalidateRes.status()).toBe(200);
 
-    // Hit cache again and verify regeneration logic is invoked
-    // In a real e2e environment this hits the backend properly. We verify the API endpoint contract.
+    // Allow some time for asynchronous local CDN invalidation
+    await new Promise(r => setTimeout(r, 100));
+
+    // 4. Hit cache again and verify regeneration logic is invoked (should be MISS again)
     let refreshed = await request.get(`http://127.0.0.1:18789/api/v1/storefront/${tenantId}/${productId}`);
     expect(refreshed.status()).toBe(200);
+    expect(refreshed.headers()['x-cache']).toBe('MISS');
   });
 
   test('generates edge storefront with premium styling and seo tags injected via builder', async ({ request, page }) => {

--- a/src/server/api/pos.rs
+++ b/src/server/api/pos.rs
@@ -90,6 +90,14 @@ async fn post_inventory_handler(
                 let edge_cache = crate::builder::edge::get_edge_cache();
                 edge_cache.invalidate_by_tag(&format!("entity:product:{}", item_id)).await;
                 edge_cache.invalidate_by_tag(&format!("tenant-id:{}", tenant_id)).await;
+
+                let item_id_owned = item_id.to_string();
+                let tenant_id_owned = tenant_id.to_string();
+                tokio::spawn(async move {
+                    let cdn = crate::utils::edge_caching_middleware::get_cdn_cache();
+                    cdn.invalidate_by_tag(&format!("entity:product:{}", item_id_owned)).await;
+                    cdn.invalidate_by_tag(&format!("tenant-id:{}", tenant_id_owned)).await;
+                });
             }
         }
     }

--- a/src/server/api/storefront_delivery.rs
+++ b/src/server/api/storefront_delivery.rs
@@ -52,7 +52,16 @@ async fn invalidate_cache_webhook(
 ) -> impl IntoResponse {
     let cache = get_edge_cache();
     let service = CacheInvalidationService::new(cache);
-    service.invalidate(payload.tags).await;
+    service.invalidate(payload.tags.clone()).await;
+
+    let tags_to_invalidate = payload.tags;
+    tokio::spawn(async move {
+        let cdn = crate::utils::edge_caching_middleware::get_cdn_cache();
+        for tag in tags_to_invalidate {
+            cdn.invalidate_by_tag(&tag).await;
+        }
+    });
+
     StatusCode::OK
 }
 

--- a/src/server/utils/edge_caching_middleware.rs
+++ b/src/server/utils/edge_caching_middleware.rs
@@ -7,11 +7,52 @@ use axum::{
 };
 use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;
+use std::sync::OnceLock;
+use crate::cache::HybridCache;
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CachedResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+}
+
+pub static CDN_CACHE: OnceLock<std::sync::Arc<HybridCache<CachedResponse>>> = OnceLock::new();
+
+pub fn get_cdn_cache() -> std::sync::Arc<HybridCache<CachedResponse>> {
+    CDN_CACHE.get_or_init(|| std::sync::Arc::new(HybridCache::new(None))).clone()
+}
 
 pub async fn edge_caching_middleware(
     req: Request,
     next: Next,
 ) -> Result<impl IntoResponse, axum::http::StatusCode> {
+    let method = req.method().clone();
+    let uri = req.uri().to_string();
+    let is_get = method == axum::http::Method::GET;
+
+    let cdn_cache = get_cdn_cache();
+    let cache_key = format!("cdn:{}", uri);
+
+    if is_get {
+        if let Some((cached, _is_stale)) = cdn_cache.get_with_swr(&cache_key).await {
+            let body = Body::from(cached.body);
+            let mut response = Response::builder()
+                .status(cached.status)
+                .body(body)
+                .unwrap();
+
+            for (k, v) in cached.headers {
+                if let (Ok(hk), Ok(hv)) = (axum::http::HeaderName::try_from(k), axum::http::HeaderValue::try_from(v)) {
+                    response.headers_mut().insert(hk, hv);
+                }
+            }
+            response.headers_mut().insert("X-Cache", "HIT".parse().unwrap());
+            return Ok(response.into_response());
+        }
+    }
+
     let response = next.run(req).await;
 
     let (mut parts, body) = response.into_parts();
@@ -48,7 +89,37 @@ pub async fn edge_caching_middleware(
         }
     }
 
+    parts.headers.insert("X-Cache", "MISS".parse().unwrap());
+
+    if is_get && parts.status.is_success() {
+        let mut tags_vec = Vec::new();
+        if let Some(surrogate) = parts.headers.get("Surrogate-Key") {
+            if let Ok(s) = surrogate.to_str() {
+                for t in s.split(' ') {
+                    if !t.is_empty() {
+                        tags_vec.push(t.to_string());
+                    }
+                }
+            }
+        }
+
+        let mut headers_vec = Vec::new();
+        for (k, v) in parts.headers.iter() {
+            if let Ok(v_str) = v.to_str() {
+                headers_vec.push((k.as_str().to_string(), v_str.to_string()));
+            }
+        }
+
+        let cached_response = CachedResponse {
+            status: parts.status.as_u16(),
+            headers: headers_vec,
+            body: bytes.to_vec(),
+        };
+
+        cdn_cache.set_with_tags(&cache_key, cached_response, tags_vec, std::time::Duration::from_secs(60)).await;
+    }
+
     let new_body = Body::from(bytes.to_vec());
     let new_response = Response::from_parts(parts, new_body);
-    Ok(new_response)
+    Ok(new_response.into_response())
 }

--- a/src/ui/next/src/app/api/v1/builder/edge/[tenantId]/[siteId]/route.test.ts
+++ b/src/ui/next/src/app/api/v1/builder/edge/[tenantId]/[siteId]/route.test.ts
@@ -15,7 +15,9 @@ describe('Edge Storefront Route', () => {
       ok: true,
       text: async () => '<!DOCTYPE html><html><head><title>Test</title></head><body>Test</body></html>',
       headers: new Headers({
-        'Cache-Tag': 'tenant-id:test-tenant'
+        'Cache-Tag': 'tenant-id:test-tenant',
+        'Surrogate-Key': 'tenant-id:test-tenant',
+        'ETag': 'W/"test-etag"'
       })
     } as any);
 
@@ -25,6 +27,8 @@ describe('Edge Storefront Route', () => {
     expect(response.headers.get('Cache-Control')).toBe('public, s-maxage=60, stale-while-revalidate=86400');
     expect(response.headers.get('Content-Type')).toBe('text/html');
     expect(response.headers.get('Cache-Tag')).toBe('tenant-id:test-tenant');
+    expect(response.headers.get('Surrogate-Key')).toBe('tenant-id:test-tenant');
+    expect(response.headers.get('ETag')).toBe('W/"test-etag"');
 
     const html = await response.text();
     expect(html).toContain('<title>Test</title>');

--- a/src/ui/next/src/app/api/v1/builder/edge/[tenantId]/[siteId]/route.ts
+++ b/src/ui/next/src/app/api/v1/builder/edge/[tenantId]/[siteId]/route.ts
@@ -51,6 +51,14 @@ export async function GET(
     if (cacheTag) {
         response.headers.set('Cache-Tag', cacheTag);
     }
+    const surrogateKey = backendResponse.headers.get('Surrogate-Key');
+    if (surrogateKey) {
+        response.headers.set('Surrogate-Key', surrogateKey);
+    }
+    const etag = backendResponse.headers.get('ETag');
+    if (etag) {
+        response.headers.set('ETag', etag);
+    }
 
     return response;
   } catch (error) {


### PR DESCRIPTION
Resolves #32046

- Add `Surrogate-Key` and `ETag` to proxy header passing in Next.js.
- Introduce `edge_caching_middleware.rs` CDN cache logic.
- Add async Cache Invalidation to `pos.rs` (`post_inventory_handler`).
- Add async Cache Invalidation to `storefront_delivery.rs` (`invalidate_cache_webhook`).
- Apply proper test coverage logic in `global_edge_storefront.spec.ts`.

Superpowers:
- Thinking through edge-caching requirements.
- Properly using OnceLock to configure local global mutable caches.

---
*PR created automatically by Jules for task [17325221185612115343](https://jules.google.com/task/17325221185612115343) started by @ql-owo-lp*