### PR TITLE
🧹 Cleaner: Fix missing RLS on shared_tasks_decomposition

### DIFF
--- a/src/server/migrations/201_rls_shared_tasks_decomposition.sql
+++ b/src/server/migrations/201_rls_shared_tasks_decomposition.sql
@@ -1,0 +1,3 @@
+ALTER TABLE IF EXISTS shared_tasks_decomposition ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation_shared_tasks_decomposition ON shared_tasks_decomposition;
+CREATE POLICY tenant_isolation_shared_tasks_decomposition ON shared_tasks_decomposition USING (organization_id::text = current_setting('app.current_tenant', true)) WITH CHECK (organization_id::text = current_setting('app.current_tenant', true));


### PR DESCRIPTION
Adds a new database migration to enable Row Level Security on the `shared_tasks_decomposition` table and adds the `tenant_isolation_shared_tasks_decomposition` policy. This fixes an issue where the table was lacking multi-tenant isolation.

---
*PR created automatically by Jules for task [1066295799158149644](https://jules.google.com/task/1066295799158149644) started by @ql-owo-lp*