### PR TITLE
Eliminate mock data in Next.js viral leaderboard and referral embed API routes

### DIFF
--- a/src/ui/next/src/app/api/v1/growth/referral-fab/embed/route.ts
+++ b/src/ui/next/src/app/api/v1/growth/referral-fab/embed/route.ts
@@ -137,9 +137,23 @@ export async function GET(request: Request) {
         e.preventDefault();
         const email = document.getElementById('ohc-referral-email').value;
         if (email) {
-            // Mock API call
-            form.style.display = 'none';
-            successDiv.style.display = 'flex';
+            fetch('/api/v1/growth/referrals/generate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ tenantId: '${escapedTenant}', email: email })
+            }).then(res => {
+                if (res.ok) return res.json();
+                throw new Error('Backend failed');
+            }).then(data => {
+                form.style.display = 'none';
+                successDiv.style.display = 'flex';
+                if (data && data.link) {
+                    linkInput.value = data.link;
+                }
+            }).catch(err => {
+                console.error('Failed to generate referral', err);
+                // Fail gracefully, could show error message
+            });
         }
     });
 

--- a/src/ui/next/src/app/api/v1/growth/viral-leaderboard/embed/route.ts
+++ b/src/ui/next/src/app/api/v1/growth/viral-leaderboard/embed/route.ts
@@ -28,17 +28,17 @@ export async function GET(request: Request) {
     const border = isDark ? '#333333' : '#e5e7eb';
     const rowBg = isDark ? '#27272a' : '#f9fafb';
 
-    const mockData = metric === 'buyers'
-      ? [
-          { name: 'Sarah J.', score: '24 purchases', emoji: '🥇' },
-          { name: 'Michael T.', score: '18 purchases', emoji: '🥈' },
-          { name: 'Emma W.', score: '12 purchases', emoji: '🥉' }
-        ]
-      : [
-          { name: 'Alex K.', score: '15 referrals', emoji: '🥇' },
-          { name: 'Jessica L.', score: '11 referrals', emoji: '🥈' },
-          { name: 'Ryan P.', score: '8 referrals', emoji: '🥉' }
-        ];
+    const backendUrl = process.env.OHC_CORE_URL || 'http://127.0.0.1:18789';
+    let leaderboardData: any[] = [];
+    try {
+        const res = await fetch(`${backendUrl}/api/v1/growth/viral-leaderboard/data?tenant=${encodedTenant}&metric=${encodeURIComponent(metric)}`);
+        if (!res.ok) {
+            return new NextResponse("Backend service unavailable", { status: 502 });
+        }
+        leaderboardData = await res.json();
+    } catch (e) {
+        return new NextResponse("Backend service unavailable", { status: 502 });
+    }
 
     const html = `
 <!DOCTYPE html>
@@ -141,15 +141,15 @@ export async function GET(request: Request) {
             <div class="subtitle">Monthly Top Performers</div>
         </div>
         <div class="leaderboard">
-            ${mockData.map(row => `
+            ${Array.isArray(leaderboardData) ? leaderboardData.map(row => `
                 <div class="row">
-                    <div class="rank">${row.emoji}</div>
+                    <div class="rank">${escapeHtml(row.emoji || '⭐')}</div>
                     <div class="info">
                         <div class="name">${escapeHtml(row.name)}</div>
                         <div class="score">${escapeHtml(row.score)}</div>
                     </div>
                 </div>
-            `).join('')}
+            `).join('') : ''}
         </div>
         ${rawBranding ? `
         <div class="footer">


### PR DESCRIPTION
This commit eliminates mock data left over in the Next.js UI API routes. Specifically:
- `src/ui/next/src/app/api/v1/growth/viral-leaderboard/embed/route.ts` no longer hardcodes leaderboard arrays but fetches them from `process.env.OHC_CORE_URL/api/v1/growth/viral-leaderboard/data`.
- `src/ui/next/src/app/api/v1/growth/referral-fab/embed/route.ts` removes the local JS mock flow on submit and delegates it to a `fetch` call mapped to `/api/v1/growth/referrals/generate`.
All related unit tests and e2e tests successfully pass after these updates.

---
*PR created automatically by Jules for task [4855697936152921558](https://jules.google.com/task/4855697936152921558) started by @ql-owo-lp*