### PR TITLE
Fix E2E module imports and test fixtures

### DIFF
--- a/src/e2e/db_utils.ts
+++ b/src/e2e/db_utils.ts
@@ -17,3 +17,7 @@ export async function e2eDbQuery(query: string, values?: any[]) {
     client.release();
   }
 }
+
+export const db = {
+  query: e2eDbQuery,
+};

--- a/src/e2e/department-handoff.spec.ts
+++ b/src/e2e/department-handoff.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { adminPage } from './fixtures';
-import { db } from './e2e-seed';
+import { db } from './db_utils';
 
 test.describe('Department Handoff Protocol', () => {
-    test('Owner Feed correctly displays and allows approval of Task Envelopes', async ({ adminPage: page }) => {
+    test('Owner Feed correctly displays and allows approval of Task Envelopes', async ({ page }) => {
         // 1. Arrange: Seed a TaskEnvelope directly into the database to simulate background agent work
         const tenantId = 'e2e-tenant';
         const envelopeId = `env-${Date.now()}`;
@@ -24,6 +24,7 @@ test.describe('Department Handoff Protocol', () => {
         `, [envelopeId, tenantId, initialPayload, routingHistory]);
 
         // 2. Act: Owner navigates to the Work Triage feed
+        await adminPage(page);
         await page.goto('/ui/triage.html');
         await page.waitForLoadState('networkidle');
 

--- a/src/e2e/field-ops-booking-lock.spec.ts
+++ b/src/e2e/field-ops-booking-lock.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { memberPage } from './fixtures';
-import { executeSql } from './db_utils';
+import { e2eDbQuery as executeSql } from './db_utils';
 
 test.describe('Agentic Field Service Scheduling & Quoting', () => {
   let customerId: string;

--- a/src/e2e/field-ops-quoting.spec.ts
+++ b/src/e2e/field-ops-quoting.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { memberPage } from './fixtures';
-import { executeSql } from './db_utils';
+import { e2eDbQuery as executeSql } from './db_utils';
 
 test.describe('Autonomous Field Service Quoting & Deposit Engine', () => {
   let customerId: string;

--- a/src/e2e/growth-milestones.spec.ts
+++ b/src/e2e/growth-milestones.spec.ts
@@ -1,26 +1,27 @@
 import { expect } from '@playwright/test';
-import { test } from './fixtures';
+import { test, adminPage } from './fixtures';
 
 test.describe('Success Milestones UI', () => {
-    test('renders the success milestones page and loads a preview card', async ({ adminPage }) => {
+    test('renders the success milestones page and loads a preview card', async ({ page }) => {
         // We know we are logged in from adminPage fixture.
-        await adminPage.goto('/milestones.html');
+        await adminPage(page);
+        await page.goto('/milestones.html');
 
         // Check for the main title
-        await expect(adminPage.locator('h1.app-title')).toHaveText(/Success Milestones/);
+        await expect(page.locator('h1.app-title')).toHaveText(/Success Milestones/);
 
         // Check for the "Your Achievements" section
-        await expect(adminPage.locator('h2.section-title').first()).toHaveText('Your Achievements');
+        await expect(page.locator('h2.section-title').first()).toHaveText('Your Achievements');
 
         // Check that at least one milestone rendered
-        await expect(adminPage.locator('.milestone-item').first()).toBeVisible();
+        await expect(page.locator('.milestone-item').first()).toBeVisible();
 
         // The first milestone is auto-selected, verify the share section is visible
-        await expect(adminPage.locator('#share-container')).toBeVisible();
-        await expect(adminPage.locator('#empty-state')).not.toBeVisible();
+        await expect(page.locator('#share-container')).toBeVisible();
+        await expect(page.locator('#empty-state')).not.toBeVisible();
 
         // Check the card preview image loaded successfully
-        const previewImage = adminPage.locator('#card-preview-img');
+        const previewImage = page.locator('#card-preview-img');
         await expect(previewImage).toBeVisible();
 
         // Assert the image source has the expected path

--- a/src/e2e/missed-lead-recovery.spec.ts
+++ b/src/e2e/missed-lead-recovery.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { adminPage } from './fixtures';
-import { db } from './db';
+import { db } from './db_utils';
 
 test.describe('Missed Lead Recovery Work Triage UI', () => {
     test.beforeAll(async () => {

--- a/src/e2e/playwright/triage-feed-agent.spec.ts
+++ b/src/e2e/playwright/triage-feed-agent.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '../fixtures';
 
 test.describe('Agentic Work Triage Feed', () => {
   test('Owner can review and approve AI-drafted replies', async ({ page, loginAs, adminUser }) => {


### PR DESCRIPTION
Fixes playwright errors causing E2E tests to fail to parse or run initially, including:
- `Cannot find module './e2e-seed'`
- `Cannot find module './db'`
- `Test has unknown parameter "adminPage"`
- `Cannot find module './fixtures'`

---
*PR created automatically by Jules for task [3512972363435560235](https://jules.google.com/task/3512972363435560235) started by @ql-owo-lp*