### PR TITLE
fix(docs): add duration to mobile optimized video response

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -234,6 +234,7 @@ pub async fn list_videos(Query(query): Query<DocsQuery>) -> Json<Vec<serde_json:
             serde_json::json!({
                 "id": v.id,
                 "title": v.title,
+                "duration": v.duration,
                 "video_url": v.video_url
             })
         } else {


### PR DESCRIPTION
Updates `list_videos` in `src/server/api/docs.rs` to include the `duration` field in the response when handling requests with `mobile_optimized=true`. This aligns the payload with the Next.js `VideoTutorialList` requirements. Checked and verified through E2E Help module tests.

---
*PR created automatically by Jules for task [6351447173113290248](https://jules.google.com/task/6351447173113290248) started by @ql-owo-lp*