### PR TITLE
💰 Miser: Pricing Cost Cents Tracking

### DIFF
--- a/src/server/telemetry/mod.rs
+++ b/src/server/telemetry/mod.rs
@@ -614,7 +614,19 @@ pub async fn record_llm_call_cost(
             "model": model,
         }),
     )
-    .await
+    .await?;
+
+    let cost_cents = (cost_usd * 100.0).round() as i64;
+    buffer_metric_i64(
+        pool,
+        "ohc_llm_cost_total_cents",
+        "counter",
+        cost_cents,
+        serde_json::json!({
+            "organization_id": organization_id,
+            "model": model,
+        }),
+    ).await
 }
 
 pub async fn record_outbound_api_cost(
@@ -995,7 +1007,7 @@ pub async fn record_task_resolution_efficiency(
         let efficiency = 1.0 / (tokens as f32 / 1000.0);
         buffer_metric(
             pool,
-            "ohc_agent_efficiency_gauge",
+            "ohc_agent_roi_efficiency_score",
             "gauge",
             efficiency,
             serde_json::json!({
@@ -1044,7 +1056,22 @@ pub async fn record_agent_cost(
             "entity": entity,
         }),
     )
-    .await
+    .await?;
+
+    let cost_cents = (cost * 100.0).round() as i64;
+    buffer_metric_i64(
+        pool,
+        "ohc_llm_cost_total_cents",
+        "counter",
+        cost_cents,
+        serde_json::json!({
+            "agent_id": agent_id,
+            "organization_id": organization_id,
+            "role": role,
+            "model": model,
+            "entity": entity,
+        }),
+    ).await
 }
 
 pub async fn record_api_call_cost(

--- a/src/server/telemetry_test.rs
+++ b/src/server/telemetry_test.rs
@@ -171,6 +171,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_record_llm_call_cost() {
+        let db_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/ohc".to_string());
+        let pool = match tokio::time::timeout(std::time::Duration::from_millis(500), sqlx::PgPool::connect(&db_url)).await {
+            Ok(Ok(p)) => p,
+            _ => return,
+        };
+
+        let res: Result<(), _> = ::server_telemetry::record_llm_call_cost(&pool, "org-1", "test-model", 2.5).await;
+        assert!(res.is_ok());
+
+        let row: sqlx::postgres::PgRow = sqlx::query("SELECT labels_json, value FROM telemetry_buffer WHERE metric_name = 'ohc_llm_call_cost' ORDER BY timestamp DESC LIMIT 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        use sqlx::Row;
+        let value: f64 = row.get("value");
+        assert_eq!(value, 2.5);
+
+        let row_cents: sqlx::postgres::PgRow = sqlx::query("SELECT value FROM telemetry_buffer WHERE metric_name = 'ohc_llm_cost_total_cents' AND labels_json::jsonb->>'organization_id' = 'org-1' ORDER BY timestamp DESC LIMIT 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let value_cents: f64 = row_cents.get("value");
+        assert_eq!(value_cents, 250.0);
+    }
+
+    #[tokio::test]
     async fn test_record_agent_cost() {
         let db_url = std::env::var("OHC_DATABASE_URL").unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/ohc".to_string());
         let pool = match tokio::time::timeout(std::time::Duration::from_millis(500), sqlx::PgPool::connect(&db_url)).await {
@@ -196,6 +224,14 @@ mod tests {
         assert_eq!(parsed["agent_id"], "agent-123");
         assert_eq!(parsed["organization_id"], "[REDACTED]");
         assert_eq!(parsed["entity"], "test-entity");
+
+        let row_cents: sqlx::postgres::PgRow = sqlx::query("SELECT value FROM telemetry_buffer WHERE metric_name = 'ohc_llm_cost_total_cents' AND labels_json::jsonb->>'agent_id' = 'agent-123' ORDER BY timestamp DESC LIMIT 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let value_cents: f64 = row_cents.get("value");
+        assert_eq!(value_cents, 150.0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Implement Pricing Cost Cents Tracking as per research document.

- Updated `src/server/telemetry/mod.rs` to emit `ohc_llm_cost_total_cents` utilizing `buffer_metric_i64` in `record_llm_call_cost` and `record_agent_cost`.
- Renamed `ohc_agent_efficiency_gauge` to `ohc_agent_roi_efficiency_score` per telemetry observability tracking document.
- Updated `src/server/telemetry_test.rs` to assert metric behavior with specific filter queries to prevent concurrent flaky assertions.

---
*PR created automatically by Jules for task [11639603738556678374](https://jules.google.com/task/11639603738556678374) started by @ql-owo-lp*