### PR TITLE
Fix pricing tier retrieval bug and update UI Free tier storage limit

### DIFF
--- a/src/server/pricing/rate_limit.rs
+++ b/src/server/pricing/rate_limit.rs
@@ -160,7 +160,7 @@ impl RedisRateLimiter {
         if tier.is_none()
             && let Some(pool) = &self.db_pool {
                 use sqlx::Row;
-                if let Ok(record) = sqlx::query("SELECT tier FROM tenants WHERE id = $1")
+                if let Ok(record) = sqlx::query("SELECT plan_tier as tier FROM tenants WHERE id = $1")
                     .bind(tenant_id)
                     .fetch_one(pool)
                     .await

--- a/src/ui/next/src/app/pricing/page.tsx
+++ b/src/ui/next/src/app/pricing/page.tsx
@@ -269,7 +269,7 @@ export default function PricingPage() {
               </div>
               <div>
                   <h3 className="font-semibold text-gray-800">What is the storage limit?</h3>
-                  <p className="text-gray-600 text-sm mt-1 leading-relaxed">Storage limits vary by plan, starting at 500MB for Free and up to 500GB for Business.</p>
+                  <p className="text-gray-600 text-sm mt-1 leading-relaxed">Storage limits vary by plan, starting at 2GB for Free and up to 500GB for Business.</p>
               </div>
             </div>
         </div>


### PR DESCRIPTION
- Fixed a bug where `rate_limit.rs` was querying `tier` instead of `plan_tier` from the `tenants` table.
- Corrected the storage limit for the Free plan on the UI pricing page from "500MB" to "2GB" to match actual limits defined in the backend.

---
*PR created automatically by Jules for task [4782909207299751236](https://jules.google.com/task/4782909207299751236) started by @ql-owo-lp*