### PR TITLE
feat(pos): show pending sync count in offline status pill

### DIFF
--- a/src/ui/next/src/app/pos/terminal/page.tsx
+++ b/src/ui/next/src/app/pos/terminal/page.tsx
@@ -26,6 +26,7 @@ export default function POSTerminal() {
   const [isOffline, setIsOffline] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [offlineConversion, setOfflineConversion] = useState(false);
+  const [pendingSyncCount, setPendingSyncCount] = useState(0);
 
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [deviceId, setDeviceId] = useState<string>('');
@@ -34,6 +35,7 @@ export default function POSTerminal() {
   useEffect(() => {
     const checkQueue = async () => {
       const qLen = await SyncManager.getInstance().getQueueLength();
+      setPendingSyncCount(qLen);
       if (navigator.onLine && qLen > 0) {
         setSyncing(true);
       } else {
@@ -536,7 +538,7 @@ export default function POSTerminal() {
         {isOffline && (
           <div className="absolute top-4 left-1/2 -translate-x-1/2 bg-white/65 backdrop-blur-[30px] saturate-[210%] border border-white/40 shadow-lg text-gray-900 px-6 py-3 rounded-full font-bold min-h-[44px] flex items-center justify-center space-x-2 z-50">
             <svg className="w-5 h-5 text-[#FF9500]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-            <span>{t('Offline Mode')}</span>
+            <span>{t('Offline Mode')}{pendingSyncCount > 0 ? ` - ${pendingSyncCount} Pending` : ''}</span>
           </div>
         )}
         {syncing && !isOffline && (


### PR DESCRIPTION
**Persona:** Fatima, Food Cart Operator
**Product-use Evidence:**
- Used Playwright/browser UI to navigate the POS offline app application.
- I noticed that the "Offline Mode" status indicator only displayed "Offline Mode" but did not show the number of pending syncing transactions queue count, hiding important visibility to the merchant regarding how many items are yet to be synced back up.
- A real owner/operator using the offline POS app would want to know if their offline transactions are increasing and how many are pending to be synced to the cloud.
- Fix: Add the pending offline outbox queue count on the UI pill using `SyncManager.getQueueLength()`.

**Superpowers Applied:**
- Verified using real UI tests with `playwright` (`//src/e2e:playwright`).
- Rebase and Atomic PR structure.
- `bazelisk test //...` 100% green.

Resolves #32532

---
*PR created automatically by Jules for task [6465018050846927895](https://jules.google.com/task/6465018050846927895) started by @ql-owo-lp*