### PR TITLE
feat: use unified-agent-feed endpoint for mobile dashboard

### DIFF
--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1728,14 +1728,14 @@
         }
         try {
           const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default';
-          const res = await fetch(`/api/ui/dashboard/unified-feed?tenant_id=${encodeURIComponent(tenantId)}`, {
+          const res = await fetch(`/api/ui/dashboard/unified-agent-feed?tenant_id=${encodeURIComponent(tenantId)}`, {
             headers: { 'X-Tenant-ID': tenantId, 'X-User-ID': 'default' }
           });
           if (!res.ok) throw new Error("Failed to load");
 
           const data = await res.json();
           // Adjust logic to match new ui triage shape if necessary
-          agentFeedItems = data.triage || (Array.isArray(data) ? data : (data.items || []));
+          const approvals = data.pending_approvals || []; const feed = data.agent_feed || []; agentFeedItems = [...approvals, ...feed];
           if (agentFeedItems.length === 0) {
             triageQueue.innerHTML = `
               <div class="triage-item glassmorphism" data-testid="onboarding-welcome-card" style="background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(30px) saturate(210%); border-radius: 16px; padding: 20px; border: 1px solid rgba(0, 102, 255, 0.2); box-shadow: 0 4px 16px rgba(0, 102, 255, 0.1);">
@@ -1890,8 +1890,8 @@
           }
           triageQueue.innerHTML = groupedCardsHTML.join('') + standaloneProposals.map(item => {
             const actionType = item.action_type || item.proposed_action?.action_type;
-            const description = item.context || item.proposed_action?.message || actionType || item.context_payload?.description || 'Agent proposed an action.';
-            const isDraft = item.proposed_action?.context?.weekly_health_report === true;
+            const description = item.context || item.proposed_action?.message || item.context_payload?.description || item.payload?.description || actionType || 'Agent proposed an action.';
+            const isDraft = item.proposed_action?.context?.weekly_health_report === true || item.context_payload?.weekly_health_report === true;
             const approveText = isDraft ? "Yes, draft it!" : "Approve";
 
 


### PR DESCRIPTION
Implemented unified agent feed in the mobile dashboard to surface actionable cards from all OHC Agents. This closes the gap where the previous implementation was attempting to render data from a legacy endpoint with mismatched data structures.

Changes:
- Switched the data source in `loadUnifiedFeed` to `/api/ui/dashboard/unified-agent-feed`.
- Merged the `pending_approvals` and `agent_feed` object values from the new endpoint.
- Adjusted payload parsing fallbacks in `renderTriageItems` to correctly support mapping item descriptions and `isDraft` properties for both agent actions and feed items.

Superpowers loaded: `browser`, `bazel`.
Ensured that playwright E2E tests for the unified agent feed continue to pass on the mobile responsive viewport.

Resolves #32211

---
*PR created automatically by Jules for task [11621946009849621432](https://jules.google.com/task/11621946009849621432) started by @ql-owo-lp*