### PR TITLE
fix: Correct back button navigation on domain step in onboarding wizard

### DIFF
--- a/src/e2e/tests/onboarding_wizard.spec.ts
+++ b/src/e2e/tests/onboarding_wizard.spec.ts
@@ -157,4 +157,58 @@ test.describe('Onboarding Wizard Flow', () => {
     await expect(errorMsg).toBeHidden();
   });
 
+  test('Back button on domain step navigates to target audience step', async ({ page }) => {
+    await expect(page.locator('body')).toContainText('Tell us about your business');
+
+    await page.getByTestId('next-step-btn').first().click();
+    await page.getByTestId('context-storefront').click();
+    await page.getByTestId('next-step-btn').nth(1).click();
+    await page.locator('#business-categories').selectOption('Other');
+    await page.getByTestId('next-step-btn').nth(2).click();
+    await page.locator('#business-name').fill('My Awesome Business');
+    await page.getByTestId('next-step-btn').nth(3).click();
+
+    // Assistant step
+    await page.getByTestId('team-support').click();
+    await page.locator('#assistant-tone').selectOption('Professional');
+    await page.getByTestId('next-step-btn').nth(4).click();
+
+    // Admin Setup step
+    await page.locator('#admin-name').fill('John Doe');
+    await page.locator('#admin-email').fill('john.doe@example.com');
+    await page.locator('#admin-password').fill('password123');
+    await page.getByTestId('next-step-btn').nth(5).click();
+
+    // What you sell step
+    await expect(page.locator('body')).toContainText('What do you sell?');
+    await page.locator('#first-offer').fill('I sell awesome products');
+    await page.getByTestId('next-step-btn').nth(6).click();
+
+    // Location step
+    await expect(page.locator('body')).toContainText('Where are you located?');
+    await page.locator('#location-input').fill('New York, NY');
+    await page.getByTestId('next-step-btn').nth(7).click();
+
+    // Target Audience step
+    await expect(page.locator('body')).toContainText('Who is your target audience?');
+    await page.locator('#target-audience').fill('Everyone');
+    await page.getByTestId('next-step-btn').nth(8).click();
+
+    // Domain step
+    await expect(page.locator('body')).toContainText('Where will your business live?');
+    await page.locator('#domain-name').fill('mybusiness');
+
+    // Wait for the animation to finish
+    await page.waitForTimeout(500);
+
+    // Click back button inside step-domain
+    const domainStep = page.locator('#step-domain');
+    await domainStep.getByTestId('prev-step-btn').click();
+
+    // Assert that we are back at Target Audience step
+    await expect(page.locator('body')).toContainText('Who is your target audience?');
+    await expect(page.locator('#step-target-audience')).toBeVisible();
+    await expect(page.locator('#step-domain')).toBeHidden();
+  });
+
 });

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2385,7 +2385,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-offer"
+            data-prev="step-target-audience"
           >
             Back
           </button>
@@ -2507,7 +2507,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-offer"
+            data-prev="step-target-audience"
           >
             Back
           </button>


### PR DESCRIPTION
Fixes a navigation bug in the onboarding wizard where clicking "Back" on the Domain step would navigate back to the Offer step instead of the preceding Target Audience step.

*   Updated `data-prev="step-offer"` to `data-prev="step-target-audience"` in `src/ui/tauri/src/ui/setup.html`
*   Added E2E test coverage for this specific flow in `src/e2e/tests/onboarding_wizard.spec.ts`

---
*PR created automatically by Jules for task [5332714198673756926](https://jules.google.com/task/5332714198673756926) started by @ql-owo-lp*