### PR TITLE
Fix share-to-unlock generator IDs to match E2E tests

### DIFF
--- a/src/ui/tauri/src/ui/share-to-unlock-generator.html
+++ b/src/ui/tauri/src/ui/share-to-unlock-generator.html
@@ -259,8 +259,8 @@
       <h2>Campaign Settings</h2>
 
       <div>
-        <label for="title">Campaign Title</label>
-        <input type="text" id="title" placeholder="e.g. Secret Weekend Deal" value="Secret Weekend Deal" />
+        <label for="campaign-title">Campaign Title</label>
+        <input type="text" id="campaign-title" placeholder="e.g. Secret Weekend Deal" value="Secret Weekend Deal" />
       </div>
 
       <div>
@@ -269,8 +269,8 @@
       </div>
 
       <div>
-        <label for="code">Hidden Discount Code</label>
-        <input type="text" id="code" placeholder="e.g. SECRET20" style="text-transform: uppercase;" value="SECRET20" />
+        <label for="hidden-code">Hidden Discount Code</label>
+        <input type="text" id="hidden-code" placeholder="e.g. SECRET20" style="text-transform: uppercase;" value="SECRET20" />
       </div>
 
       <div>
@@ -313,9 +313,9 @@
   <a href="/dashboard.html" class="back-link">&larr; Back to Dashboard</a>
 
   <script>
-    const titleInput = document.getElementById('title');
+    const titleInput = document.getElementById('campaign-title');
     const rewardInput = document.getElementById('reward');
-    const codeInput = document.getElementById('code');
+    const codeInput = document.getElementById('hidden-code');
 
     const previewTitle = document.getElementById('preview-title');
     const previewReward = document.getElementById('preview-reward-text');


### PR DESCRIPTION
Fixes mismatch in HTML IDs between the `share-to-unlock-generator.html` UI and the Playwright E2E test (`viral_share_to_unlock.spec.ts`).

- Updated `<input id="title">` to `<input id="campaign-title">`
- Updated `<input id="code">` to `<input id="hidden-code">`
- Updated corresponding label `for` attributes and JavaScript `document.getElementById` calls.

---
*PR created automatically by Jules for task [5962015496381020827](https://jules.google.com/task/5962015496381020827) started by @ql-owo-lp*