### PR TITLE
feat: AI Unified Inbox Differentiation & Omnichannel Customer Memory

### DIFF
--- a/src/e2e/tests/unified_work_triage.spec.ts
+++ b/src/e2e/tests/unified_work_triage.spec.ts
@@ -27,7 +27,7 @@ test.describe('AI Unified Work Triage Architecture', () => {
         await expect(page.locator('strong', { hasText: 'Instagram DM' }).first()).toBeVisible();
         await expect(page.locator('div.triage-context', { hasText: 'vegan chocolate cakes?' }).first()).toBeVisible();
         await expect(page.locator('div', { hasText: 'Draft Reply:' }).first()).toBeVisible();
-        await expect(page.locator('div', { hasText: 'Hi there! Thanks for your message' }).first()).toBeVisible();
+
 
         const approveBtn = page.locator('button', { hasText: /Approve|Send/i }).first();
         await expect(approveBtn).toBeVisible();

--- a/src/server/api/unified_inbox_webhook.rs
+++ b/src/server/api/unified_inbox_webhook.rs
@@ -81,6 +81,65 @@ pub struct LocalUiTenantQuery {
     pub mobile_optimized: Option<bool>,
 }
 
+
+async fn generate_draft_reply(
+    tenant_id: &str,
+    customer_message: &str,
+    context_summary: &str,
+    db: &Arc<DB>,
+) -> String {
+    let (business_name, industry): (String, String) = match &db.store {
+        crate::db::DbStore::Postgres => sqlx::query_as(
+            "SELECT name, COALESCE(industry, '') FROM tenants WHERE id = $1"
+        )
+        .bind(tenant_id)
+        .fetch_optional(&db.pool)
+        .await
+        .unwrap_or(None)
+        .unwrap_or_else(|| ("A business".to_string(), "".to_string())),
+        crate::db::DbStore::Sqlite(sqlite_pool) => sqlx::query_as(
+            "SELECT name, COALESCE(industry, '') FROM tenants WHERE id = ?"
+        )
+        .bind(tenant_id)
+        .fetch_optional(sqlite_pool)
+        .await
+        .unwrap_or(None)
+        .unwrap_or_else(|| ("A business".to_string(), "".to_string())),
+    };
+
+    let business_context = if industry.is_empty() {
+        format!("A business named {}", business_name)
+    } else {
+        format!("A {} business named {}", industry, business_name)
+    };
+
+    let prompt = format!(
+        "Write one concise, warm customer-service reply. Business context: {}. Customer recent history: {}. Customer message: {}",
+        business_context, context_summary, customer_message
+    );
+    let compressed_prompt = ::server_pricing::compression::reduce_tokens(&prompt);
+
+    let llm_res = match std::env::var("OHC_LLM_PROVIDER").as_deref() {
+        Ok("gemini") => {
+            crate::minimax::LocalLLMClient::new().reason(&compressed_prompt).await
+        }
+        Ok("minimax") => {
+            let api_key = std::env::var("MINIMAX_API_KEY").unwrap_or_default();
+            if api_key.is_empty() {
+                crate::minimax::LocalLLMClient::new().reason(&compressed_prompt).await
+            } else {
+                crate::minimax::MinimaxClient::new(api_key).reason(&compressed_prompt).await
+            }
+        }
+        _ => crate::minimax::LocalLLMClient::new().reason(&compressed_prompt).await,
+    };
+
+    match llm_res {
+        Ok(reply) => reply,
+        Err(_) => format!("Hi there! Thanks for your message: '{}'. How can we help?", customer_message),
+    }
+}
+
 fn get_ui_tenant_id(query: &LocalUiTenantQuery) -> String {
     query
         .tenant_id
@@ -176,10 +235,12 @@ pub async fn handle_unified_webhook(
                 .bind(&payload.message)
                 .execute(&state.db.pool).await;
 
-            let draft_reply = format!(
-                "Hi there! Thanks for your message: '{}'. How can we help?",
-                payload.message
-            );
+            let draft_reply = generate_draft_reply(
+                tenant_id,
+                &payload.message,
+                &context_summary,
+                &state.db,
+            ).await;
             let action_payload = serde_json::to_string(&DraftedResponse {
                 customer_id: customer_id.clone(),
                 context_summary,
@@ -230,10 +291,12 @@ pub async fn handle_unified_webhook(
                 .bind(&payload.message)
                 .execute(sqlite_pool).await;
 
-            let draft_reply = format!(
-                "Hi there! Thanks for your message: '{}'. How can we help?",
-                payload.message
-            );
+            let draft_reply = generate_draft_reply(
+                tenant_id,
+                &payload.message,
+                &context_summary,
+                &state.db,
+            ).await;
             let action_payload = serde_json::to_string(&DraftedResponse {
                 customer_id: customer_id.clone(),
                 context_summary,

--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -827,7 +827,7 @@ impl AuthService for AuthServiceServerImpl {
         let req = request.into_inner();
 
         let (final_org_id, final_role) = if ::server_config::get().multitenant {
-            (uuid::Uuid::new_v4().to_string(), ROLE_ADMIN.to_string())
+            (sqlx::types::Uuid::new_v4().to_string(), ROLE_ADMIN.to_string())
         } else {
             (req.organization_id.clone(), ROLE_VIEWER.to_string())
         };


### PR DESCRIPTION
This pull request introduces dynamic contextual AI responses to the unified inbox, effectively completing issue #32113.

It changes the unified inbox webhook from using a hardcoded placeholder message to constructing a specialized AI prompt containing the tenant's business context, the customer's prior interaction history, and the incoming message. It then queries the configured LLM to draft a reply that is immediately accessible in the mobile UI's action feed.

It also introduces an E2E test fix to allow for dynamic agent responses and includes a small build fix for resolving `uuid` types correctly in `auth/mod.rs`.

Resolves #32113.

---
*PR created automatically by Jules for task [9430356665572256955](https://jules.google.com/task/9430356665572256955) started by @ql-owo-lp*