### PR TITLE
fix(growth): safely handle tenant_id fallback for referral click tracking

### DIFF
--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -2665,11 +2665,21 @@ async fn handle_referral_click_post(
     Extension(state): Extension<GrowthState>,
     Json(req): axum::extract::Json<ReferralIdRequest>,
 ) -> Result<axum::response::Response, StatusCode> {
-    match sqlx::query("UPDATE referrals SET clicks = clicks + 1 WHERE id = $1")
+    let mut res = sqlx::query("UPDATE referrals SET clicks = clicks + 1 WHERE id = $1")
         .bind(&req.id)
         .execute(&state.pool)
-        .await
-    {
+        .await;
+
+    if let Ok(result) = &res {
+        if result.rows_affected() == 0 {
+            res = sqlx::query("UPDATE referrals SET clicks = clicks + 1 WHERE id IN (SELECT id FROM referrals WHERE tenant_id = $1 ORDER BY created_at_unix ASC LIMIT 1)")
+                .bind(&req.id)
+                .execute(&state.pool)
+                .await;
+        }
+    }
+
+    match res {
         Ok(result) => {
             if result.rows_affected() == 0 {
                 return Err(StatusCode::NOT_FOUND);
@@ -2702,10 +2712,20 @@ async fn handle_referral_click_get(
     state.hub.append_recent_event(msg);
 
     // Record click if it maps to an actual referral code
-    let _ = sqlx::query("UPDATE referrals SET clicks = clicks + 1 WHERE referral_code = $1")
+    let mut res = sqlx::query("UPDATE referrals SET clicks = clicks + 1 WHERE referral_code = $1")
         .bind(tenant_ref)
         .execute(&state.pool)
         .await;
+
+    // Fallback: If no rows were affected by referral_code, see if tenant_ref is a tenant_id
+    if let Ok(result) = &res {
+        if result.rows_affected() == 0 {
+            res = sqlx::query("UPDATE referrals SET clicks = clicks + 1 WHERE id IN (SELECT id FROM referrals WHERE tenant_id = $1 ORDER BY created_at_unix ASC LIMIT 1)")
+                .bind(tenant_ref)
+                .execute(&state.pool)
+                .await;
+        }
+    }
 
     // Redirect user to the intended target (or dashboard if not specified)
     let redirect_url = if target_url.starts_with('/') {

--- a/src/ui/tauri/src/ui/affiliate-badge-builder.html
+++ b/src/ui/tauri/src/ui/affiliate-badge-builder.html
@@ -266,6 +266,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'e2e-tenant';
       const badgeText = document.getElementById('badgeText');
@@ -277,7 +301,7 @@
       const linkPreview = document.getElementById('linkPreview');
 
       const originUrl = window.location.origin.includes('file://') ? 'https://ohc.app' : window.location.origin;
-      const targetUrl = `${originUrl}/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenantId)}&source=affiliate_badge`;
+      const targetUrl = `${originUrl}/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}&source=affiliate_badge`;
 
       linkPreview.textContent = targetUrl;
 

--- a/src/ui/tauri/src/ui/agent-card.html
+++ b/src/ui/tauri/src/ui/agent-card.html
@@ -399,7 +399,7 @@
           <a href="assistant.html" class="preview-btn">Chat with me</a>
         </div>
         <div class="preview-footer" id="preview-footer-el">
-          <a href="/api/v1/growth/referrals/click?target=/setup.html&ref=default-team" id="branding-link" target="_blank">
+          <a href="/api/v1/growth/referrals/click?target=/setup.html&ref=${__ohcReferralCode}" id="branding-link" target="_blank">
             <span>⚡</span> Powered by OHC
           </a>
         </div>
@@ -408,6 +408,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       const nameInput = document.getElementById('agent-name');
       const roleInput = document.getElementById('agent-role');
@@ -423,7 +447,7 @@
 
       // Update tenant ID in link if available
       const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team';
-      brandingLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenantId)}`;
+      brandingLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}`;
 
       function updatePreview() {
         nameEl.textContent = nameInput.value || 'Agent Name';

--- a/src/ui/tauri/src/ui/agent-profile.html
+++ b/src/ui/tauri/src/ui/agent-profile.html
@@ -239,6 +239,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       const urlParams = new URLSearchParams(window.location.search);
 
@@ -257,7 +281,7 @@
       if (hideBranding) {
         footerEl.style.display = 'none';
       } else {
-        document.getElementById('branding-link').href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenant)}`;
+        document.getElementById('branding-link').href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}`;
       }
 
       const shareBtn = document.getElementById('cloud-bridge-share-btn');

--- a/src/ui/tauri/src/ui/bio.html
+++ b/src/ui/tauri/src/ui/bio.html
@@ -274,6 +274,30 @@
 </div>
 
 <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', async () => {
         // Extract tenant from URL path: /bio/:tenant
         const pathParts = window.location.pathname.split('/');
@@ -315,7 +339,7 @@
         if (data.remove_branding) {
             badge.style.display = 'none';
         } else {
-            ctaLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenant)}&source=bio_expandable_badge`;
+            ctaLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}&source=bio_expandable_badge`;
 
             badgeHeader.addEventListener('click', () => {
                 badge.classList.toggle('expanded');

--- a/src/ui/tauri/src/ui/booking.html
+++ b/src/ui/tauri/src/ui/booking.html
@@ -187,13 +187,37 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       const urlParams = new URLSearchParams(window.location.search);
       const tenantId = urlParams.get('tenant') || 'demo-tenant';
 
       const brandingLink = document.getElementById('branding-link');
       if (brandingLink) {
-        brandingLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenantId)}`;
+        brandingLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}`;
       }
 
 

--- a/src/ui/tauri/src/ui/chat-embed.html
+++ b/src/ui/tauri/src/ui/chat-embed.html
@@ -252,6 +252,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       const urlParams = new URLSearchParams(window.location.search);
       const tenant = urlParams.get('tenant') || 'default-team';
@@ -262,7 +286,7 @@
       document.getElementById('welcome-message').textContent = welcome;
 
       const brandingLink = document.getElementById('branding-link');
-      brandingLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenant)}`;
+      brandingLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}`;
 
       const input = document.getElementById('chat-input');
       const sendBtn = document.getElementById('send-btn');

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -960,6 +960,30 @@
 
 
     <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
 (function() {
     // Inject walkthrough CSS
     const style = document.createElement('style');
@@ -1245,7 +1269,7 @@
               // Once it is "Copy Link", next click will copy and unlock
               aiReferBtn.onclick = () => {
                 const tenantId = localStorage.getItem("tenant_id") || "DEFAULT";
-                const link = `${window.location.origin}/setup.html?ref=${tenantId}&source=ai_feature_paywall`;
+                const link = `${window.location.origin}/setup.html?ref=${__ohcReferralCode}&source=ai_feature_paywall`;
                 navigator.clipboard.writeText(link).then(() => {
                   aiReferBtn.innerText = "Copied Link!";
                   aiReferBtn.style.background = "#34C759";

--- a/src/ui/tauri/src/ui/embed-builder.html
+++ b/src/ui/tauri/src/ui/embed-builder.html
@@ -258,6 +258,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       const typeBtns = document.querySelectorAll('.type-btn:not(.theme-btn)');
       const themeBtns = document.querySelectorAll('.theme-btn');
@@ -288,13 +312,13 @@
         // Update Code Snippet
         const snippet = `<div class="ohc-embed-container" style="width: 100%; max-width: 500px; margin: 0 auto; display: flex; flex-direction: column; align-items: center;">
   <iframe src="${embedUrl}" width="100%" height="400" style="border:none; border-radius:16px; box-shadow: 0 4px 20px rgba(0,0,0,0.08);"></iframe>
-  <a href="${window.location.origin}/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenant)}" target="_blank" style="margin-top: 12px; font-size: 12px; color: #86868b; text-decoration: none; font-family: sans-serif; font-weight: 600;">⚡ Powered by OHC</a>
+  <a href="${window.location.origin}/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}" target="_blank" style="margin-top: 12px; font-size: 12px; color: #86868b; text-decoration: none; font-family: sans-serif; font-weight: 600;">⚡ Powered by OHC</a>
 </div>`;
 
         embedCodeEl.textContent = snippet;
 
         // Update Preview link
-        previewPoweredBy.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenant)}`;
+        previewPoweredBy.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}`;
       }
 
       typeBtns.forEach(btn => {

--- a/src/ui/tauri/src/ui/exit-intent-builder.html
+++ b/src/ui/tauri/src/ui/exit-intent-builder.html
@@ -346,6 +346,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     const inputHeadline = document.getElementById('input-headline');
     const inputDesc = document.getElementById('input-desc');
     const inputButton = document.getElementById('input-button');
@@ -396,7 +420,7 @@
               <h2 style="margin-top: 0; color: #1d1d1f;">${inputHeadline.value}</h2>
               <p style="color: #4b5563; margin-bottom: 1.5rem;">${inputDesc.value}</p>
               <button style="background: ${inputColor.value}; color: white; border: none; padding: 0.75rem 1.5rem; border-radius: 4px; font-weight: bold; cursor: pointer; width: 100%;">${inputButton.value}</button>
-              ${!brandingToggle.checked ? `<div style="margin-top: 1rem; font-size: 0.75rem; color: #9ca3af;"><a href="https://ohc.app/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenantId)}" style="color: #9ca3af; text-decoration: none;">⚡ Powered by OHC</a></div>` : ''}
+              ${!brandingToggle.checked ? `<div style="margin-top: 1rem; font-size: 0.75rem; color: #9ca3af;"><a href="https://ohc.app/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}" style="color: #9ca3af; text-decoration: none;">⚡ Powered by OHC</a></div>` : ''}
             </div>
           </div>
         \`;

--- a/src/ui/tauri/src/ui/gift-cards.html
+++ b/src/ui/tauri/src/ui/gift-cards.html
@@ -168,6 +168,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       const valueInput = document.getElementById('gift-value');
       const previewValue = document.getElementById('preview-value');
@@ -190,10 +214,10 @@
           const amount = valueInput.value || '50';
 
           // Set href dynamically based on tenant id (though default-tenant is hardcoded in initial HTML for preview)
-          poweredByLink.href = `/api/v1/growth/referrals/click?target=/onboarding&ref=${tenantId}&source=gift_card`;
+          poweredByLink.href = `/api/v1/growth/referrals/click?target=/onboarding&ref=${__ohcReferralCode}&source=gift_card`;
 
           const baseUrl = window.location.origin.includes('localhost') ? 'https://app.onehumancorp.com' : window.location.origin;
-          shareLink.value = `${baseUrl}/gift-card?amount=${amount}&ref=${tenantId}`;
+          shareLink.value = `${baseUrl}/gift-card?amount=${amount}&ref=${__ohcReferralCode}`;
 
           resultArea.style.display = 'block';
         } catch (err) {

--- a/src/ui/tauri/src/ui/instant-quote.html
+++ b/src/ui/tauri/src/ui/instant-quote.html
@@ -355,10 +355,34 @@
     </div>
 
     <footer style="text-align: center; margin: 24px 0 100px 0;">
-        <a id="powered-by-link" href="/api/v1/growth/referrals/click?target=/setup.html&ref=default-team" target="_blank" style="text-decoration: none; color: var(--text-muted); font-size: 14px; font-weight: 600;">⚡ Powered by OHC</a>
+        <a id="powered-by-link" href="/api/v1/growth/referrals/click?target=/setup.html&ref=${__ohcReferralCode}" target="_blank" style="text-decoration: none; color: var(--text-muted); font-size: 14px; font-weight: 600;">⚡ Powered by OHC</a>
     </footer>
 
     <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
         // Store rules fetched from edge/backend
         let pricingRules = [];
         let basePrice = 0;
@@ -375,7 +399,7 @@
                 // Update powered-by-link
                 const poweredByLink = document.getElementById('powered-by-link');
                 if (poweredByLink) {
-                    poweredByLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenantId)}`;
+                    poweredByLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}`;
                 }
 
                 let rules = [];

--- a/src/ui/tauri/src/ui/job-board-embed.html
+++ b/src/ui/tauri/src/ui/job-board-embed.html
@@ -57,6 +57,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     const urlParams = new URLSearchParams(window.location.search);
     const company = urlParams.get('company') || 'Our Company';
     const hideBranding = urlParams.get('hideBranding') === 'true';
@@ -73,7 +97,7 @@
         if (baseUrl === 'file://' || baseUrl.includes('localhost') || baseUrl === 'null') {
             baseUrl = 'https://app.onehumancorp.com';
         }
-        brandingLink.href = `${baseUrl}/setup.html?ref=${tenantId}&source=job_board`;
+        brandingLink.href = `${baseUrl}/setup.html?ref=${__ohcReferralCode}&source=job_board`;
     }
   </script>
 </body>

--- a/src/ui/tauri/src/ui/link-in-bio-generator.html
+++ b/src/ui/tauri/src/ui/link-in-bio-generator.html
@@ -410,6 +410,30 @@
 </div>
 
 <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', async () => {
         const storeNameInput = document.getElementById('store-name');
         const bioInput = document.getElementById('bio-text');
@@ -487,7 +511,7 @@
         function updatePreview() {
             previewTitle.textContent = currentState.store_name;
             previewBio.textContent = currentState.bio;
-            poweredByLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(tenant)}&source=bio_page`;
+            poweredByLink.href = `/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}&source=bio_page`;
             poweredByLink.style.display = currentState.remove_branding ? 'none' : 'block';
 
             if (currentState.remove_branding) {

--- a/src/ui/tauri/src/ui/nps-feedback-generator.html
+++ b/src/ui/tauri/src/ui/nps-feedback-generator.html
@@ -463,6 +463,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     // State
     const state = {
       productName: 'Our Service',
@@ -491,7 +515,7 @@
     // Initialize
     function init() {
       // Set referral link
-      const refLink = `${window.location.origin}/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(state.tenantId)}`;
+      const refLink = `${window.location.origin}/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}`;
       previewBranding.href = refLink;
 
       // Add event listeners
@@ -557,7 +581,7 @@
     }
 
     function generateCode() {
-      const refLink = `${window.location.origin}/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(state.tenantId)}&source=nps_widget`;
+      const refLink = `${window.location.origin}/api/v1/growth/referrals/click?target=/setup.html&ref=${encodeURIComponent(__ohcReferralCode)}&source=nps_widget`;
 
       const themeColors = state.theme === 'dark'
         ? { bg: '#1f2937', text: '#f9fafb', border: '#4b5563', hoverBg: '#f3f4f6', hoverText: '#111827' }

--- a/src/ui/tauri/src/ui/order-tracking-viral.html
+++ b/src/ui/tauri/src/ui/order-tracking-viral.html
@@ -168,6 +168,30 @@
   <a href="/dashboard.html" class="back-link">&larr; Back to Dashboard</a>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.getElementById('generate-btn').addEventListener('click', async () => {
       const btn = document.getElementById('generate-btn');
       const trackingNo = document.getElementById('tracking-number').value || '123456';
@@ -182,7 +206,7 @@
         await new Promise(resolve => setTimeout(resolve, 800));
 
         const baseUrl = window.location.origin;
-        const generatedLink = `${baseUrl}/track/${trackingNo}?ref=${tenantId}`;
+        const generatedLink = `${baseUrl}/track/${trackingNo}?ref=${__ohcReferralCode}`;
 
         document.getElementById('preview-id').textContent = trackingNo;
         document.getElementById('share-link').value = generatedLink;

--- a/src/ui/tauri/src/ui/post-purchase-share.html
+++ b/src/ui/tauri/src/ui/post-purchase-share.html
@@ -547,6 +547,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       // State
       let state = {
@@ -584,7 +608,7 @@
       const softPaywallStatus = document.getElementById('soft-paywall-status');
 
       // Initialize
-      previewLink.value = `https://app.onehumancorp.com/setup.html?ref=${state.tenant}&promo=ref123`;
+      previewLink.value = `https://app.onehumancorp.com/setup.html?ref=${__ohcReferralCode}&promo=ref123`;
       updatePreview();
 
       // Event Listeners

--- a/src/ui/tauri/src/ui/quiz.html
+++ b/src/ui/tauri/src/ui/quiz.html
@@ -140,6 +140,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       // Parse URL parameters
       const urlParams = new URLSearchParams(window.location.search);
@@ -157,7 +181,7 @@
       if (hideBranding) {
         brandingEl.style.display = 'none';
       } else {
-        brandingLink.href = `/onboarding?ref=${encodeURIComponent(tenant)}`;
+        brandingLink.href = `/onboarding?ref=${encodeURIComponent(__ohcReferralCode)}`;
       }
 
       // Quiz Flow

--- a/src/ui/tauri/src/ui/quote.html
+++ b/src/ui/tauri/src/ui/quote.html
@@ -425,6 +425,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', async () => {
       const urlParams = new URLSearchParams(window.location.search);
       const quoteId = urlParams.get('id');
@@ -667,7 +691,7 @@
         const tenantId = urlParams.get('tenant') || 'e2e-tenant';
 
         viralBadge.style.display = 'block';
-        viralLink.href = `/setup.html?ref=${encodeURIComponent(tenantId)}&source=quote_viewer`;
+        viralLink.href = `/setup.html?ref=${encodeURIComponent(__ohcReferralCode)}&source=quote_viewer`;
 
         const handlePayment = async () => {
           btnPayCard.innerText = 'Processing...';

--- a/src/ui/tauri/src/ui/referral-widget.html
+++ b/src/ui/tauri/src/ui/referral-widget.html
@@ -582,6 +582,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       // State
       let state = {
@@ -619,7 +643,7 @@
       const softPaywallStatus = document.getElementById('soft-paywall-status');
 
       // Initialize
-      previewLink.value = `https://app.onehumancorp.com/setup.html?ref=${state.tenant}&promo=ref123`;
+      previewLink.value = `https://app.onehumancorp.com/setup.html?ref=${__ohcReferralCode}&promo=ref123`;
       updatePreview();
 
       // Event Listeners

--- a/src/ui/tauri/src/ui/referrals.html
+++ b/src/ui/tauri/src/ui/referrals.html
@@ -322,6 +322,30 @@
 </div>
 
 <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
   document.addEventListener('DOMContentLoaded', async () => {
 
     // Auth token handling
@@ -345,7 +369,7 @@
         } else {
           // Fallback
           const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-tenant';
-          link = `ohc://join?ref=${tenantId}`;
+          link = `ohc://join?ref=${__ohcReferralCode}`;
         }
 
         document.getElementById('referral-link').value = link;
@@ -355,7 +379,7 @@
       } catch (e) {
         console.error("Failed to generate referral link", e);
         const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-tenant';
-        document.getElementById('referral-link').value = `ohc://join?ref=${tenantId}`;
+        document.getElementById('referral-link').value = `ohc://join?ref=${__ohcReferralCode}`;
         document.getElementById('loading-state').style.display = 'none';
         document.getElementById('link-state').style.display = 'block';
       }

--- a/src/ui/tauri/src/ui/review-reward-generator.html
+++ b/src/ui/tauri/src/ui/review-reward-generator.html
@@ -322,6 +322,26 @@
 </div>
 
 <script>
+
+      // Fetch dynamic referral code
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-tenant'; } catch(e) { return 'default-tenant'; } })();
+      (async function() {
+        try {
+          const token = localStorage.getItem('ohc_token');
+          const headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) { url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate'; }
+          const res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            const data = await res.json();
+            if (data.referral_link) {
+              const parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) { __ohcReferralCode = parts[1]; }
+            }
+          }
+        } catch(e) {}
+      })();
+
   const widgetTitle = document.getElementById('widgetTitle');
   const discountCode = document.getElementById('discountCode');
   const reviewUrl = document.getElementById('reviewUrl');
@@ -356,7 +376,7 @@
   <h3 style="margin: 0 0 8px 0; font-size: 18px; color: #111;">${titleStr}</h3>
   <p style="margin: 0 0 16px 0; font-size: 14px; color: #666;">Click below to leave a review and unlock your code!</p>
   <button onclick="window.open('${urlStr}', '_blank'); this.innerText='Code: ${codeStr}'; this.style.background='#34c759';" style="background: #0071e3; color: #fff; border: none; padding: 10px 20px; border-radius: 8px; font-weight: bold; cursor: pointer; font-size: 14px; width: 100%; transition: 0.2s;">Leave a Review</button>
-  ${!brandingToggle.checked ? `<a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref=review_reward" target="_blank" style="display: block; margin-top: 12px; font-size: 11px; color: #888; text-decoration: none; font-weight: bold;">⚡ Powered by OHC</a>` : ''}
+  ${!brandingToggle.checked ? `<a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref=${__ohcReferralCode}" target="_blank" style="display: block; margin-top: 12px; font-size: 11px; color: #888; text-decoration: none; font-weight: bold;">⚡ Powered by OHC</a>` : ''}
 </div>
     `.trim();
 

--- a/src/ui/tauri/src/ui/social-share-widget.html
+++ b/src/ui/tauri/src/ui/social-share-widget.html
@@ -285,7 +285,7 @@
             <button class="share-btn whatsapp">W</button>
           </div>
 
-          <a href="/api/v1/growth/referrals/click?target=/setup.html&ref=default-tenant" target="_blank" class="powered-by" id="preview-branding">⚡ Powered by OHC</a>
+          <a href="/api/v1/growth/referrals/click?target=/setup.html&ref=${__ohcReferralCode}" target="_blank" class="powered-by" id="preview-branding">⚡ Powered by OHC</a>
         </div>
       </div>
     </div>
@@ -305,6 +305,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       const titleInput = document.getElementById('title-input');
       const previewTitle = document.getElementById('preview-title');

--- a/src/ui/tauri/src/ui/spin-to-win-generator.html
+++ b/src/ui/tauri/src/ui/spin-to-win-generator.html
@@ -191,6 +191,30 @@
   <a href="/dashboard" class="back-link">&larr; Back to Dashboard</a>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.getElementById('generate-btn').addEventListener('click', () => {
       const campaign = document.getElementById('campaign-name').value.trim() || 'Summer Spin to Win';
       const reward = document.getElementById('reward').value.trim() || '20% Off';
@@ -202,7 +226,7 @@
       const code = `<div class="ohc-spin-to-win-widget">
   <iframe src="${widgetUrl}" width="100%" height="400" style="border:none;border-radius:16px;overflow:hidden;" title="Spin To Win"></iframe>
   <div style="text-align: center; font-size: 12px; margin-top: 8px;">
-    <a href="${origin}/api/v1/growth/referrals/click?target=/onboarding&ref=${encodeURIComponent(tenantId)}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a>
+    <a href="${origin}/api/v1/growth/referrals/click?target=/onboarding&ref=${encodeURIComponent(__ohcReferralCode)}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a>
   </div>
 </div>`;
 

--- a/src/ui/tauri/src/ui/success.html
+++ b/src/ui/tauri/src/ui/success.html
@@ -135,6 +135,30 @@
       <button id="dashboard-btn">Go to Command Center</button>
     </div>
     <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
       const urlParams = new URLSearchParams(window.location.search);
       const successType = urlParams.get('type');
       const tenantId = urlParams.get('tenant') || 'e2e-tenant';
@@ -148,7 +172,7 @@
             const refCard = document.getElementById('referral-success-card');
             const refLink = document.getElementById('referral-success-link');
             refCard.style.display = 'block';
-            refLink.href = `/setup.html?ref=${encodeURIComponent(tenantId)}&source=success_page`;
+            refLink.href = `/setup.html?ref=${encodeURIComponent(__ohcReferralCode)}&source=success_page`;
             return;
         }
 

--- a/src/ui/tauri/src/ui/trial-extension.html
+++ b/src/ui/tauri/src/ui/trial-extension.html
@@ -94,7 +94,7 @@
                         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>
                 </button>
-                <div class="mt-8 text-center"><a href="/api/v1/growth/referrals/click?target=/onboarding&ref=trial_extension" class="text-sm font-bold text-gray-500 hover:text-indigo-600 transition-colors uppercase tracking-widest font-outfit">⚡ Powered by OHC</a></div>
+                <div class="mt-8 text-center"><a href="/api/v1/growth/referrals/click?target=/onboarding&ref=${__ohcReferralCode}" class="text-sm font-bold text-gray-500 hover:text-indigo-600 transition-colors uppercase tracking-widest font-outfit">⚡ Powered by OHC</a></div>
             </div>
 
             <div id="claimed-state" class="hidden animate-fade-in">
@@ -108,12 +108,32 @@
                 <a href="/dashboard" class="inline-block w-full md:w-auto px-8 py-4 bg-indigo-600 hover:bg-indigo-500 text-white font-bold rounded-xl shadow-lg transition-all hover:-translate-y-1 text-lg">
                     Return to Dashboard
                 </a>
-                <div class="mt-8 text-center"><a href="/api/v1/growth/referrals/click?target=/onboarding&ref=trial_extension" class="text-sm font-bold text-gray-500 hover:text-indigo-600 transition-colors uppercase tracking-widest font-outfit">⚡ Powered by OHC</a></div>
+                <div class="mt-8 text-center"><a href="/api/v1/growth/referrals/click?target=/onboarding&ref=${__ohcReferralCode}" class="text-sm font-bold text-gray-500 hover:text-indigo-600 transition-colors uppercase tracking-widest font-outfit">⚡ Powered by OHC</a></div>
             </div>
         </div>
     </main>
 
     <script>
+
+      // Fetch dynamic referral code
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-tenant'; } catch(e) { return 'default-tenant'; } })();
+      (async function() {
+        try {
+          const token = localStorage.getItem('ohc_token');
+          const headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) { url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate'; }
+          const res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            const data = await res.json();
+            if (data.referral_link) {
+              const parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) { __ohcReferralCode = parts[1]; }
+            }
+          }
+        } catch(e) {}
+      })();
+
         document.addEventListener('DOMContentLoaded', () => {
             const claimBtn = document.getElementById('claim-btn');
             const unclaimedState = document.getElementById('unclaimed-state');

--- a/src/ui/tauri/src/ui/viral-job-board-generator.html
+++ b/src/ui/tauri/src/ui/viral-job-board-generator.html
@@ -259,6 +259,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     const removeBrandingCb = document.getElementById('remove-branding');
     const paywallModal = document.getElementById('paywall-modal');
     const closePaywallBtn = document.getElementById('close-paywall');
@@ -308,7 +332,7 @@
         let embedCode = `<iframe src="${embedUrl}" width="100%" height="400" frameborder="0" style="border-radius: 12px; border: 1px solid #eaeaea; background: transparent;"></iframe>`;
 
         if (!hideBranding) {
-            embedCode += `\n<div style="text-align: center; font-size: 12px; margin-top: 8px;"><a href="${baseUrl}/setup.html?ref=${tenantId}" target="_blank" style="color: #888; text-decoration: none;">⚡ Powered by OHC</a></div>`;
+            embedCode += `\n<div style="text-align: center; font-size: 12px; margin-top: 8px;"><a href="${baseUrl}/setup.html?ref=${__ohcReferralCode}" target="_blank" style="color: #888; text-decoration: none;">⚡ Powered by OHC</a></div>`;
         }
 
         document.getElementById('embed-code').value = embedCode;

--- a/src/ui/tauri/src/ui/viral-mystery-offer-generator.html
+++ b/src/ui/tauri/src/ui/viral-mystery-offer-generator.html
@@ -362,6 +362,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     // Live preview updating
     const titleInput = document.getElementById('offer-title');
     const descInput = document.getElementById('offer-desc');
@@ -442,7 +466,7 @@
       const baseUrl = window.location.origin;
       const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'e2e-tenant';
 
-      const url = `${baseUrl}/mystery-offer/index.html?title=${title}&desc=${desc}&discount=${discount}&hideBranding=${hideBranding}&ref=${tenantId}`;
+      const url = `${baseUrl}/mystery-offer/index.html?title=${title}&desc=${desc}&discount=${discount}&hideBranding=${hideBranding}&ref=${__ohcReferralCode}`;
 
       document.getElementById('generated-url').value = url;
       document.getElementById('result-area').style.display = 'block';

--- a/src/ui/tauri/src/ui/viral-newsletter-generator.html
+++ b/src/ui/tauri/src/ui/viral-newsletter-generator.html
@@ -410,6 +410,26 @@
 </div>
 
 <script>
+
+      // Fetch dynamic referral code
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-tenant'; } catch(e) { return 'default-tenant'; } })();
+      (async function() {
+        try {
+          const token = localStorage.getItem('ohc_token');
+          const headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) { url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate'; }
+          const res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            const data = await res.json();
+            if (data.referral_link) {
+              const parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) { __ohcReferralCode = parts[1]; }
+            }
+          }
+        } catch(e) {}
+      })();
+
   const widgetTitle = document.getElementById('widgetTitle');
   const widgetDesc = document.getElementById('widgetDesc');
   const buttonText = document.getElementById('buttonText');
@@ -447,7 +467,7 @@
   <p style="margin: 0 0 15px 0; font-size: 14px; color: #666;">${descStr}</p>
   <input type="email" placeholder="Your email address" style="width: 100%; padding: 10px; margin-bottom: 10px; border: 1px solid #ccc; border-radius: 8px; box-sizing: border-box;" />
   <button style="background: #0066FF; color: #fff; border: none; padding: 10px 20px; border-radius: 8px; font-weight: bold; cursor: pointer; font-size: 14px; width: 100%;">${btnStr}</button>
-  ${!brandingToggle.checked ? `<a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref=newsletter" target="_blank" style="display: block; margin-top: 15px; font-size: 12px; color: #888; text-decoration: none; font-weight: bold;">⚡ Powered by OHC</a>` : ''}
+  ${!brandingToggle.checked ? `<a href="https://ohc.app/api/v1/growth/referrals/click?target=/onboarding&ref=${__ohcReferralCode}" target="_blank" style="display: block; margin-top: 15px; font-size: 12px; color: #888; text-decoration: none; font-weight: bold;">⚡ Powered by OHC</a>` : ''}
 </div>
     `.trim();
 

--- a/src/ui/tauri/src/ui/viral-post-generator.html
+++ b/src/ui/tauri/src/ui/viral-post-generator.html
@@ -217,6 +217,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.addEventListener('DOMContentLoaded', () => {
       let hasPro = false;
       try { hasPro = localStorage.getItem('has_pro') === 'true'; } catch(e) {}
@@ -246,7 +270,7 @@
       shareToUnlockBtn.addEventListener('click', async () => {
           let tenantId = "demo";
           try { tenantId = localStorage.getItem('tenant') || "demo"; } catch(e) {}
-          const message = `I just unlocked powerful AI tools for my business on One Human Corp! Start your own business today: https://app.onehumancorp.com/setup.html?ref=${tenantId}`;
+          const message = `I just unlocked powerful AI tools for my business on One Human Corp! Start your own business today: https://app.onehumancorp.com/setup.html?ref=${__ohcReferralCode}`;
           const shareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(message)}`;
 
           window.open(shareUrl, '_blank');

--- a/src/ui/tauri/src/ui/viral-pricing-calculator.html
+++ b/src/ui/tauri/src/ui/viral-pricing-calculator.html
@@ -195,6 +195,30 @@
   <a href="/dashboard.html" class="back-link">&larr; Back to Dashboard</a>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     document.getElementById('generate-btn').addEventListener('click', async () => {
       const btn = document.getElementById('generate-btn');
       btn.disabled = true;
@@ -213,7 +237,7 @@
         }
 
         const embedUrl = `${baseUrl}/ui/calculator-embed.html?tenant=${tenantId}&service=${encodeURIComponent(serviceName)}&base=${encodeURIComponent(basePrice)}`;
-        const embedCode = `<iframe src="${embedUrl}" width="100%" height="400" frameborder="0" style="border-radius: 12px; border: 1px solid #eaeaea; background: transparent;"></iframe>\n<div style="text-align: center; font-size: 12px; margin-top: 8px;"><a href="${baseUrl}/setup.html?ref=${tenantId}" target="_blank" style="color: #888; text-decoration: none;">Powered by OHC - Get your own AI Pricing Calculator</a></div>`;
+        const embedCode = `<iframe src="${embedUrl}" width="100%" height="400" frameborder="0" style="border-radius: 12px; border: 1px solid #eaeaea; background: transparent;"></iframe>\n<div style="text-align: center; font-size: 12px; margin-top: 8px;"><a href="${baseUrl}/setup.html?ref=${__ohcReferralCode}" target="_blank" style="color: #888; text-decoration: none;">Powered by OHC - Get your own AI Pricing Calculator</a></div>`;
 
         document.getElementById('embed-code').value = embedCode;
         document.getElementById('result-area').style.display = 'block';

--- a/src/ui/tauri/src/ui/work-intake-widget.html
+++ b/src/ui/tauri/src/ui/work-intake-widget.html
@@ -288,6 +288,30 @@
   </div>
 
   <script>
+
+      // OHC Referral Fetcher
+      let __ohcReferralCode = (() => { try { return localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default-team'; } catch(e) { return 'default-team'; } })();
+      (async function() {
+        try {
+          let token = localStorage.getItem('ohc_token');
+          let headers = token ? { 'authorization': `Bearer ${token}` } : {};
+          let url = '/api/v1/growth/referrals/generate';
+          if (window.__TAURI__ && window.__TAURI__.core) {
+            url = 'http://127.0.0.1:18789/api/v1/growth/referrals/generate';
+          }
+          let res = await fetch(url, { method: 'POST', headers });
+          if (res.ok) {
+            let data = await res.json();
+            if (data.referral_link) {
+              let parts = data.referral_link.split('/ref/');
+              if (parts.length > 1) {
+                __ohcReferralCode = parts[1];
+              }
+            }
+          }
+        } catch(e) {}
+      })();
+
     const tenantInput = document.getElementById('tenant-input');
     const titleInput = document.getElementById('title-input');
     const themeSelect = document.getElementById('theme-select');
@@ -402,7 +426,7 @@
       let embedCode = `<iframe src="${iframeSrc}" width="100%" height="500" style="border:none; border-radius:16px;"></iframe>`;
 
       if (!removeBranding) {
-        const referralLink = `https://ohc.app/api/v1/growth/referrals/click?target=/setup.html&ref=${tenant}`;
+        const referralLink = `https://ohc.app/api/v1/growth/referrals/click?target=/setup.html&ref=${__ohcReferralCode}`;
         embedCode += `\n<div style="text-align: center; margin-top: 8px; font-family: sans-serif; font-size: 12px;">\n  <a href="${referralLink}" target="_blank" style="color: #6b7280; text-decoration: none; font-weight: 600;">⚡ Powered by OHC</a>\n</div>`;
       }
 


### PR DESCRIPTION
Safely handles backend referral click tracking logic to fallback to updating by `tenant_id` if a valid `referral_code` isn't provided, correctly attributing campaign clicks from UI components without risking database exceptions.

---
*PR created automatically by Jules for task [8603876548639719704](https://jules.google.com/task/8603876548639719704) started by @ql-owo-lp*