### PR TITLE
Fix Docker Compose valkey overlayFS mount error

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: redis:7-alpine
+    image: redis:7
     pull_policy: missing
     ports:
       - "${OHC_DOCKER_VALKEY_PORT:-6379}:6379"
@@ -147,7 +147,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: postgres:15-alpine
+    image: postgres:15
     pull_policy: missing
     command: ["postgres", "-c", "wal_level=logical"]
     environment:


### PR DESCRIPTION
This PR fixes the local Docker Compose environment startup issue caused by an overlay filesystem mount error during container creation (`invalid argument` during `overlay` mount).

The fix replaces the `redis:7-alpine` and `postgres:15-alpine` images with their standard Debian-based counterparts (`redis:7` and `postgres:15`). This bypasses the Alpine-specific driver/mount incompatibility with the local Docker builder/daemon cache, enabling developers and the E2E testing environment to launch the local stack successfully. All E2E tests have been verified to ensure no existing tests are broken by this image change.

---
*PR created automatically by Jules for task [2990857142238342902](https://jules.google.com/task/2990857142238342902) started by @ql-owo-lp*