### PR TITLE
Fix Cost Transparency Dashboard title tag and E2E timeouts

### DIFF
--- a/src/e2e/cost_dashboard.spec.ts
+++ b/src/e2e/cost_dashboard.spec.ts
@@ -76,7 +76,7 @@ test.describe('Cost Dashboard "My Plan" functionality', () => {
 
     // Verify Cost Transparency Dashboard headers and text
     await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' }).first()).toBeVisible({ timeout: 15000 });
-    await expect(page.locator('h2', { hasText: 'Total Costs' }).first()).toBeVisible();
+    await expect(page.locator('h2', { hasText: 'Total Costs' }).first()).toBeVisible({ timeout: 15000 });
     await expect(page.locator('h2:has-text("Cost Breakdown")').first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'LLM Usage' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Storage' }).first()).toBeVisible();

--- a/src/e2e/miser_cost_features.spec.ts
+++ b/src/e2e/miser_cost_features.spec.ts
@@ -15,8 +15,8 @@ test.describe('Miser Cost Features E2E', () => {
     await expect(page.locator('text=Cost Transparency Dashboard')).toBeVisible();
 
     // Verify key metrics are rendered (we match the text labels)
-    await expect(page.locator('text=Total Costs')).toBeVisible();
-    await expect(page.locator('text=Projected Monthly Cost').first()).toBeVisible();
+    await expect(page.locator('text=Total Costs')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('text=Projected Monthly Cost').first()).toBeVisible({ timeout: 15000 });
 
     const backToMyPlanBtn = page.locator('button', { hasText: 'Back to My Plan' });
     await expect(backToMyPlanBtn).toBeVisible();

--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -273,7 +273,7 @@ export default function CostDashboardPage() {
             <div className="app-panel-header backdrop-blur-md bg-white/70 px-6 py-4">
                <div className="flex justify-between items-center">
                    <div>
-                       <h2 className="app-panel-title text-xl font-bold font-outfit text-gray-900 dark:text-white">Cost Transparency Dashboard</h2>
+                       <h1 className="app-panel-title text-xl font-bold font-outfit text-gray-900 dark:text-white">Cost Transparency Dashboard</h1>
                        <span id="cost-dashboard-period" className="text-sm text-gray-500 font-medium">Period: {data?.period_start} to {data?.period_end}</span>
                    </div>
                    <button id="download-invoice-btn" onClick={handleDownloadInvoice} className="px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-800 rounded-lg text-sm font-medium transition-colors">


### PR DESCRIPTION
This PR fixes an issue where the "Cost Transparency Dashboard" title was incorrectly rendered as an `h2` tag instead of an `h1` tag. It also increases the timeout for E2E tests related to "Total Costs" and "Projected Monthly Cost" metrics to prevent flaky test failures caused by rendering delays.

---
*PR created automatically by Jules for task [15942550000916553102](https://jules.google.com/task/15942550000916553102) started by @ql-owo-lp*