### PR TITLE
feat: growth viral loyalty widget UI and tests

### DIFF
--- a/src/e2e/viral-loyalty-widget.spec.ts
+++ b/src/e2e/viral-loyalty-widget.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { adminPage } from './fixtures';
+
+test.describe('Viral Loyalty Widget', () => {
+  test('should load the widget and generate a loyalty program', async ({ page }) => {
+    // Navigate using the real application stack
+    await page.goto('/ui/viral-loyalty-widget.html');
+
+    // Setup local storage to bypass auth issues that may occur if the user is not fully logged in during the isolated test
+    await page.evaluate(() => {
+      localStorage.setItem('tenant', 'e2e-tenant');
+      localStorage.setItem('tenant_id', 'e2e-tenant');
+    });
+
+    // Wait for main elements
+    await expect(page.locator('h1')).toHaveText('Viral Loyalty Widget Generator');
+    const generateBtn = page.locator('#generate-btn');
+    await expect(generateBtn).toBeVisible();
+
+    // Check initial stamps state
+    const emptyStamps = page.locator('.stamp.empty');
+    await expect(emptyStamps).toHaveCount(4);
+
+    // Click generate
+    await generateBtn.click();
+
+    // Verify animation starts
+    await expect(generateBtn).toBeDisabled();
+    await expect(generateBtn).toHaveText('Generating...');
+
+    // Wait for the animation to finish and result to show
+    const resultArea = page.locator('#result-area');
+    await expect(resultArea).toBeVisible({ timeout: 5000 });
+
+    // Verify filled stamps
+    const filledStamps = page.locator('.stamp.filled');
+    await expect(filledStamps).toHaveCount(4);
+
+    // Check share link generated correctly (since we removed the mock, wait for real generated link format)
+    const shareLink = page.locator('#share-link');
+    await expect(shareLink).toHaveValue(/loyalty\/join\?ref=/);
+  });
+});


### PR DESCRIPTION
Created `viral-loyalty-widget.spec.ts` for the viral loyalty widget that was introduced in HTML layout. Removed network mocking per PR constraints and replaced it with local test interactions.

Verified with Bazel and Playwright locally.

---
*PR created automatically by Jules for task [17704020418342510154](https://jules.google.com/task/17704020418342510154) started by @ql-owo-lp*