### PR TITLE
⚡ Bolt: Fix compiler and linter warnings to improve code cleanliness

### DIFF
--- a/src/server/integrations/acuity/client.rs
+++ b/src/server/integrations/acuity/client.rs
@@ -16,7 +16,7 @@ impl AcuityClient {
     }
 
     pub async fn get_appointment_types(&self) -> Result<String, String> {
-        let url = format!("https://acuityscheduling.com/api/v1/appointment-types");
+        let url = "https://acuityscheduling.com/api/v1/appointment-types".to_string();
         let res = self.http_client.get(&url)
             .basic_auth(&self.user_id, Some(&self.api_key))
             .send()

--- a/src/server/integrations/buffer/client.rs
+++ b/src/server/integrations/buffer/client.rs
@@ -14,7 +14,7 @@ impl BufferClient {
     }
 
     pub async fn get_profiles(&self) -> Result<String, String> {
-        let url = format!("https://api.bufferapp.com/1/profiles.json");
+        let url = "https://api.bufferapp.com/1/profiles.json".to_string();
         let res = self.http_client.get(&url)
             .bearer_auth(&self.access_token)
             .send()

--- a/src/server/integrations/cal_com/client.rs
+++ b/src/server/integrations/cal_com/client.rs
@@ -16,7 +16,7 @@ impl CalComClient {
 
 impl CalComClient {
     pub async fn get_free_busy(&self, time_min: &str, time_max: &str) -> Result<String, String> {
-        let url = format!("https://api.cal.com/v1/availability");
+        let url = "https://api.cal.com/v1/availability".to_string();
 
         let res = self.http_client.get(&url)
             .query(&[
@@ -41,7 +41,7 @@ impl CalComClient {
     }
 
     pub async fn create_event(&self, summary: &str, start_time: &str, end_time: &str) -> Result<String, String> {
-        let url = format!("https://api.cal.com/v1/bookings");
+        let url = "https://api.cal.com/v1/bookings".to_string();
 
         let payload = serde_json::json!({
             "title": summary,
@@ -71,7 +71,7 @@ impl CalComClient {
     }
 
     pub async fn get_booking_link(&self, event_type: &str) -> Result<String, String> {
-        let url = format!("https://api.cal.com/v1/event-types");
+        let url = "https://api.cal.com/v1/event-types".to_string();
 
         let res = self.http_client.get(&url)
             .query(&[("apiKey", &self.access_token)])

--- a/src/server/integrations/messagebird/client.rs
+++ b/src/server/integrations/messagebird/client.rs
@@ -14,7 +14,7 @@ impl MessageBirdClient {
     }
 
     pub async fn send_sms(&self, originator: &str, recipients: &str, body: &str) -> Result<String, String> {
-        let url = format!("https://rest.messagebird.com/messages");
+        let url = "https://rest.messagebird.com/messages".to_string();
         let payload = serde_json::json!({
             "originator": originator,
             "recipients": recipients,

--- a/src/server/integrations/nylas/client.rs
+++ b/src/server/integrations/nylas/client.rs
@@ -14,7 +14,7 @@ impl NylasClient {
     }
 
     pub async fn get_calendars(&self) -> Result<String, String> {
-        let url = format!("https://api.nylas.com/calendars");
+        let url = "https://api.nylas.com/calendars".to_string();
         let res = self.http_client.get(&url)
             .bearer_auth(&self.access_token)
             .send()

--- a/src/server/integrations/shipengine/client.rs
+++ b/src/server/integrations/shipengine/client.rs
@@ -14,7 +14,7 @@ impl ShipengineClient {
     }
 
     pub async fn create_label(&self, carrier_id: &str, service_code: &str) -> Result<String, String> {
-        let url = format!("https://api.shipengine.com/v1/labels");
+        let url = "https://api.shipengine.com/v1/labels".to_string();
         let payload = serde_json::json!({
             "shipment": {
                 "carrier_id": carrier_id,

--- a/src/server/integrations/stripe/payout_batcher.rs
+++ b/src/server/integrations/stripe/payout_batcher.rs
@@ -15,7 +15,6 @@ use serde_json::json;
 /// - Unbatched: 100 * $0.25 = $25.00 in fixed fees
 /// - Batched (1 payout of $1000): 1 * $0.25 = $0.25 in fixed fees
 /// - Total savings = $24.75 per 100 transactions!
-
 pub struct PayoutBatcher {
     pool: Option<Arc<PgPool>>,
     batch_threshold_cents: i64,

--- a/src/server/integrations/teams/client.rs
+++ b/src/server/integrations/teams/client.rs
@@ -14,7 +14,7 @@ impl TeamsClient {
     }
 
     pub async fn create_meeting(&self, subject: &str) -> Result<String, String> {
-        let url = format!("https://graph.microsoft.com/v1.0/me/onlineMeetings");
+        let url = "https://graph.microsoft.com/v1.0/me/onlineMeetings".to_string();
         let payload = serde_json::json!({
             "startDateTime": "2025-01-01T10:00:00Z",
             "endDateTime": "2025-01-01T11:00:00Z",

--- a/src/server/utils/gzip_middleware.rs
+++ b/src/server/utils/gzip_middleware.rs
@@ -47,7 +47,7 @@ mod tests {
         let data = b"hello world";
         let compressed = gzip_compress(data).unwrap();
         
-        assert!(compressed.len() > 0);
+        assert!(!compressed.is_empty());
         
         let mut decoder = GzDecoder::new(&compressed[..]);
         let mut decompressed = Vec::new();

--- a/src/server/utils/payload_validator.rs
+++ b/src/server/utils/payload_validator.rs
@@ -4,7 +4,6 @@ use serde_json::Value;
 /// Payload Schema Validator for OHC-SIP
 /// This module provides strict runtime schema validation for complex JSON payloads
 /// embedded within `agent_missions`. It guarantees type safety across Cloud and Local DB syncs.
-
 pub enum SchemaError {
     MissingField(String),
     TypeMismatch(String, String),


### PR DESCRIPTION
### Description

This PR fixes various codebase linter issues across backend integration clients and util modules as part of proactive codebase maintenance and optimization. 

Specifically, it replaces multiple instances of `format!("...")` with `"..."`.to_string() in server integrations where formatting variables are unnecessary, reducing small overheads in string allocation syntax:
- `src/server/integrations/cal_com/client.rs`
- `src/server/integrations/buffer/client.rs`
- `src/server/integrations/acuity/client.rs`
- `src/server/integrations/messagebird/client.rs`
- `src/server/integrations/nylas/client.rs`
- `src/server/integrations/shipengine/client.rs`
- `src/server/integrations/teams/client.rs`

It also resolves multiple `cargo clippy` warnings in the codebase:
- Replaced `compressed.len() > 0` with `!compressed.is_empty()` in `src/server/utils/gzip_middleware.rs`.
- Removed unnecessary empty lines following doc comments to appease clippy's `empty_line_after_doc_comments` warning in `src/server/utils/payload_validator.rs` and `src/server/integrations/stripe/payout_batcher.rs`.

### Testing

All tests in `//src/server/...` and E2E Playwright tests passed locally. The integration and util specific targets passed `bazelisk test`. No core feature functionality or payload structure is changed.

---
*PR created automatically by Jules for task [3030907212675527663](https://jules.google.com/task/3030907212675527663) started by @ql-owo-lp*