### PR TITLE
fix(dashboard): Handle PAUSED state for agent feed

### DIFF
--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -67,7 +67,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
   const [activeTab, setActiveTab] = useState<"proposals" | "activity">(
     "proposals",
   );
-  const [activities, setActivities] = useState<OHCLedgerEntry[]>([]);
+  const [activities, setActivities] = useState<any[]>(initialData?.activity || []);
 
   const groupedProposals = useMemo(() => {
     const groups: Record<string, { groupKey: string; title: string; items: AgentFeedItem[] }> = {};

--- a/src/ui/next/src/app/dashboard/page.tsx
+++ b/src/ui/next/src/app/dashboard/page.tsx
@@ -267,11 +267,11 @@ export default function Dashboard() {
         setDashboardData((prev: any) => ({ ...prev, initialAgentFeed: agentFeedData }));
 
         if (approvalsData && Array.isArray(approvalsData) && approvalsData.length > 0 && !agentFeedData.items?.length) {
-            setPendingApprovals(approvalsData.filter((i: any) => i.status !== "APPROVED" && i.status !== "REJECTED"));
-            setActivities(approvalsData.filter((i: any) => i.status === "APPROVED" || i.status === "REJECTED"));
+            setPendingApprovals(approvalsData.filter((i: any) => i.status !== "APPROVED" && i.status !== "REJECTED" && i.status !== "PAUSED"));
+            setActivities(approvalsData.filter((i: any) => i.status === "APPROVED" || i.status === "REJECTED" || i.status === "PAUSED"));
         } else if (agentFeedData && agentFeedData.items) {
-            setPendingApprovals(agentFeedData.items.filter((i: any) => i.lifecycle_state !== "APPROVED" && i.lifecycle_state !== "DISMISSED"));
-            setActivities(agentFeedData.items.filter((i: any) => i.lifecycle_state === "APPROVED" || i.lifecycle_state === "DISMISSED").map((a: any) => ({
+            setPendingApprovals(agentFeedData.items.filter((i: any) => i.lifecycle_state !== "APPROVED" && i.lifecycle_state !== "DISMISSED" && i.lifecycle_state !== "PAUSED"));
+            setActivities(agentFeedData.items.filter((i: any) => i.lifecycle_state === "APPROVED" || i.lifecycle_state === "DISMISSED" || i.lifecycle_state === "PAUSED").map((a: any) => ({
                 id: a.id,
                 event_type: a.lifecycle_state,
                 department: a.event_source,


### PR DESCRIPTION
Properly process PAUSED approvals into the unified agent feed items so that they appear on the dashboard UI instead of missing completely.

---
*PR created automatically by Jules for task [12025419676322538212](https://jules.google.com/task/12025419676322538212) started by @ql-owo-lp*