### PR TITLE
fix: enforce fail-closed architecture on walkthrough API route

### DIFF
--- a/src/ui/next/src/app/api/walkthrough/[page]/route.test.ts
+++ b/src/ui/next/src/app/api/walkthrough/[page]/route.test.ts
@@ -15,13 +15,14 @@ describe('Walkthrough API Route', () => {
     expect(data).toEqual([{ targetId: 'test-target', title: 'Test Step', content: 'Step content', position: 'bottom' }]);
   });
 
-  it('returns empty array on error', async () => {
+  it('handles backend error by returning 502', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
     const req = new NextRequest('http://localhost:3000/api/walkthrough/test-page');
     const res = await GET(req, { params: { page: 'test-page' } });
     const data = await res.json();
-    expect(data).toEqual([]);
+    expect(res.status).toBe(502);
+    expect(data).toEqual({ error: 'Backend walkthrough service unavailable' });
   });
 });

--- a/src/ui/next/src/app/api/walkthrough/[page]/route.ts
+++ b/src/ui/next/src/app/api/walkthrough/[page]/route.ts
@@ -25,6 +25,6 @@ export async function GET(
     return NextResponse.json(mappedData);
   } catch (error) {
     console.error(`Failed to fetch walkthrough for page ${page}:`, error);
-    return NextResponse.json([], { status: 200 }); // Graceful fallback
+    return NextResponse.json({ error: 'Backend walkthrough service unavailable' }, { status: 502 });
   }
 }


### PR DESCRIPTION
This PR enforces a fail-closed architecture on the `/api/walkthrough/[page]/route.ts` Next.js endpoint.

**Key Changes:**
- Removed graceful fallback mock that returned `200 OK` and an empty array `[]` on backend fetch failure.
- Configured the route to fail closed and return `502 Bad Gateway` with a structured error response `{ error: 'Backend walkthrough service unavailable' }`.
- Updated unit test assertions to expect the new `502` status and error object instead of an empty array.

This aligns with the `docs/superpowers/specs/2026-07-01-mock-elimination-design.md` architectural requirements by eliminating silent fallback masking of backend failures.

---
*PR created automatically by Jules for task [27337987534994167](https://jules.google.com/task/27337987534994167) started by @ql-owo-lp*