### PR TITLE
Add test coverage for viral post and widget growth features

### DIFF
--- a/src/e2e/viral_post_generator.spec.ts
+++ b/src/e2e/viral_post_generator.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from './fixtures';
+
+test.describe('Viral Post Generator', () => {
+  test('should allow owner to generate post and handle paywall', async ({ page, context }) => {
+    // 1. Navigate to dashboard
+    await page.goto('/dashboard');
+
+    // 2. Find and click the Promoter Agent / Viral Post Generator link in GrowBusinessCard
+    const promoterLink = page.locator('a[href="/viral-post-generator"]');
+    await expect(promoterLink).toBeVisible();
+    await promoterLink.click();
+
+    // Verify page content
+    await expect(page.getByRole('heading', { name: 'Promoter Agent Post Generator' })).toBeVisible();
+
+    // Wait to ensure client-side hydration doesn't interrupt filling
+    await page.waitForTimeout(500);
+
+    // 3. Fill in details
+    const productNameInput = page.getByPlaceholder('e.g. Signature Coffee Blend');
+    await productNameInput.fill('Ultimate Developer Coffee');
+
+    const keyBenefitInput = page.getByPlaceholder('e.g. a bold start to your morning');
+    await keyBenefitInput.fill('maximum focus and energy');
+
+    // Generate the post
+    const generateBtn = page.getByRole('button', { name: 'Generate Post' });
+    await generateBtn.click();
+
+    // Verify output
+    await expect(page.getByText(/Ultimate Developer Coffee/)).toBeVisible();
+    await expect(page.getByText(/maximum focus and energy/)).toBeVisible();
+    await expect(page.getByText(/Powered by OHC/)).toBeVisible();
+
+    // 4. Try to remove branding
+    const removeBrandingCheckbox = page.getByRole('checkbox', { name: /Remove "Powered by OHC" branding/i });
+    await removeBrandingCheckbox.click();
+
+    // Paywall appears
+    await expect(page.getByRole('heading', { name: 'Upgrade to Pro' })).toBeVisible();
+
+    // Close the paywall
+    await page.getByRole('button', { name: 'Close paywall' }).click();
+
+    // Ensure paywall is gone
+    await expect(page.getByRole('heading', { name: 'Upgrade to Pro' })).toBeHidden();
+
+    // 5. Copy the post
+    const copyButton = page.getByRole('button', { name: 'Copy to Clipboard' });
+    await expect(copyButton).toBeVisible();
+
+    await copyButton.click();
+    await expect(page.getByText('Copied!')).toBeVisible();
+  });
+});

--- a/src/e2e/viral_powered_widget.spec.ts
+++ b/src/e2e/viral_powered_widget.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from './fixtures';
+
+test.describe('Viral Powered By OHC Widget', () => {
+  test('should allow owner to configure the viral widget, view preview and trigger paywall', async ({ page, context }) => {
+    // 1. Navigate to dashboard
+    await page.goto('/dashboard');
+
+    // 2. Find and click the Viral Widget link in GrowBusinessCard
+    const widgetLink = page.locator('a[href="/viral-powered-by-ohc-widget"]');
+    await expect(widgetLink).toBeVisible();
+    await widgetLink.click();
+
+    // Verify page content
+    await expect(page.getByRole('heading', { name: 'Viral Widget Builder' })).toBeVisible();
+
+    // Wait to ensure client-side hydration doesn't interrupt filling
+    await page.waitForTimeout(500);
+
+    // 3. Configure the widget
+    const titleInput = page.getByRole('textbox');
+    await titleInput.fill('Special Viral Offer');
+
+    const themeSelect = page.getByRole('combobox');
+    await themeSelect.selectOption('dark');
+
+    // 4. Try to remove branding, expect paywall
+    const removeBrandingCheckbox = page.getByRole('checkbox', { name: /Remove "Powered by OHC" Badge/i });
+    await removeBrandingCheckbox.click();
+
+    await expect(page.getByRole('heading', { name: 'Upgrade to Remove Branding' })).toBeVisible();
+
+    // Close the paywall
+    await page.getByRole('button', { name: 'Close paywall' }).click();
+
+    // Ensure paywall is gone
+    await expect(page.getByRole('heading', { name: 'Upgrade to Remove Branding' })).toBeHidden();
+
+    // 5. Copy the embed code
+    const copyButton = page.getByRole('button', { name: 'Copy Embed Code' });
+    await expect(copyButton).toBeVisible();
+
+    // Note: Clipboard operations in headless mode might fail, but we check if the button text updates
+    await copyButton.click();
+    await expect(page.getByText('Copied to Clipboard!')).toBeVisible();
+  });
+});

--- a/src/ui/next/next-env.d.ts
+++ b/src/ui/next/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/ui/next/src/app/viral-post-generator/page.test.tsx
+++ b/src/ui/next/src/app/viral-post-generator/page.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ViralPostGeneratorPage from './page';
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+  })),
+}));
+
+describe('ViralPostGeneratorPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn(),
+      },
+    });
+
+    const localStorageMock = {
+      getItem: vi.fn((key) => {
+        if (key === 'tenant') return 'test-tenant';
+        if (key === 'has_pro') return 'false';
+        if (key === 'ohc_post_gen_shared') return 'false';
+        return null;
+      }),
+      setItem: vi.fn(),
+      clear: vi.fn()
+    };
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true
+    });
+
+    // Mock window.open
+    Object.defineProperty(window, 'open', {
+        value: vi.fn(),
+        writable: true
+    });
+  });
+
+  it('renders correctly', () => {
+    render(<ViralPostGeneratorPage />);
+    expect(screen.getByText('Promoter Agent Post Generator 🚀')).toBeDefined();
+  });
+
+  it('generates a post', () => {
+    render(<ViralPostGeneratorPage />);
+
+    const productNameInput = screen.getByPlaceholderText('e.g. Signature Coffee Blend');
+    fireEvent.change(productNameInput, { target: { value: 'Test Product' } });
+
+    const keyBenefitInput = screen.getByPlaceholderText('e.g. a bold start to your morning');
+    fireEvent.change(keyBenefitInput, { target: { value: 'Testing benefits' } });
+
+    const generateBtn = screen.getByRole('button', { name: 'Generate Post' });
+    fireEvent.click(generateBtn);
+
+    expect(screen.getByText(/Test Product/)).toBeDefined();
+    expect(screen.getByText(/Testing benefits/)).toBeDefined();
+    expect(screen.getAllByText(/Powered by OHC/).length).toBeGreaterThan(0);
+  });
+
+  it('copies to clipboard', () => {
+    render(<ViralPostGeneratorPage />);
+
+    const productNameInput = screen.getByPlaceholderText('e.g. Signature Coffee Blend');
+    fireEvent.change(productNameInput, { target: { value: 'Test Product' } });
+
+    const keyBenefitInput = screen.getByPlaceholderText('e.g. a bold start to your morning');
+    fireEvent.change(keyBenefitInput, { target: { value: 'Testing benefits' } });
+
+    const generateBtn = screen.getByRole('button', { name: 'Generate Post' });
+    fireEvent.click(generateBtn);
+
+    const copyBtn = screen.getByRole('button', { name: 'Copy to Clipboard' });
+    fireEvent.click(copyBtn);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    expect(screen.getByText('Copied!')).toBeDefined();
+  });
+
+  it('shows paywall when toggling remove branding', () => {
+    render(<ViralPostGeneratorPage />);
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    expect(screen.getAllByText('Upgrade to Pro').length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'Share on X to Unlock for Free' })).toBeDefined();
+  });
+
+  it('claims trial extension', () => {
+    render(<ViralPostGeneratorPage />);
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    const shareBtn = screen.getByRole('button', { name: 'Share on X to Unlock for Free' });
+    fireEvent.click(shareBtn);
+
+    expect(window.open).toHaveBeenCalledWith(expect.stringContaining('twitter.com/intent/tweet'), '_blank');
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('ohc_post_gen_shared', 'true');
+    expect(screen.queryByText('Upgrade to Pro')).toBeNull(); // Paywall closed
+  });
+});

--- a/src/ui/next/src/app/viral-powered-by-ohc-widget/page.test.tsx
+++ b/src/ui/next/src/app/viral-powered-by-ohc-widget/page.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ViralPoweredByOHCWidgetPage from './page';
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+  })),
+}));
+
+describe('ViralPoweredByOHCWidgetPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn(),
+      },
+    });
+
+    const localStorageMock = {
+      getItem: vi.fn((key) => {
+        if (key === 'tenant') return 'test-tenant';
+        if (key === 'has_pro') return 'false';
+        return null;
+      }),
+      setItem: vi.fn(),
+      clear: vi.fn()
+    };
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true
+    });
+  });
+
+  it('renders correctly', () => {
+    render(<ViralPoweredByOHCWidgetPage />);
+    expect(screen.getByText('Viral Widget Builder')).toBeDefined();
+  });
+
+  it('updates title input', () => {
+    render(<ViralPoweredByOHCWidgetPage />);
+    const titleInput = screen.getByDisplayValue('Viral Widget');
+    fireEvent.change(titleInput, { target: { value: 'New Test Widget' } });
+    expect(screen.getByDisplayValue('New Test Widget')).toBeDefined();
+  });
+
+  it('toggles theme', () => {
+    render(<ViralPoweredByOHCWidgetPage />);
+    const themeSelect = screen.getByDisplayValue('Light');
+    fireEvent.change(themeSelect, { target: { value: 'dark' } });
+    expect(screen.getByDisplayValue('Dark')).toBeDefined();
+  });
+
+  it('copies embed code to clipboard', () => {
+    render(<ViralPoweredByOHCWidgetPage />);
+    const copyButton = screen.getByRole('button', { name: /Copy Embed Code/i });
+    fireEvent.click(copyButton);
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    expect(screen.getByText('Copied to Clipboard!')).toBeDefined();
+  });
+
+  it('shows paywall when removing branding without pro', () => {
+    render(<ViralPoweredByOHCWidgetPage />);
+    const checkbox = screen.getByRole('checkbox', { name: /Remove "Powered by OHC" Badge/i });
+    fireEvent.click(checkbox);
+    expect(screen.getAllByText('Upgrade to Remove Branding').length).toBeGreaterThan(0);
+  });
+});

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Adds comprehensive test coverage for previously untested viral growth features.

- `viral-powered-by-ohc-widget`: Added unit tests verifying UI state, clipboard functionality, and paywall trigger. Added Playwright flow.
- `viral-post-generator`: Added unit tests for generation logic, clipboard, and sharing trial extension. Added Playwright flow.

---
*PR created automatically by Jules for task [10400087087256634221](https://jules.google.com/task/10400087087256634221) started by @ql-owo-lp*