### PR TITLE
fix: resolve viral widget embed formatting and mobile layout

### DIFF
--- a/src/e2e/tests/viral_widget.spec.ts
+++ b/src/e2e/tests/viral_widget.spec.ts
@@ -2,6 +2,9 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Viral Widget Builder E2E', () => {
   test('should allow interacting with widget builder and updating preview', async ({ page }) => {
+    // Set viewport size for mobile testing
+    await page.setViewportSize({ width: 375, height: 812 });
+
     // Navigate to the viral widget builder page
     await page.goto('/viral-powered-by-ohc-widget');
 
@@ -16,6 +19,12 @@ test.describe('Viral Widget Builder E2E', () => {
     // The iframe src should update to contain the URI encoded title.
     const iframe = page.locator('iframe').last();
     await expect(iframe).toHaveAttribute('src', /title=My%20Awesome%20Viral%20Tool/);
+
+    // Verify iframe layout responsive properties
+    const iframeBox = await iframe.boundingBox();
+    expect(iframeBox).toBeDefined();
+    // width shouldn't exceed the viewport size minus padding
+    expect(iframeBox!.width).toBeLessThanOrEqual(375);
 
     // 2. Test theme selection
     const themeSelect = page.getByRole('combobox');

--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -4203,7 +4203,12 @@ pub async fn handle_viral_widget_embed(
         <h2>{title}</h2>
         <p>This is a viral widget for {tenant}. Share it with your friends!</p>
         <button onclick="window.open('https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref={tenant}', '_blank')">Share Now</button>
-"#
+"#,
+        bg_color = bg_color,
+        border_color = border_color,
+        text_color = text_color,
+        title = title,
+        tenant = tenant
     );
 
     if show_branding {

--- a/src/ui/next/src/app/viral-powered-by-ohc-widget/page.tsx
+++ b/src/ui/next/src/app/viral-powered-by-ohc-widget/page.tsx
@@ -43,7 +43,7 @@ export default function ViralPoweredByOHCWidgetPage() {
 
   return (
     <div className="flex flex-col min-h-screen font-inter bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50 items-center justify-center py-10 px-4">
-      <div className="w-full max-w-4xl bg-white/80 backdrop-blur-xl rounded-[24px] shadow-sm border border-gray-100 flex flex-col md:flex-row gap-8">
+      <div className="w-full max-w-4xl bg-white/80 backdrop-blur-xl rounded-[24px] shadow-sm border border-gray-100 flex flex-col lg:flex-row gap-8">
         <div className="flex-1 p-8">
           <h1 className="text-3xl font-bold font-outfit text-gray-900 mb-6">Viral Widget Builder</h1>
           <div className="space-y-4">


### PR DESCRIPTION
This submission addresses an issue where the Viral Widget failed to resolve the correct `title` and `tenant` in its HTML markup generation in `src/server/api/growth.rs`. Additionally, it updates the `src/ui/next/src/app/viral-powered-by-ohc-widget/page.tsx` class layout to `lg:flex-row` to ensure a consistent, zero horizontal scroll experience at the 375px mobile viewport. Playwright e2e tests were supplemented to verify this bound restriction and both unit/e2e testing verify correct implementation.

---
*PR created automatically by Jules for task [16288432349546359335](https://jules.google.com/task/16288432349546359335) started by @ql-owo-lp*