### PR TITLE
chore: align error message with telemetry category for stagnant backlog

### DIFF
--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -477,11 +477,11 @@ impl HybridSyncDaemon {
         const PG_QUEUED_WHERE: &str = "status = 'QUEUED' AND created_at < NOW() - INTERVAL '24 hours'";
 
         let sqlite_running_update = format!("UPDATE sub_agent_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE {}", SQLITE_RUNNING_WHERE);
-        let sqlite_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'job_failed', 'sub_agent_queue', json_object('id', id, 'payload', json(COALESCE(payload, '{{}}'))), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE {}", SQLITE_QUEUED_WHERE);
+        let sqlite_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'job_failed', 'sub_agent_queue', json_object('id', id, 'payload', json(COALESCE(payload, '{{}}'))), '[cleanup] stagnant backlog item in QUEUED for > 24 hours' FROM sub_agent_queue WHERE {}", SQLITE_QUEUED_WHERE);
         let sqlite_queued_delete = format!("DELETE FROM sub_agent_queue WHERE {}", SQLITE_QUEUED_WHERE);
 
         let pg_running_update = format!("UPDATE sub_agent_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE {}", PG_RUNNING_WHERE);
-        let pg_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'job_failed', 'sub_agent_queue', json_build_object('id', id, 'payload', COALESCE(payload::jsonb, '{{}}'::jsonb))::text, '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE {}", PG_QUEUED_WHERE);
+        let pg_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'job_failed', 'sub_agent_queue', json_build_object('id', id, 'payload', COALESCE(payload::jsonb, '{{}}'::jsonb))::text, '[cleanup] stagnant backlog item in QUEUED for > 24 hours' FROM sub_agent_queue WHERE {}", PG_QUEUED_WHERE);
         let pg_queued_delete = format!("DELETE FROM sub_agent_queue WHERE {}", PG_QUEUED_WHERE);
 
         // SQLite queue

--- a/src/server/orchestration/queue/ohc_job_queue.rs
+++ b/src/server/orchestration/queue/ohc_job_queue.rs
@@ -140,12 +140,12 @@ impl OHCJobQueue {
         // Clean up stagnant backlog items: PENDING jobs stuck for > 24 hours
         let query_str = if is_standalone {
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
-             SELECT id, tenant_id, 'job_failed', 'job_queue', CAST(payload AS TEXT), '[cleanup] Stagnant backlog item stuck in PENDING for > 24 hours'
+             SELECT id, tenant_id, 'job_failed', 'job_queue', CAST(payload AS TEXT), '[cleanup] stagnant backlog item in PENDING for > 24 hours'
              FROM ohc_job_queue
              WHERE status = 'PENDING' AND created_at < datetime('now', '-24 hours')"
         } else {
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
-             SELECT id, tenant_id, 'job_failed', 'job_queue', payload::text, '[cleanup] Stagnant backlog item stuck in PENDING for > 24 hours'
+             SELECT id, tenant_id, 'job_failed', 'job_queue', payload::text, '[cleanup] stagnant backlog item in PENDING for > 24 hours'
              FROM ohc_job_queue
              WHERE status = 'PENDING' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
         };

--- a/src/server/queue.rs
+++ b/src/server/queue.rs
@@ -425,7 +425,7 @@ impl TaskQueue for PostgresTaskQueue {
         // Clean up stagnant backlog items: QUEUED jobs stuck for > 24 hours
         sqlx::query(
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
-             SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload::text, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours'
+             SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload::text, '{}'), '[cleanup] stagnant backlog item in QUEUED for > 24 hours'
              FROM sub_agent_queue
              WHERE status = 'QUEUED' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
         )
@@ -1149,7 +1149,7 @@ impl TaskQueue for SqliteTaskQueue {
         // Clean up stagnant backlog items: QUEUED jobs stuck for > 24 hours
         let _ = sqlx::query(
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
-             SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours'
+             SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload, '{}'), '[cleanup] stagnant backlog item in QUEUED for > 24 hours'
              FROM sub_agent_queue
              WHERE status = 'QUEUED' AND created_at < datetime('now', '-24 hour')"
         )


### PR DESCRIPTION
This PR resolves an issue where error signals for stagnant backlog items were incorrectly categorized in telemetry due to string mismatches. It updates all queue cleanup SQL queries to emit the exact lower-cased phrase `[cleanup] stagnant backlog item` that is expected by the telemetry categorization logic.

---
*PR created automatically by Jules for task [8170158461316485948](https://jules.google.com/task/8170158461316485948) started by @ql-owo-lp*