### PR TITLE
feat(dashboard): implement Unified Agent Feed in the mobile dashboard

### DIFF
--- a/src/ui/next/public/api/ui/dashboard.html
+++ b/src/ui/next/public/api/ui/dashboard.html
@@ -1031,9 +1031,9 @@
         triageSection.style.display = 'block';
         try {
           // Adjust port for Tauri dev server, or use relative if integrated
-          let url = '/api/ui/dashboard/unified-feed';
+          let url = '/api/ui/dashboard/unified-agent-feed';
           if (false) {
-            url = '/api/ui/dashboard/unified-feed';
+            url = '/api/ui/dashboard/unified-agent-feed';
           }
 
           const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default';
@@ -1041,7 +1041,22 @@
           if (!res.ok) throw new Error("Failed to load");
 
           const data = await res.json();
-          let items = data.triage || data.agent_feed || (Array.isArray(data) ? data : (data.items || []));
+
+          // Handle new unified-agent-feed shape while maintaining fallback
+          let parsedData = data;
+          if (typeof data === 'string') {
+              try { parsedData = JSON.parse(data); } catch(e){}
+          }
+          let pending_approvals = parsedData.pending_approvals || [];
+          let agent_feed = parsedData.agent_feed || [];
+          let items = [...pending_approvals, ...agent_feed];
+
+          if (items.length === 0) {
+             if (parsedData.triage) items = parsedData.triage;
+             else if (Array.isArray(parsedData)) items = parsedData;
+             else if (parsedData.items) items = parsedData.items;
+             else if (parsedData.agent_feed) items = parsedData.agent_feed;
+          }
 
           if (!Array.isArray(items) || items.length === 0) {
             triageQueue.innerHTML = '<div class="triage-card empty">No items need your attention right now. Great job!</div>';

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1728,14 +1728,28 @@
         }
         try {
           const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default';
-          const res = await fetch(`/api/ui/dashboard/unified-feed?tenant_id=${encodeURIComponent(tenantId)}`, {
+          const res = await fetch(`/api/ui/dashboard/unified-agent-feed?tenant_id=${encodeURIComponent(tenantId)}`, {
             headers: { 'X-Tenant-ID': tenantId, 'X-User-ID': 'default' }
           });
           if (!res.ok) throw new Error("Failed to load");
 
           const data = await res.json();
           // Adjust logic to match new ui triage shape if necessary
-          agentFeedItems = data.triage || (Array.isArray(data) ? data : (data.items || []));
+
+          // Handle new unified-agent-feed shape while maintaining fallback
+          let parsedData = data;
+          if (typeof data === 'string') {
+              try { parsedData = JSON.parse(data); } catch(e){}
+          }
+          let pending_approvals = parsedData.pending_approvals || [];
+          let agent_feed = parsedData.agent_feed || [];
+
+          if (!parsedData.pending_approvals && !parsedData.agent_feed) {
+             if (parsedData.triage) pending_approvals = parsedData.triage;
+             else if (Array.isArray(parsedData)) pending_approvals = parsedData;
+             else if (parsedData.items) pending_approvals = parsedData.items;
+          }
+          agentFeedItems = [...pending_approvals, ...agent_feed];
           if (agentFeedItems.length === 0) {
             triageQueue.innerHTML = `
               <div class="triage-item glassmorphism" data-testid="onboarding-welcome-card" style="background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(30px) saturate(210%); border-radius: 16px; padding: 20px; border: 1px solid rgba(0, 102, 255, 0.2); box-shadow: 0 4px 16px rgba(0, 102, 255, 0.1);">


### PR DESCRIPTION
**Product-use evidence:**
Persona: Mobile-First Operator
Attempted UI Flow: Log in to the application and navigate to the home dashboard on a 375px mobile view.
Observed CUJ Gap: The agent feed logic previously fetched from an outdated `/api/ui/dashboard/unified-feed` endpoint that didn't provide properly structured `pending_approvals` and `agent_feed` objects, or it wasn't parsing them into the `agentFeedItems` array accurately.
Reason for Fix: A non-technical small business owner relies on the command center feed to process quick approvals (e.g. proposed social media posts, replies, pricing changes). They need to instantly see the queue of actionable cards generated by their agents.
Repeated UI Flow: Checked the dashboard again. The frontend now fetches from `/api/ui/dashboard/unified-agent-feed`, correctly parses `pending_approvals` and `agent_feed`, and presents the feed actionable cards correctly.

**Interaction Audit Table**
| Element | Designed Purpose | Observed Result | Fix |
|---|---|---|---|
| Dashboard Triage Load | To display unified agent cards on load | Didn't use the correct data shape or API | Adjusted the URL to `unified-agent-feed` and updated data payload merging array logic |

Superpowers:
Applied Mobile-First Operations Paradigm and Chat & Approval UI paradigm to the dashboard by fetching the proper agent action cards.

Resolves #32211

---
*PR created automatically by Jules for task [6033970361336950003](https://jules.google.com/task/6033970361336950003) started by @ql-owo-lp*