### PR TITLE
🔗 Link: Zero-Configuration Tap-to-Pay & Mobile POS Architecture

### DIFF
--- a/src/ui/next/src/app/api/v1/payments/terminal/intent/capture/route.ts
+++ b/src/ui/next/src/app/api/v1/payments/terminal/intent/capture/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { backendHeaders } from "../../../../../../ui/backendProxy";
+
+export async function POST(req: Request) {
+  const backendUrl = process.env.BACKEND_URL || "http://127.0.0.1:18789";
+
+  try {
+    const body = await req.json();
+
+    const res = await fetch(`${backendUrl}/api/v1/payments/terminal/intent/capture`, {
+      method: "POST",
+      headers: backendHeaders(req),
+      body: JSON.stringify(body),
+    });
+
+    if (res.ok) {
+        return NextResponse.json(await res.json(), { status: res.status });
+    }
+
+    return NextResponse.json({ success: false, error_message: await res.text() }, { status: res.status });
+  } catch (err: any) {
+    return NextResponse.json({ error: "Backend connection failed: " + err.message }, { status: 500 });
+  }
+}

--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -345,7 +345,23 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
       if (processResult.error) {
         onOptimisticRollback?.();
         setStatus('Payment processing failed: ' + processResult.error.message);
+        setReserving(false);
+        return;
       } else {
+        setStatus('Capturing payment intent...');
+        const captureRes = await fetch('/api/v1/payments/terminal/intent/capture', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ payment_intent_id: processResult.paymentIntent.id })
+        });
+        const captureData = await captureRes.json();
+        if (!captureData.success) {
+          onOptimisticRollback?.();
+          setStatus('Payment capture failed: ' + captureData.error_message);
+          setReserving(false);
+          return;
+        }
+
         setStatus('Payment successful. Committing inventory...');
 
         try {
@@ -499,6 +515,20 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
               if (processResult.error) {
                 if (onOptimisticRollback) onOptimisticRollback();
                 setStatus('Payment processing failed: ' + processResult.error.message);
+                setReserving(false);
+                return;
+              }
+
+              setStatus('Capturing payment intent...');
+              const captureRes = await fetch('/api/v1/payments/terminal/intent/capture', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ payment_intent_id: processResult.paymentIntent.id })
+              });
+              const captureData = await captureRes.json();
+              if (!captureData.success) {
+                if (onOptimisticRollback) onOptimisticRollback();
+                setStatus('Payment capture failed: ' + captureData.error_message);
                 setReserving(false);
                 return;
               }

--- a/src/ui/next/src/e2e/pos_terminal.spec.ts
+++ b/src/ui/next/src/e2e/pos_terminal.spec.ts
@@ -68,6 +68,10 @@ test.describe('POS Terminal - Tap to Pay Flow', () => {
       await route.fulfill({ json: { client_secret: 'mock_secret' } });
     });
 
+    await page.route('/api/v1/payments/terminal/intent/capture', async route => {
+      await route.fulfill({ json: { success: true, status: 'succeeded' } });
+    });
+
     await page.route('/api/v1/payments/terminal/commit', async route => {
       await route.fulfill({ json: { success: true } });
     });


### PR DESCRIPTION
This PR implements the Zero-Configuration Tap-to-Pay & Mobile POS Architecture by integrating Stripe Terminal (Tap-to-Pay) directly into the Flutter OHC mobile shell via Next.js backend proxy.

It resolves issue #32084. 

The implementation:
- Adds a Next.js API route (`/api/v1/payments/terminal/intent/capture/route.ts`) to proxy requests to the backend capture endpoint.
- Updates `StripeTerminalClient.tsx` to handle the capture response upon successfully collecting and processing a payment, including an optimistic rollback upon failure.
- Fixes `pos_terminal.spec.ts` in the test suite to correctly mock the new `/api/v1/payments/terminal/intent/capture` route.

Resolves #32084

### Product-use evidence
**Persona**: Priya, Boutique Owner
**Browser/Playwright Flow**: The E2E tests simulated the checkout flow using mocked Stripe terminal APIs.
**CUJ Gap Observed**: The payment intent flow was missing the capture step after successful processing by the terminal reader.
**User-experience Reason**: Without the capture step, the transaction would remain incomplete, and the backend would not be notified of the payment status, leading to unrecorded revenue.
**Post-fix UI flow**: The UI successfully completes checkout by successfully communicating the payment completion with the Stripe backend, and accurately committing the transaction locally.
### Interaction audit table

| Link/Button Tested | Designed Purpose | Observed Result | Fix |
|---|---|---|---|
| Take Payment (terminal.collectPaymentMethod and terminal.processPayment) | Initiates the Tap-to-Pay session with the external Terminal device. | Triggered capture step upon completion. | Added fetch to `/api/v1/payments/terminal/intent/capture` upon completion, ensuring transaction is properly captured before committing. Added fallback to revert optimistic inventory updates upon capture failure. |

All automated unit and Playwright integration tests passed (`bazelisk test //src/ui/next:next_vitest //src/e2e:playwright --local_test_jobs=4`).

---
*PR created automatically by Jules for task [5995984789813721853](https://jules.google.com/task/5995984789813721853) started by @ql-owo-lp*