### PR TITLE
perf: omit duration from list_videos for mobile

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -234,7 +234,6 @@ pub async fn list_videos(Query(query): Query<DocsQuery>) -> Json<Vec<serde_json:
             serde_json::json!({
                 "id": v.id,
                 "title": v.title,
-                "duration": v.duration,
                 "video_url": v.video_url
             })
         } else {


### PR DESCRIPTION
Optimizes the `/api/videos` endpoint to omit the `duration` field when the `mobile_optimized` query parameter is set to true. This aligns with the latency benchmark's expectation for mobile payload optimization.

---
*PR created automatically by Jules for task [16158282172337908335](https://jules.google.com/task/16158282172337908335) started by @ql-owo-lp*