### PR TITLE
Fix Rust compiler linting failure (unused import) in server module

### DIFF
--- a/src/server/api/integrations_settings.rs
+++ b/src/server/api/integrations_settings.rs
@@ -1,4 +1,4 @@
-use axum::{extract::State, Json, response::IntoResponse, http::StatusCode};
+use axum::{extract::State, Json, response::IntoResponse};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use crate::integrations::registry::IntegrationsRegistry;


### PR DESCRIPTION
This PR fixes a strict Rust linting failure (`-D warnings`) by removing an unused import of `http::StatusCode` in `src/server/api/integrations_settings.rs`.

It ensures that the `bazelisk build //src/server:server_lib` target and the global Bazel test suite can execute without compiler-level errors, complementing prior fixes to the Node/Vitest test mocks and package dependencies.

---
*PR created automatically by Jules for task [1696693236692777759](https://jules.google.com/task/1696693236692777759) started by @ql-owo-lp*