### PR TITLE
🔗 Link: [fix: add offline mode pill to POS interface]

### DIFF
--- a/src/e2e/e2e_mobile_pos_optimistic.spec.ts
+++ b/src/e2e/e2e_mobile_pos_optimistic.spec.ts
@@ -52,6 +52,9 @@ test.describe('Mobile POS Optimistic Inventory Sync', () => {
     await page.context().setOffline(true);
     await page.evaluate(() => window.dispatchEvent(new Event('offline')));
 
+    // Verify offline pill appears
+    await expect(page.locator('text=Offline - Cash & Saved Cards Only')).toBeVisible({ timeout: 5000 });
+
     // Click charge (simulates tap to pay when offline)
     await chargeBtn.click();
 
@@ -71,5 +74,9 @@ test.describe('Mobile POS Optimistic Inventory Sync', () => {
     // Restore network
     await page.context().setOffline(false);
     await page.evaluate(() => window.dispatchEvent(new Event('online')));
+
+    // Verify offline pill disappears (or changes to syncing state before disappearing)
+    // Here we just verify it doesn't say offline cash only anymore eventually.
+    await expect(page.locator('text=Offline - Cash & Saved Cards Only')).toBeHidden({ timeout: 10000 });
   });
 });

--- a/src/server/workers/pos_sync_worker.rs
+++ b/src/server/workers/pos_sync_worker.rs
@@ -10,8 +10,11 @@ impl PosSyncWorker {
     pub fn new(db: Arc<DB>) -> Self {
         Self { db }
     }
+}
 
-    pub async fn handle(&self, job: crate::queue::Job) -> Result<Result<(), String>, String> {
+#[async_trait::async_trait]
+impl crate::queue::TaskJobHandler for PosSyncWorker {
+    async fn handle(&self, job: crate::queue::Job) -> Result<(), String> {
         let payload: serde_json::Value = serde_json::from_str(&job.payload).unwrap();
         let transaction_id = payload.get("transaction_id").and_then(|v| v.as_str())
             .or_else(|| payload.get("pos_transaction_id").and_then(|v| v.as_str()))
@@ -98,7 +101,7 @@ impl PosSyncWorker {
             .await;
 
             tx.commit().await.unwrap();
-            return Ok(Ok(()));
+            return Ok(());
         }
 
         sqlx::query("UPDATE pos_offline_transactions SET status = 'RESOLVED', _sync_status = 'synced' WHERE id = $1")
@@ -139,7 +142,7 @@ impl PosSyncWorker {
                 .unwrap();
 
             tx.commit().await.unwrap();
-            return Ok(Ok(()));
+            return Ok(());
         }
 
         if let Some(mutation) = payload.get("mutation") {
@@ -567,7 +570,7 @@ impl PosSyncWorker {
 
         tx.commit().await.unwrap();
 
-        Ok(Ok(()))
+        Ok(())
     }
 }
 

--- a/src/server/workers/pos_sync_worker.rs
+++ b/src/server/workers/pos_sync_worker.rs
@@ -622,8 +622,9 @@ mod tests {
             parent_task_id: "".to_string(),
         };
 
+        use crate::queue::TaskJobHandler;
         let handle = worker.handle(job);
-        let res = handle.await.unwrap();
+        let res = handle.await;
         assert!(res.is_ok());
 
         let count: (i32,) = sqlx::query_as("SELECT inventory_count FROM products WHERE id = 'prod-worker-test-1'")
@@ -691,8 +692,9 @@ mod tests {
             parent_task_id: "".to_string(),
         };
 
+        use crate::queue::TaskJobHandler;
         let handle = worker.handle(job);
-        let res = handle.await.unwrap();
+        let res = handle.await;
         assert!(res.is_ok());
 
         let count: (i32,) = sqlx::query_as("SELECT available_quantity FROM products WHERE id = 'prod-worker-test-conflict'")
@@ -759,8 +761,9 @@ mod tests {
             parent_task_id: "".to_string(),
         };
 
+        use crate::queue::TaskJobHandler;
         let handle = worker.handle(job);
-        let res = handle.await.unwrap();
+        let res = handle.await;
         assert!(res.is_ok());
 
         let count: (i32,) = sqlx::query_as("SELECT inventory_count FROM products WHERE id = 'prod-worker-test-2'")

--- a/src/ui/tauri/src/ui/pos.html
+++ b/src/ui/tauri/src/ui/pos.html
@@ -372,7 +372,7 @@
       <div id="network-status-indicator" class="hidden fixed top-2 left-1/2 transform -translate-x-1/2 z-50 flex items-center justify-center pointer-events-none" style="display: none;">
         <div class="bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] px-4 py-1.5 rounded-full shadow border border-white/40 dark:border-white/10 flex items-center gap-2 pointer-events-auto">
           <div id="network-status-dot" class="w-2 h-2 rounded-full bg-yellow-400"></div>
-          <span id="network-status-text" class="text-sm font-semibold text-gray-800">Syncing Paused</span>
+          <span id="network-status-text" class="text-sm font-semibold text-gray-800">Offline - Cash & Saved Cards Only</span>
         </div>
       </div>
       <div id="queue-dashboard" class="hidden" style="display: none; background-color: #fef08a; color: #854d0e; padding: 12px; border-radius: 8px; margin-bottom: 16px; font-weight: bold; text-align: center;">0 Payments Pending Sync</div>
@@ -1637,7 +1637,7 @@ initWalkthrough();
             networkIndicator.style.display = "flex";
             networkIndicator.classList.remove("hidden");
             if (dot) dot.className = "w-2 h-2 rounded-full bg-yellow-400";
-            if (text) text.innerText = "Syncing Paused";
+            if (text) text.innerText = "Offline - Cash & Saved Cards Only";
         } else if (queue.length > 0) {
             networkIndicator.style.display = "flex";
             networkIndicator.classList.remove("hidden");


### PR DESCRIPTION
This PR adds the "Offline - Cash & Saved Cards Only" pill to the POS terminal when network connectivity is lost, as specified by the "Instant Localized Offline-First POS Architecture" requirement (Issue #32700).

Changes:
- Updates `src/ui/tauri/src/ui/pos.html` to replace the "Syncing Paused" state with the required "Offline - Cash & Saved Cards Only" styling.
- Extends the existing optimistic offline e2e tests in `src/e2e/e2e_mobile_pos_optimistic.spec.ts` to assert that this pill appears when `navigator.onLine` is false and disappears once restored.
- Resolves an existing syntax compiler error in `src/server/workers/pos_sync_worker.rs` that prevented test suites from properly completing.

---
*PR created automatically by Jules for task [6737477722478056584](https://jules.google.com/task/6737477722478056584) started by @ql-owo-lp*

Resolves #32700