### PR TITLE
fix(integrations): fetch tool integrations from backend API instead of using mock data

### DIFF
--- a/src/server/api/tool_integrations.rs
+++ b/src/server/api/tool_integrations.rs
@@ -1,7 +1,7 @@
 use axum::{
     extract::{State, Path},
     response::IntoResponse,
-    routing::post,
+    routing::{get, post},
     Json, Router,
 };
 use std::sync::Arc;
@@ -127,9 +127,58 @@ pub async fn connect_integration_handler(
     }).into_response()
 }
 
+#[derive(Serialize)]
+pub struct IntegrationInfo {
+    pub id: String,
+    pub status: String,
+}
+
+#[derive(Serialize)]
+pub struct GetIntegrationsResponse {
+    pub success: bool,
+    pub integrations: Vec<IntegrationInfo>,
+    pub message: Option<String>,
+}
+
+pub async fn get_integrations_handler(
+    State(state): State<ToolIntegrationsApiState>,
+    axum::extract::Extension(user): axum::extract::Extension<::server_common::Claims>,
+) -> impl IntoResponse {
+    let tenant_id = user.organization_id.unwrap_or_else(|| "default".to_string());
+
+    let query = match &state.db.store {
+        crate::db::DbStore::Postgres => "SELECT id, status FROM tool_integrations WHERE tenant_id = $1",
+        crate::db::DbStore::Sqlite(_) => "SELECT id, status FROM tool_integrations WHERE tenant_id = ?",
+    };
+
+    let rows = match sqlx::query_as::<_, (String, String)>(query)
+        .bind(&tenant_id)
+        .fetch_all(&state.db.pool)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, Json(GetIntegrationsResponse {
+                success: false,
+                integrations: vec![],
+                message: Some(format!("Database error: {}", e)),
+            })).into_response();
+        }
+    };
+
+    let integrations = rows.into_iter().map(|(id, status)| IntegrationInfo { id, status }).collect();
+
+    Json(GetIntegrationsResponse {
+        success: true,
+        integrations,
+        message: None,
+    }).into_response()
+}
+
 pub fn router<S: Clone + Send + Sync + 'static>(db: Arc<DB>) -> Router<S> {
     let state = ToolIntegrationsApiState { db };
     Router::new()
+        .route("/", get(get_integrations_handler))
         .route("/{id}/connect", post(connect_integration_handler))
         .with_state(state)
 }

--- a/src/ui/next/src/app/integrations/page.test.tsx
+++ b/src/ui/next/src/app/integrations/page.test.tsx
@@ -30,15 +30,37 @@ describe("Integrations", () => {
       configurable: true,
       value: { assign },
     });
-    (global.fetch as any).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        authorization_url: "https://oauth.example/shippo",
-      }),
+    (global.fetch as any).mockImplementation((url: string) => {
+        if (url === '/api/integrations') {
+            return Promise.resolve({
+                ok: true,
+                json: async () => ({
+                    success: true,
+                    integrations: []
+                })
+            });
+        }
+        if (url === '/api/integrations/shippo/connect') {
+            return Promise.resolve({
+                ok: true,
+                json: async () => ({
+                    authorization_url: "https://oauth.example/shippo",
+                })
+            });
+        }
+        return Promise.resolve({ ok: false });
     });
 
     render(<Integrations />);
-    fireEvent.click(screen.getAllByRole("button", { name: "Connect" })[4]);
+
+    // Wait for initial load fetch to complete
+    await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith("/api/integrations");
+    });
+
+    const connectButtons = screen.getAllByRole("button", { name: "Connect" });
+    // Ayrshare is index 0, Cal is index 1, MailerLite is index 2, Mercado is 3, Shippo is 4
+    fireEvent.click(connectButtons[4]);
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith("/api/integrations/shippo/connect", {

--- a/src/ui/next/src/app/integrations/page.tsx
+++ b/src/ui/next/src/app/integrations/page.tsx
@@ -1,30 +1,56 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { AppShell } from "../components/AppShell";
+
+const INTEGRATION_TEMPLATE = [
+  { id: "ayrshare", name: "Ayrshare", category: "marketing", status: "disconnected", icon: "📱", description: "Single API for posting and retrieving messages across social networks." },
+  { id: "cal_com", name: "Cal.com", category: "operations", status: "disconnected", icon: "📅", description: "Zero-Config Booking & Calendar Sync." },
+  { id: "mailerlite", name: "MailerLite", category: "marketing", status: "disconnected", icon: "📨", description: "Embedded, No-Jargon Email Campaigns." },
+  { id: "mercadopago", name: "Mercado Pago", category: "finance", status: "disconnected", icon: "🌎", description: "Accept credit cards and local payment methods in Latin America." },
+  { id: "shippo", name: "Shippo", category: "operations", status: "disconnected", icon: "📦", description: "Painless Shipping Labels & Tracking." },
+  { id: "taxjar", name: "TaxJar", category: "finance", status: "disconnected", icon: "🏛️", description: "Automatically calculate and track sales tax for your orders." },
+  { id: "twilio", name: "Twilio Conversations", category: "operations", status: "disconnected", icon: "🔔", description: "Central omnichannel inbox via Twilio Conversations API for SMS, WhatsApp, and chat." },
+  { id: "whereby", name: "Whereby", category: "operations", status: "disconnected", icon: "📹", description: "Zero-Setup Online Lessons and video conferencing." },
+  { id: "resend", name: "Resend", category: "marketing", status: "disconnected", icon: "📧", description: "Transactional and Marketing Emails." },
+  { id: "whatsapp_cloud_api", name: "WhatsApp Cloud API", category: "social", status: "disconnected", icon: "💬", description: "Direct WhatsApp Cloud API connection for messages." },
+  { id: "whatsapp", name: "Twilio for WhatsApp", category: "social", status: "disconnected", icon: "💬", description: "Central WhatsApp Inbox for Work Triage and Customer Assistant powered by Twilio." },
+  { id: "meta", name: "Meta Graph API", category: "social", status: "disconnected", icon: "💬", description: "Central Instagram and Facebook Inbox." },
+  { id: "front", name: "Front", category: "operations", status: "disconnected", icon: "📥", description: "Central omnichannel inbox aggregating messages across all channels." },
+  { id: "zoom", name: "Zoom", category: "operations", status: "disconnected", icon: "📹", description: "Automated Online Lesson Links." }
+];
 
 export default function Integrations() {
   const [activeTab, setActiveTab] = useState("all");
   const router = useRouter();
   const [statusMessage, setStatusMessage] = useState("");
 
-  const [integrations, setIntegrations] = useState([
-    { id: "ayrshare", name: "Ayrshare", category: "marketing", status: "disconnected", icon: "📱", description: "Single API for posting and retrieving messages across social networks." },
-    { id: "cal_com", name: "Cal.com", category: "operations", status: "disconnected", icon: "📅", description: "Zero-Config Booking & Calendar Sync." },
-    { id: "mailerlite", name: "MailerLite", category: "marketing", status: "disconnected", icon: "📨", description: "Embedded, No-Jargon Email Campaigns." },
-    { id: "mercadopago", name: "Mercado Pago", category: "finance", status: "disconnected", icon: "🌎", description: "Accept credit cards and local payment methods in Latin America." },
-    { id: "shippo", name: "Shippo", category: "operations", status: "disconnected", icon: "📦", description: "Painless Shipping Labels & Tracking." },
-    { id: "taxjar", name: "TaxJar", category: "finance", status: "disconnected", icon: "🏛️", description: "Automatically calculate and track sales tax for your orders." },
-    { id: "twilio", name: "Twilio Conversations", category: "operations", status: "disconnected", icon: "🔔", description: "Central omnichannel inbox via Twilio Conversations API for SMS, WhatsApp, and chat." },
-    { id: "whereby", name: "Whereby", category: "operations", status: "disconnected", icon: "📹", description: "Zero-Setup Online Lessons and video conferencing." },
-    { id: "resend", name: "Resend", category: "marketing", status: "disconnected", icon: "📧", description: "Transactional and Marketing Emails." },
-    { id: "whatsapp_cloud_api", name: "WhatsApp Cloud API", category: "social", status: "disconnected", icon: "💬", description: "Direct WhatsApp Cloud API connection for messages." },
-    { id: "whatsapp", name: "Twilio for WhatsApp", category: "social", status: "disconnected", icon: "💬", description: "Central WhatsApp Inbox for Work Triage and Customer Assistant powered by Twilio." },
-    { id: "meta", name: "Meta Graph API", category: "social", status: "disconnected", icon: "💬", description: "Central Instagram and Facebook Inbox." },
-    { id: "front", name: "Front", category: "operations", status: "disconnected", icon: "📥", description: "Central omnichannel inbox aggregating messages across all channels." },
-    { id: "zoom", name: "Zoom", category: "operations", status: "disconnected", icon: "📹", description: "Automated Online Lesson Links." }
-  ]);
+  const [integrations, setIntegrations] = useState(INTEGRATION_TEMPLATE);
+  useEffect(() => {
+    async function loadIntegrations() {
+      try {
+        const res = await fetch("/api/integrations");
+        if (res.ok) {
+          const data = await res.json();
+          if (data && data.success && Array.isArray(data.integrations)) {
+            const connectedIds = data.integrations
+              .filter((i: any) => i.status === "connected")
+              .map((i: any) => i.id);
+
+            setIntegrations(prev => prev.map(integration =>
+              connectedIds.includes(integration.id)
+                ? { ...integration, status: "connected" }
+                : integration
+            ));
+          }
+        }
+      } catch (e) {
+        console.error("Failed to load integrations", e);
+      }
+    }
+    loadIntegrations();
+  }, []);
 
   const filteredIntegrations = activeTab === "all" ? integrations : integrations.filter(i => i.category === activeTab);
 


### PR DESCRIPTION
Replaces the hardcoded mock data array for tool integrations in the UI with an API call to a newly added `GET /api/integrations` endpoint. This endpoint dynamically fetches the current tenant's connected integrations from the `tool_integrations` table in the database and updates the UI accordingly. Ensures real data truth and removes UI mock-driven workflows.

---
*PR created automatically by Jules for task [5725409465112818847](https://jules.google.com/task/5725409465112818847) started by @ql-owo-lp*