### PR TITLE
🚀 Nova: Add unit test coverage for API mock elimination

### DIFF
--- a/src/ui/next/src/app/api/kitchen/orders/translate/route.test.ts
+++ b/src/ui/next/src/app/api/kitchen/orders/translate/route.test.ts
@@ -1,0 +1,72 @@
+import { POST } from "./route";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("POST /api/kitchen/orders/translate", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    vi.stubEnv("BACKEND_URL", "http://backend.internal");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should proxy the request to the backend and return the response", async () => {
+    const mockResponseData = { translated: "translated text" };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponseData,
+    });
+
+    const body = { order_id: "123" };
+    const req = new Request("http://localhost/api/kitchen/orders/translate", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(global.fetch).toHaveBeenCalledWith("http://backend.internal/api/pos/orders/translate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(200);
+    expect(data).toEqual(mockResponseData);
+  });
+
+  it("should handle backend failure by returning 502", async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const req = new Request("http://localhost/api/kitchen/orders/translate", {
+      method: "POST",
+      body: JSON.stringify({ order_id: "123" }),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(data).toEqual({ error: "Failed to translate order notes" });
+  });
+
+  it("should handle network failure by returning 502", async () => {
+    (global.fetch as any).mockRejectedValue(new Error("Network Error"));
+
+    const req = new Request("http://localhost/api/kitchen/orders/translate", {
+      method: "POST",
+      body: JSON.stringify({ order_id: "123" }),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(data).toEqual({ error: "Failed to translate order notes" });
+  });
+});

--- a/src/ui/next/src/app/api/v1/growth/campaign/send-receipt/route.test.ts
+++ b/src/ui/next/src/app/api/v1/growth/campaign/send-receipt/route.test.ts
@@ -1,0 +1,76 @@
+import { POST } from "./route";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("POST /api/v1/growth/campaign/send-receipt", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    vi.stubEnv("BACKEND_URL", "http://backend.internal");
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should proxy the request to the backend and return the response", async () => {
+    const mockResponseData = { success: true };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponseData,
+    });
+
+    const body = { receiptId: "123" };
+    const req = new Request("http://localhost/api/v1/growth/campaign/send-receipt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(global.fetch).toHaveBeenCalledWith("http://backend.internal/api/v1/growth/campaign/send-receipt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(200);
+    expect(data).toEqual(mockResponseData);
+  });
+
+  it("should handle backend failure by returning 502", async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const req = new Request("http://localhost/api/v1/growth/campaign/send-receipt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ receiptId: "123" }),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(data).toEqual({ error: "Backend error" });
+  });
+
+  it("should handle network failure by returning 502", async () => {
+    (global.fetch as any).mockRejectedValue(new Error("Network Error"));
+
+    const req = new Request("http://localhost/api/v1/growth/campaign/send-receipt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ receiptId: "123" }),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(data).toEqual({ error: "Network error" });
+  });
+});

--- a/src/ui/next/src/app/api/v1/growth/wrapped/route.test.ts
+++ b/src/ui/next/src/app/api/v1/growth/wrapped/route.test.ts
@@ -1,0 +1,73 @@
+import { GET } from "./route";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("GET /api/v1/growth/wrapped", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    vi.stubEnv("OHC_CORE_URL", "http://backend.internal");
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should proxy the request to the backend and return the response", async () => {
+    const mockResponseData = { data: "wrapped data" };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponseData,
+    });
+
+    const req = new Request("http://localhost/api/v1/growth/wrapped?tenant_id=test-tenant", {
+      method: "GET",
+      headers: {
+        "x-spiffe-id": "spiffe://ohc/test",
+      },
+    });
+
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(global.fetch).toHaveBeenCalledWith("http://backend.internal/api/v1/growth/wrapped?tenant_id=test-tenant", {
+      method: "GET",
+      headers: {
+        "x-spiffe-id": "spiffe://ohc/test",
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(data).toEqual(mockResponseData);
+  });
+
+  it("should handle backend failure by returning 502", async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const req = new Request("http://localhost/api/v1/growth/wrapped?tenant_id=test-tenant", {
+      method: "GET",
+    });
+
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(data).toEqual({ error: "Backend wrapped service unavailable" });
+  });
+
+  it("should handle network error by returning 502", async () => {
+    (global.fetch as any).mockRejectedValue(new Error("Network error"));
+
+    const req = new Request("http://localhost/api/v1/growth/wrapped?tenant_id=test-tenant", {
+      method: "GET",
+    });
+
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(data).toEqual({ error: "Backend wrapped service unavailable" });
+  });
+});


### PR DESCRIPTION
As part of the initiative to eliminate local mock data in favor of relying on strict backend API responses, I added test coverage to three key Next.js API endpoints: `send-receipt`, `wrapped`, and `orders/translate`. The tests use Vitest to mock the global `fetch` API, ensuring that upon backend response failures or network errors, the routes correctly fail closed (returning 502 statuses) rather than returning hardcoded local data.

Also, inspected the `viral-loyalty-widget.html` and verified the requested changes to UI styling and the stamp animations inside the `<script>` tag were completely implemented.

**Tested:**
- Ran `bazelisk test //src/ui/next/...` to ensure all newly written API tests pass correctly under the Vitest environment.

---
*PR created automatically by Jules for task [9434287213344413006](https://jules.google.com/task/9434287213344413006) started by @ql-owo-lp*