### PR TITLE
test(growth): fix viral loyalty widget e2e test

### DIFF
--- a/src/e2e/viral-loyalty-widget.spec.ts
+++ b/src/e2e/viral-loyalty-widget.spec.ts
@@ -1,15 +1,22 @@
 import { test, expect } from '@playwright/test';
 import { adminPage } from './fixtures';
+import * as fs from 'fs';
+import * as path from 'path';
 
 test.describe('Viral Loyalty Widget', () => {
   test('should load the widget and generate a loyalty program', async ({ page }) => {
     // We mock the backend response here specifically because this is a static UI page
     // in the tauri bundle that simulates growth mechanics.
-    await page.route('/api/v1/growth/referrals/generate', async route => {
+    await page.route('**/api/v1/growth/referrals/generate', async route => {
       await route.fulfill({ json: { referral_link: 'http://example.com/ref/12345' } });
     });
 
-    await page.goto('/ui/viral-loyalty-widget.html');
+    const fileContent = fs.readFileSync(path.resolve(__dirname, '../ui/tauri/src/ui/viral-loyalty-widget.html'), 'utf8');
+    await page.route('http://example.com/ui/viral-loyalty-widget.html', async route => {
+      await route.fulfill({ contentType: 'text/html', body: fileContent });
+    });
+
+    await page.goto('http://example.com/ui/viral-loyalty-widget.html');
 
     // Wait for main elements
     await expect(page.locator('h1')).toHaveText('Viral Loyalty Widget Generator');


### PR DESCRIPTION
Fixes the e2e test for the Viral Loyalty Widget growth loop to ensure that Playwright correctly loads the HTML from a mocked HTTP protocol domain, which avoids TypeError when the `fetch` API is executed on relative endpoints.

---
*PR created automatically by Jules for task [7214635380161475699](https://jules.google.com/task/7214635380161475699) started by @ql-owo-lp*