### PR TITLE
feat(growth): implement viral job board generator

### DIFF
--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -379,6 +379,7 @@ where
         .route("/one-tap-referral/embed", get(handle_one_tap_referral_embed))
         .route("/viral-goal-tracker", get(handle_viral_goal_tracker))
         .route("/quiz/generate", post(handle_generate_viral_quiz))
+        .route("/job-board/generate", post(handle_job_board_generate))
         .route("/referrals/generate", post(handle_referral_generate))
         .route("/onboarding-metrics", get(handle_onboarding_metrics))
         .route("/discount_share/generate", post(handle_generate_discount_share))
@@ -700,6 +701,36 @@ pub struct InviteIdRequest {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ReferralGenerateResponse {
     pub referral_link: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct JobBoardGenerateRequest {
+    pub title: String,
+    pub description: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JobBoardGenerateResponse {
+    pub job_board_link: String,
+}
+
+async fn handle_job_board_generate(
+    Extension(state): Extension<GrowthState>,
+    axum::extract::Extension(auth_info): axum::extract::Extension<::server_auth::orchestration::AuthInfo>,
+    Json(req): Json<JobBoardGenerateRequest>,
+) -> Result<Json<JobBoardGenerateResponse>, StatusCode> {
+    let board_id = uuid::Uuid::new_v4().to_string();
+    let msg = state.hub.sanitize_hub_event(serde_json::json!({
+        "type": "growth.job_board_generated",
+        "tenant_id": auth_info.org_id,
+        "board_id": board_id,
+        "title": req.title
+    }));
+    state.hub.append_recent_event(msg);
+
+    Ok(Json(JobBoardGenerateResponse {
+        job_board_link: format!("https://ohc.app/jobs/{}", board_id),
+    }))
 }
 
 

--- a/src/ui/tauri/src/ui/viral-job-board-generator.html
+++ b/src/ui/tauri/src/ui/viral-job-board-generator.html
@@ -298,21 +298,46 @@
       try {
         const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'e2e-tenant';
 
-        let baseUrl = window.location.origin;
-        if (baseUrl === 'file://' || baseUrl.includes('localhost') || baseUrl === 'null') {
-          baseUrl = 'https://app.onehumancorp.com';
+        let apiUrl = '/api/v1/growth/job-board/generate';
+        if (window.__TAURI__ && window.__TAURI__.core) {
+            apiUrl = 'http://127.0.0.1:18789/api/v1/growth/job-board/generate';
         }
 
-        const embedUrl = `${baseUrl}/ui/job-board-embed.html?tenant=${tenantId}&company=${encodeURIComponent(companyName)}&hideBranding=${hideBranding}`;
+        const res = await fetch(apiUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-spiffe-id': 'spiffe://onehumancorp.io/' + tenantId + '/agent1'
+            },
+            body: JSON.stringify({
+                title: companyName,
+                description: 'Viral Job Board widget'
+            })
+        });
 
-        let embedCode = `<iframe src="${embedUrl}" width="100%" height="400" frameborder="0" style="border-radius: 12px; border: 1px solid #eaeaea; background: transparent;"></iframe>`;
+        if (res.ok) {
+            const data = await res.json();
+            const jobBoardLink = data.job_board_link;
 
-        if (!hideBranding) {
-            embedCode += `\n<div style="text-align: center; font-size: 12px; margin-top: 8px;"><a href="${baseUrl}/setup.html?ref=${tenantId}" target="_blank" style="color: #888; text-decoration: none;">⚡ Powered by OHC</a></div>`;
+            let baseUrl = window.location.origin;
+            if (baseUrl === 'file://' || baseUrl.includes('localhost') || baseUrl === 'null') {
+              baseUrl = 'https://app.onehumancorp.com';
+            }
+
+            const embedUrl = `${baseUrl}/ui/job-board-embed.html?tenant=${tenantId}&company=${encodeURIComponent(companyName)}&hideBranding=${hideBranding}&board_url=${encodeURIComponent(jobBoardLink)}`;
+
+            let embedCode = `<iframe src="${embedUrl}" width="100%" height="400" frameborder="0" style="border-radius: 12px; border: 1px solid #eaeaea; background: transparent;"></iframe>`;
+
+            if (!hideBranding) {
+                embedCode += `\n<div style="text-align: center; font-size: 12px; margin-top: 8px;"><a href="${baseUrl}/setup.html?ref=${tenantId}" target="_blank" style="color: #888; text-decoration: none;">⚡ Powered by OHC</a></div>`;
+            }
+
+            document.getElementById('embed-code').value = embedCode;
+            document.getElementById('result-area').style.display = 'block';
+        } else {
+            console.error('Failed to generate job board');
+            alert('Failed to generate. Please try again.');
         }
-
-        document.getElementById('embed-code').value = embedCode;
-        document.getElementById('result-area').style.display = 'block';
 
       } catch (err) {
         console.error("Error generating job board:", err);


### PR DESCRIPTION
This PR adds the actual backend implementation for the Viral Job Board generator growth feature.

### Changes:
- **Backend:** `src/server/api/growth.rs` - Added `handle_job_board_generate` for `POST /api/v1/growth/job-board/generate` route.
- **Frontend:** `src/ui/tauri/src/ui/viral-job-board-generator.html` - Integrated actual fetch logic with `apiUrl` fallback for Tauri to POST to backend and render correct response iframe format.

### Verification
Ran frontend verification locally with playwright screenshot and successfully passed all backend/e2e bazelisk tests (`//src/server/api/...` and `//src/e2e/...`).

---
*PR created automatically by Jules for task [14712313423974329141](https://jules.google.com/task/14712313423974329141) started by @ql-owo-lp*