### PR TITLE
fix: resolve onboarding e2e failures related to step-instant

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2823,7 +2823,6 @@
           "step-target-audience",
           "step-domain",
           "step-template",
-          "step-instant",
           "step-chat",
         ];
 
@@ -2979,8 +2978,7 @@
             "step-target-audience",
             "step-domain",
             "step-template",
-            "step-instant",
-            "step-chat",
+          "step-chat",
           ];
           if (state.step < steps.length) {
             goToStep(steps[state.step]);
@@ -3041,8 +3039,7 @@
             "step-target-audience",
             "step-domain",
             "step-template",
-            "step-instant",
-            "step-chat",
+          "step-chat",
           ].indexOf(activeStep.id);
           if (stepIndex !== -1) {
             state.step = stepIndex;
@@ -3093,7 +3090,6 @@
 
         if (
           stepId === "step-initial" ||
-          stepId === "step-instant" ||
           stepId === "step-chat" ||
           stepId === "step-approval"
         ) {
@@ -3294,7 +3290,6 @@
         const stepperIndicator = document.getElementById("stepper-indicator");
         if (
           stepId === "step-initial" ||
-          stepId === "step-instant" ||
           stepId === "step-chat" ||
           stepId === "step-approval"
         ) {
@@ -3402,7 +3397,7 @@
       }
 
       function goToStep(stepId, shouldSave = true) {
-        if (stepId === "step-instant") {
+        if (stepId === "step-initial") {
           const instantBioInputEl = document.getElementById("instant-bio");
           const generateStorefrontBtn = document.getElementById("generate-storefront-btn");
           if (instantBioInputEl && generateStorefrontBtn) {
@@ -4288,7 +4283,7 @@
               if (nextBtn) {
                 nextBtn.click();
               } else if (
-                activeStep.id === "step-instant" ||
+                activeStep.id === "step-initial" ||
                 activeStep.id === "step-template"
               ) {
                 const launchBtn = activeStep.querySelector(


### PR DESCRIPTION
### Description
Fixed failing E2E tests related to the Instant Build flow. The step identifier `step-instant` was changed to `step-initial` in the DOM structure but the associated Javascript logic in `goToStep` and other logic arrays was not fully updated.

This PR cleans up duplicate conditionals (e.g. `stepId === 'step-initial' || stepId === 'step-instant'`) and ensures the instant build input validation correctly checks `step-initial`.

### Testing
- `npx @bazel/bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"` completes successfully and 13/13 onboarding tests pass.

---
*PR created automatically by Jules for task [6899419412262355294](https://jules.google.com/task/6899419412262355294) started by @ql-owo-lp*