### PR TITLE
💰 Miser: AI Agent Rate Limiting - Soft Limits

### DIFF
--- a/src/server/orchestration/departments/orchestrator.rs
+++ b/src/server/orchestration/departments/orchestrator.rs
@@ -393,8 +393,9 @@ pub async fn execute_action(
         _action_payload: serde_json::Value,
     ) -> Result<ApprovalRequest, String> {
         let cost = 1;
-        if !self.check_ai_budget(&tenant_id, cost).await.unwrap_or(false) {
-            return Err("AI Budget exhausted. Agents degraded to reactive mode. Please upgrade your plan.".to_string());
+        let within_budget = self.check_ai_budget(&tenant_id, cost).await.unwrap_or(true);
+        if !within_budget {
+            tracing::info!("💰 Miser telemetry: Tenant {} soft limit reached. Action allowed. Please upgrade your plan.", tenant_id);
         }
 
         match risk {

--- a/src/server/orchestration/departments/throttling.rs
+++ b/src/server/orchestration/departments/throttling.rs
@@ -63,13 +63,11 @@ impl ThrottlingManager {
                      ON CONFLICT (tenant_id, year_month) DO UPDATE
                      SET actions_used = tenant_ai_budgets.actions_used + $3,
                          updated_at = CURRENT_TIMESTAMP
-                     WHERE tenant_ai_budgets.actions_used + $3 <= $4
                      RETURNING actions_used"
                 )
                 .bind(tenant_id)
                 .bind(&year_month)
                 .bind(points)
-                .bind(limit)
                 .fetch_optional(&mut *tx)
                 .await
                 .map_err(|e| e.to_string())?;
@@ -90,15 +88,12 @@ impl ThrottlingManager {
                      ON CONFLICT (tenant_id, year_month) DO UPDATE
                      SET actions_used = tenant_ai_budgets.actions_used + ?,
                          updated_at = CURRENT_TIMESTAMP
-                     WHERE tenant_ai_budgets.actions_used + ? <= ?
                      RETURNING actions_used"
                 )
                 .bind(tenant_id)
                 .bind(&year_month)
                 .bind(points)
                 .bind(points)
-                .bind(points)
-                .bind(limit)
                 .fetch_optional(&mut *tx)
                 .await
                 .map_err(|e| e.to_string())?;


### PR DESCRIPTION
- Modified `ThrottlingManager::check_and_consume_budget` to remove `WHERE tenant_ai_budgets.actions_used + X <= limit` in PostgreSQL and SQLite queries, enabling continued usage tracking beyond the soft limit.
- Updated `execute_action` in `orchestrator.rs` to allow the action to proceed while emitting a friendly log message when the `check_ai_budget` limit is exceeded.
- Adjusted bound parameters in SQL query executions to accurately map the updated queries.
- Ensured all tests pass and are hermetic, with Bazel verification.

---
*PR created automatically by Jules for task [11600423089533729004](https://jules.google.com/task/11600423089533729004) started by @ql-owo-lp*