### PR TITLE
💰 Miser: Fix prompt caching truncate_context heuristic

### DIFF
--- a/src/server/pricing/prompt_caching.rs
+++ b/src/server/pricing/prompt_caching.rs
@@ -247,7 +247,7 @@ impl PromptCache {
             // Keep at least some content if the last space is too early.
             // Using char_count / 2 to avoid slicing a UTF-8 character based on bytes.
             let space_char_count = slice[..last_space].chars().count();
-            if space_char_count > char_count / 2 {
+            if space_char_count > max_chars / 2 {
                 slice = &slice[..last_space];
             }
         }


### PR DESCRIPTION
The truncate_context function previously compared the space character count to the original string's `char_count / 2` instead of the `max_chars / 2` limit. This caused the "intelligent word boundary" fallback to fail on very large strings, truncating to nothing instead of the nearest valid space within the maximum token limit. This corrects the heuristic.

---
*PR created automatically by Jules for task [1093662225833481493](https://jules.google.com/task/1093662225833481493) started by @ql-owo-lp*