### PR TITLE
💰 Miser: update dashboard to correctly query cents metrics

### DIFF
--- a/deploy/docker/grafana/provisioning/dashboards/tenant-cost.json
+++ b/deploy/docker/grafana/provisioning/dashboards/tenant-cost.json
@@ -43,7 +43,7 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "ohc_llm_cost_total",
+          "expr": "ohc_llm_cost_total_cents",
           "legendFormat": "LLM Cost - {{organization_id}}",
           "range": true,
           "refId": "A"
@@ -71,7 +71,7 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "ohc_storage_savings_total",
+          "expr": "ohc_storage_savings_total_cents",
           "legendFormat": "Storage Savings - {{organization_id}}",
           "range": true,
           "refId": "A"

--- a/deploy/grafana/dashboards/tenant-cost.json
+++ b/deploy/grafana/dashboards/tenant-cost.json
@@ -43,7 +43,7 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "ohc_llm_cost_total",
+          "expr": "ohc_llm_cost_total_cents",
           "legendFormat": "LLM Cost - {{organization_id}}",
           "range": true,
           "refId": "A"
@@ -71,7 +71,7 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "ohc_storage_savings_total",
+          "expr": "ohc_storage_savings_total_cents",
           "legendFormat": "Storage Savings - {{organization_id}}",
           "range": true,
           "refId": "A"

--- a/deploy/helm/ohc/dashboards/tenant-cost.json
+++ b/deploy/helm/ohc/dashboards/tenant-cost.json
@@ -43,7 +43,7 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "ohc_llm_cost_total",
+          "expr": "ohc_llm_cost_total_cents",
           "legendFormat": "LLM Cost - {{organization_id}}",
           "range": true,
           "refId": "A"
@@ -71,7 +71,7 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "ohc_storage_savings_total",
+          "expr": "ohc_storage_savings_total_cents",
           "legendFormat": "Storage Savings - {{organization_id}}",
           "range": true,
           "refId": "A"

--- a/src/server/monitoring/dashboards/tenant-cost.json
+++ b/src/server/monitoring/dashboards/tenant-cost.json
@@ -43,7 +43,7 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "ohc_llm_cost_total",
+          "expr": "ohc_llm_cost_total_cents",
           "legendFormat": "LLM Cost - {{organization_id}}",
           "range": true,
           "refId": "A"
@@ -71,7 +71,7 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "ohc_storage_savings_total",
+          "expr": "ohc_storage_savings_total_cents",
           "legendFormat": "Storage Savings - {{organization_id}}",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
Fixes observability bug where telemetry dashboards were tracking an out-of-date metric name without the `_cents` suffix, leading to broken data after the backend telemetry started writing cost values in cents.

---
*PR created automatically by Jules for task [6401412740671477195](https://jules.google.com/task/6401412740671477195) started by @ql-owo-lp*