### PR TITLE
🔨 Forge: Automated Re-engagement Agent for Service Bookings

### DIFF
--- a/src/e2e/booking_reengagement.spec.ts
+++ b/src/e2e/booking_reengagement.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { Pool } from 'pg';
+
+test.describe('Automated Re-engagement Agent for Service Bookings', () => {
+    let pool: Pool;
+    const testTenant = 'e2e-tenant-reengagement';
+    const testCustomerId = 'e2e-cust-123';
+    const testCustomerName = 'Leo Customer';
+
+    test.beforeAll(async () => {
+        const dbUrl = process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/ohc';
+        pool = new Pool({ connectionString: dbUrl });
+
+        try {
+            await pool.query('SELECT 1');
+        } catch (e) {
+            console.log('Database not available, skipping setup');
+            return;
+        }
+
+        // Setup tenant
+        await pool.query(`INSERT INTO tenants (id, name) VALUES ($1, 'Test Tenant') ON CONFLICT DO NOTHING`, [testTenant]);
+
+        // Clean up previous test data
+        await pool.query(`DELETE FROM bookings WHERE tenant_id = $1`, [testTenant]);
+        await pool.query(`DELETE FROM customers WHERE tenant_id = $1`, [testTenant]);
+        await pool.query(`DELETE FROM ohc_job_queue WHERE tenant_id = $1`, [testTenant]);
+        await pool.query(`DELETE FROM agent_feed_items WHERE tenant_id = $1`, [testTenant]);
+
+        // Insert test customer
+        await pool.query(`INSERT INTO customers (id, tenant_id, name, email) VALUES ($1, $2, $3, 'leo@example.com')`,
+            [testCustomerId, testTenant, testCustomerName]);
+
+        // Insert two past bookings to make them qualify for re-engagement
+        const pastDate1 = new Date();
+        pastDate1.setDate(pastDate1.getDate() - 30);
+        const pastDate2 = new Date();
+        pastDate2.setDate(pastDate2.getDate() - 20); // More than 14 days ago
+
+        await pool.query(`
+            INSERT INTO bookings (id, tenant_id, customer_id, start_time, end_time, status)
+            VALUES ($1, $2, $3, $4, $5, 'completed')`,
+            ['booking-1', testTenant, testCustomerId, pastDate1, pastDate1]);
+
+        await pool.query(`
+            INSERT INTO bookings (id, tenant_id, customer_id, start_time, end_time, status)
+            VALUES ($1, $2, $3, $4, $5, 'completed')`,
+            ['booking-2', testTenant, testCustomerId, pastDate2, pastDate2]);
+
+        // Insert a booking_reengagement_check job to simulate the daily routine worker finding this customer
+        await pool.query(`
+            INSERT INTO ohc_job_queue (id, tenant_id, job_type, payload, status, next_retry_at)
+            VALUES ($1, $2, 'booking_reengagement_check', $3, 'PENDING', CURRENT_TIMESTAMP)`,
+            ['job-reengage', testTenant, JSON.stringify({ customer_id: testCustomerId })]);
+    });
+
+    test.afterAll(async () => {
+        if (pool) {
+            await pool.end();
+        }
+    });
+
+    test('should generate a context-aware re-engagement message for dormant customers', async ({ page }) => {
+        // Set tenant context for local storage
+        await page.goto('/ui/dashboard.html');
+        await page.evaluate((tenant) => {
+            localStorage.setItem('tenant_id', tenant);
+        }, testTenant);
+        await page.reload();
+
+        // Navigate to Unified Agent Feed
+        await expect(page.locator('h2:has-text("Command Center")')).toBeVisible({ timeout: 15000 });
+        const feedSection = page.locator('section[aria-label="Unified Agent Feed"]');
+
+        // Verify the card appears
+        await expect(feedSection.locator(`text=AI detected Leo Customer is a dormant customer`)).toBeVisible({ timeout: 15000 });
+
+        // Verify the drafted message exists (or part of it)
+        const approveButton = feedSection.locator('button:has-text("Approve")').first();
+        await expect(approveButton).toBeVisible();
+
+        // Clean up
+        await page.evaluate(() => {
+            localStorage.removeItem('tenant_id');
+        });
+    });
+});

--- a/src/server/workers/booking_reengagement.rs
+++ b/src/server/workers/booking_reengagement.rs
@@ -168,37 +168,48 @@ impl BookingReengagementWorker {
                         }
                     };
 
-                    let drafted_message = format!("Hi {}, I noticed we haven't had a session in a while! Hope everything is going great with your progress. Would you like to jump back in this week? I have some slots available. Here is a quick booking link: [Link]", customer_name);
+                    let context_payload = json!({
+                        "feature_type": "booking_reengagement",
+                        "customer_name": customer_name,
+                        "description": format!("AI detected {} is a dormant customer. Please reach out and offer them a new booking slot.", customer_name)
+                    });
 
                     match &db.store {
                         crate::db::DbStore::Postgres => {
-                            let _ = sqlx::query(
-                                r#"
-                                INSERT INTO shared_tasks (id, organization_id, title, description, status, priority, action_risk, approval_status, proposed_content)
-                                VALUES ($1, $2, 'Approve Re-engagement for ' || $3, 'AI detected that ' || $3 || ' is a returning customer who hasn''t booked in 14 days. This follow-up helps maintain momentum.', 'PENDING', 'P1', 'LOW', 'PENDING', $4)
-                                "#
-                            )
-                            .bind(Uuid::new_v4().to_string())
-                            .bind(&tenant_id)
-                            .bind(&customer_name)
-                            .bind(&drafted_message)
-                            .execute(&pool)
-                            .await;
+                            let service = crate::services::agent_feed::service::AgentFeedService::new(pool.clone());
+                            let _ = service.process_event(&tenant_id, "sales", &context_payload).await;
                         },
-                        crate::db::DbStore::Sqlite(sqlite_pool) => {
+                        crate::db::DbStore::Sqlite(_) => {
+                             // AgentFeedService only supports Postgres pool currently, so we fallback for sqlite manually
+                             let ai_prompt = format!("Generate a friendly, context-aware re-engagement SMS message for a customer named {} who hasn't booked in a while. Suggest they book a new slot.", customer_name);
+                             let ai_prompt_reduced = crate::pricing::compression::reduce_tokens(&ai_prompt);
+                             let drafted_message = match std::env::var("OHC_LLM_PROVIDER").as_deref() {
+                                 Ok("gemini") => crate::minimax::LocalLLMClient::new().reason(&ai_prompt_reduced).await.unwrap_or_else(|_| "Hi! It's been a while, would you like to book a new session?".to_string()),
+                                 Ok("minimax") => {
+                                     let api_key = std::env::var("MINIMAX_API_KEY").unwrap_or_default();
+                                     crate::minimax::MinimaxClient::new(api_key).reason(&ai_prompt_reduced).await.unwrap_or_else(|_| "Hi! It's been a while, would you like to book a new session?".to_string())
+                                 }
+                                 _ => crate::minimax::LocalLLMClient::new().reason(&ai_prompt_reduced).await.unwrap_or_else(|_| "Hi! It's been a while, would you like to book a new session?".to_string()),
+                             };
+
+                             let proposed_action = json!({
+                                 "action_type": "send_message",
+                                 "draft_action": drafted_message,
+                                 "message": drafted_message
+                             });
+
                              let _ = sqlx::query(
-                                r#"
-                                INSERT INTO shared_tasks (id, organization_id, title, description, status, priority, action_risk, approval_status, proposed_content)
-                                VALUES (?, ?, 'Approve Re-engagement for ' || ?, 'AI detected that ' || ? || ' is a returning customer who hasn''t booked in 14 days. This follow-up helps maintain momentum.', 'PENDING', 'P1', 'LOW', 'PENDING', ?)
-                                "#
-                            )
-                            .bind(Uuid::new_v4().to_string())
-                            .bind(&tenant_id)
-                            .bind(&customer_name)
-                            .bind(&customer_name)
-                            .bind(&drafted_message)
-                            .execute(sqlite_pool)
-                            .await;
+                                 r#"
+                                 INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state, created_at, updated_at)
+                                 VALUES (?, ?, 'sales', ?, ?, 'PENDING_APPROVAL', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                                 "#
+                             )
+                             .bind(Uuid::new_v4().to_string())
+                             .bind(&tenant_id)
+                             .bind(sqlx::types::Json(context_payload))
+                             .bind(sqlx::types::Json(proposed_action))
+                             .execute(&db.pool)
+                             .await;
                         }
                     }
                 }

--- a/src/server/workers/daily_ops_routine_worker.rs
+++ b/src/server/workers/daily_ops_routine_worker.rs
@@ -51,6 +51,79 @@ impl DailyOpsRoutineWorker {
                         }
                     };
 
+                    // Find dormant customers and insert into ohc_job_queue
+                    let dormant_customers: Vec<String> = match &db.store {
+                        crate::db::DbStore::Postgres => {
+                            sqlx::query_scalar(
+                                r#"
+                                WITH customer_stats AS (
+                                    SELECT customer_id, COUNT(*) as total_bookings, MAX(start_time) as last_booking
+                                    FROM bookings
+                                    WHERE tenant_id = $1
+                                    GROUP BY customer_id
+                                )
+                                SELECT customer_id
+                                FROM customer_stats
+                                WHERE total_bookings > 1 AND last_booking < CURRENT_TIMESTAMP - INTERVAL '14 days'
+                                AND customer_id NOT IN (
+                                    SELECT payload->>'customer_id'
+                                    FROM ohc_job_queue
+                                    WHERE tenant_id = $1 AND job_type = 'booking_reengagement_check' AND status IN ('PENDING', 'PROCESSING', 'COMPLETED') AND created_at > CURRENT_TIMESTAMP - INTERVAL '14 days'
+                                )
+                                "#
+                            )
+                            .bind(&tenant_id)
+                            .fetch_all(&db.pool).await.unwrap_or_default()
+                        },
+                        crate::db::DbStore::Sqlite(_) => {
+                            sqlx::query_scalar(
+                                r#"
+                                WITH customer_stats AS (
+                                    SELECT customer_id, COUNT(*) as total_bookings, MAX(start_time) as last_booking
+                                    FROM bookings
+                                    WHERE tenant_id = $1
+                                    GROUP BY customer_id
+                                )
+                                SELECT customer_id
+                                FROM customer_stats
+                                WHERE total_bookings > 1 AND last_booking < datetime('now', '-14 days')
+                                AND customer_id NOT IN (
+                                    SELECT json_extract(payload, '$.customer_id')
+                                    FROM ohc_job_queue
+                                    WHERE tenant_id = $1 AND job_type = 'booking_reengagement_check' AND status IN ('PENDING', 'PROCESSING', 'COMPLETED') AND created_at > datetime('now', '-14 days')
+                                )
+                                "#
+                            )
+                            .bind(&tenant_id)
+                            .fetch_all(&db.pool).await.unwrap_or_default()
+                        }
+                    };
+
+                    for dormant_customer in dormant_customers {
+                        let payload = json!({"customer_id": dormant_customer});
+                        match &db.store {
+                            crate::db::DbStore::Postgres => {
+                                let _ = sqlx::query(
+                                    "INSERT INTO ohc_job_queue (id, tenant_id, job_type, payload, status, next_retry_at) VALUES ($1, $2, 'booking_reengagement_check', $3, 'PENDING', CURRENT_TIMESTAMP)"
+                                )
+                                .bind(Uuid::new_v4().to_string())
+                                .bind(&tenant_id)
+                                .bind(sqlx::types::Json(payload))
+                                .execute(&db.pool).await;
+                            },
+                            crate::db::DbStore::Sqlite(_) => {
+                                let payload_str = payload.to_string();
+                                let _ = sqlx::query(
+                                    "INSERT INTO ohc_job_queue (id, tenant_id, job_type, payload, status, next_retry_at) VALUES (?, ?, 'booking_reengagement_check', ?, 'PENDING', CURRENT_TIMESTAMP)"
+                                )
+                                .bind(Uuid::new_v4().to_string())
+                                .bind(&tenant_id)
+                                .bind(payload_str)
+                                .execute(&db.pool).await;
+                            }
+                        }
+                    }
+
                     if !has_pending {
                         let context_payload = json!({
                             "feature_type": "daily_prep_checklist",


### PR DESCRIPTION
Resolves #32275

**Persona**: Leo the Music Tutor

**Browser/Playwright Flow**:
1. Log into OHC and access the Dashboard (Command Center).
2. The daily background job automatically detects a dormant customer (Leo Customer) who hasn't booked in the last 14 days, despite having past bookings.
3. The background job delegates to the Re-engagement Agent, drafting an AI-powered personalized message in the background.
4. Leo visits the Unified Agent Feed and is presented with a card proposing to send the generated re-engagement message to the customer. He can review the message before approving.

**CUJ Gap Observed**: The system previously had a dormant `booking_reengagement.rs` worker that lacked a trigger, and when manually invoked, it pushed records to a legacy `shared_tasks` table instead of surfacing them in the new `agent_feed_items` Unified Agent Feed. This caused missed lead recovery options for service owners who rely on repeat business.

**Fix**:
1. Added a check inside `daily_ops_routine_worker.rs` to detect dormant customers and queue a `booking_reengagement_check` job per affected customer.
2. Updated `booking_reengagement.rs` to invoke the `AgentFeedService` (or fallback AI service for SQLite) to create an AI-powered context-aware re-engagement message and persist it to the `agent_feed_items` table.
3. Added an E2E test `booking_reengagement.spec.ts` that explicitly seeds a dormant user scenario and asserts the feed correctly displays the AI's proposal.

**UI Interaction Audit**:
- "Approve" button on Agent Feed action card correctly surfaces and is actionable for the drafted message. Tested automatically in `booking_reengagement.spec.ts`.

Superpowers verified for completeness and hermetic data flow constraints were upheld.

---
*PR created automatically by Jules for task [3342103264167497510](https://jules.google.com/task/3342103264167497510) started by @ql-owo-lp*