### PR TITLE
Fix Help portal videos render test and widget DOM collision

### DIFF
--- a/src/e2e/documentation_verification.spec.ts
+++ b/src/e2e/documentation_verification.spec.ts
@@ -8,13 +8,18 @@ test.describe('Documentation UI Verification', () => {
     // Make sure the title renders properly
     await expect(page.locator('h1')).toContainText('In-App Help Center');
 
+    // Open floating widget
+    const helpBtn = page.locator('#ohc-floating-help-btn');
+    await helpBtn.waitFor({ state: 'visible' });
+    await helpBtn.click();
+
     // Open videos tab
     const videosTab = page.locator('[data-target="tab-videos"]');
     await videosTab.waitFor({ state: 'visible' });
     await videosTab.click();
 
     // Verify video list is populated
-    const videoList = page.locator('#video-list');
+    const videoList = page.locator('.ohc-help-content.active #video-list').first();
     await videoList.waitFor({ state: 'visible' });
     await expect(videoList).not.toBeEmpty();
     // Verify it isn't just loading text

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -3390,7 +3390,7 @@ document.addEventListener('DOMContentLoaded', () => {
             document.getElementById(tab.getAttribute('data-target')).classList.add('active');
             if (tab.getAttribute("data-target") === "tab-videos") {
                 fetch("/api/videos").then(r => r.json()).then(data => {
-                    const list = document.getElementById("video-list");
+                    const list = widget.querySelector("#video-list") || document.getElementById("video-list");
                     let html = "";
                     data.forEach(v => {
                         const safeTitle = v.title.replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -3406,7 +3406,10 @@ document.addEventListener('DOMContentLoaded', () => {
                         </div>`;
                     });
                     list.innerHTML = html;
-                }).catch(e => { document.getElementById("video-list").innerHTML = "Error loading videos."; });
+                }).catch(e => {
+                    const errVl = widget.querySelector("#video-list") || document.getElementById("video-list");
+                    if (errVl) errVl.innerHTML = "Error loading videos.";
+                });
             }
         });
     });

--- a/src/ui/tauri/src/ui/help-widget.mjs
+++ b/src/ui/tauri/src/ui/help-widget.mjs
@@ -359,7 +359,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (tab.getAttribute("data-target") === "tab-videos") {
                 fetch("/api/videos").then(r => r.json()).then(data => {
-                    const vl = document.getElementById("video-list");
+                    const vl = widget.querySelector("#video-list") || document.getElementById("video-list");
                     vl.innerHTML = "";
                     data.forEach(v => {
                         vl.innerHTML += `<div style="background: white; border: 1px solid rgba(0,0,0,0.1); border-radius: 8px; padding: 12px; cursor: pointer;" onclick="if(window.openVideo) { window.openVideo('${v.video_url}', '${v.title.replace(/'/g, "\\'")}', '${v.duration}'); } else { alert('Playing video: ' + '${v.title.replace(/'/g, "\\'")}' + '\\nURL: ' + '${v.video_url}'); }">` +
@@ -367,7 +367,10 @@ document.addEventListener('DOMContentLoaded', () => {
                             `<span style="font-size: 12px; color: #64748b;">${v.duration}</span>` +
                             `</div>`;
                     });
-                }).catch(e => { document.getElementById("video-list").innerHTML = "Error loading videos."; });
+                }).catch(e => {
+                    const errVl = widget.querySelector("#video-list") || document.getElementById("video-list");
+                    if (errVl) errVl.innerHTML = "Error loading videos.";
+                });
             }
         });
     });

--- a/src/ui/tauri/src/ui/help.html
+++ b/src/ui/tauri/src/ui/help.html
@@ -1264,7 +1264,7 @@ document.addEventListener('DOMContentLoaded', () => {
             document.getElementById(tab.getAttribute('data-target')).classList.add('active');
             if (tab.getAttribute("data-target") === "tab-videos") {
                 fetch("/api/videos").then(r => r.json()).then(data => {
-                    const vl = document.getElementById("video-list");
+                    const vl = widget.querySelector("#video-list") || document.getElementById("video-list");
                     vl.innerHTML = "";
                     data.forEach(v => {
                         vl.innerHTML += `<div style="background: white; border: 1px solid rgba(0,0,0,0.1); border-radius: 8px; padding: 12px; cursor: pointer;" onclick="alert('Playing video: ' + v.title)">` +
@@ -1272,7 +1272,10 @@ document.addEventListener('DOMContentLoaded', () => {
                             `<span style="font-size: 12px; color: #64748b;">${v.duration}</span>` +
                             `</div>`;
                     });
-                }).catch(e => { document.getElementById("video-list").innerHTML = "Error loading videos."; });
+                }).catch(e => {
+                    const errVl = widget.querySelector("#video-list") || document.getElementById("video-list");
+                    if (errVl) errVl.innerHTML = "Error loading videos.";
+                });
             }
         });
     });


### PR DESCRIPTION
Fixes the failing `Help portal videos render` E2E test by ensuring the test simulates accurate user interaction with the floating help widget and correctly targets the active video list in the DOM. Fixed the underlying bug in the UI logic that caused DOM element collision when fetching and populating the video list from `/api/videos`.

---
*PR created automatically by Jules for task [8768884154019707875](https://jules.google.com/task/8768884154019707875) started by @ql-owo-lp*