### PR TITLE
🗺️ Guide: Fix .glassmorphism border-radius for container/card/panel in setup wizard

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1120,6 +1120,7 @@
       .glassmorphism.container,
       .glassmorphism.card,
       .glassmorphism.panel {
+        border-radius: 16px;
       }
           #instant-bio { min-height: 44px; box-sizing: border-box; }
       .context-card { min-height: 44px; box-sizing: border-box; }


### PR DESCRIPTION
Based on the market research/ux analysis, we needed to make sure all `.glassmorphism` containers, cards, and panels enforce a `16px` border-radius in the new onboarding setup wizard flow (`src/ui/tauri/src/ui/setup.html`).

I added `border-radius: 16px;` to the `.glassmorphism.container, .glassmorphism.card, .glassmorphism.panel` selector block which aligns the setup wizard containers exactly to the OHC Premium Standards mandate for 16px rounded curves.

---
*PR created automatically by Jules for task [12328460296787531877](https://jules.google.com/task/12328460296787531877) started by @ql-owo-lp*