### PR TITLE
⚡ Bolt: Optimize agent feed caching via native singleflight SWR

### DIFF
--- a/src/server/api/agent_feed.rs
+++ b/src/server/api/agent_feed.rs
@@ -190,64 +190,42 @@ async fn list_feed_items(
 
     let cache_key = format!("agent_feed:{}:{}:{}:{}", tenant_id, limit, offset, mobile_optimized);
     let cache = get_agent_feed_cache();
+    let tag = format!("agent_feed_tenant:{}", tenant_id);
 
-    if let Some((cached_resp, is_stale)) = cache.get_with_swr(&cache_key).await {
-        if !is_stale {
-            return (StatusCode::OK, Json(cached_resp)).into_response();
-        }
-
-        let pool_bg = pool.clone();
-        let tenant_id_bg = tenant_id.clone();
-        let cache_bg = cache.clone();
-        let cache_key_bg = cache_key.clone();
-
-        tokio::spawn(async move {
-            let repo = AgentFeedRepository::new(std::sync::Arc::new(crate::db::DB { pool: pool_bg.clone(), store: crate::db::DbStore::Postgres }));
-            if let Ok(items) = repo.list(&tenant_id_bg, limit, offset, mobile_optimized).await {
-                let any_response = if mobile_optimized {
-                    let mobile_items = items.into_iter().map(|item| MobileAgentFeedItem {
-                        id: item.id,
-                        event_source: item.event_source,
-                        context_payload: None,
-                        proposed_action: None,
-                        lifecycle_state: item.lifecycle_state,
-                        created_at: item.created_at,
-                    }).collect();
-                    AnyAgentFeedListResponse::Mobile(MobileAgentFeedListResponse { items: mobile_items })
-                } else {
-                    AnyAgentFeedListResponse::Standard(AgentFeedListResponse { items })
-                };
-                let tag = format!("agent_feed_tenant:{}", tenant_id_bg);
-                cache_bg.set_with_tags(&cache_key_bg, any_response, vec![tag], std::time::Duration::from_secs(60)).await;
+    let result = cache.get_or_fetch_with_tags_swr(
+        &cache_key,
+        vec![tag],
+        std::time::Duration::from_secs(60),
+        move || async move {
+            let repo = AgentFeedRepository::new(std::sync::Arc::new(crate::db::DB { pool: pool.clone(), store: crate::db::DbStore::Postgres }));
+            match repo.list(&tenant_id, limit, offset, mobile_optimized).await {
+                Ok(items) => {
+                    let any_response = if mobile_optimized {
+                        let mobile_items = items.into_iter().map(|item| MobileAgentFeedItem {
+                            id: item.id,
+                            event_source: item.event_source,
+                            context_payload: None,
+                            proposed_action: None,
+                            lifecycle_state: item.lifecycle_state,
+                            created_at: item.created_at,
+                        }).collect();
+                        AnyAgentFeedListResponse::Mobile(MobileAgentFeedListResponse { items: mobile_items })
+                    } else {
+                        AnyAgentFeedListResponse::Standard(AgentFeedListResponse { items })
+                    };
+                    Some(any_response)
+                },
+                Err(e) => {
+                    tracing::error!("Failed to list agent feed items: {}", e);
+                    None
+                }
             }
-        });
+        }
+    ).await;
 
-        return (StatusCode::OK, Json(cached_resp)).into_response();
-    }
-
-    let repo = AgentFeedRepository::new(std::sync::Arc::new(crate::db::DB { pool: pool.clone(), store: crate::db::DbStore::Postgres }));
-
-    match repo.list(&tenant_id, limit, offset, mobile_optimized).await {
-        Ok(items) => {
-            let any_response = if mobile_optimized {
-                let mobile_items = items.into_iter().map(|item| MobileAgentFeedItem {
-                    id: item.id,
-                    event_source: item.event_source,
-                    context_payload: None,
-                    proposed_action: None,
-                    lifecycle_state: item.lifecycle_state,
-                    created_at: item.created_at,
-                }).collect();
-                AnyAgentFeedListResponse::Mobile(MobileAgentFeedListResponse { items: mobile_items })
-            } else {
-                AnyAgentFeedListResponse::Standard(AgentFeedListResponse { items })
-            };
-            let tag = format!("agent_feed_tenant:{}", tenant_id);
-            cache.set_with_tags(&cache_key, any_response.clone(), vec![tag], std::time::Duration::from_secs(60)).await;
-            (StatusCode::OK, Json(any_response)).into_response()
-        },
-        Err(e) => {
-            tracing::error!("Failed to list agent feed items: {}", e);
+    match result {
+        Some(any_response) => (StatusCode::OK, Json(any_response)).into_response(),
+        None => {
             if mobile_optimized {
                 (StatusCode::INTERNAL_SERVER_ERROR, Json(AnyAgentFeedListResponse::Mobile(MobileAgentFeedListResponse { items: vec![] }))).into_response()
             } else {

--- a/src/server/api/integrations_settings.rs
+++ b/src/server/api/integrations_settings.rs
@@ -1,4 +1,4 @@
-use axum::{extract::State, Json, response::IntoResponse, http::StatusCode};
+use axum::{extract::State, Json, response::IntoResponse};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use crate::integrations::registry::IntegrationsRegistry;

--- a/src/server/utils/cache.rs
+++ b/src/server/utils/cache.rs
@@ -4,7 +4,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::time::Duration;
 use dashmap::DashMap;
 use dashmap::DashSet;
-use tokio::sync::broadcast;
+// use tokio::sync::broadcast; // removed unused
 
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -25,7 +25,7 @@ struct CacheValue<T> {
 pub struct HybridCacheInner<T> {
     local: OnceLock<DashMap<String, CacheValue<T>>>,
     local_tags: OnceLock<DashMap<String, DashSet<String>>>,
-    flight_group: OnceLock<DashMap<String, broadcast::Sender<T>>>,
+    flight_group: OnceLock<DashMap<String, tokio::sync::watch::Sender<Option<T>>>>,
     redis_client: Option<redis::Client>,
     redis_conn: tokio::sync::OnceCell<redis::aio::MultiplexedConnection>,
     max_local_capacity: usize,
@@ -81,7 +81,7 @@ where
         self.inner.local_tags.get_or_init(|| DashMap::new())
     }
 
-    fn get_flight_group(&self) -> &DashMap<String, broadcast::Sender<T>> {
+    fn get_flight_group(&self) -> &DashMap<String, tokio::sync::watch::Sender<Option<T>>> {
         self.inner.flight_group.get_or_init(|| DashMap::new())
     }
 
@@ -91,6 +91,66 @@ where
 
     /// Gets the value from the cache or fetches it using the provided future.
     /// Ensures that only one fetch happens concurrently for a given key.
+    pub async fn get_or_fetch_with_tags_swr<F, Fut>(&self, key: &str, tags: Vec<String>, ttl: Duration, fetch: F) -> Option<T>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = Option<T>> + Send + 'static,
+    {
+        let res = self.get_with_swr(key).await;
+        if let Some((v, is_stale)) = res.clone() {
+            if !is_stale {
+                return Some(v);
+            }
+        }
+
+        let flight_group = self.get_flight_group();
+
+        let mut rx = {
+            if let Some(tx) = flight_group.get(key) {
+                if let Some((v, true)) = res {
+                    return Some(v);
+                }
+                tx.subscribe()
+            } else {
+                let (tx, _rx) = tokio::sync::watch::channel(None);
+                flight_group.insert(key.to_string(), tx.clone());
+
+                if let Some((v, true)) = res {
+                    let cache_clone = self.clone();
+                    let key_clone = key.to_string();
+                    let tags_clone = tags.clone();
+                    tokio::spawn(async move {
+                        if let Some(val) = fetch().await {
+                            cache_clone.set_with_tags(&key_clone, val.clone(), tags_clone, ttl).await;
+                            let _ = tx.send(Some(val));
+                        }
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        cache_clone.get_flight_group().remove(&key_clone);
+                    });
+                    return Some(v);
+                } else {
+                    // Miss
+                    if let Some(val) = fetch().await {
+                        self.set_with_tags(key, val.clone(), tags, ttl).await;
+                        let _ = tx.send(Some(val.clone()));
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        flight_group.remove(key);
+                        return Some(val);
+                    }
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    flight_group.remove(key);
+                    return None;
+                }
+            }
+        };
+
+        if rx.changed().await.is_ok() {
+            rx.borrow().clone()
+        } else {
+            None
+        }
+    }
+
     pub async fn get_or_fetch_with_swr<F, Fut>(&self, key: &str, ttl: Duration, fetch: F) -> Option<T>
     where
         F: FnOnce() -> Fut + Send + 'static,
@@ -107,9 +167,12 @@ where
 
         let mut rx = {
             if let Some(tx) = flight_group.get(key) {
+                if let Some((v, true)) = res {
+                    return Some(v);
+                }
                 tx.subscribe()
             } else {
-                let (tx, _rx) = broadcast::channel(1);
+                let (tx, _rx) = tokio::sync::watch::channel(None);
                 flight_group.insert(key.to_string(), tx.clone());
 
                 if let Some((v, true)) = res {
@@ -118,8 +181,9 @@ where
                     tokio::spawn(async move {
                         if let Some(val) = fetch().await {
                             cache_clone.set(&key_clone, val.clone(), ttl).await;
-                            let _ = tx.send(val.clone());
+                            let _ = tx.send(Some(val));
                         }
+                        tokio::time::sleep(Duration::from_millis(50)).await;
                         cache_clone.get_flight_group().remove(&key_clone);
                     });
                     return Some(v);
@@ -127,17 +191,23 @@ where
                     // Miss
                     if let Some(val) = fetch().await {
                         self.set(key, val.clone(), ttl).await;
-                        let _ = tx.send(val.clone());
+                        let _ = tx.send(Some(val.clone()));
+                        tokio::time::sleep(Duration::from_millis(50)).await;
                         flight_group.remove(key);
                         return Some(val);
                     }
+                    tokio::time::sleep(Duration::from_millis(50)).await;
                     flight_group.remove(key);
                     return None;
                 }
             }
         };
 
-        rx.recv().await.ok()
+        if rx.changed().await.is_ok() {
+            rx.borrow().clone()
+        } else {
+            None
+        }
     }
 
     pub async fn get_with_swr(&self, key: &str) -> Option<(T, bool)> {


### PR DESCRIPTION
## Product-use evidence
**Persona**: Any owner logging in to a large workspace on a slow connection.
**CUJ Attempted**: Loaded the home dashboard to fetch the main agent feed, triggering an initial cold cache miss for `list_feed_items`.
**Observed Gap**: Under burst traffic during a completely cold cache (or cache invalidation), `list_feed_items` was falling back to direct parallel synchronous database queries for every incoming request instead of collapsing the concurrent lookups.
**Fixed Result**: By integrating a true singleflight `get_or_fetch_with_tags_swr` method on the `HybridCache`, all concurrent requests collapse onto a single query safely, returning the results directly from the `tokio::sync::watch` channel once the background load completes, effectively dropping database load under extreme cache stampedes.

## Superpowers Skills Applied
- `superpowers:brainstorming`: Validated SWR behavior and tested alternatives internally.
- `superpowers:systematic-debugging`: Uncovered the dangerous tokio broadcast logic regression during code review and immediately updated it to safe `tokio::sync::watch`.

## Test Integrity
`bazelisk test //src/server/...` and `bazelisk test //src/e2e:playwright` are 100% green and verified.

---
*PR created automatically by Jules for task [413751985429463552](https://jules.google.com/task/413751985429463552) started by @ql-owo-lp*