### PR TITLE
Fix E2E tests for cost dashboard and pricing pages

### DIFF
--- a/src/e2e/pricing.spec.ts
+++ b/src/e2e/pricing.spec.ts
@@ -13,12 +13,22 @@ test.describe('Pricing Page', () => {
     await expect(page.locator('h3', { hasText: 'What is the storage limit?' })).toBeVisible();
   });
 
+
+  test('should display My Plan section', async ({ page }) => {
+    await page.goto('/pricing');
+    await expect(page.locator('h2', { hasText: 'My Plan: Free' })).toBeVisible();
+    await expect(page.locator('p', { hasText: 'AI Actions Used' })).toBeVisible();
+    await expect(page.locator('p', { hasText: 'Storage Used' })).toBeVisible();
+    await expect(page.locator('p', { hasText: 'Estimated Next Bill' })).toBeVisible();
+    await expect(page.locator('button', { hasText: 'Manage Plan & Billing' })).toBeVisible();
+  });
+
   test('should display all four pricing tiers', async ({ page }) => {
     await page.goto('/pricing');
-    await expect(page.locator('.plan-name', { hasText: 'Free' })).toBeVisible();
-    await expect(page.locator('.plan-name', { hasText: 'Starter' })).toBeVisible();
-    await expect(page.locator('.plan-name', { hasText: 'Pro' })).toBeVisible();
-    await expect(page.locator('.plan-name', { hasText: 'Business' })).toBeVisible();
+    await expect(page.locator('h3', { hasText: 'Free' })).toBeVisible();
+    await expect(page.locator('h3', { hasText: 'Starter' })).toBeVisible();
+    await expect(page.locator('h3', { hasText: 'Pro' })).toBeVisible();
+    await expect(page.locator('h3', { hasText: 'Business' })).toBeVisible();
   });
 
   test('should verify Back button functions', async ({ page }) => {
@@ -26,7 +36,7 @@ test.describe('Pricing Page', () => {
     const backButton = page.locator('a', { hasText: 'Back to Dashboard' });
     await expect(backButton).toBeVisible();
     await backButton.click();
-    await expect(page.url()).toContain('/dashboard.html');
+    await expect(page.url()).toContain('/dashboard');
   });
 
   test('should verify upgrade button routes to checkout', async ({ page }) => {

--- a/src/ui/next/src/e2e/cost-dashboard.spec.ts
+++ b/src/ui/next/src/e2e/cost-dashboard.spec.ts
@@ -19,10 +19,11 @@ test.describe('Cost Dashboard Loop', () => {
     await expect(page.locator('h2', { hasText: 'Cost Breakdown' })).toBeVisible({ timeout: 15000 });
 
     // Check for individual breakdown items
-    await expect(page.locator('span', { hasText: 'LLM Usage' })).toBeVisible();
+    await expect(page.locator('span', { hasText: 'Base Platform' })).toBeVisible();
     await expect(page.locator('span', { hasText: /^Storage$/ })).toBeVisible();
     await expect(page.locator('span', { hasText: 'Payment Fees' })).toBeVisible();
     await expect(page.locator('span', { hasText: 'Compute Usage' })).toBeVisible();
+    await expect(page.locator('span', { hasText: 'Network & Bandwidth' }).first()).toBeVisible();
     await expect(page.locator('span', { hasText: 'Email Sends' })).toBeVisible();
     await expect(page.locator('span', { hasText: 'Outbound API Calls' })).toBeVisible();
   });

--- a/src/ui/next/src/e2e/pricing.spec.ts
+++ b/src/ui/next/src/e2e/pricing.spec.ts
@@ -28,7 +28,7 @@ test.describe('Pricing Page Loop', () => {
 
   test('Pricing page Back button navigates to dashboard', async ({ page }) => {
     await page.goto('/pricing');
-    await page.locator('button', { hasText: 'Back' }).click();
+    await page.locator('a', { hasText: 'Back to Dashboard' }).click();
     await expect(page).toHaveURL('/dashboard');
   });
 });


### PR DESCRIPTION
Fixed the E2E tests for `cost-dashboard.spec.ts` (in `src/ui/next/src/e2e`) and `pricing.spec.ts` (both in `src/e2e` and `src/ui/next/src/e2e`). 

The test locators were updated to match the latest UI components rendered by Next.js, including exact texts for "Base Platform" and "Network & Bandwidth" in the cost dashboard and correcting back navigation from a `button` to an `a` tag in the pricing dashboard. Additionally, the `src/e2e/pricing.spec.ts` file now uses `h3` tags rather than `.plan-name` CSS classes and explicitly tests the `My Plan` feature box.

---
*PR created automatically by Jules for task [11239398363936186459](https://jules.google.com/task/11239398363936186459) started by @ql-owo-lp*