### PR TITLE
fix(sync): properly mark stuck missions and queued items as FAILED instead of deleting them

### DIFF
--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -445,15 +445,15 @@ impl HybridSyncDaemon {
         const SQLITE_WHERE_CLAUSE: &str = "(status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hours') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hours')))";
         const PG_WHERE_CLAUSE: &str = "(status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))";
 
-        let sqlite_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_failed', 'agent_missions', json_object('id', id, 'payload', json(COALESCE(payload, '{{}}'))), '[cleanup] Mission became stuck' FROM agent_missions WHERE {}", SQLITE_WHERE_CLAUSE);
-        let sqlite_delete = format!("DELETE FROM agent_missions WHERE {}", SQLITE_WHERE_CLAUSE);
+        let sqlite_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_stuck', 'agent_missions', json_object('id', id, 'payload', json(COALESCE(payload, '{{}}'))), '[cleanup] Mission became stuck' FROM agent_missions WHERE {}", SQLITE_WHERE_CLAUSE);
+        let sqlite_update = format!("UPDATE agent_missions SET status = 'FAILED' WHERE {}", SQLITE_WHERE_CLAUSE);
 
-        let pg_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'mission_failed', 'agent_missions', json_build_object('id', id, 'payload', COALESCE(payload::jsonb, '{{}}'::jsonb))::text, '[cleanup] Mission became stuck' FROM agent_missions WHERE {}", PG_WHERE_CLAUSE);
-        let pg_delete = format!("DELETE FROM agent_missions WHERE {}", PG_WHERE_CLAUSE);
+        let pg_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'mission_stuck', 'agent_missions', json_build_object('id', id, 'payload', COALESCE(payload::jsonb, '{{}}'::jsonb))::text, '[cleanup] Mission became stuck' FROM agent_missions WHERE {}", PG_WHERE_CLAUSE);
+        let pg_update = format!("UPDATE agent_missions SET status = 'FAILED' WHERE {}", PG_WHERE_CLAUSE);
 
         // SQLite
         let _ = sqlx::query(&sqlite_insert).execute(&self.sqlite_pool).await;
-        if let Ok(res) = sqlx::query(&sqlite_delete).execute(&self.sqlite_pool).await {
+        if let Ok(res) = sqlx::query(&sqlite_update).execute(&self.sqlite_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck agent missions from SQLite", res.rows_affected());
             }
@@ -461,7 +461,7 @@ impl HybridSyncDaemon {
 
         // PG
         let _ = sqlx::query(&pg_insert).execute(&self.pg_pool).await;
-        if let Ok(res) = sqlx::query(&pg_delete).execute(&self.pg_pool).await {
+        if let Ok(res) = sqlx::query(&pg_update).execute(&self.pg_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck agent missions from PostgreSQL", res.rows_affected());
             }

--- a/src/server/orchestration/hybrid_sync/daemon_test.rs
+++ b/src/server/orchestration/hybrid_sync/daemon_test.rs
@@ -558,20 +558,20 @@ async fn test_hybrid_sync_pos_offline_transactions() {
         daemon.prune_stuck_agent_missions().await.unwrap();
         daemon.prune_stuck_sub_agent_queue().await.unwrap();
 
-        // Verify SQLite mission is failed (now deleted)
+        // Verify SQLite mission is failed
         let row_sqlite = sqlx::query("SELECT status FROM agent_missions WHERE id = 'stuck_mission_sqlite'")
             .fetch_optional(&sqlite_pool).await.unwrap();
-        assert!(row_sqlite.is_none());
+        use sqlx::Row;
+        assert_eq!(row_sqlite.unwrap().get::<String, _>("status"), "FAILED");
 
-        // Verify PG mission is failed (now deleted)
+        // Verify PG mission is failed
         let row_pg = sqlx::query("SELECT status FROM agent_missions WHERE id = 'stuck_mission_pg'")
             .fetch_optional(&pg_pool).await.unwrap();
-        assert!(row_pg.is_none());
+        assert_eq!(row_pg.unwrap().get::<String, _>("status"), "FAILED");
 
         // Verify SQLite queue is failed
         let row_queue_sqlite = sqlx::query("SELECT status FROM sub_agent_queue WHERE id = 'stuck_queue_sqlite'")
             .fetch_one(&sqlite_pool).await.unwrap();
-        use sqlx::Row;
         assert_eq!(row_queue_sqlite.get::<String, _>("status"), "FAILED");
 
         // Verify PG queue is failed


### PR DESCRIPTION
This fixes a bug in the hybrid sync daemon where stuck agent missions and queued items were being deleted during pruning, erasing their history. Now they are correctly marked as `FAILED`.

---
*PR created automatically by Jules for task [1514539186056912363](https://jules.google.com/task/1514539186056912363) started by @ql-owo-lp*