### PR TITLE
Fix duplicate spawning of MemoryConsolidationWorker

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -2456,8 +2456,8 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
         crate::db::DbStore::Postgres => ohc_builtin_agent::memory_store::VectorRepository::new(db.pool.clone()),
         crate::db::DbStore::Sqlite(sqlite_pool) => ohc_builtin_agent::memory_store::VectorRepository::new_sqlite(sqlite_pool.clone()),
     });
-    let cb = std::sync::Arc::new(|msg: &str, _err: &str| { ::server_telemetry::record_error_signal(msg); }) as std::sync::Arc<dyn Fn(&str, &str) + Send + Sync>; let consolidation_worker = std::sync::Arc::new(crate::workers::memory::MemoryConsolidationWorker::new(vector_repo.clone(), std::time::Duration::from_secs(3600), 180, Some(cb))); let _ = consolidation_worker.clone().spawn_background_task();
-    let _ = consolidation_worker.clone().spawn_background_task();
+    let cb = std::sync::Arc::new(|msg: &str, _err: &str| { ::server_telemetry::record_error_signal(msg); }) as std::sync::Arc<dyn Fn(&str, &str) + Send + Sync>; let consolidation_worker = std::sync::Arc::new(crate::workers::memory::MemoryConsolidationWorker::new(vector_repo.clone(), std::time::Duration::from_secs(3600), 180, Some(cb)));
+    let _ = consolidation_worker.spawn_background_task();
 
     let replenishment_job = crate::workers::subscription_replenishment_job::SubscriptionReplenishmentJob::new(db.clone());
     replenishment_job.start();

--- a/test_ui.spec.ts
+++ b/test_ui.spec.ts
@@ -1,1 +1,0 @@
-import { test, expect } from '@playwright/test';


### PR DESCRIPTION
Removed a duplicate call to `spawn_background_task` for the `MemoryConsolidationWorker` in `src/server/lib.rs` which could have caused background worker duplication and resource contention. Removed an unnecessary `.clone()` in the single remaining spawn call, and removed an unused temporary test file.

---
*PR created automatically by Jules for task [6928589581035676359](https://jules.google.com/task/6928589581035676359) started by @ql-owo-lp*