### PR TITLE
refactor: optimize mobile POS styling to Unifi translucent glass standard

### DIFF
--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -391,13 +391,13 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
 
   return (
     <WalkthroughTarget id="pos-keypad">
-    <div className="p-6 rounded-3xl shadow-2xl mt-6 relative overflow-hidden bg-white/70 backdrop-blur-[32px] saturate-[200%] border border-white/50">
+    <div className="p-6 rounded-3xl shadow-2xl mt-6 relative overflow-hidden bg-white/70 backdrop-blur-3xl saturate-200 border border-white/60">
       <h2 className="text-lg font-bold font-outfit text-gray-900 mb-2">Tap to Pay via Terminal</h2>
-      <p className={`text-sm mb-6 font-medium p-3 rounded-xl border ${status?.toLowerCase()?.includes('fail') || status?.toLowerCase()?.includes('error') || status?.toLowerCase()?.includes('sold out') ? 'bg-red-50/80 backdrop-blur-[30px] saturate-[210%] text-red-800 border-red-200' : 'text-gray-600 border-transparent'}`}>Status: {status}</p>
+      <p className={`text-sm mb-6 font-medium p-3 rounded-xl border ${status?.toLowerCase()?.includes('fail') || status?.toLowerCase()?.includes('error') || status?.toLowerCase()?.includes('sold out') ? 'bg-red-50/80 backdrop-blur-xl saturate-200 text-red-800 border-red-200' : 'bg-gray-50/50 backdrop-blur-md text-gray-700 border-gray-200/50'}`}>Status: {status}</p>
 
       {pendingReconciliation.length > 0 && (
-        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 backdrop-blur-[30px] saturate-[210%] p-4">
-           <div className="bg-white/85 backdrop-blur-[40px] saturate-[210%] border border-white/50 rounded-3xl p-6 shadow-2xl max-w-sm w-full text-center">
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4">
+           <div className="bg-white/85 backdrop-blur-3xl saturate-200 border border-white/60 rounded-3xl p-6 shadow-2xl max-w-sm w-full text-center">
              <h2 className="text-xl font-bold font-outfit text-gray-900 mb-4">Inventory Conflict Detected</h2>
              <p className="text-sm text-gray-600 mb-6">Some offline sales conflicted with online inventory. The Operations Agent has drafted an alternative offer for the online customer.</p>
              <ul className="space-y-2 mb-6">
@@ -566,7 +566,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
           </button>
           <ul className="mt-4 space-y-2">
             {discoveredReaders.map(reader => (
-              <li key={reader.id} className="flex justify-between items-center p-4 border border-white/50 rounded-2xl bg-white/60 backdrop-blur-[30px] saturate-[210%] shadow-sm transition-all hover:bg-white/80">
+              <li key={reader.id} className="flex justify-between items-center p-4 border border-white/40 rounded-2xl bg-white/50 backdrop-blur-2xl saturate-200 shadow-sm transition-all hover:bg-white/70">
                 <span className="font-medium text-gray-800 text-sm">{reader.label || reader.id}</span>
                 <button onClick={() => connectReader(reader)} className="bg-[#34C759] text-white px-5 py-2 min-h-[44px] min-w-[44px] rounded-xl text-sm font-bold shadow-sm shadow-green-500/20 hover:bg-green-600 transition-colors active:scale-[0.98]">
                   Connect

--- a/src/ui/next/src/app/pos/terminal/page.tsx
+++ b/src/ui/next/src/app/pos/terminal/page.tsx
@@ -332,7 +332,7 @@ export default function POSTerminal() {
       <div className="w-full max-w-[375px] mx-auto min-h-[100dvh] md:h-[812px] md:min-h-0 bg-white md:shadow-2xl overflow-hidden flex flex-col relative border-x border-gray-200 mobile-pos-container">
 
         {/* Header */}
-        <div className="pt-12 pb-6 px-6 bg-white/65 backdrop-blur-[30px] border-b border-gray-200 sticky top-0 z-10 flex justify-between items-center">
+        <div className="pt-12 pb-6 px-6 bg-white/60 backdrop-blur-3xl saturate-200 border-b border-white/50 sticky top-0 z-10 flex justify-between items-center">
           <div>
             <h1 className="text-2xl font-bold font-outfit text-gray-900 tracking-tight">{activeStaff?.name}</h1>
             <p className="text-[#0071E3] font-medium text-sm mt-1">{t(activeStaff?.role)}</p>
@@ -356,8 +356,8 @@ export default function POSTerminal() {
         {/* Content */}
         <div className="flex-1 overflow-y-auto px-4 py-6 bg-[#F5F5F7]">
 
-           <div className="app-card rounded-2xl p-6 shadow-lg mb-6 text-center bg-white/70 backdrop-blur-[32px] saturate-[200%] border border-white/50">
-             <div className={`w-16 h-16 mx-auto rounded-full flex items-center justify-center mb-4 ${clockedIn ? 'bg-green-100 text-green-600' : 'bg-gray-100 text-gray-400'}`}>
+           <div className="app-card rounded-3xl p-6 shadow-sm mb-6 text-center bg-white/70 backdrop-blur-3xl saturate-200 border border-white/60">
+             <div className={`w-16 h-16 mx-auto rounded-full flex items-center justify-center mb-4 ${clockedIn ? 'bg-green-100/80 border border-green-200 text-green-600' : 'bg-gray-100/80 border border-gray-200 text-gray-400'}`}>
                 <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
@@ -392,7 +392,7 @@ export default function POSTerminal() {
              <button
                 onClick={handleQuickCharge}
                 disabled={reserving}
-                className={`charge-btn min-h-[44px] min-w-[44px] p-4 rounded-[8px] text-left shadow-lg bg-white/70 backdrop-blur-[32px] saturate-[200%] border border-white/50 ${reserving ? 'opacity-50' : 'active:scale-[0.98]'}`}
+                className={`charge-btn min-h-[44px] min-w-[44px] p-4 rounded-2xl text-left shadow-sm bg-white/70 backdrop-blur-3xl saturate-200 border border-white/60 hover:bg-white/80 transition-all ${reserving ? 'opacity-50' : 'active:scale-[0.98]'}`}
              >
                <div className="text-[#0066FF] mb-2">
                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
@@ -400,7 +400,7 @@ export default function POSTerminal() {
                <span className="font-medium text-gray-900">{t('Quick Charge $50')}</span>
              </button>
 
-             <button className="min-h-[44px] min-w-[44px] p-4 rounded-[8px] text-left shadow-lg active:scale-[0.98] bg-white/70 backdrop-blur-[32px] saturate-[200%] border border-white/50">
+             <button className="min-h-[44px] min-w-[44px] p-4 rounded-2xl text-left shadow-sm active:scale-[0.98] bg-white/70 backdrop-blur-3xl saturate-200 border border-white/60 hover:bg-white/80 transition-all">
                <div className="text-[#FF9500] mb-2">
                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z" /></svg>
                </div>
@@ -417,7 +417,7 @@ export default function POSTerminal() {
                 <button
                   key={product.id}
                   onClick={() => handleAddToCart(product)} disabled={reserving || isCartOpen}
-                  className={`p-4 rounded-[8px] text-left transition-all active:scale-[0.98] min-h-[64px] min-w-[44px] shadow-lg backdrop-blur-[30px] saturate-[210%] ${selectedProduct?.id === product.id ? 'bg-white/80 ring-1 ring-[#0066FF] border border-[#0066FF]' : 'bg-white/65 border border-white/50'}`}
+                  className={`p-4 rounded-xl text-left transition-all active:scale-[0.98] min-h-[64px] min-w-[44px] shadow-sm backdrop-blur-2xl saturate-200 ${selectedProduct?.id === product.id ? 'bg-white/80 ring-2 ring-[#0066FF] border-transparent' : 'bg-white/60 hover:bg-white/80 border border-white/50'}`}
                 >
                   <div className="flex justify-between items-center">
                     <div>
@@ -434,10 +434,10 @@ export default function POSTerminal() {
 
            {/* Bottom Bar */}
            {cartItemCount > 0 && !checkoutComplete && (
-             <div className="fixed bottom-0 left-0 right-0 p-4 bg-white/80 backdrop-blur-[30px] border-t border-gray-200 z-40 pb-safe pb-8">
+             <div className="fixed bottom-0 left-0 right-0 p-4 bg-white/60 backdrop-blur-2xl saturate-200 border-t border-white/50 z-40 pb-safe pb-8">
                <button
                  onClick={() => setIsCartOpen(true)}
-                 className="w-full bg-[#0066FF] text-white rounded-xl min-h-[60px] text-lg font-bold flex justify-between items-center px-6 shadow-lg active:scale-[0.98]"
+                 className="w-full bg-[#0066FF] text-white rounded-2xl min-h-[60px] text-lg font-bold flex justify-between items-center px-6 shadow-xl shadow-blue-500/20 active:scale-[0.98] transition-all hover:bg-blue-600"
                >
                  <span className="bg-white/20 px-3 py-1 rounded-full text-sm">{cartItemCount} item{cartItemCount > 1 ? 's' : ''}</span>
                  <span>Charge ${(cartTotal / 100).toFixed(2)}</span>
@@ -448,11 +448,11 @@ export default function POSTerminal() {
            {/* Cart Drawer */}
            {isCartOpen && !checkoutComplete && (
              <div className="fixed inset-0 z-50 flex flex-col justify-end">
-               <div className="absolute inset-0 bg-black/40 backdrop-blur-[30px] saturate-[210%]" onClick={() => setIsCartOpen(false)}></div>
-               <div className="relative bg-white/85 backdrop-blur-[40px] saturate-[210%] border-t border-white/50 rounded-t-3xl p-6 shadow-2xl animate-in slide-in-from-bottom max-h-[90vh] overflow-y-auto">
+               <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={() => setIsCartOpen(false)}></div>
+               <div className="relative bg-white/80 backdrop-blur-3xl saturate-200 border-t border-white/50 rounded-t-3xl p-6 shadow-[0_-8px_30px_-15px_rgba(0,0,0,0.3)] animate-in slide-in-from-bottom max-h-[90vh] overflow-y-auto">
                  <div className="flex justify-between items-center mb-6">
                    <h2 className="text-xl font-bold font-outfit text-gray-900">Current Order</h2>
-                   <button onClick={() => setIsCartOpen(false)} className="p-2 bg-gray-100 rounded-full text-gray-500 hover:bg-gray-200">
+                   <button onClick={() => setIsCartOpen(false)} className="p-2 bg-black/5 rounded-full text-gray-600 hover:bg-black/10 active:scale-95 transition-all">
                      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                    </button>
                  </div>
@@ -491,9 +491,9 @@ export default function POSTerminal() {
 
            {/* Post-Sale Screen */}
            {checkoutComplete && (
-             <div className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-white/80 backdrop-blur-[30px] saturate-[210%]">
-               <div className="bg-white rounded-3xl p-8 shadow-2xl border border-gray-200 w-full max-w-sm text-center animate-in zoom-in-95">
-                 <div className="w-20 h-20 bg-green-100 text-green-600 rounded-full flex items-center justify-center mx-auto mb-6">
+             <div className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-white/60 backdrop-blur-2xl saturate-200">
+               <div className="bg-white/80 backdrop-blur-3xl saturate-200 rounded-3xl p-8 shadow-2xl border border-white/60 w-full max-w-sm text-center animate-in zoom-in-95">
+                 <div className="w-20 h-20 bg-green-100/80 border border-green-200 text-green-600 rounded-full flex items-center justify-center mx-auto mb-6">
                    <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" /></svg>
                  </div>
                  <h2 className="text-2xl font-bold font-outfit text-gray-900 mb-2">Payment Successful!</h2>
@@ -534,7 +534,7 @@ export default function POSTerminal() {
         </div>
 
         {syncing && (
-          <div className="absolute bottom-6 left-1/2 -translate-x-1/2 bg-[#0071E3]/90 backdrop-blur-[30px] saturate-[210%] border border-white/20 text-white px-6 py-3 rounded-full shadow-lg font-bold min-h-[44px] flex items-center justify-center space-x-2 z-50">
+          <div className="absolute bottom-6 left-1/2 -translate-x-1/2 bg-[#0071E3]/90 backdrop-blur-xl saturate-200 border border-white/20 text-white px-6 py-3 rounded-full shadow-lg font-bold min-h-[44px] flex items-center justify-center space-x-2 z-50">
             <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
@@ -543,7 +543,7 @@ export default function POSTerminal() {
           </div>
         )}
         {offlineConversion && (
-          <div className="absolute bottom-16 left-1/2 -translate-x-1/2 bg-amber-100/80 backdrop-blur-[30px] saturate-[210%] border border-amber-200 shadow-xl shadow-amber-500/20 text-amber-900 px-4 py-2 rounded-full text-xs font-bold animate-bounce">
+          <div className="absolute bottom-16 left-1/2 -translate-x-1/2 bg-amber-100/80 backdrop-blur-xl saturate-200 border border-amber-200 shadow-xl shadow-amber-500/20 text-amber-900 px-4 py-2 rounded-full text-xs font-bold animate-bounce">
             {t('Using cached rates - Syncing soon')}
           </div>
         )}


### PR DESCRIPTION
In investigating the "Architectural Gap: Offline-Tolerant Mobile POS & Agentic Inventory Sync" issue, I found that the core offline transaction queue, background agent sync worker, database schemas with row-level security, and Stripe Terminal Tap-to-Pay client were already implemented.

Per the universal engineering directive to continuously optimize the codebase when core objectives are met, I refactored the visual layout of the Mobile POS terminal UI. 

This PR upgrades the POS terminal components to adhere to the requested "macOS Translucent Glass" and "UniFi" design standards by:
- Replacing arbitrary Tailwind utility strings (e.g. `backdrop-blur-[32px]`) with standardized scale classes (e.g. `backdrop-blur-3xl`).
- Enhancing hover and active interaction states across product selection buttons and payment action buttons.
- Softening borders, backgrounds, and drop shadows to achieve a high-end glassmorphic aesthetic.
- Verifying stability through 100% successful runs of the existing Playwright E2E flows and Bazel unit tests.

Resolves #32454

---
*PR created automatically by Jules for task [8697653239558058693](https://jules.google.com/task/8697653239558058693) started by @ql-owo-lp*