### PR TITLE
💰 Miser: Plan Page Soft Limit Banner

### DIFF
--- a/src/ui/next/src/app/plan/page.test.tsx
+++ b/src/ui/next/src/app/plan/page.test.tsx
@@ -36,6 +36,8 @@ describe('MyPlanPage', () => {
             storage_used_bytes: 2 * 1024 * 1024, // 2MB
             storage_limit_bytes: 5 * 1024 * 1024 * 1024, // 5GB
             next_bill_estimated: 2900,
+            soft_limit_reached: false,
+            user_message: "You've reached your Free tier limit of 100 AI actions. Upgrade to unlock more power!",
           }),
         };
       }
@@ -59,6 +61,33 @@ describe('MyPlanPage', () => {
     expect(screen.getByText('My Plan')).toBeDefined();
     expect(screen.getByText('Starter')).toBeDefined();
     expect(screen.getByText('$29.00')).toBeDefined();
+  });
+
+  it('renders soft limit reached message', async () => {
+    (global.fetch as any).mockImplementation(async (url) => {
+      if (url === '/api/billing/my-plan') {
+        return {
+          ok: true,
+          json: async () => ({
+            current_plan: 'Starter',
+            ai_actions_used: 1000,
+            ai_actions_limit: 1000,
+            storage_used_bytes: 2 * 1024 * 1024, // 2MB
+            storage_limit_bytes: 5 * 1024 * 1024 * 1024, // 5GB
+            next_bill_estimated: 2900,
+            soft_limit_reached: true,
+            user_message: "You've reached your Starter tier limit of 1000 AI actions. Upgrade to unlock more power!",
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    await act(async () => {
+      render(<MyPlanPage />);
+    });
+
+    expect(screen.getByText("You've reached your Starter tier limit of 1000 AI actions. Upgrade to unlock more power!")).toBeDefined();
   });
 
   it('navigates to pricing on upgrade click', async () => {

--- a/src/ui/next/src/app/plan/page.tsx
+++ b/src/ui/next/src/app/plan/page.tsx
@@ -11,6 +11,8 @@ interface MyPlanData {
   storage_used_bytes: number;
   storage_limit_bytes: number | null;
   next_bill_estimated: number;
+  soft_limit_reached?: boolean;
+  user_message?: string;
 }
 
 export default function MyPlanPage() {
@@ -106,6 +108,15 @@ export default function MyPlanPage() {
       </header>
 
       <main className="p-4 md:p-8 flex-1 max-w-4xl mx-auto w-full flex flex-col gap-6">
+
+        {data?.soft_limit_reached && data?.user_message && (
+            <div className="mb-2 p-4 bg-amber-50 border border-amber-200 rounded-xl text-amber-800 flex items-start gap-3 shadow-sm">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 mt-0.5 shrink-0 text-amber-600" style={{ width: '20px', height: '20px' }}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+              <p className="text-sm font-medium">{data.user_message}</p>
+            </div>
+        )}
 
         {/* Status Snapshot */}
         <section className="app-card ohc-growth-card glass-card backdrop-blur-xl bg-white/40 border border-white/20 shadow-lg hover:shadow-2xl transition-all duration-300 p-6 rounded-2xl">


### PR DESCRIPTION
# Product-use evidence:
- Persona: Service Agency Owner (Nora).
- Gap observed: When reaching the soft limit for their tier, the owner was not shown a friendly notification in their plan page.
- Reason for fix: To ensure that OHC users can see when they hit their tier limits and are prompted correctly to upgrade.
- Verification: Wrote playwright scripts to intercept network requests and verified that the banner correctly displays. Also ran frontend tests.

---
*PR created automatically by Jules for task [1035601900298848922](https://jules.google.com/task/1035601900298848922) started by @ql-owo-lp*