### PR TITLE
chore: fix compile error and unit test unused error

### DIFF
--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -512,7 +512,7 @@ mod auth_utils_tests {
             .connect_lazy(&database_url)
             .unwrap();
 
-        let repo = PgUserRepository::new(pool.clone());
+        let _repo = PgUserRepository::new(pool.clone());
 
         temp_env::async_with_vars([("OHC_MULTITENANT", Some("true"))], async {
             let mut tx = pool.begin().await.unwrap();

--- a/src/server/pricing/engine.rs
+++ b/src/server/pricing/engine.rs
@@ -141,43 +141,22 @@ mod tests {
         let non_peak_time_3 = Utc.with_ymd_and_hms(2023, 10, 25, 12, 0, 0).single().expect("failed to unwrap");
         assert_eq!(calculate_heuristic_yield(non_peak_time_3, 5000), 5000);
     }
+
+    #[test]
+    fn test_calculate_heuristic_yield_edge_cases() {
+        let peak_start = Utc.with_ymd_and_hms(2023, 10, 25, 17, 0, 0).single().unwrap();
+        assert_eq!(calculate_heuristic_yield(peak_start, 1000), 1150);
+
+        let peak_end = Utc.with_ymd_and_hms(2023, 10, 25, 20, 59, 59).single().unwrap();
+        assert_eq!(calculate_heuristic_yield(peak_end, 1000), 1150);
+
+        let just_before_peak = Utc.with_ymd_and_hms(2023, 10, 25, 16, 59, 59).single().unwrap();
+        assert_eq!(calculate_heuristic_yield(just_before_peak, 1000), 1000);
+
+        let just_after_peak = Utc.with_ymd_and_hms(2023, 10, 25, 21, 0, 0).single().unwrap();
+        assert_eq!(calculate_heuristic_yield(just_after_peak, 1000), 1000);
+
+        assert_eq!(calculate_heuristic_yield(peak_start, 0), 0);
+        assert_eq!(calculate_heuristic_yield(peak_start, -1000), -1150);
+    }
 }
-
-    #[test]
-    fn test_calculate_heuristic_yield_edge_cases() {
-        use chrono::TimeZone;
-        let peak_start = Utc.with_ymd_and_hms(2023, 10, 25, 17, 0, 0).single().unwrap();
-        assert_eq!(calculate_heuristic_yield(peak_start, 1000), 1150);
-
-        let peak_end = Utc.with_ymd_and_hms(2023, 10, 25, 20, 59, 59).single().unwrap();
-        assert_eq!(calculate_heuristic_yield(peak_end, 1000), 1150);
-
-        let just_before_peak = Utc.with_ymd_and_hms(2023, 10, 25, 16, 59, 59).single().unwrap();
-        assert_eq!(calculate_heuristic_yield(just_before_peak, 1000), 1000);
-
-        let just_after_peak = Utc.with_ymd_and_hms(2023, 10, 25, 21, 0, 0).single().unwrap();
-        assert_eq!(calculate_heuristic_yield(just_after_peak, 1000), 1000);
-
-        assert_eq!(calculate_heuristic_yield(peak_start, 0), 0);
-        assert_eq!(calculate_heuristic_yield(peak_start, -1000), -1150);
-
-    #[test]
-    fn test_calculate_heuristic_yield_edge_cases() {
-        use chrono::TimeZone;
-        use chrono::Utc;
-        let peak_start = Utc.with_ymd_and_hms(2023, 10, 25, 17, 0, 0).single().unwrap();
-        assert_eq!(calculate_heuristic_yield(peak_start, 1000), 1150);
-
-        let peak_end = Utc.with_ymd_and_hms(2023, 10, 25, 20, 59, 59).single().unwrap();
-        assert_eq!(calculate_heuristic_yield(peak_end, 1000), 1150);
-
-        let just_before_peak = Utc.with_ymd_and_hms(2023, 10, 25, 16, 59, 59).single().unwrap();
-        assert_eq!(calculate_heuristic_yield(just_before_peak, 1000), 1000);
-
-        let just_after_peak = Utc.with_ymd_and_hms(2023, 10, 25, 21, 0, 0).single().unwrap();
-        assert_eq!(calculate_heuristic_yield(just_after_peak, 1000), 1000);
-
-        assert_eq!(calculate_heuristic_yield(peak_start, 0), 0);
-        assert_eq!(calculate_heuristic_yield(peak_start, -1000), -1150);
-    }
-    }


### PR DESCRIPTION
Resolved an unused variable warning that was causing the `server_auth_unit_test` to fail by renaming `repo` to `_repo`. Fixed a malformed unit test module where a duplicated function was placed outside the `mod tests` brace in `server_pricing_unit_test`, preventing successful compilation. Test coverage and edge-case assertions were strictly maintained. Codebase health improved allowing `bazelisk test //...` to run successfully locally.

---
*PR created automatically by Jules for task [15339288782079548270](https://jules.google.com/task/15339288782079548270) started by @ql-owo-lp*