### PR TITLE
fix(growth): Prevent server crash on NULL trial extension claims

### DIFF
--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -569,7 +569,7 @@ async fn handle_trial_extension_claim(
     };
 
     // First check if already claimed
-    let has_claimed: Option<bool> = match sqlx::query_scalar("SELECT has_claimed_trial_extension FROM tenants WHERE id = $1 OR tenant_id = $1")
+    let has_claimed: Option<bool> = match sqlx::query_scalar("SELECT COALESCE(has_claimed_trial_extension, false) FROM tenants WHERE id = $1 OR tenant_id = $1")
         .bind(parsed_uuid)
         .fetch_optional(&state.pool)
         .await
@@ -3398,7 +3398,7 @@ mod tests {
 
         assert_eq!(plan_tier, "pro");
 
-        let has_claimed: bool = sqlx::query_scalar("SELECT has_claimed_trial_extension FROM tenants WHERE id = $1::uuid")
+        let has_claimed: bool = sqlx::query_scalar("SELECT COALESCE(has_claimed_trial_extension, false) FROM tenants WHERE id = $1::uuid")
             .bind(tenant_id)
             .fetch_one(&pool).await.unwrap();
 


### PR DESCRIPTION
The `has_claimed_trial_extension` column defaults to false, but for older records or specific paths it may exist as NULL. This caused `sqlx::query_scalar` expecting a `bool` to fail decoding, throwing a 500 error instead of correctly evaluating as false and returning a 404/400.
  
  This commit fixes the issue by updating the `SELECT` query in `handle_trial_extension_claim` (and its corresponding test) to use `COALESCE(has_claimed_trial_extension, false)`, correctly mapping `NULL` values to `false` and preventing decoding crashes.
  
  Resolves #9690

---
*PR created automatically by Jules for task [11354077187115437516](https://jules.google.com/task/11354077187115437516) started by @ql-owo-lp*