### PR TITLE
fix: remove test fallbacks and implement real fetch in growth tools

### DIFF
--- a/src/ui/tauri/src/ui/cart-recovery.html
+++ b/src/ui/tauri/src/ui/cart-recovery.html
@@ -302,7 +302,6 @@
           const data = await response.json();
           cartCount = data.count || 0;
         } else {
-          // No mocked fallbacks
           cartCount = 0;
         }
       } catch (e) {
@@ -378,12 +377,7 @@
             alert("Failed to activate trial.");
         }
       } catch (e) {
-        // Fallback for tests
-        alert("Your 7-day Pro trial has been activated.");
-        hasPro = true;
-        localStorage.setItem('has_pro', 'true');
-        document.getElementById('paywall-modal').classList.remove('active');
-        generateCampaign();
+        alert("Failed to activate trial due to a network error.");
       }
     });
 

--- a/src/ui/tauri/src/ui/viral-mystery-offer-generator.html
+++ b/src/ui/tauri/src/ui/viral-mystery-offer-generator.html
@@ -406,29 +406,30 @@
     });
 
     document.getElementById('share-to-unlock-btn').addEventListener('click', async () => {
-      // Mock unlocking process
       const originalText = document.getElementById('share-to-unlock-btn').textContent;
       document.getElementById('share-to-unlock-btn').textContent = 'Unlocking...';
 
       try {
-        // In real app, this might call an API
-        localStorage.setItem('has_pro', 'true');
-        hasPro = true;
-
-        setTimeout(() => {
-          paywallModal.classList.remove('active');
-          brandingCheckbox.checked = true;
-          previewBranding.style.display = 'none';
-          document.getElementById('share-to-unlock-btn').textContent = originalText;
-
-          alert('7-Day Pro Trial Unlocked! You can now remove branding.');
-        }, 1000);
-      } catch(e) {
-        // Test fallback
-        hasPro = true;
-        paywallModal.classList.remove('active');
-        brandingCheckbox.checked = true;
-        previewBranding.style.display = 'none';
+        const tenant = localStorage.getItem('tenant') || 'my-store';
+        const response = await fetch('/api/v1/growth/trial/extend', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ tenant_id: tenant })
+        });
+        if (response.ok) {
+            alert("7-Day Pro Trial Unlocked! You can now remove branding.");
+            hasPro = true;
+            localStorage.setItem('has_pro', 'true');
+            paywallModal.classList.remove('active');
+            brandingCheckbox.checked = true;
+            previewBranding.style.display = 'none';
+        } else {
+            alert("Failed to activate trial.");
+        }
+      } catch (e) {
+        alert("Failed to activate trial due to a network error.");
+      } finally {
+        document.getElementById('share-to-unlock-btn').textContent = originalText;
       }
     });
 


### PR DESCRIPTION
- Removed `mocked fallbacks` comment in `cart-recovery.html` and changed catch block to show a real network error instead of failing open to `hasPro = true`.
- Removed `// Mock unlocking process` logic and `setTimeout` from `viral-mystery-offer-generator.html` and implemented a proper `fetch` call to `/api/v1/growth/trial/extend`, matching the logic used in other growth components.

---
*PR created automatically by Jules for task [784237934850862340](https://jules.google.com/task/784237934850862340) started by @ql-owo-lp*