### PR TITLE
feat: integrate telemetry settings toggle with backend persistence

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6198,6 +6198,28 @@ async fn create_ui_bom_item_handler(
                 axum::response::Json(serde_json::json!({ "success": true }))
             }
         }))
+        .route("/api/settings/telemetry", axum::routing::get({
+            let settings_store = settings_store.clone();
+            move |axum::extract::Extension(_user): axum::extract::Extension<::server_common::Claims>| async move {
+                let settings = settings_store.get();
+                axum::response::Json(serde_json::json!({
+                    "product_telemetry_enabled": settings.product_telemetry_enabled,
+                }))
+            }
+        }))
+        .route("/api/settings/telemetry", axum::routing::post({
+            let settings_store = settings_store.clone();
+            move |axum::extract::Extension(_user): axum::extract::Extension<::server_common::Claims>, axum::Json(req): axum::Json<serde_json::Value>| async move {
+                let enabled = req.get("product_telemetry_enabled").and_then(|v| v.as_bool()).unwrap_or(false);
+
+                if let Err(e) = settings_store.set_product_telemetry(enabled) {
+                    ::server_telemetry::record_error_signal("[bug] Failed to save telemetry settings");
+                    tracing::error!("Failed to save telemetry settings: {}", e);
+                    return axum::response::Json(serde_json::json!({ "success": false }));
+                }
+                axum::response::Json(serde_json::json!({ "success": true }))
+            }
+        }))
         .route("/api/settings/voice", axum::routing::get({
             let settings_store = settings_store.clone();
             move |axum::extract::Extension(_user): axum::extract::Extension<::server_common::Claims>| async move {

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -33,6 +33,7 @@ pub struct AppSettings {
     pub voice_receptionist_number: Option<String>,
     pub voice_receptionist_persona: Option<String>,
     pub voice_receptionist_instructions: Option<String>,
+    pub product_telemetry_enabled: bool,
 }
 
 impl AppSettings {
@@ -57,6 +58,7 @@ impl AppSettings {
             voice_receptionist_number: None,
             voice_receptionist_persona: Some("Friendly".to_string()),
             voice_receptionist_instructions: None,
+            product_telemetry_enabled: false,
         }
     }
 }
@@ -146,6 +148,13 @@ impl Store {
         data.voice_receptionist_number = number;
         data.voice_receptionist_persona = persona;
         data.voice_receptionist_instructions = instructions;
+        drop(data);
+        self.save()
+    }
+
+    pub fn set_product_telemetry(&self, enabled: bool) -> Result<(), String> {
+        let mut data = self.data.write().unwrap();
+        data.product_telemetry_enabled = enabled;
         drop(data);
         self.save()
     }

--- a/src/ui/next/src/app/settings/page.tsx
+++ b/src/ui/next/src/app/settings/page.tsx
@@ -75,6 +75,15 @@ export default function SettingsPage() {
         })
         .catch(e => console.error("Failed to load voice settings", e)),
 
+      fetch("/api/settings/telemetry")
+        .then(res => res.json())
+        .then(data => {
+          if (data && data.product_telemetry_enabled !== undefined) {
+            setEnableProductTelemetry(data.product_telemetry_enabled);
+          }
+        })
+        .catch(e => console.error("Failed to load telemetry settings", e)),
+
       fetch("/api/local_seo/discovery_report")
         .then(res => res.json())
         .then(data => {
@@ -104,6 +113,19 @@ export default function SettingsPage() {
       });
     } catch (e) {
       console.error("Failed to save delivery settings", e);
+    }
+  };
+
+  const handleTelemetryChange = async (checked: boolean) => {
+    setEnableProductTelemetry(checked);
+    try {
+      await fetch("/api/settings/telemetry", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ product_telemetry_enabled: checked }),
+      });
+    } catch (e) {
+      console.error("Failed to save telemetry settings", e);
     }
   };
 
@@ -547,6 +569,8 @@ export default function SettingsPage() {
               <input
                 type="checkbox"
                 aria-label="Enable Product Telemetry (Standalone Mode)"
+                checked={enableProductTelemetry}
+                onChange={(e) => handleTelemetryChange(e.target.checked)}
                 className="rounded border-gray-300 text-[#0f766e] focus:ring-[#0f766e] w-5 h-5 cursor-pointer"
               />
             </label>


### PR DESCRIPTION
This PR fully implements the "Enable Product Telemetry (Standalone Mode)" toggle in the Workspace Settings UI by adding backend persistence.

Changes:
- Added `product_telemetry_enabled` to `AppSettings`.
- Added GET and POST routes to fetch and save the telemetry setting via the API.
- Re-wired the UI toggle to accurately read and persist its value to the backend upon interaction.
- Includes appropriate error handling and logging via tracing and telemetry modules.

---
*PR created automatically by Jules for task [2868837063516136925](https://jules.google.com/task/2868837063516136925) started by @ql-owo-lp*