### PR TITLE
💰 Miser: Update Free tier storage quota to 500MB

### DIFF
--- a/src/server/pricing/rate_limit.rs
+++ b/src/server/pricing/rate_limit.rs
@@ -74,7 +74,7 @@ impl PlanTier {
             }
 
         match self {
-            PlanTier::Free => Some(2048), // 2GB
+            PlanTier::Free => Some(500), // 500MB
             PlanTier::Starter => Some(5120), // 5GB
             PlanTier::Pro => Some(51200),    // 50GB
             PlanTier::Business => Some(512000),      // 500GB
@@ -490,7 +490,7 @@ mod tests {
         assert_eq!(PlanTier::Free.agent_action_limit(), Some(20));
         assert_eq!(PlanTier::Starter.agent_action_limit(), Some(200));
 
-        assert_eq!(PlanTier::Free.storage_limit_mb(), Some(2048));
+        assert_eq!(PlanTier::Free.storage_limit_mb(), Some(500));
         assert_eq!(PlanTier::Starter.storage_limit_mb(), Some(5120));
         assert_eq!(PlanTier::Pro.storage_limit_mb(), Some(51200));
         assert_eq!(PlanTier::Business.storage_limit_mb(), Some(512000));

--- a/src/ui/next/src/app/pricing/page.tsx
+++ b/src/ui/next/src/app/pricing/page.tsx
@@ -149,7 +149,7 @@ export default function PricingPage() {
               <ul className="text-sm text-gray-700 space-y-3 mb-6">
                 <li className="flex items-center gap-2"><span>✓</span> 1 Agent Limit</li>
                 <li className="flex items-center gap-2"><span>✓</span> 100 AI actions / month</li>
-                <li className="flex items-center gap-2"><span>✓</span> 2GB Storage Quota</li>
+                <li className="flex items-center gap-2"><span>✓</span> 500MB Storage Quota</li>
                 <li className="flex items-center gap-2"><span>✓</span> 10 Products Limit</li>
               </ul>
             </div>
@@ -269,7 +269,7 @@ export default function PricingPage() {
               </div>
               <div>
                   <h3 className="font-semibold text-gray-800">What is the storage limit?</h3>
-                  <p className="text-gray-600 text-sm mt-1 leading-relaxed">Storage limits vary by plan, starting at 2GB for Free and up to 500GB for Business.</p>
+                  <p className="text-gray-600 text-sm mt-1 leading-relaxed">Storage limits vary by plan, starting at 500MB for Free and up to 500GB for Business.</p>
               </div>
             </div>
         </div>


### PR DESCRIPTION
This change updates the storage limit for the Free tier to 500MB, aligning the backend enforcement, UI display, and E2E test expectations.

---
*PR created automatically by Jules for task [9428349793129531800](https://jules.google.com/task/9428349793129531800) started by @ql-owo-lp*