### PR TITLE
⚡ Bolt: [mobile payload optimization]

### DIFF
--- a/src/server/api/agent_feed.rs
+++ b/src/server/api/agent_feed.rs
@@ -21,7 +21,9 @@ use redis::AsyncCommands;
 pub struct MobileAgentFeedItem {
     pub id: String,
     pub event_source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub context_payload: Option<sqlx::types::Json<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub proposed_action: Option<sqlx::types::Json<serde_json::Value>>,
     pub lifecycle_state: String,
     pub created_at: Option<DateTime<Utc>>,

--- a/src/server/api/unified_inbox_webhook.rs
+++ b/src/server/api/unified_inbox_webhook.rs
@@ -61,6 +61,7 @@ pub struct UnifiedTriageAction {
     pub tenant_id: String,
     pub thread_id: String,
     pub action_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub action_payload: Option<String>,
     pub status: String,
     pub created_at: String,
@@ -506,6 +507,7 @@ async fn fetch_unified_feed_items(state: &AppState, tenant_id: &str, mobile_opti
                 }
                 for action in &mut triage_actions {
                     action.tenant_id = String::new();
+                    action.action_payload = None;
                 }
             }
 


### PR DESCRIPTION
Loaded superpowers: none.

This commit shrinks the size of API payloads intended for mobile clients (when `mobile_optimized = true`) by marking unused `Option<T>` fields with `#[serde(skip_serializing_if = "Option::is_none")]` and setting large JSON blobs to `None` so they are stripped out entirely rather than serialized as `null`.

**Product-use evidence:**
A real operator using the platform on mobile over a cellular connection needs lightweight responses to ensure sub-second UI responsiveness. Stripping out the `action_payload` and `context_payload` blocks allows the agent feed lists to load significantly faster since the payload consists entirely of metadata/IDs and not full JSON blobs intended for deep desktop workflows.

---
*PR created automatically by Jules for task [16668035296770307385](https://jules.google.com/task/16668035296770307385) started by @ql-owo-lp*