### PR TITLE
Fix local docker compose postgres and redis image errors

### DIFF
--- a/deploy/docker-compose.override.yml
+++ b/deploy/docker-compose.override.yml
@@ -8,12 +8,12 @@ services:
     image: onehumancorp/server:latest
 
   postgres:
-    image: ankane/pgvector:v0.5.1
+    image: pgvector/pgvector:pg15
     pull_policy: missing
     command: ["postgres", "-c", "wal_level=logical"]
 
   valkey:
-    image: redis:alpine
+    image: valkey/valkey:7.2
     pull_policy: missing
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]


### PR DESCRIPTION
This fixes the `docker compose up` failure in local development caused by missing external images (docker hub rate limit) combined with layer extraction whiteout errors on alpine-based images (`ankane/pgvector:v0.5.1` and `redis:alpine`). It replaces them with non-alpine, compatible official counterparts (`pgvector/pgvector:pg15` and `valkey/valkey:7.2`) in `docker-compose.override.yml`.

---
*PR created automatically by Jules for task [3671780391957278608](https://jules.google.com/task/3671780391957278608) started by @ql-owo-lp*