### PR TITLE
UX/UI: Apply Translucent Glass mandate to onboarding widgets

### DIFF
--- a/src/ui/next/src/app/website-builder/page.tsx
+++ b/src/ui/next/src/app/website-builder/page.tsx
@@ -792,7 +792,7 @@ export default function WebsiteBuilderPage() {
           <p className="text-gray-500 dark:text-[#a1a1a6] mb-6 text-sm">Your automated storefront is successfully published.</p>
           <p className="text-gray-500 dark:text-[#a1a1a6] mb-6 text-sm">You're set up! Here's what to do next:</p>
 
-          <div className="w-full glassmorphism p-3 rounded-[16px] mb-6 flex items-center justify-between">
+          <div className="w-full glassmorphism p-3 mb-6 flex items-center justify-between">
             <span className="text-sm text-gray-700 dark:text-[#a1a1a6] truncate mr-2 font-medium">{liveUrl}</span>
             <button className="text-[#0071E3] font-semibold text-sm hover:underline shrink-0">Copy</button>
           </div>

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -120,7 +120,7 @@
         box-sizing: border-box;
       }
       /* Cleaned up duplicate glassmorphism */
-      textarea.glassmorphism, input.glassmorphism, select.glassmorphism {
+      textarea.glassmorphism, input.glassmorphism, select.glassmorphism, button.glassmorphism {
         background: rgba(255, 255, 255, 0.65);
         backdrop-filter: blur(30px) saturate(210%);
         -webkit-backdrop-filter: blur(30px) saturate(210%);
@@ -129,7 +129,7 @@
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
       }
       @media (prefers-color-scheme: dark) {
-        textarea.glassmorphism, input.glassmorphism, select.glassmorphism {
+        textarea.glassmorphism, input.glassmorphism, select.glassmorphism, button.glassmorphism {
           background: rgba(22, 22, 26, 0.7);
           backdrop-filter: blur(30px) saturate(210%);
           -webkit-backdrop-filter: blur(30px) saturate(210%);


### PR DESCRIPTION
- Fixed border radius logic to conform to OHC Premium Design Standards
- Added `button.glassmorphism` to `setup.html` styling section to apply 8px radii.
- Removed redundant Tailwind CSS classes `rounded-[16px]` on containers already targeted by the `.glassmorphism` 16px radius logic in `globals.css`.
- Preserved necessary padding and bottom margins.

---
*PR created automatically by Jules for task [6909046876331543435](https://jules.google.com/task/6909046876331543435) started by @ql-owo-lp*