### PR TITLE
fix(ui/next): resolve missing product telemetry state hook in settings page causing build failure

### DIFF
--- a/src/ui/next/src/app/settings/page.tsx
+++ b/src/ui/next/src/app/settings/page.tsx
@@ -37,6 +37,7 @@ export default function SettingsPage() {
   const [seoReports, setSeoReports] = useState<any[]>([]);
   const [hitRate, setHitRate] = useState<string>("");
   const [enableLazyToolLoading, setEnableLazyToolLoading] = useState(false);
+  const [productTelemetryEnabled, setProductTelemetryEnabled] = useState(false);
 
 
   useEffect(() => {
@@ -79,7 +80,7 @@ export default function SettingsPage() {
         .then(res => res.json())
         .then(data => {
           if (data && data.product_telemetry_enabled !== undefined) {
-            setEnableProductTelemetry(data.product_telemetry_enabled);
+            setProductTelemetryEnabled(data.product_telemetry_enabled);
           }
         })
         .catch(e => console.error("Failed to load telemetry settings", e)),
@@ -117,7 +118,7 @@ export default function SettingsPage() {
   };
 
   const handleTelemetryChange = async (checked: boolean) => {
-    setEnableProductTelemetry(checked);
+    setProductTelemetryEnabled(checked);
     try {
       await fetch("/api/settings/telemetry", {
         method: "POST",
@@ -569,7 +570,7 @@ export default function SettingsPage() {
               <input
                 type="checkbox"
                 aria-label="Enable Product Telemetry (Standalone Mode)"
-                checked={enableProductTelemetry}
+                checked={productTelemetryEnabled}
                 onChange={(e) => handleTelemetryChange(e.target.checked)}
                 className="rounded border-gray-300 text-[#0f766e] focus:ring-[#0f766e] w-5 h-5 cursor-pointer"
               />


### PR DESCRIPTION
This commit resolves a compilation failure occurring during `npm run build` in `src/ui/next` caused by an undeclared React state tuple. 

- Initialized `productTelemetryEnabled` and `setProductTelemetryEnabled` within `src/app/settings/page.tsx`.
- Renamed the undefined handlers in the code referencing product telemetry variables.
- Validated via successful build generation.

---
*PR created automatically by Jules for task [4165888164382058020](https://jules.google.com/task/4165888164382058020) started by @ql-owo-lp*