### PR TITLE
🗺️ Guide: [reduce keyboard friction in onboarding wizard]

### DIFF
--- a/src/e2e/onboarding_keyboard_friction.spec.ts
+++ b/src/e2e/onboarding_keyboard_friction.spec.ts
@@ -42,6 +42,7 @@ test.describe('Onboarding Keyboard Friction Mitigation', () => {
 
     // Step Categories
     await page.locator('#business-categories').selectOption('Handyman');
+    await page.locator('#business-categories').focus();
     // For select, we need to focus it or body to press Enter, let's just press Enter globally
     await page.keyboard.press('Enter');
     await expect(page.locator('#step-name')).toHaveClass(/active/);

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -3437,8 +3437,8 @@
 
       window.goToStep = goToStep;
 
-      // Enter key support for select inputs
-      document.querySelectorAll("select").forEach((input) => {
+      // Enter key support for inputs
+      document.querySelectorAll("select, input").forEach((input) => {
         input.addEventListener("keydown", (e) => {
           if (e.key === "Enter") {
             e.preventDefault();


### PR DESCRIPTION
This commit reduces keyboard friction during the onboarding wizard flow by extending `Enter` key support from just `<select>` elements to all `<input>` elements. This allows users to smoothly advance through the setup wizard using their keyboard. It also updates the related Playwright E2E tests to correctly simulate focus before pressing `Enter` on `<select>` elements.

---
*PR created automatically by Jules for task [5975394090465689649](https://jules.google.com/task/5975394090465689649) started by @ql-owo-lp*