### PR TITLE
fix(db): Add missing RLS policy for shared_task_dependencies

### DIFF
--- a/src/server/db/migrations/167_fix_missing_rls_final.sql
+++ b/src/server/db/migrations/167_fix_missing_rls_final.sql
@@ -72,6 +72,11 @@ ALTER TABLE IF EXISTS tool_integrations ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS tenant_isolation_tool_integrations ON tool_integrations;
 CREATE POLICY tenant_isolation_tool_integrations ON tool_integrations USING (tenant_id = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id = current_setting('app.current_tenant', true));
 
+-- 15. shared_task_dependencies
+ALTER TABLE IF EXISTS shared_task_dependencies ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation_shared_task_dependencies ON shared_task_dependencies;
+CREATE POLICY tenant_isolation_shared_task_dependencies ON shared_task_dependencies USING (organization_id::text = current_setting('app.current_tenant', true)) WITH CHECK (organization_id::text = current_setting('app.current_tenant', true));
+
 -- +goose Down
 -- Revert RLS
 DROP POLICY IF EXISTS tenant_isolation_bookings ON bookings;
@@ -115,3 +120,6 @@ ALTER TABLE IF EXISTS task_dependencies DISABLE ROW LEVEL SECURITY;
 
 DROP POLICY IF EXISTS tenant_isolation_tool_integrations ON tool_integrations;
 ALTER TABLE IF EXISTS tool_integrations DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_shared_task_dependencies ON shared_task_dependencies;
+ALTER TABLE IF EXISTS shared_task_dependencies DISABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
This PR adds the missing Row-Level Security (RLS) tenant isolation policy for the `shared_task_dependencies` table in `167_fix_missing_rls_final.sql`.

Loaded Superpowers:
- Sentry Reliability
- Visual Excellence
- Coverage and E2E

Product-use evidence:
- Persona: Nora (Agency Principal)
- Attempted: Creating tasks inside of a shared project workspace and linking them with dependencies to view the dependency graph.
- Gap: The database queries for fetching the `shared_task_dependencies` resulted in RLS policy violation errors. The RLS was missing for the `shared_task_dependencies` table in the final RLS migration, although it was present in an earlier one.
- Rationale: The `shared_task_dependencies` data needs to be correctly isolated to the current tenant. The fix correctly uses the `organization_id` as the tenant scoping identifier, bringing the isolation in line with the `shared_tasks` table.

---
*PR created automatically by Jules for task [10767601053698020198](https://jules.google.com/task/10767601053698020198) started by @ql-owo-lp*