### PR TITLE
🔗 Link: [Implement AI-Assisted Offline-First Inventory Management for Remote Ops]

### DIFF
--- a/src/server/api/integrations_settings.rs
+++ b/src/server/api/integrations_settings.rs
@@ -1,4 +1,4 @@
-use axum::{extract::State, Json, response::IntoResponse, http::StatusCode};
+use axum::{extract::State, Json, response::IntoResponse};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use crate::integrations::registry::IntegrationsRegistry;

--- a/src/server/workers/pos_sync_worker.rs
+++ b/src/server/workers/pos_sync_worker.rs
@@ -158,7 +158,7 @@ impl PosSyncWorker {
                 let stock: i32 = sqlx::Row::get(&row, "available_quantity");
                 let is_conflict = stock < quantity_deducted as i32;
 
-                let _ = sqlx::query("UPDATE products SET inventory_count = GREATEST(0, inventory_count - $1), available_quantity = GREATEST(0, available_quantity - $1) WHERE id = $2 AND tenant_id = $3")
+                let _ = sqlx::query("UPDATE products SET pn_counter_n = pn_counter_n + $1, inventory_count = GREATEST(0, pn_counter_p - (pn_counter_n + $1)), available_quantity = GREATEST(0, available_quantity - $1) WHERE id = $2 AND tenant_id = $3")
                     .bind(quantity_deducted)
                     .bind(product_id)
                     .bind(&job.tenant_id)
@@ -374,7 +374,7 @@ impl PosSyncWorker {
                             let stock: i32 = sqlx::Row::get(&row, "available_quantity");
                             let is_conflict = stock < qty as i32;
 
-                            let _ = sqlx::query("UPDATE products SET inventory_count = GREATEST(0, inventory_count - $1), available_quantity = GREATEST(0, available_quantity - $1) WHERE id = $2 AND tenant_id = $3")
+                            let _ = sqlx::query("UPDATE products SET pn_counter_n = pn_counter_n + $1, inventory_count = GREATEST(0, pn_counter_p - (pn_counter_n + $1)), available_quantity = GREATEST(0, available_quantity - $1) WHERE id = $2 AND tenant_id = $3")
                                 .bind(qty)
                                 .bind(product_id)
                                 .bind(&job.tenant_id)

--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -170,20 +170,6 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
              timestamp: new Date().toISOString()
           };
 
-          for (const item of (cart || [{product: {id: productId}, quantity: 1}])) {
-            const crdtTx = {
-              id: `crdt_${transactionId}_${item.product.id}`,
-              type: 'CRDT_MUTATION',
-              timestamp: new Date().toISOString(),
-              payload: {
-                 entity_id: item.product.id,
-                 data: {
-                    pn_counter_n_increment: -item.quantity
-                 }
-              }
-            };
-            await SyncManager.getInstance().enqueue(crdtTx);
-          }
           await SyncManager.getInstance().enqueue(tx);
 
           setStatus('Cash sale saved offline. Will sync when network is restored.');


### PR DESCRIPTION
Resolves #32073.
This PR implements offline-first AI sync for mobile Point-of-Sale scenarios:
1. Updated `pos_sync_worker.rs` to process POS sync offline transactions using CRDT `pn_counter_n` logic correctly. Instead of standard subtraction, offline deductions safely increment `pn_counter_n` and calculate inventory dynamically to prevent conflicts from overriding online changes destructively.
2. Removed duplicate manual enqueueing of `CRDT_MUTATION` from `StripeTerminalClient.tsx` because the POS sync worker handles it directly off the `pos_transaction` object.
3. Cleaned up an unused import in `integrations_settings.rs` to appease CI linting.
Playwright E2E and Backend integration tests passing locally.

---
*PR created automatically by Jules for task [11474351263483421979](https://jules.google.com/task/11474351263483421979) started by @ql-owo-lp*