### PR TITLE
🎨 Canvas: AI Unified Inbox Differentiation & Omnichannel Customer Memory

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -3260,7 +3260,7 @@ async fn load_ui_omni_inbox_from_db(db: &crate::db::DB, tenant_id: &str, mobile_
     match &db.store {
         crate::db::DbStore::Postgres => {
             if mobile_optimized {
-                sqlx::query("SELECT id, COALESCE(source, '') AS source, COALESCE(status, '') AS status, COALESCE(sender_id, '') AS sender_id, CAST(created_at AS text) AS created_at FROM omni_inbox_messages WHERE tenant_id = $1 AND status != 'resolved' ORDER BY created_at DESC LIMIT 50")
+                sqlx::query("SELECT id, COALESCE(source, '') AS source, COALESCE(status, '') AS status, COALESCE(sender_id, '') AS sender_id, COALESCE(customer_id, '') AS customer_id, CAST(created_at AS text) AS created_at FROM omni_inbox_messages WHERE tenant_id = $1 AND status != 'resolved' ORDER BY created_at DESC LIMIT 50")
                     .bind(tenant_id)
                     .fetch_all(&db.pool)
                     .await.map(|rows| rows.into_iter().map(|row| {
@@ -3269,11 +3269,12 @@ async fn load_ui_omni_inbox_from_db(db: &crate::db::DB, tenant_id: &str, mobile_
                             "source": row.get::<String, _>("source"),
                             "status": row.get::<String, _>("status"),
                             "sender_id": row.get::<String, _>("sender_id"),
+                            "customer_id": row.get::<String, _>("customer_id"),
                             "created_at": row.get::<String, _>("created_at")
                         })
                     }).collect())
             } else {
-                sqlx::query("SELECT id, COALESCE(source, '') AS source, COALESCE(original_content, '') AS original_content, COALESCE(draft_reply, '') AS draft_reply, COALESCE(status, '') AS status, COALESCE(sender_id, '') AS sender_id, CAST(created_at AS text) AS created_at FROM omni_inbox_messages WHERE tenant_id = $1 AND status != 'resolved' ORDER BY created_at DESC LIMIT 50")
+                sqlx::query("SELECT id, COALESCE(source, '') AS source, COALESCE(original_content, '') AS original_content, COALESCE(draft_reply, '') AS draft_reply, COALESCE(status, '') AS status, COALESCE(sender_id, '') AS sender_id, COALESCE(customer_id, '') AS customer_id, CAST(created_at AS text) AS created_at FROM omni_inbox_messages WHERE tenant_id = $1 AND status != 'resolved' ORDER BY created_at DESC LIMIT 50")
                     .bind(tenant_id)
                     .fetch_all(&db.pool)
                     .await.map(|rows| rows.into_iter().map(|row| {
@@ -3284,6 +3285,7 @@ async fn load_ui_omni_inbox_from_db(db: &crate::db::DB, tenant_id: &str, mobile_
                             "draft_reply": row.get::<String, _>("draft_reply"),
                             "status": row.get::<String, _>("status"),
                             "sender_id": row.get::<String, _>("sender_id"),
+                            "customer_id": row.get::<String, _>("customer_id"),
                             "created_at": row.get::<String, _>("created_at")
                         })
                     }).collect())
@@ -3300,6 +3302,7 @@ async fn load_ui_omni_inbox_from_db(db: &crate::db::DB, tenant_id: &str, mobile_
                             "source": row.get::<String, _>("source"),
                             "status": row.get::<String, _>("status"),
                             "sender_id": row.get::<String, _>("sender_id"),
+                            "customer_id": row.get::<String, _>("customer_id"),
                             "created_at": row.get::<String, _>("created_at")
                         })
                     }).collect())
@@ -3315,6 +3318,7 @@ async fn load_ui_omni_inbox_from_db(db: &crate::db::DB, tenant_id: &str, mobile_
                             "draft_reply": row.get::<String, _>("draft_reply"),
                             "status": row.get::<String, _>("status"),
                             "sender_id": row.get::<String, _>("sender_id"),
+                            "customer_id": row.get::<String, _>("customer_id"),
                             "created_at": row.get::<String, _>("created_at")
                         })
                     }).collect())
@@ -4639,7 +4643,7 @@ async fn load_ui_inbox_from_db(db: &crate::db::DB, tenant_id: &str, mobile_optim
                         })
                     }).collect())
             } else {
-                sqlx::query("SELECT id, COALESCE(source, '') AS source, COALESCE(content, '') AS content, COALESCE(original_content, content, '') AS original_content, COALESCE(translated_from_language, '') AS translated_from_language, COALESCE(draft_reply, '') AS draft_reply, COALESCE(status, '') AS status, COALESCE(sender_id, '') AS sender_id, CAST(created_at AS text) AS created_at FROM inbox_messages WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT 50")
+                sqlx::query("SELECT id, COALESCE(source, '') AS source, COALESCE(content, '') AS content, COALESCE(original_content, content, '') AS original_content, COALESCE(translated_from_language, '') AS translated_from_language, COALESCE(draft_reply, '') AS draft_reply, COALESCE(status, '') AS status, COALESCE(sender_id, '') AS sender_id, COALESCE(customer_id, '') AS customer_id, CAST(created_at AS text) AS created_at FROM inbox_messages WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT 50")
                     .bind(tenant_id)
                     .fetch_all(&db.pool)
                     .await.map(|rows| rows.into_iter().map(|row| {
@@ -4652,6 +4656,7 @@ async fn load_ui_inbox_from_db(db: &crate::db::DB, tenant_id: &str, mobile_optim
                             "generated_response": row.get::<String, _>("draft_reply"),
                             "status": row.get::<String, _>("status"),
                             "sender_id": row.get::<String, _>("sender_id"),
+                            "customer_id": row.get::<String, _>("customer_id"),
                             "created_at": row.get::<String, _>("created_at")
                         })
                     }).collect())
@@ -4684,6 +4689,7 @@ async fn load_ui_inbox_from_db(db: &crate::db::DB, tenant_id: &str, mobile_optim
                             "generated_response": row.get::<String, _>("draft_reply"),
                             "status": row.get::<String, _>("status"),
                             "sender_id": row.get::<String, _>("sender_id"),
+                            "customer_id": row.get::<String, _>("customer_id"),
                             "created_at": row.get::<String, _>("created_at")
                         })
                     }).collect())

--- a/src/ui/next/src/app/api/memory/summary/[tenantId]/[customerId]/route.ts
+++ b/src/ui/next/src/app/api/memory/summary/[tenantId]/[customerId]/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.API_URL || 'http://localhost:18789';
+
+export async function GET(request: Request, { params }: { params: Promise<{ tenantId: string, customerId: string }> }) {
+  try {
+    const authHeader = request.headers.get("Authorization");
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (authHeader) headers["Authorization"] = authHeader;
+
+    const { tenantId, customerId } = await params;
+
+    const res = await fetch(`${BACKEND_URL}/api/memory/summary/${tenantId}/${customerId}`, {
+      method: 'GET',
+      headers,
+    });
+
+    if (!res.ok) {
+        return NextResponse.json({ error: "Backend error" }, { status: res.status });
+    }
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
This change adds `customer_id` support for `omni_inbox_messages` returning to the UI to correctly load the CustomerContextCard. It also exposes `/api/memory/summary/[tenantId]/[customerId]` on the next.js proxy so that the UI can successfully fetch the context summary. Resolves #32113.

---
*PR created automatically by Jules for task [13001827036683488676](https://jules.google.com/task/13001827036683488676) started by @ql-owo-lp*