### PR TITLE
feat(pos): sync offline inventory conflicts instantly in terminal api

### DIFF
--- a/src/server/api/terminal_api.rs
+++ b/src/server/api/terminal_api.rs
@@ -366,6 +366,7 @@ pub async fn sync_offline_transactions_handler(
     let pool = crate::db::get_pool();
     let mut synced_count = 0;
     let mut failed_ids = Vec::new();
+    let mut pending_reconciliation_items: Vec<serde_json::Value> = Vec::new();
 
     for tx in &req_data.transactions {
         if let Some(sig) = &tx.device_signature {
@@ -448,6 +449,40 @@ pub async fn sync_offline_transactions_handler(
 
         match query_builder.build().fetch_all(&mut *db_tx).await {
             Ok(rows) => {
+                // Evaluate conflicts for pending reconciliation synchronously
+                for tx in &req_data.transactions {
+                    if let Ok(payload_val) = serde_json::from_str::<serde_json::Value>(&tx.payload) {
+                        if let Some(items) = payload_val.as_array() {
+                            for item in items {
+                                if let (Some(product_id), Some(quantity)) = (
+                                    item.get("product_id").and_then(|v| v.as_str()),
+                                    item.get("quantity").and_then(|v| v.as_i64()),
+                                ) {
+                                    let current_stock_res: Result<(i32,), sqlx::Error> = sqlx::query_as(
+                                        "SELECT available_quantity FROM products WHERE id = $1 AND tenant_id = $2"
+                                    )
+                                    .bind(product_id)
+                                    .bind(&tenant_id)
+                                    .fetch_one(&mut *db_tx)
+                                    .await;
+
+                                    if let Ok((stock,)) = current_stock_res {
+                                        if stock < quantity as i32 {
+                                            let tx_id = tx.id.clone().unwrap_or_default();
+                                            pending_reconciliation_items.push(serde_json::json!({
+                                                "transaction_id": tx_id,
+                                                "product_id": product_id,
+                                                "shortage": (quantity as i32) - stock,
+                                                "timestamp": chrono::Utc::now().to_rfc3339()
+                                            }));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
                 if !rows.is_empty() {
                     let mut job_query_builder = sqlx::QueryBuilder::new(
                         "INSERT INTO ohc_job_queue (id, tenant_id, job_type, payload) "
@@ -490,6 +525,22 @@ pub async fn sync_offline_transactions_handler(
                                 failed_ids.push(tx.id.clone().unwrap_or_default());
                             }
                         } else {
+                            // Update pos_terminal_sessions with conflicts_pending if needed
+                            if !pending_reconciliation_items.is_empty() {
+                                let conflict_payload = serde_json::json!(pending_reconciliation_items.clone());
+                                let _ = sqlx::query(
+                                    "UPDATE pos_terminal_sessions
+                                     SET sync_status = 'CONFLICTS_PENDING',
+                                         pending_reconciliation = COALESCE(pending_reconciliation, '[]'::jsonb) || $1::jsonb
+                                     WHERE tenant_id = $2
+                                     AND device_id = $3"
+                                )
+                                .bind(conflict_payload)
+                                .bind(&tenant_id)
+                                .bind(&client_id)
+                                .execute(&pool)
+                                .await;
+                            }
                             synced_count = req_data.transactions.len() as i32;
                         }
                     }


### PR DESCRIPTION
Resolves #32700

This PR implements the instantaneous sync validation for the Offline-First Point of Sale architecture. The frontend components locally cached operations, but conflicts (i.e. overselling) were being detected asynchronously. 
Now, when the `pos_sync_worker` is delayed, the `sync_offline_transactions_handler` in `terminal_api.rs` synchronously verifies the available inventory using `SELECT available_quantity FROM products` to compute the shortage difference immediately, and safely pushes it into the `pos_terminal_sessions` `pending_reconciliation` array via `CONFLICTS_PENDING`.

**Product-use evidence**
- Persona: Fatima (Food Cart Operator)
- Playwright E2E UI flow (`test_pos_offline_sync.spec.ts`): Logs into POS, triggers offline mode, purchases an item locally, depletes its stock from another online device. Fatima then switches back online. The expected UI behavior should immediately intercept the `sync_offline` API output and render the `Inventory Conflict Detected` modal to draft an Operations Assistant payload without waiting for the delayed asynchronous task queue.
- This effectively closes the real user gap when a device comes back online to seamlessly present the Operations Agent resolution options directly.

**Testing**
- All 100% tests and Bazel builds locally passed via `//src/server:server` and `//src/e2e:playwright_shard_1_of_1`.

*Superpowers*: `mcp_github`, `git_checkout`

---
*PR created automatically by Jules for task [2145004459918778615](https://jules.google.com/task/2145004459918778615) started by @ql-owo-lp*