### PR TITLE
feat(ui): Polish Onboarding Wizard Glassmorphism & E2E Coverage

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -326,3 +326,10 @@ oci.pull(
     ],
 )
 use_repo(oci, "distroless_cc", "distroless_cc_linux_amd64", "distroless_cc_linux_arm64_v8", "distroless_static", "distroless_static_linux_amd64", "distroless_static_linux_arm64_v8", "nginx_alpine", "nginx_alpine_linux_amd64", "nginx_alpine_linux_arm64_v8")
+
+# Fix for xds codeload fetch failure
+git_override(
+    module_name = "xds",
+    remote = "https://github.com/cncf/xds.git",
+    commit = "9013c7db8154e20ef0d19eeb6f1eeb4e64f8de80",
+)

--- a/src/e2e/onboarding_glassmorphism_cuj.spec.ts
+++ b/src/e2e/onboarding_glassmorphism_cuj.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Next.js Onboarding Wizard CUJ (Glassmorphism & Polish)', () => {
+  // Common setup for Next.js app flow
+  test.beforeEach(async ({ page }) => {
+    // Intercept API calls made by the Next.js frontend
+    await page.route('**/api/onboarding/start', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ organization_id: 'test-org-123' })
+      });
+    });
+  });
+
+  // Scenario 1: Verify styling on the main container
+  test('Persona: New User sees the polished glassmorphism setup wizard', async ({ page }) => {
+    await page.goto('http://localhost:3000/onboarding');
+    const setupContainer = page.locator('#setup-screen');
+    await expect(setupContainer).toBeVisible();
+    await expect(setupContainer).toHaveClass(/glassmorphism/);
+    await expect(setupContainer).toHaveClass(/rounded-\[16px\]/);
+  });
+
+  // Scenario 2: Validation
+  test('Persona: Business Owner is blocked if submitting empty form on step 2', async ({ page }) => {
+    await page.goto('http://localhost:3000/onboarding');
+
+    // Step 1 -> Step 2
+    await page.locator('button:has-text("Storefront or Cafe")').click();
+
+    // Attempt to proceed without entering business name (it requires at least 3 chars)
+    const nextButton = page.locator('button', { hasText: 'Continue' });
+    await expect(nextButton).toBeVisible();
+    await nextButton.click();
+
+    // The validation error should appear
+    await expect(page.getByText('Business Name must be at least 3 characters.')).toBeVisible();
+  });
+
+  // Scenario 3: Progression
+  test('Persona: Business Owner can progress through the wizard by filling valid data', async ({ page }) => {
+    await page.goto('http://localhost:3000/onboarding');
+
+    // Click category
+    await page.locator('button:has-text("Storefront or Cafe")').click();
+
+    // Fill Business Name
+    const nameInput = page.getByPlaceholder('e.g. Acme Coffee');
+    await expect(nameInput).toBeVisible();
+    await nameInput.fill('Acme Corp Bakery');
+
+    // Proceed to Step 3 (Assistant Tone)
+    const nextButton = page.locator('button', { hasText: 'Continue' });
+    await expect(nextButton).toBeVisible();
+    await nextButton.click();
+
+    // Verify we reached the AI Tone step
+    await expect(page.getByText(/Tone & Personality/)).toBeVisible();
+  });
+
+  // Scenario 4: Back tracking
+  test('Persona: Business Owner can track backwards through steps', async ({ page }) => {
+    await page.goto('http://localhost:3000/onboarding');
+
+    // Move forward
+    await page.locator('button:has-text("Storefront or Cafe")').click();
+    await page.getByPlaceholder('e.g. Acme Coffee').fill('Acme Corp Bakery');
+    await page.locator('button', { hasText: 'Continue' }).click();
+
+    // Ensure we are on Step 3
+    await expect(page.getByText(/Tone & Personality/)).toBeVisible();
+
+    // Click Back
+    const backButton = page.locator('button', { hasText: 'Back' });
+    await expect(backButton).toBeVisible();
+    await backButton.click();
+
+    // Ensure we are back on Step 2
+    await expect(page.getByText('Tell us about your business')).toBeVisible();
+  });
+
+  // Scenario 5: Skip setup flow
+  test('Persona: Advanced Owner can skip the setup wizard entirely', async ({ page }) => {
+    await page.goto('http://localhost:3000/onboarding');
+
+    const skipButton = page.locator('button', { hasText: 'Skip setup' });
+    await expect(skipButton).toBeVisible();
+
+    await skipButton.click();
+
+    // Clicking skip triggers the start API and moves to the final terminal state (Step 6)
+    // The final state shows the Shareable Link and buttons to Open Assistant
+    await expect(page.getByText('Your Shareable Link')).toBeVisible();
+  });
+});

--- a/src/ui/next/BUILD.bazel
+++ b/src/ui/next/BUILD.bazel
@@ -58,7 +58,7 @@ sh_test(
         "package.json",
         "package-lock.json",
         "tsconfig.json",
-        "vitest.config.mts",
+        "vitest.config.ts",
         "vitest.setup.ts",
         ":node_modules",
         "//deploy:hybrid_telemetry_dashboard_mirrors",

--- a/src/ui/next/bazel_vitest_test.sh
+++ b/src/ui/next/bazel_vitest_test.sh
@@ -48,7 +48,7 @@ for file in \
   fi
 done
 
-for file in next-env.d.ts package.json package-lock.json tsconfig.json vitest.setup.ts vitest.config.mts; do
+for file in next-env.d.ts package.json package-lock.json tsconfig.json vitest.setup.ts vitest.config.ts; do
   if [[ -f "$file" ]]; then
     cp -L "$file" "$work_dir/$file"
   else

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -680,7 +680,7 @@ Image provided: ${instantImageUrl}`;
 
   return (
     <div className="setup-page min-h-screen w-full bg-[#F5F5F7] dark:bg-[#16161a] flex items-center justify-center sm:p-4 font-inter overflow-x-hidden">
-      <div id="setup-screen" className="w-full max-w-[375px] sm:max-w-md lg:max-w-lg xl:max-w-2xl mx-auto overflow-hidden flex flex-col min-h-[100vh] sm:min-h-[812px] relative bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border-0 sm:border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-none sm:shadow-[0_18px_44px_rgba(15,23,42,0.12)] glassmorphism">
+      <div id="setup-screen" className="w-full max-w-[375px] sm:max-w-md lg:max-w-lg xl:max-w-2xl mx-auto overflow-hidden flex flex-col min-h-[100vh] sm:min-h-[812px] relative bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border-0 sm:border border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-none sm:shadow-[0_18px_44px_rgba(15,23,42,0.12)] rounded-[16px] glassmorphism">
         <div className="px-6 pt-5 text-center">
           <div className="setup-header-main">
             {showIntroBack ? (
@@ -1482,7 +1482,7 @@ Image provided: ${instantImageUrl}`;
                       onChange={(e) => updateState({ aiAutoRespond: e.target.checked })}
                     />
                     <div className={`w-10 h-6 rounded-full transition-colors ${aiAutoRespond ? 'bg-[#34C759]' : 'bg-gray-300 dark:bg-gray-600'} relative`}>
-                       <div className={`w-4 h-4 rounded-full bg-white absolute top-1 transition-transform ${aiAutoRespond ? 'translate-x-5' : 'translate-x-1'}`}></div>
+                       <div className={`w-4 h-4 rounded-full bg-[#F5F5F7] absolute top-1 transition-transform ${aiAutoRespond ? 'translate-x-5' : 'translate-x-1'}`}></div>
                     </div>
                   </label>
                 </div>

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"

--- a/src/ui/next/vitest.setup.ts
+++ b/src/ui/next/vitest.setup.ts
@@ -197,3 +197,25 @@ console.error = (...args: any[]) => {
 
 // Set IS_REACT_ACT_ENVIRONMENT
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// Mock Worker
+class WorkerMock {
+  constructor(stringUrl: string) {}
+  onmessage() {}
+  postMessage() {}
+  terminate() {}
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent() { return false; }
+  onerror() {}
+  onmessageerror() {}
+}
+globalThis.Worker = WorkerMock as any;
+
+// Mock navigator locks
+Object.defineProperty(navigator, 'locks', {
+  value: {
+    request: vi.fn(),
+    query: vi.fn()
+  }
+});


### PR DESCRIPTION
This PR addresses the UI/UX polish for the Next.js onboarding wizard, elevating it to the required "Premium" macOS Translucent Glass standards. 

Key changes:
- Adjusted the main `setup-screen` container in `page.tsx` to explicitly use `rounded-[16px]` alongside the `.glassmorphism` class, fixing boxy edges.
- Refined color choices from hardcoded white to `#F5F5F7`.
- Introduced `src/e2e/onboarding_glassmorphism_cuj.spec.ts` with 5 persona-driven test scenarios for the Next.js flow (validation, multi-step progression, tracking).
- Ensured all UI and server tests pass by repairing Vitest environment locks and resolving the `codeload.github.com` fetch timeout for `xds` in Bazel.

---
*PR created automatically by Jules for task [16986779602067695610](https://jules.google.com/task/16986779602067695610) started by @ql-owo-lp*