### PR TITLE
feat(growth): implement viral loop metrics endpoints

### DIFF
--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -380,6 +380,7 @@ where
         .route("/viral-goal-tracker", get(handle_viral_goal_tracker))
         .route("/quiz/generate", post(handle_generate_viral_quiz))
         .route("/referrals/generate", post(handle_referral_generate))
+        .route("/viral-loop/metrics", get(handle_viral_loop_metrics))
         .route("/onboarding-metrics", get(handle_onboarding_metrics))
         .route("/discount_share/generate", post(handle_generate_discount_share))
         .route("/seasonal-promo/generate", post(handle_promo_generate))
@@ -2911,6 +2912,15 @@ async fn handle_create_team_invite(
     }
 }
 
+async fn handle_viral_loop_metrics(
+    Extension(state): Extension<GrowthState>,
+) -> impl IntoResponse {
+    let (invites_sent, invites_accepted) = state.viral_loop_tracker.get_metrics();
+    Json(serde_json::json!({
+        "invites_sent": invites_sent,
+        "invites_accepted": invites_accepted
+    }))
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/server/services/growth/viral_loop.rs
+++ b/src/server/services/growth/viral_loop.rs
@@ -35,6 +35,13 @@ impl ViralLoopTracker {
         self.invites_accepted_metric.add(1, &[]);
     }
 
+    pub fn get_metrics(&self) -> (i32, i32) {
+        (
+            *self.invites_sent.read().unwrap(),
+            *self.invites_accepted.read().unwrap()
+        )
+    }
+
     pub fn calculate_k_factor(&self) -> f64 {
         let sent = self.invites_sent.read().unwrap();
         let accepted = self.invites_accepted.read().unwrap();

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1442,6 +1442,13 @@
             document.getElementById('viral-loop-active-referrals').innerText = data.metrics?.active_referrals || '0';
             document.getElementById('viral-loop-revenue').innerText = '$' + (data.metrics?.revenue || 0).toFixed(2);
             document.getElementById('viral-loop-pending-rewards').innerText = '$' + (data.metrics?.pending_rewards || 0).toFixed(2);
+
+            // Also fetch the real-time tracker counts
+            const vtRes = await fetch('/api/v1/growth/viral-loop/metrics', { headers: { 'Authorization': token ? `Bearer ${token}` : '' } });
+            if (vtRes.ok) {
+              const vtData = await vtRes.json();
+              document.getElementById('viral-loop-invites-sent').innerText = (data.total_invites || 0) + (vtData.invites_sent || 0);
+            }
           }
         } catch (e) {
           console.error("Failed to fetch viral loop metrics", e);
@@ -2814,6 +2821,7 @@ document.addEventListener('DOMContentLoaded', () => {
               btn.style.display = 'none';
               container.style.display = 'block';
             }
+            setTimeout(() => { fetchViralLoopMetrics(); }, 500);
         });
 
         copyBtn.addEventListener('click', () => {


### PR DESCRIPTION
Added real-time metrics extraction for the Viral Loop.

This change directly ties the OHC growth model to the frontend, allowing for the dashboard to accurately aggregate realtime numbers on the `Invites Sent` and active loops correctly.

Tested against unit tests locally and playwright UI suite.

---
*PR created automatically by Jules for task [12840499271997032843](https://jules.google.com/task/12840499271997032843) started by @ql-owo-lp*