### PR TITLE
💰 Miser: Fix E2E test locator for Cost Dashboard Back button

### DIFF
--- a/src/e2e/miser_cost_features.spec.ts
+++ b/src/e2e/miser_cost_features.spec.ts
@@ -18,7 +18,7 @@ test.describe('Miser Cost Features E2E', () => {
     await expect(page.locator('text=Total Costs')).toBeVisible({ timeout: 15000 });
     await expect(page.locator('text=Projected Monthly Cost').first()).toBeVisible({ timeout: 15000 });
 
-    const backToMyPlanBtn = page.locator('button', { hasText: 'Back to My Plan' });
+    const backToMyPlanBtn = page.locator('a', { hasText: 'Back to My Plan' });
     await expect(backToMyPlanBtn).toBeVisible();
     await backToMyPlanBtn.click();
     await expect(page.locator('text=Your Current Usage')).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
### Description
Fixed a failing Playwright E2E test in `miser_cost_features.spec.ts` where the test was incorrectly trying to find a `<button>` with the text "Back to My Plan". The underlying `AppShell` component correctly renders this action as an anchor (`<a>`) tag.

### Product-use evidence
- **Persona:** Business Owner / Admin
- **Attempted flow:** Navigate from the Cost Transparency Dashboard back to the My Plan screen.
- **Observed gap:** The automated E2E test failed to locate the "Back to My Plan" button because it was rendered as a link (anchor tag) using `AppShell`, resulting in a test failure.
- **Reason for fix:** The E2E test must accurately reflect the real UI elements rendered to correctly verify the CUJ navigation.
- **Post-fix flow:** E2E test now clicks the correct `<a>` tag, successfully navigating back to the My Plan screen and passing the test.

### Interaction Audit
| Element | Designed Purpose | Observed Result | Fix |
|---|---|---|---|
| `Back to My Plan` Action Link | Return to My Plan page | E2E Test incorrectly assumed it was a `<button>`. Rendered as `<a>`. | Updated Playwright locator to expect an `<a>` element. |

### Superpowers applied
Followed requirements to ensure UI gaps are discovered through Playwright/browser use first, verifying the CUJ gap and testing the actual flow. Verified interaction points without mocking.

### Testing
- `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)" --test_filter="Miser Cost Features E2E"` -> PASSED
- `bazel test //...` -> All 100 tests PASSED.

---
*PR created automatically by Jules for task [2484312430542871405](https://jules.google.com/task/2484312430542871405) started by @ql-owo-lp*