### PR TITLE
fix: update selector in miser_cost_features.spec.ts to correctly target button

### DIFF
--- a/src/e2e/miser_cost_features.spec.ts
+++ b/src/e2e/miser_cost_features.spec.ts
@@ -18,7 +18,7 @@ test.describe('Miser Cost Features E2E', () => {
     await expect(page.locator('text=Total Costs')).toBeVisible();
     await expect(page.locator('text=Projected Monthly Cost').first()).toBeVisible();
 
-    const backToMyPlanBtn = page.locator('a', { hasText: 'Back to My Plan' });
+    const backToMyPlanBtn = page.locator('button', { hasText: 'Back to My Plan' });
     await expect(backToMyPlanBtn).toBeVisible();
     await backToMyPlanBtn.click();
     await expect(page.locator('text=Your Current Usage')).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
The test `src/e2e/miser_cost_features.spec.ts` was attempting to find the "Back to My Plan" button using an anchor (`a`) tag locator (`page.locator('a', { hasText: 'Back to My Plan' })`). However, inspecting `src/ui/tauri/src/ui/cost-dashboard.html` reveals that the element is actually a button (`<button id="back-to-my-plan" ...>Back to My Plan</button>`).

This mismatch caused the test to fail as the element could not be found. This pull request fixes the test by updating the locator to correctly target a `button` element, ensuring the E2E test accurately reflects the DOM and passes successfully.

---
*PR created automatically by Jules for task [8586766736210127356](https://jules.google.com/task/8586766736210127356) started by @ql-owo-lp*