### PR TITLE
🚀 Nova: [new growth feature] Add missing waitlist embed route

### DIFF
--- a/src/e2e/waitlist_embed.spec.ts
+++ b/src/e2e/waitlist_embed.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Waitlist Embed Widget', () => {
+    test('renders waitlist embed with correct branding and product name', async ({ page }) => {
+        // Go to the new embed route we just fixed
+        await page.goto('/api/v1/growth/waitlist/embed?tenant=test-tenant&product=Awesome%20Product&goal=5&theme=light&hideBranding=false');
+
+        // Check if the title is correctly set
+        await expect(page.locator('h2')).toContainText('Join the Awesome Product Waitlist');
+
+        // Check description text
+        await expect(page.locator('p').first()).toContainText('Be the first to access our new launch. Refer 5 friends to jump to the front of the line!');
+
+        // Check for OHC branding
+        const brandingLink = page.locator('a:has-text("⚡ Powered by OHC")');
+        await expect(brandingLink).toBeVisible();
+        await expect(brandingLink).toHaveAttribute('href', /ref=test-tenant/);
+
+        // Check the form and inputs
+        await expect(page.locator('input[type="email"]')).toBeVisible();
+        await expect(page.locator('button:has-text("Join Waitlist")')).toBeVisible();
+    });
+});

--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -368,6 +368,7 @@ where
         .route("/referrals/tier", get(handle_referral_tier))
         .route("/team-invites/accept", post(handle_team_invite_accept))
         .route("/waitlist/generate", post(handle_generate_viral_waitlist))
+        .route("/waitlist/embed", get(handle_waitlist_embed))
         .route("/cloud-bridge/invite", post(handle_cloud_bridge_invite))
         .route("/embed/widget", get(handle_embed_widget))
         .route("/one-tap-referral/embed", get(handle_one_tap_referral_embed))


### PR DESCRIPTION
## PR Description
This PR addresses an issue where the Waitlist Embed Widget route was failing because it was missing in the backend router API.

### Changes Made:
- Added `.route("/waitlist/embed", get(handle_waitlist_embed))` inside `src/server/api/growth.rs`.
- Created an end-to-end (E2E) playwright test `src/e2e/waitlist_embed.spec.ts` testing the render functionality, OHC branding checks, and email form structure.

### Product-use evidence
- **Persona:** Business Owner Maya
- **Flow Attempted:** Visiting the Pre-Order Waitlist generator -> Clicking "Generate Widget Embed Code" -> Verifying the generated iframe rendered properly.
- **Observed:** The generated `waitlist/embed` URL originally resulted in an API error since the route was missing.
- **After Fix:** The Waitlist widget successfully renders returning proper custom parameters.

### Verification
- `bazel test //...` verified no internal tests were impacted.
- `bazel test //src/e2e:playwright` executed to verify waitlist rendered securely across all E2E pipelines.

---
*PR created automatically by Jules for task [15303470592336960415](https://jules.google.com/task/15303470592336960415) started by @ql-owo-lp*