### PR TITLE
Fix missing playwright_spec_coverage_check_test target

### DIFF
--- a/bazel/rules/playwright/playwright_tests.bzl
+++ b/bazel/rules/playwright/playwright_tests.bzl
@@ -101,7 +101,7 @@ def define_playwright_tests(specs, ci_specs = [], ci_shard_count = 16, data = []
     ci_specs = sorted(ci_specs)
 
     coverage_attrs = {
-        "name": "playwright_spec_coverage",
+        "name": "playwright_spec_coverage_check_test",
         "srcs": ["//bazel/rules/playwright:playwright_spec_coverage_check.sh"],
         "size": "small",
         "tags": ["playwright"],
@@ -134,5 +134,5 @@ def define_playwright_tests(specs, ci_specs = [], ci_shard_count = 16, data = []
     native.test_suite(
         name = "playwright",
         tags = ["manual"],
-        tests = [":playwright_spec_coverage"] + shard_targets,
+        tests = [":playwright_spec_coverage_check_test"] + shard_targets,
     )


### PR DESCRIPTION
Fix missing playwright_spec_coverage_check_test target

The `define_playwright_tests` macro was generating a target named `playwright_spec_coverage` instead of `playwright_spec_coverage_check_test`, causing `bazel test //...` to fail because `playwright_spec_coverage_check_test` could not be found. This patch renames the generated target to resolve the build failure.

---
*PR created automatically by Jules for task [18409771002628116245](https://jules.google.com/task/18409771002628116245) started by @ql-owo-lp*