### PR TITLE
Fix Local Sovereignty E2E test failures and missing API proxy routes

### DIFF
--- a/src/e2e/local_sovereignty.spec.ts
+++ b/src/e2e/local_sovereignty.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures';
 test.describe('OHC: Local Sovereignty UI Tests', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/settings');
-    await expect(page.getByRole('heading', { name: 'Workspace Settings' }).first()).toBeVisible({ timeout: 45000 });
+    await expect(page.locator('h1', { hasText: 'Workspace Settings' }).first()).toBeVisible({ timeout: 45000 });
   });
 
   test('should display Local Sovereignty & Data Sharing controls', async ({ page }) => {

--- a/src/ui/next/src/app/api/settings/delivery/route.ts
+++ b/src/ui/next/src/app/api/settings/delivery/route.ts
@@ -1,0 +1,9 @@
+import { proxyBackendGet, proxyBackendPost } from "../../ui/backendProxy";
+
+export async function GET(req: Request) {
+  return proxyBackendGet(req, "/api/settings/delivery");
+}
+
+export async function POST(req: Request) {
+  return proxyBackendPost(req, "/api/settings/delivery");
+}

--- a/src/ui/next/src/app/api/settings/sms-confirm/route.ts
+++ b/src/ui/next/src/app/api/settings/sms-confirm/route.ts
@@ -1,0 +1,9 @@
+import { proxyBackendGet, proxyBackendPost } from "../../ui/backendProxy";
+
+export async function GET(req: Request) {
+  return proxyBackendGet(req, "/api/settings/sms-confirm");
+}
+
+export async function POST(req: Request) {
+  return proxyBackendPost(req, "/api/settings/sms-confirm");
+}

--- a/src/ui/next/src/app/api/settings/sms-preferences/route.ts
+++ b/src/ui/next/src/app/api/settings/sms-preferences/route.ts
@@ -1,0 +1,9 @@
+import { proxyBackendGet, proxyBackendPost } from "../../ui/backendProxy";
+
+export async function GET(req: Request) {
+  return proxyBackendGet(req, "/api/settings/sms-preferences");
+}
+
+export async function POST(req: Request) {
+  return proxyBackendPost(req, "/api/settings/sms-preferences");
+}

--- a/src/ui/next/src/app/api/settings/sms-verify/route.ts
+++ b/src/ui/next/src/app/api/settings/sms-verify/route.ts
@@ -1,0 +1,9 @@
+import { proxyBackendGet, proxyBackendPost } from "../../ui/backendProxy";
+
+export async function GET(req: Request) {
+  return proxyBackendGet(req, "/api/settings/sms-verify");
+}
+
+export async function POST(req: Request) {
+  return proxyBackendPost(req, "/api/settings/sms-verify");
+}

--- a/src/ui/next/src/app/api/settings/telemetry/route.ts
+++ b/src/ui/next/src/app/api/settings/telemetry/route.ts
@@ -1,0 +1,9 @@
+import { proxyBackendGet, proxyBackendPost } from "../../ui/backendProxy";
+
+export async function GET(req: Request) {
+  return proxyBackendGet(req, "/api/settings/telemetry");
+}
+
+export async function POST(req: Request) {
+  return proxyBackendPost(req, "/api/settings/telemetry");
+}

--- a/src/ui/next/src/app/api/settings/voice/route.ts
+++ b/src/ui/next/src/app/api/settings/voice/route.ts
@@ -1,0 +1,9 @@
+import { proxyBackendGet, proxyBackendPost } from "../../ui/backendProxy";
+
+export async function GET(req: Request) {
+  return proxyBackendGet(req, "/api/settings/voice");
+}
+
+export async function POST(req: Request) {
+  return proxyBackendPost(req, "/api/settings/voice");
+}


### PR DESCRIPTION
This patch resolves the E2E test failures related to the Local Sovereignty feature.
The NextJS API proxy routes for the backend settings (`/api/settings/telemetry`, `/api/settings/voice`, `/api/settings/delivery`, `/api/settings/sms-verify`, `/api/settings/sms-confirm`, `/api/settings/sms-preferences`) were missing. This caused `ECONNREFUSED` and `404` network errors in the UI, breaking the E2E tests. I've added these proxy routes using the established, secure `proxyBackendGet` and `proxyBackendPost` pattern, ensuring tenant isolation context and auth is safely forwarded. I also updated the `Workspace Settings` test locator to use `h1` `hasText` to be more robust against nested spans. All Bazel Playwright E2E tests now cleanly pass.

---
*PR created automatically by Jules for task [661115991546593728](https://jules.google.com/task/661115991546593728) started by @ql-owo-lp*