### PR TITLE
feat: Optimize memory_store upsert logic and expand memory E2E tests

### DIFF
--- a/src/agents/builtin/memory_store.rs
+++ b/src/agents/builtin/memory_store.rs
@@ -95,66 +95,64 @@ impl VectorRepository {
         let emb_str = serde_json::to_string(&record.embedding)
             .map_err(|e| format!("VectorRepository Upsert JSON Serialization Error: {}", e))?;
 
+        const UPSERT_ON_CONFLICT_CLAUSE: &str = "ON CONFLICT(id) DO UPDATE SET \
+            content=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.content WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.content ELSE consolidated_memory.content END, \
+            embedding=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.embedding WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.embedding ELSE consolidated_memory.embedding END, \
+            created_at=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.created_at WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.created_at ELSE consolidated_memory.created_at END, \
+            last_referenced_at=excluded.last_referenced_at, \
+            reference_count=excluded.reference_count, \
+            reliability_score=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.reliability_score WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.reliability_score ELSE consolidated_memory.reliability_score END, \
+            owner_override=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.owner_override WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.owner_override ELSE consolidated_memory.owner_override END, \
+            metadata=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.metadata WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.metadata ELSE consolidated_memory.metadata END";
+
         match &self.store {
             VectorMemoryStore::Postgres(pool) => {
-                sqlx::query(
+                let query_str = format!(
                     "INSERT INTO consolidated_memory (id, tenant_id, agent_id, content, embedding, source_type, created_at, last_referenced_at, reference_count, reliability_score, owner_override, metadata) \
                      VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $10, $11, $12) \
-                     ON CONFLICT(id) DO UPDATE SET \
-                         content=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.content WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.content ELSE consolidated_memory.content END, \
-                         embedding=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.embedding WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.embedding ELSE consolidated_memory.embedding END, \
-                         created_at=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.created_at WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.created_at ELSE consolidated_memory.created_at END, \
-                         last_referenced_at=excluded.last_referenced_at, \
-                         reference_count=excluded.reference_count, \
-                         reliability_score=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.reliability_score WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.reliability_score ELSE consolidated_memory.reliability_score END, \
-                         owner_override=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.owner_override WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.owner_override ELSE consolidated_memory.owner_override END, \
-                         metadata=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.metadata WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.metadata ELSE consolidated_memory.metadata END"
-                )
-                .bind(&record.id)
-                .bind(&record.tenant_id)
-                .bind(&record.agent_id)
-                .bind(&record.content)
-                .bind(&emb_str)
-                .bind(&record.source_type)
-                .bind(record.created_at)
-                .bind(record.last_referenced_at)
-                .bind(record.reference_count)
-                .bind(record.reliability_score)
-                .bind(record.owner_override)
-                .bind(&record.metadata)
-                .execute(pool)
-                .await
-                .map_err(|e| e.to_string())?;
+                     {}",
+                    UPSERT_ON_CONFLICT_CLAUSE
+                );
+                sqlx::query(&query_str)
+                    .bind(&record.id)
+                    .bind(&record.tenant_id)
+                    .bind(&record.agent_id)
+                    .bind(&record.content)
+                    .bind(&emb_str)
+                    .bind(&record.source_type)
+                    .bind(record.created_at)
+                    .bind(record.last_referenced_at)
+                    .bind(record.reference_count)
+                    .bind(record.reliability_score)
+                    .bind(record.owner_override)
+                    .bind(&record.metadata)
+                    .execute(pool)
+                    .await
+                    .map_err(|e| e.to_string())?;
             }
             VectorMemoryStore::Sqlite(pool) => {
-                sqlx::query(
+                let query_str = format!(
                     "INSERT INTO consolidated_memory (id, tenant_id, agent_id, content, embedding, source_type, created_at, last_referenced_at, reference_count, reliability_score, owner_override, metadata) \
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
-                     ON CONFLICT(id) DO UPDATE SET \
-                         content=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.content WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.content ELSE consolidated_memory.content END, \
-                         embedding=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.embedding WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.embedding ELSE consolidated_memory.embedding END, \
-                         created_at=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.created_at WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.created_at ELSE consolidated_memory.created_at END, \
-                         last_referenced_at=excluded.last_referenced_at, \
-                         reference_count=excluded.reference_count, \
-                         reliability_score=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.reliability_score WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.reliability_score ELSE consolidated_memory.reliability_score END, \
-                         owner_override=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.owner_override WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.owner_override ELSE consolidated_memory.owner_override END, \
-                         metadata=CASE WHEN consolidated_memory.owner_override = TRUE THEN consolidated_memory.metadata WHEN excluded.owner_override = TRUE OR excluded.reliability_score > consolidated_memory.reliability_score OR (excluded.reliability_score = consolidated_memory.reliability_score AND excluded.created_at >= consolidated_memory.created_at) THEN excluded.metadata ELSE consolidated_memory.metadata END"
-                )
-                .bind(&record.id)
-                .bind(&record.tenant_id)
-                .bind(&record.agent_id)
-                .bind(&record.content)
-                .bind(&emb_str)
-                .bind(&record.source_type)
-                .bind(record.created_at)
-                .bind(record.last_referenced_at)
-                .bind(record.reference_count)
-                .bind(record.reliability_score)
-                .bind(record.owner_override)
-                .bind(&record.metadata)
-                .execute(pool)
-                .await
-                .map_err(|e| e.to_string())?;
+                     {}",
+                    UPSERT_ON_CONFLICT_CLAUSE
+                );
+                sqlx::query(&query_str)
+                    .bind(&record.id)
+                    .bind(&record.tenant_id)
+                    .bind(&record.agent_id)
+                    .bind(&record.content)
+                    .bind(&emb_str)
+                    .bind(&record.source_type)
+                    .bind(record.created_at)
+                    .bind(record.last_referenced_at)
+                    .bind(record.reference_count)
+                    .bind(record.reliability_score)
+                    .bind(record.owner_override)
+                    .bind(&record.metadata)
+                    .execute(pool)
+                    .await
+                    .map_err(|e| e.to_string())?;
             }
         }
 

--- a/src/e2e/customer_memory_graph_ui.spec.ts
+++ b/src/e2e/customer_memory_graph_ui.spec.ts
@@ -5,6 +5,41 @@ test.describe('Omnichannel Unified Customer Memory Graph UI', () => {
   const tenantId = `tenant_${uuidv4().substring(0, 8)}`;
   const customerId = uuidv4();
 
+  test('should show error when customerId is missing from query parameters', async ({ page }) => {
+    await page.goto(`/customer/memory-graph?tenantId=${tenantId}`);
+    await expect(page.getByText('Customer not found.').or(page.getByText('Missing customer ID'))).toBeVisible();
+  });
+
+  test('should show error when tenantId is missing from query parameters', async ({ page }) => {
+    await page.goto(`/customer/memory-graph?customerId=${customerId}`);
+    await expect(page.getByText('Customer not found.').or(page.getByText('Missing tenant ID'))).toBeVisible();
+  });
+
+  test('should be responsive and show error text on mobile viewport (375x667)', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto(`/customer/memory-graph?tenantId=${tenantId}&customerId=${customerId}`);
+    await expect(page.locator('text=Failed to fetch customer history.').or(page.locator('text=Loading customer history...'))).toBeVisible();
+    await expect(page.getByText('Customer not found.')).toBeVisible();
+  });
+
+  test('should be responsive and show error text on tablet viewport (768x1024)', async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await page.goto(`/customer/memory-graph?tenantId=${tenantId}&customerId=${customerId}`);
+    await expect(page.locator('text=Failed to fetch customer history.').or(page.locator('text=Loading customer history...'))).toBeVisible();
+    await expect(page.getByText('Customer not found.')).toBeVisible();
+  });
+
+  test('should show loading state temporarily before network failure resolves', async ({ page }) => {
+    await page.route('**/api/inbox/summary/**', async route => {
+      await new Promise(resolve => setTimeout(resolve, 500));
+      await route.fulfill({ status: 404, body: 'Not found' });
+    });
+
+    await page.goto(`/customer/memory-graph?tenantId=${tenantId}&customerId=${customerId}`);
+    await expect(page.locator('text=Loading customer history...')).toBeVisible();
+    await expect(page.getByText('Customer not found.')).toBeVisible();
+  });
+
   test('should display the memory graph correctly for an existing customer', async ({ page, request }) => {
     // Navigate to the memory graph page
     await page.goto(`/customer/memory-graph?tenantId=${tenantId}&customerId=${customerId}`);


### PR DESCRIPTION
feat: Optimize memory_store upsert logic and expand memory E2E tests

- Refactored `src/agents/builtin/memory_store.rs` by extracting a large duplicated `ON CONFLICT` SQL block into `UPSERT_ON_CONFLICT_CLAUSE` for both `Postgres` and `Sqlite` upsert calls. This removes significant code duplication and improves maintainability.
- Added 5 new Playwright UI tests in `src/e2e/customer_memory_graph_ui.spec.ts` addressing missing query parameter handling, mobile and tablet viewport responsiveness, and loading states simulating network delays.

---
*PR created automatically by Jules for task [4332230921918598476](https://jules.google.com/task/4332230921918598476) started by @ql-owo-lp*