### PR TITLE
Fix failing Daily Work E2E test by updating data-testids

### DIFF
--- a/src/e2e/playwright/daily_work_generation.spec.ts
+++ b/src/e2e/playwright/daily_work_generation.spec.ts
@@ -29,11 +29,11 @@ test.describe('Autonomous AI Work Triage and Daily Work Generation', () => {
     await expect(page.locator('text=Loading your work feed...')).not.toBeVisible({ timeout: 10000 });
 
     // 3. Verify the surfaced actionable card
-    const card = page.locator(`[data-testid="triage-card-${workItemId}"]`);
+    const card = page.locator(`[data-testid="daily-work-card-${workItemId}"]`);
     await expect(card).toBeVisible({ timeout: 10000 });
 
     // Find the approve button
-    const approveButton = card.locator(`[data-testid="triage-approve-${workItemId}"]`);
+    const approveButton = card.locator(`[data-testid="approve-${workItemId}"]`);
     await expect(approveButton).toBeVisible();
 
     // Check touch target for mobile

--- a/src/ui/next/src/app/dashboard/daily-work/DailyWorkCard.tsx
+++ b/src/ui/next/src/app/dashboard/daily-work/DailyWorkCard.tsx
@@ -24,7 +24,7 @@ export function DailyWorkCard({ item, onApprove, onDismiss }: Props) {
 
   return (
     <div
-      data-testid="daily-work-card"
+      data-testid={`daily-work-card-${item.id}`}
       className="glassmorphism p-5 shadow-sm flex flex-col gap-4 mb-4"
     >
       <div className="flex justify-between items-start">


### PR DESCRIPTION
Fixes failing E2E test for the Daily Work Generation feature by ensuring the test selectors match the data-testid attributes used in the UI components.

---
*PR created automatically by Jules for task [991972242680181555](https://jules.google.com/task/991972242680181555) started by @ql-owo-lp*