### PR TITLE
feat: fix hybrid sync test schema and optimize hpa scaling

### DIFF
--- a/deploy/helm/ohc/values.yaml
+++ b/deploy/helm/ohc/values.yaml
@@ -4,7 +4,7 @@ backend:
     maxReplicas: 100
     minReplicas: 2
     targetCPUUtilizationPercentage: 75
-    targetMemoryUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 75
   headless: false
   image: onehumancorp/server:latest
   multiTenant: true
@@ -28,8 +28,8 @@ chatwoot:
     enabled: true
     maxReplicas: 100
     minReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 80
+    targetCPUUtilizationPercentage: 75
+    targetMemoryUtilizationPercentage: 75
   databaseUrl: ''
   enabled: true
   image: chatwoot/chatwoot:v3.15.1
@@ -103,8 +103,8 @@ ohcCore:
     enabled: true
     maxReplicas: 100
     minReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 80
+    targetCPUUtilizationPercentage: 75
+    targetMemoryUtilizationPercentage: 75
   enabled: true
   image: onehumancorp/mono-core:latest
   networkPolicy:
@@ -126,8 +126,8 @@ powersync:
     enabled: true
     maxReplicas: 100
     minReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 80
+    targetCPUUtilizationPercentage: 75
+    targetMemoryUtilizationPercentage: 75
   enabled: true
   image: journeyapps/powersync-service:latest
   networkPolicy:

--- a/src/server/orchestration/hybrid_sync/daemon_test.rs
+++ b/src/server/orchestration/hybrid_sync/daemon_test.rs
@@ -542,16 +542,16 @@ async fn test_hybrid_sync_pos_offline_transactions() {
         .unwrap();
 
         // Insert stuck tasks
-        sqlx::query("INSERT INTO agent_missions (id, status, last_synced_at, tenant_id) VALUES ('stuck_mission_sqlite', 'IN_PROGRESS', datetime('now', '-2 hour'), 'tenant1')")
+        sqlx::query("INSERT INTO agent_missions (id, status, last_synced_at, tenant_id, payload) VALUES ('stuck_mission_sqlite', 'IN_PROGRESS', datetime('now', '-2 hour'), 'tenant1', '{}')")
             .execute(&sqlite_pool).await.unwrap();
 
-        sqlx::query("INSERT INTO agent_missions (id, status, last_synced_at, tenant_id) VALUES ('stuck_mission_pg', 'RUNNING', NOW() - INTERVAL '2 hours', 'tenant1')")
+        sqlx::query("INSERT INTO agent_missions (id, status, last_synced_at, tenant_id, payload) VALUES ('stuck_mission_pg', 'RUNNING', NOW() - INTERVAL '2 hours', 'tenant1', '{}')")
             .execute(&pg_pool).await.unwrap();
 
-        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, updated_at) VALUES ('stuck_queue_sqlite', 'tenant1', 'RUNNING', datetime('now', '-2 hour'))")
+        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, updated_at, payload) VALUES ('stuck_queue_sqlite', 'tenant1', 'RUNNING', datetime('now', '-2 hour'), '{}')")
             .execute(&sqlite_pool).await.unwrap();
 
-        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, updated_at) VALUES ('stuck_queue_pg', 'tenant1', 'RUNNING', NOW() - INTERVAL '2 hours')")
+        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, updated_at, payload) VALUES ('stuck_queue_pg', 'tenant1', 'RUNNING', NOW() - INTERVAL '2 hours', '{}')")
             .execute(&pg_pool).await.unwrap();
 
         let daemon = super::daemon::HybridSyncDaemon::new(sqlite_pool.clone(), pg_pool.clone());
@@ -636,10 +636,10 @@ async fn test_hybrid_sync_pos_offline_transactions() {
         sqlx::query("CREATE TABLE IF NOT EXISTS department_dead_letters (id VARCHAR PRIMARY KEY, tenant_id VARCHAR, event_type VARCHAR, department VARCHAR, payload TEXT, error_message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)").execute(&pg_pool).await.unwrap();
 
         // Insert stuck queued tasks
-        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, created_at) VALUES ('stuck_queued_sqlite', 'tenant1', 'QUEUED', datetime('now', '-25 hour'))")
+        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, created_at, payload) VALUES ('stuck_queued_sqlite', 'tenant1', 'QUEUED', datetime('now', '-25 hour'), '{}')")
             .execute(&sqlite_pool).await.unwrap();
 
-        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, created_at) VALUES ('stuck_queued_pg', 'tenant1', 'QUEUED', NOW() - INTERVAL '25 hours')")
+        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, created_at, payload) VALUES ('stuck_queued_pg', 'tenant1', 'QUEUED', NOW() - INTERVAL '25 hours', '{}')")
             .execute(&pg_pool).await.unwrap();
 
         let daemon = super::daemon::HybridSyncDaemon::new(sqlite_pool.clone(), pg_pool.clone());
@@ -701,10 +701,10 @@ async fn test_hybrid_sync_pos_offline_transactions() {
         .unwrap();
 
         // Insert stuck mission
-        sqlx::query("INSERT INTO agent_missions (id, status, last_synced_at, tenant_id) VALUES ('stuck_mission_sqlite_cat', 'IN_PROGRESS', datetime('now', '-2 hour'), 'tenant1')")
+        sqlx::query("INSERT INTO agent_missions (id, status, last_synced_at, tenant_id, payload) VALUES ('stuck_mission_sqlite_cat', 'IN_PROGRESS', datetime('now', '-2 hour'), 'tenant1', '{}')")
             .execute(&sqlite_pool).await.unwrap();
 
-        sqlx::query("INSERT INTO agent_missions (id, status, last_synced_at, tenant_id) VALUES ('stuck_mission_pg_cat', 'RUNNING', NOW() - INTERVAL '2 hours', 'tenant1')")
+        sqlx::query("INSERT INTO agent_missions (id, status, last_synced_at, tenant_id, payload) VALUES ('stuck_mission_pg_cat', 'RUNNING', NOW() - INTERVAL '2 hours', 'tenant1', '{}')")
             .execute(&pg_pool).await.unwrap();
 
         let daemon = super::daemon::HybridSyncDaemon::new(sqlite_pool.clone(), pg_pool.clone());


### PR DESCRIPTION
This change applies the necessary test fixture schema fixes inside `daemon_test.rs` that broke standard unit testing queries on `department_dead_letters`. It also aligns K8s manifest properties (`values.yaml`) to the specified Apple/Ubiquiti standard of `75%` limit optimization for Multi-tenant isolation.
Evidence observed in `telemetry_test.rs` and `custom.css` indicate no further modifications are needed to clear those objectives.

Superpowers loaded: superpowers:test-driven-development, superpowers:systematic-debugging

---
*PR created automatically by Jules for task [9891190425366384469](https://jules.google.com/task/9891190425366384469) started by @ql-owo-lp*