### PR TITLE
🚀 Nova: Implement Powered by OHC branding loop on storefront

### DIFF
--- a/src/e2e/playwright/storefront_branding_loop.spec.ts
+++ b/src/e2e/playwright/storefront_branding_loop.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '../fixtures';
+
+test.describe('Storefront Branding Loop E2E', () => {
+  test('verify storefront footer viral link contains correct referral', async ({ page }) => {
+    // Navigate and login
+    await page.goto('/login');
+    await page.getByPlaceholder('Email').fill('test@example.com');
+    await page.getByPlaceholder('Password').fill('password123');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+
+    // Wait for auth to complete and land on dashboard
+    await page.waitForURL('**/dashboard**');
+    await page.waitForLoadState('networkidle');
+
+    // Go to storefront preview page
+    await page.goto('/storefront.html');
+    await page.waitForLoadState('networkidle');
+
+    // Check if the viral footer link exists
+    const footerLink = page.getByTestId('storefront-footer-viral-link');
+    await expect(footerLink).toBeVisible({ timeout: 15000 });
+
+    // Check if the text matches
+    await expect(footerLink).toContainText('⚡ Powered by OHC');
+
+    // Check if it has the correct referral URL using the seeded tenant 'e2e-tenant'
+    const href = await footerLink.getAttribute('href');
+    expect(href).toContain('ref=e2e-tenant');
+    expect(href).toContain('source=storefront_footer');
+  });
+});

--- a/src/ui/tauri/src/ui/storefront.html
+++ b/src/ui/tauri/src/ui/storefront.html
@@ -116,12 +116,23 @@
             <div class="loading" id="loading-state">Loading your catalog...</div>
             <iframe id="storefront-iframe" style="display: none;" title="Live Storefront Preview"></iframe>
         </div>
+
+        <footer style="margin-top: 24px; text-align: center; padding: 16px; font-size: 14px; font-weight: 600; background: rgba(255, 255, 255, 0.4); border-radius: 12px; width: 100%; box-sizing: border-box;">
+            <a href="/setup.html" id="storefront-footer-viral-link" data-testid="storefront-footer-viral-link" style="color: #6b7280; text-decoration: none; display: flex; align-items: center; justify-content: center; gap: 8px;">
+                <span style="background: #0066FF; color: white; padding: 4px 8px; border-radius: 8px; font-size: 10px; font-weight: 800;">OHC</span>
+                ⚡ Powered by OHC
+            </a>
+        </footer>
     </div>
 
     <script>
         document.addEventListener('DOMContentLoaded', async () => {
             const tenantId = localStorage.getItem('tenant_id') || 'default';
             const copyBtn = document.getElementById('copy-link-btn');
+            const footerLink = document.getElementById('storefront-footer-viral-link');
+            if (footerLink) {
+                footerLink.href = `/setup.html?ref=${encodeURIComponent(tenantId)}&source=storefront_footer`;
+            }
             const iframe = document.getElementById('storefront-iframe');
             const loading = document.getElementById('loading-state');
 


### PR DESCRIPTION
Implement "Powered by OHC" footer branding loop on storefront

Added a "Powered by OHC" branding widget on the owner's storefront preview
which acts as a viral growth loop. The widget passes the tenant's ID
into the onboarding URL, correctly establishing the organic referral channel.

Also included an end-to-end test.

---
*PR created automatically by Jules for task [1923006304950081007](https://jules.google.com/task/1923006304950081007) started by @ql-owo-lp*