### PR TITLE
fix(ui): add missing setup wizard steps to stepper indicator

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1810,7 +1810,7 @@
         role="progressbar"
         aria-label="Setup progress"
         aria-valuemin="0"
-        aria-valuemax="8"
+        aria-valuemax="10"
       >
         <div class="stepper-progress" id="stepper-progress"></div>
         <div class="step-indicator active" data-step="step-context"></div>
@@ -1819,6 +1819,8 @@
         <div class="step-indicator" data-step="step-assistant"></div>
         <div class="step-indicator" data-step="step-admin"></div>
         <div class="step-indicator" data-step="step-offer"></div>
+        <div class="step-indicator" data-step="step-location"></div>
+        <div class="step-indicator" data-step="step-target-audience"></div>
         <div class="step-indicator" data-step="step-domain"></div>
         <div class="step-indicator" data-step="step-template"></div>
       </div>
@@ -3446,6 +3448,8 @@
           "step-assistant",
           "step-admin",
           "step-offer",
+          "step-location",
+          "step-target-audience",
           "step-domain",
           "step-template",
         ];
@@ -3455,7 +3459,7 @@
 
         const stepperProgress = document.getElementById("stepper-progress");
         if (stepperProgress) {
-          stepperProgress.style.width = (currentIndex / 7) * 100 + "%";
+          stepperProgress.style.width = (currentIndex / (steps.length - 1)) * 100 + "%";
         }
 
         document


### PR DESCRIPTION
The `setup.html` progress bar skipped logic when transitioning through `step-location` and `step-target-audience` because those steps were missing from the indicator items in the DOM and logic.

This commit adds `step-location` and `step-target-audience` into `.stepper` items and the `steps` array in the `updateStepper` function. It changes the `.stepper-progress` width calculation to dynamically use `steps.length - 1` rather than hardcoding `7` and correctly increments `aria-valuemax` to `10`.

This makes the progress bar step smoothly without jumping backwards. Verified manual Playwright E2E UI testing successfully navigated wizard flows with accurate progress rendering.

---
*PR created automatically by Jules for task [11456598951851029034](https://jules.google.com/task/11456598951851029034) started by @ql-owo-lp*