### PR TITLE
🛡️ Sentry: [reliability fix] Clean up unused code and warnings

### DIFF
--- a/src/server/api/agents/pydantic.rs
+++ b/src/server/api/agents/pydantic.rs
@@ -24,9 +24,9 @@ pub fn router<S>() -> Router<S> where S: Clone + Send + Sync + 'static {
 async fn validate_pydantic(
     Json(payload): Json<PydanticValidateRequest>,
 ) -> axum::response::Response {
-    use axum::response::{IntoResponse, Response};
-use axum::http::StatusCode;
-    use ohc_builtin_agent::types::{format_pydantic_error_string, format_pydantic_error};
+    use axum::response::IntoResponse;
+
+    use ohc_builtin_agent::types::format_pydantic_error;
 
     let mut err_msg = None;
     let mut is_recoverable = false;

--- a/src/server/api/inbox/action_required_test.rs
+++ b/src/server/api/inbox/action_required_test.rs
@@ -1,8 +1,8 @@
-use axum::{body::Body, http::{Request, StatusCode}, Router};
+use axum::{body::Body, http::{Request, StatusCode}};
 use std::sync::Arc;
 use tower::ServiceExt;
 
-use crate::{db::{DB, DbStore}, domain::repository::action_required_queue_repo::ActionRequiredQueueRepo};
+use crate::db::{DB, DbStore};
 
 #[tokio::test]
 async fn test_list_pending_drafts_unauthorized() {

--- a/src/server/api/storefront_delivery.rs
+++ b/src/server/api/storefront_delivery.rs
@@ -259,7 +259,6 @@ fn set_storefront_headers(response: &mut axum::response::Response, html: &str, t
 
 #[cfg(test)]
 mod tests {
-    use super::*;
 
     #[test]
     fn test_storefront_headers_dummy() {

--- a/src/server/api/terminal_api.rs
+++ b/src/server/api/terminal_api.rs
@@ -675,7 +675,7 @@ pub async fn create_payment_intent_handler(
     .fetch_optional(&pool)
     .await.unwrap_or(None);
 
-    if let Some((stripe_id,)) = existing {
+    if let Some((_stripe_id,)) = existing {
         // Return existing client secret from stripe - though we might not have it in db, we can re-construct or just return a generic success since it's idempotent.
         // Actually Stripe's idempotency will return the exact same response anyway if we just pass the idempotency key down.
         // Let's just let Stripe handle the idempotency by passing the key, but we need to make sure we don't crash on DB unique constraint if it already exists.

--- a/src/server/workers/agent_action_worker.rs
+++ b/src/server/workers/agent_action_worker.rs
@@ -135,8 +135,6 @@ impl AgentActionWorker {
 #[cfg(test)]
 mod tests {
     // use super::*
-    use super::*;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_ml_resilience_agent_action_timeout() {

--- a/src/server/workers/agent_memory_pipeline.rs
+++ b/src/server/workers/agent_memory_pipeline.rs
@@ -334,8 +334,6 @@ mod tests {
 #[cfg(test)]
 mod tests2 {
     // use super::*
-    use super::*;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_ml_resilience_agent_memory_pipeline_timeout() {


### PR DESCRIPTION
🧹 Swarm Category: CODE AUDITOR

**Phase 1 (Risk Assessment):** Low. All changes are limited to removing unused imports and prefixing unused variables with `_` to suppress compilation warnings.

**Phase 2/3 (Implementation):**
1. Removed `use axum::{body::Body, http::{Request, StatusCode}, Router}` in `action_required_test.rs`.
2. Cleaned up `use axum::response::{IntoResponse, Response}` and `use axum::http::StatusCode` in `pydantic.rs`.
3. Removed unused `super::*` in `storefront_delivery.rs`, `agent_action_worker.rs`, and `agent_memory_pipeline.rs`.
4. Suppressed unused variable `stripe_id` by renaming to `_stripe_id` in `terminal_api.rs`.

**Phase 4 (Finalize):** `bazelisk test //...` run clean without compiler warnings.

Loaded superpowers:
* https://github.com/obra/superpowers/blob/main/rules/rust_coding_standards.md
* https://github.com/obra/superpowers/blob/main/rules/bazel_hygiene.md

---
*PR created automatically by Jules for task [10363825651510490591](https://jules.google.com/task/10363825651510490591) started by @ql-owo-lp*