### PR TITLE
🧙 Wizard: Fix glassmorphism UI specs and rust compiler warnings

### DIFF
--- a/src/server/api/agents/pydantic.rs
+++ b/src/server/api/agents/pydantic.rs
@@ -24,9 +24,8 @@ pub fn router<S>() -> Router<S> where S: Clone + Send + Sync + 'static {
 async fn validate_pydantic(
     Json(payload): Json<PydanticValidateRequest>,
 ) -> axum::response::Response {
-    use axum::response::{IntoResponse, Response};
-use axum::http::StatusCode;
-    use ohc_builtin_agent::types::{format_pydantic_error_string, format_pydantic_error};
+    use axum::response::IntoResponse;
+    use ohc_builtin_agent::types::format_pydantic_error;
 
     let mut err_msg = None;
     let mut is_recoverable = false;
@@ -34,7 +33,7 @@ use axum::http::StatusCode;
     match payload.tool_name.as_str() {
         "TopicRetrieve" => {
             #[derive(Deserialize)]
-            struct Args { topic_name: String }
+            struct Args { #[allow(dead_code)] topic_name: String }
             if let Err(e) = serde_json::from_value::<Args>(payload.arguments.clone()) {
                 err_msg = Some(format_pydantic_error(&e, Some(&payload.arguments.to_string()), None));
                 is_recoverable = true;
@@ -42,7 +41,7 @@ use axum::http::StatusCode;
         }
         "TranscriptSearch" => {
             #[derive(Deserialize)]
-            struct Args { query: String }
+            struct Args { #[allow(dead_code)] query: String }
             if let Err(e) = serde_json::from_value::<Args>(payload.arguments.clone()) {
                 err_msg = Some(format_pydantic_error(&e, Some(&payload.arguments.to_string()), None));
                 is_recoverable = true;
@@ -50,7 +49,7 @@ use axum::http::StatusCode;
         }
         "TopicWrite" => {
             #[derive(Deserialize)]
-            struct Args { topic_name: String, content: String }
+            struct Args { #[allow(dead_code)] topic_name: String, #[allow(dead_code)] content: String }
             if let Err(e) = serde_json::from_value::<Args>(payload.arguments.clone()) {
                 err_msg = Some(format_pydantic_error(&e, Some(&payload.arguments.to_string()), None));
                 is_recoverable = true;
@@ -58,7 +57,7 @@ use axum::http::StatusCode;
         }
         "Bash" => {
             #[derive(Deserialize)]
-            struct Args { command: String }
+            struct Args { #[allow(dead_code)] command: String }
             if let Err(e) = serde_json::from_value::<Args>(payload.arguments.clone()) {
                 err_msg = Some(format_pydantic_error(&e, Some(&payload.arguments.to_string()), None));
                 is_recoverable = true;

--- a/src/server/api/inbox/action_required_test.rs
+++ b/src/server/api/inbox/action_required_test.rs
@@ -1,8 +1,8 @@
-use axum::{body::Body, http::{Request, StatusCode}, Router};
+use axum::{body::Body, http::{Request, StatusCode}};
 use std::sync::Arc;
 use tower::ServiceExt;
 
-use crate::{db::{DB, DbStore}, domain::repository::action_required_queue_repo::ActionRequiredQueueRepo};
+use crate::db::{DB, DbStore};
 
 #[tokio::test]
 async fn test_list_pending_drafts_unauthorized() {

--- a/src/server/api/storefront_delivery.rs
+++ b/src/server/api/storefront_delivery.rs
@@ -259,8 +259,6 @@ fn set_storefront_headers(response: &mut axum::response::Response, html: &str, t
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     fn test_storefront_headers_dummy() {
         assert!(true);

--- a/src/server/workers/agent_action_worker.rs
+++ b/src/server/workers/agent_action_worker.rs
@@ -134,9 +134,6 @@ impl AgentActionWorker {
 
 #[cfg(test)]
 mod tests {
-    // use super::*
-    use super::*;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_ml_resilience_agent_action_timeout() {

--- a/src/server/workers/agent_memory_pipeline.rs
+++ b/src/server/workers/agent_memory_pipeline.rs
@@ -333,9 +333,6 @@ mod tests {
 
 #[cfg(test)]
 mod tests2 {
-    // use super::*
-    use super::*;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_ml_resilience_agent_memory_pipeline_timeout() {

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1120,6 +1120,7 @@
       .glassmorphism.container,
       .glassmorphism.card,
       .glassmorphism.panel {
+          border-radius: 16px;
       }
           #instant-bio { min-height: 44px; box-sizing: border-box; }
       .context-card { min-height: 44px; box-sizing: border-box; }


### PR DESCRIPTION
This PR addresses failing E2E UI Playwright tests by enforcing a 16px border radius on glassmorphism elements within `setup.html` as required by the OHC Premium Design Standards.

Furthermore, this PR fixes several Rust compilation warnings across different modules (`pydantic.rs`, tests, and worker modules) for unused fields and unused imports to ensure the `bazel test //...` command executes and completes without failures. 

**E2E Validation:**
- Tested the Playwright `setup.spec.ts` flow ensuring glassmorphism style validations correctly execute.
- Verified test suite passes using the `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"` and `bazelisk test //...` run configurations.

---
*PR created automatically by Jules for task [9214319549635161061](https://jules.google.com/task/9214319549635161061) started by @ql-owo-lp*