### PR TITLE
🧹 Cleaner: Hybrid Hygiene and Dead Code Cleanup

### DIFF
--- a/src/agents/builtin/json_store.rs
+++ b/src/agents/builtin/json_store.rs
@@ -64,19 +64,27 @@ impl NamespaceJsonStore {
         let content = serde_json::to_string_pretty(entries)
             .map_err(|e| format!("Failed to serialize JSON: {}", e))?;
 
-        let mut file = fs::File::create(&tmp_path)
-            .await
-            .map_err(|e| format!("Failed to create temp file: {}", e))?;
-        file.write_all(content.as_bytes())
-            .await
-            .map_err(|e| format!("Failed to write temp file: {}", e))?;
-        file.sync_all()
-            .await
-            .map_err(|e| format!("Failed to sync temp file: {}", e))?;
+        let mut file = match fs::File::create(&tmp_path).await {
+            Ok(f) => f,
+            Err(e) => return Err(format!("Failed to create temp file: {}", e)),
+        };
 
-        fs::rename(&tmp_path, &path)
-            .await
-            .map_err(|e| format!("Failed to commit file: {}", e))?;
+        if let Err(e) = file.write_all(content.as_bytes()).await {
+            drop(file);
+            let _ = fs::remove_file(&tmp_path).await;
+            return Err(format!("Failed to write temp file: {}", e));
+        }
+
+        if let Err(e) = file.sync_all().await {
+            drop(file);
+            let _ = fs::remove_file(&tmp_path).await;
+            return Err(format!("Failed to sync temp file: {}", e));
+        }
+
+        if let Err(e) = fs::rename(&tmp_path, &path).await {
+            let _ = fs::remove_file(&tmp_path).await;
+            return Err(format!("Failed to commit file: {}", e));
+        }
         Ok(())
     }
 }

--- a/src/agents/builtin/mesh/transport.rs
+++ b/src/agents/builtin/mesh/transport.rs
@@ -10,7 +10,9 @@ pub use crate::proto::hub::TeammateMeshEvent as Message;
 #[async_trait]
 pub trait MeshTransport: Send + Sync {
     /// Adds a known peer to this transport instance (used primarily for overlay/hybrid setups).
-    fn add_peer(&self, _peer: Peer) {}
+    fn add_peer(&self, _peer: Peer) {
+        // Default no-op for transports that do not require explicit peer management
+    }
 
     /// Publishes a TeammateMeshEvent to the specified topic/channel.
     async fn publish(&self, topic: &str, message: Message) -> Result<(), String>;

--- a/src/agents/builtin/observability.rs
+++ b/src/agents/builtin/observability.rs
@@ -173,10 +173,18 @@ mod tests {
         fn log_run_start(&self, _task: &str, _run_id: &str) {
             self.log.lock().unwrap().push("run_start".to_string());
         }
-        fn log_llm_request(&self, _run_id: &str, _req: &ChatRequest) {}
-        fn log_llm_response(&self, _run_id: &str, _resp: &ChatResponse) {}
-        fn log_tool_call(&self, _run_id: &str, _tool_call: &ToolCall) {}
-        fn log_tool_result(&self, _run_id: &str, _tool_id: &str, _result: &str) {}
+        fn log_llm_request(&self, _run_id: &str, _req: &ChatRequest) {
+            self.log.lock().unwrap().push("llm_request".to_string());
+        }
+        fn log_llm_response(&self, _run_id: &str, _resp: &ChatResponse) {
+            self.log.lock().unwrap().push("llm_response".to_string());
+        }
+        fn log_tool_call(&self, _run_id: &str, _tool_call: &ToolCall) {
+            self.log.lock().unwrap().push("tool_call".to_string());
+        }
+        fn log_tool_result(&self, _run_id: &str, _tool_id: &str, _result: &str) {
+            self.log.lock().unwrap().push("tool_result".to_string());
+        }
         fn log_run_end(&self, _run_id: &str, _final_output: &str) {
             self.log.lock().unwrap().push("run_end".to_string());
         }

--- a/src/server/orchestration/departments/orchestrator.rs
+++ b/src/server/orchestration/departments/orchestrator.rs
@@ -48,7 +48,9 @@ pub trait Department: Send + Sync {
     async fn query_memory(&self, query: &str) -> Result<Vec<String>, String>;
     async fn request_approval(&self, description: String, tenant_id: String, risk: ActionRisk) -> Result<ApprovalRequest, String>;
     fn get_config(&self, tenant_id: &str) -> Option<DepartmentConfig>;
-    fn set_config(&mut self, _tenant_id: String, _config: DepartmentConfig) {}
+    fn set_config(&mut self, _tenant_id: String, _config: DepartmentConfig) {
+        // Default no-op for departments that don't need config overrides
+    }
 }
 
 pub struct DummyDepartment {

--- a/src/server/utils/fs.rs
+++ b/src/server/utils/fs.rs
@@ -121,4 +121,26 @@ pub fn cleanup_stale_temp_files() {
             }
         }
     }
+
+    // Clean up .tmp files created by agents/builtin/json_store.rs
+    let ohc_runtime_dir = std::env::var("OHC_RUNTIME_DIR").unwrap_or_else(|_| ".ohc/runtime".to_string());
+    let memory_dir = std::path::PathBuf::from(ohc_runtime_dir).join("memory");
+    if let Ok(entries) = std::fs::read_dir(&memory_dir) {
+        let now = std::time::SystemTime::now();
+        for entry in entries.flatten() {
+            if let Some(ext) = entry.path().extension() {
+                if ext == "tmp" {
+                    if let Ok(meta) = entry.metadata() {
+                        if let Ok(modified) = meta.modified() {
+                            if let Ok(duration) = now.duration_since(modified) {
+                                if duration.as_secs() > 3600 {
+                                    let _ = std::fs::remove_file(entry.path());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/ui/next/src/app/api/agents/approvals/[id]/approve/route.ts
+++ b/src/ui/next/src/app/api/agents/approvals/[id]/approve/route.ts
@@ -25,7 +25,6 @@ export async function POST(request: Request, context: { params: Promise<{ id: st
       if (action_type === 'Draft Booking' || (payload && payload.action_type === 'Draft Booking')) {
         const tenantId = '00000000-0000-0000-0000-000000000001';
         // In reality, this would hit the gRPC BookingService or a worker would process it
-        console.log("Processing Draft Booking approval for:", payload.suggested_time);
       }
     }
 


### PR DESCRIPTION
🧹 Cleaner: Hybrid Hygiene and Dead Code Cleanup

- Fixed unbounded temporary file leakage in `src/agents/builtin/json_store.rs` by dropping the file handle and explicitly deleting the file if writing or syncing fails.
- Expanded `cleanup_stale_temp_files` in `src/server/utils/fs.rs` to sweep `.tmp` files in the agent `memory` directory.
- Replaced empty function definitions in `MockObservabilityProvider` with actual logging mock behavior.
- Documented intentional no-op implementations in `MeshTransport::add_peer` and `Department::set_config`.
- Removed a `console.log` in `src/ui/next/src/app/api/agents/approvals/[id]/approve/route.ts` to ensure multi-tenant safety by preventing payload leakage.

---
*PR created automatically by Jules for task [6800864026999993889](https://jules.google.com/task/6800864026999993889) started by @ql-owo-lp*