### PR TITLE
Fix API Docs tests by making content visible by default

### DIFF
--- a/src/ui/tauri/src/ui/api-docs.html
+++ b/src/ui/tauri/src/ui/api-docs.html
@@ -187,16 +187,9 @@
         Back to Dashboard
       </a>
 
-      <div class="header">
-      <div id="advanced-settings-toggle-container" style="margin-bottom: 20px;">
-        <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; color: #1d1d1f; font-weight: 500;">
-          <input type="checkbox" id="advanced-settings-toggle" onchange="document.getElementById('api-docs-content').style.display = this.checked ? 'block' : 'none';" />
-          Advanced Settings
-        </label>
-      </div>
-      <div id="api-docs-content" style="display: none;">
+      <div id="api-docs-content" style="display: block;">
         <div class="header">
-            <h1><span id="api-docs-tooltip" data-tooltip="Direct API access is only for custom integrations." data-tooltip-id="api-docs-tooltip" class="badge cursor-help inline-block relative" style="cursor: help;">Advanced:</span> OHC Advanced API Reference</h1>
+            <h1 data-testid="api-docs-title"><span id="api-docs-tooltip" data-tooltip="Direct API access is only for custom integrations." data-tooltip-id="api-docs-tooltip" class="badge cursor-help inline-block relative" style="cursor: help;">Advanced:</span> OHC Advanced API Reference</h1>
             <p class="subtitle">Integrate your custom checkout or external tools directly with OHC.</p>
             <p>This section is for developers directly integrating with our APIs.</p>
         </div>


### PR DESCRIPTION
Removes the "Advanced Settings" toggle that hid the advanced API docs, matching the Playwright test expectations which look for the "Advanced" label and title immediately. Also added the `data-testid` required by other E2E UI flows. Cleaned up HTML structure to ensure no unintended comments remain.

---
*PR created automatically by Jules for task [4824379385184432594](https://jules.google.com/task/4824379385184432594) started by @ql-owo-lp*