### PR TITLE
💰 Miser: Fix /api/billing/report-cost to write to telemetry_buffer

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -117,6 +117,19 @@ pub async fn report_cost_handler(
         hub.get_cost_auditor().record_manual_cost(agent_id, &tenant_id, req.value);
     }
 
+    let pool = crate::db::get_pool();
+    let mut labels = req.labels.clone();
+    labels.insert("tenant_id".to_string(), tenant_id.clone());
+    let labels_value = serde_json::to_value(labels).unwrap_or(serde_json::json!({}));
+
+    let _ = ::server_telemetry::buffer_metric_i64(
+        &pool,
+        &req.metric_name,
+        "gauge",
+        req.value,
+        labels_value
+    ).await;
+
     Ok(Json(serde_json::json!({ "success": true })))
 }
 


### PR DESCRIPTION
Fix /api/billing/report-cost to write to telemetry_buffer

This commit fixes an issue where `/api/billing/report-cost` only updated the in-memory auditor but failed to write to the `telemetry_buffer` database table. As a result, dashboard aggregates were not showing the reported costs, causing E2E test failures (`miser_cost_features.spec.ts`).

By adding a call to `::server_telemetry::buffer_metric_i64`, reported costs are correctly persisted and picked up by the cost dashboard aggregation logic.

---
*PR created automatically by Jules for task [2090019185247768656](https://jules.google.com/task/2090019185247768656) started by @ql-owo-lp*