### PR TITLE
🔗 Link: Fix simulated Instagram DM triage payload

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -3390,7 +3390,7 @@ pub async fn simulate_ui_triage_item_handler(
             .bind(&item_id)
             .bind(&tenant_id)
             .bind("Draft Reply")
-            .bind("Hi! Yes, we have 2 vegan chocolate cakes left for this weekend. Would you like me to hold one for you? [Link to $20 deposit]")
+            .bind(r#"{"feature_type": "instagram_dm", "draft_reply": "Hi! Yes, we have 2 vegan chocolate cakes left for this weekend. Would you like me to hold one for you? [Link to $20 deposit]", "customer_message": "Do you have vegan chocolate cake available this weekend?"}"#)
             .execute(&mut *tx)
             .await {
                 tracing::error!("Failed to insert triage_proposed_actions: {:?}", e);
@@ -3433,7 +3433,7 @@ pub async fn simulate_ui_triage_item_handler(
             .bind(&item_id)
             .bind(&tenant_id)
             .bind("Draft Reply")
-            .bind("Hi! Yes, we have 2 vegan chocolate cakes left for this weekend. Would you like me to hold one for you? [Link to $20 deposit]")
+            .bind(r#"{"feature_type": "instagram_dm", "draft_reply": "Hi! Yes, we have 2 vegan chocolate cakes left for this weekend. Would you like me to hold one for you? [Link to $20 deposit]", "customer_message": "Do you have vegan chocolate cake available this weekend?"}"#)
             .execute(&mut *tx)
             .await {
                 tracing::error!("Failed to insert triage_proposed_actions: {:?}", e);


### PR DESCRIPTION
Resolves #32647

The simulated triage payload for Instagram DM did not conform to the expected JSON format used by `UnifiedAgentFeed.tsx`. This PR updates the mock payload generation in `src/server/lib.rs` (`simulate_ui_triage_item_handler`) to ensure it injects valid JSON with `feature_type: "instagram_dm"` instead of a simple string, which enables correctly rendering the `InstagramDMCard` in the unified feed.

Product-use evidence:
Persona: Maya (baker using OHC mobile)
When Maya simulates an Instagram DM while using the app, she navigates to her unified dashboard and expects an Instagram DM draft reply to be correctly parsed and rendered using the custom Instagram DM card (`InstagramDMCard`). Before this change, the UI parsed the payload as a string, preventing the rendering of the `InstagramDMCard`. With this fix, the card renders properly, the approve and dismiss buttons map to the expected tests, and `bazelisk test //src/e2e:playwright` continues to pass, showing that the triage action card correctly aligns with UI requirements.

Loaded superpowers:
None.

Interaction audit:
- Simulated Instagram DM via `/api/dev/simulate-triage-item`.
- Verified `UnifiedAgentFeed.tsx` parses JSON payload with `feature_type` properly.
- `bazelisk test //...` verified locally with 100% test pass.

---
*PR created automatically by Jules for task [213839456700206714](https://jules.google.com/task/213839456700206714) started by @ql-owo-lp*