### PR TITLE
Fix Twilio integration routing for WhatsApp (#32655)

### DIFF
--- a/src/server/domain/inbox.rs
+++ b/src/server/domain/inbox.rs
@@ -32,16 +32,37 @@ pub async fn handle_inbox_action(tenant_id: &str, payload: &Value, pool: &PgPool
 
         if let Some((source, sender_id)) = row {
             if source == "whatsapp" {
-                let registry = crate::integrations::registry::IntegrationsRegistry::new();
-                let draft_reply_clone = draft_reply.to_string();
-                let sender_id_clone = sender_id.to_string();
-                tokio::spawn(async move {
-                    if let Err(e) = registry.send_whatsapp("whatsapp_cloud_api", &sender_id_clone, "omni", &draft_reply_clone).await {
-                        tracing::error!("Failed to send WhatsApp reply: {}", e);
+                let creds: Result<(String, String, String, String), sqlx::Error> = sqlx::query_as(
+                    "SELECT integration_id, bot_token, api_token, from_phone FROM integration_credentials WHERE tenant_id = $1 AND integration_id IN ('whatsapp', 'twilio', 'whatsapp_cloud_api') LIMIT 1"
+                )
+                .bind(tenant_id)
+                .fetch_optional(pool)
+                .await
+                .map(|opt| opt.unwrap_or(("whatsapp_cloud_api".to_string(), "".to_string(), "".to_string(), "omni".to_string())));
+
+                if let Ok((integration_id, bot_token, api_token, from_phone)) = creds {
+                    let draft_reply_clone = draft_reply.to_string();
+                    let sender_id_clone = sender_id.to_string();
+                    if integration_id == "whatsapp" || integration_id == "twilio" {
+                        let provider = crate::integrations::twilio::provider::TwilioProvider::new(bot_token, api_token);
+                        tokio::spawn(async move {
+                            if let Err(e) = provider.send_whatsapp(&sender_id_clone, &from_phone, &draft_reply_clone).await {
+                                tracing::error!("Failed to send Twilio WhatsApp reply: {}", e);
+                            } else {
+                                tracing::info!("Successfully sent Twilio WhatsApp reply to {}", sender_id_clone);
+                            }
+                        });
                     } else {
-                        tracing::info!("Successfully sent WhatsApp reply to {}", sender_id_clone);
+                        let provider = crate::integrations::meta::provider::MetaProvider::new(api_token);
+                        tokio::spawn(async move {
+                            if let Err(e) = provider.send_message("whatsapp", &sender_id_clone, &draft_reply_clone).await {
+                                tracing::error!("Failed to send Meta WhatsApp reply: {}", e);
+                            } else {
+                                tracing::info!("Successfully sent Meta WhatsApp reply to {}", sender_id_clone);
+                            }
+                        });
                     }
-                });
+                }
             } else if source == "instagram" || source == "facebook" {
                 let meta_creds: Result<String, sqlx::Error> = sqlx::query_scalar(
                     "SELECT api_token FROM integration_credentials WHERE integration_id = 'meta' AND tenant_id = $1 LIMIT 1"

--- a/src/server/integrations/registry.rs
+++ b/src/server/integrations/registry.rs
@@ -237,7 +237,7 @@ impl IntegrationsRegistry {
                 creds.api_token.clone()
             )));
         }
-        if integration_id == "whatsapp" || integration_id == "whatsapp_cloud_api" {
+        if integration_id == "whatsapp_cloud_api" {
             let mut clients = self.whatsapp_clients.write().unwrap();
             clients.insert(integration_id.to_string(), std::sync::Arc::new(crate::integrations::meta::provider::MetaProvider::new(
                 creds.api_token.clone()
@@ -467,7 +467,7 @@ impl IntegrationsRegistry {
     }
 
     pub async fn send_whatsapp(&self, integration_id: &str, to: &str, from: &str, body: &str) -> Result<(), String> {
-        if integration_id == "twilio" {
+        if integration_id == "twilio" || integration_id == "whatsapp" {
             let client = {
                 let clients = self.twilio_clients.read().unwrap();
                 clients.get(integration_id).cloned()
@@ -475,9 +475,9 @@ impl IntegrationsRegistry {
             if let Some(c) = client {
                 return c.send_whatsapp(to, from, body).await;
             }
-        } else if integration_id == "meta" || integration_id == "whatsapp" || integration_id == "whatsapp_cloud_api" {
+        } else if integration_id == "meta" || integration_id == "whatsapp_cloud_api" {
             let client = {
-                if integration_id == "whatsapp" || integration_id == "whatsapp_cloud_api" {
+                if integration_id == "whatsapp_cloud_api" {
                     let clients = self.whatsapp_clients.read().unwrap();
                     clients.get(integration_id).cloned()
                 } else {
@@ -588,7 +588,7 @@ impl IntegrationsRegistry {
             if integration_id == "meta" {
                 let clients = self.meta_clients.read().unwrap();
                 clients.get(integration_id).cloned()
-            } else if integration_id == "whatsapp" || integration_id == "whatsapp_cloud_api" {
+            } else if integration_id == "whatsapp_cloud_api" {
                 let clients = self.whatsapp_clients.read().unwrap();
                 clients.get(integration_id).cloned()
             } else {


### PR DESCRIPTION
Fixes a routing issue where "whatsapp" integrations connected with Twilio erroneously resolved to the Meta provider backend, breaking WhatsApp direct messaging. Includes fixes for retrieving integration credentials during AI message triage dispatching.

---
*PR created automatically by Jules for task [1887921348018251618](https://jules.google.com/task/1887921348018251618) started by @ql-owo-lp*

Resolves #32655