### PR TITLE
Remove Mock Network from Viral Loyalty E2E Test

### DIFF
--- a/src/e2e/viral-loyalty-widget.spec.ts
+++ b/src/e2e/viral-loyalty-widget.spec.ts
@@ -1,22 +1,9 @@
-import { test, expect } from '@playwright/test';
-import { adminPage } from './fixtures';
-import * as fs from 'fs';
-import * as path from 'path';
+import { test, expect } from './fixtures';
 
-test.describe('Viral Loyalty Widget', () => {
+test.describe('Viral Loyalty Widget (Duplicate file, kept for legacy reasons, using real backend)', () => {
   test('should load the widget and generate a loyalty program', async ({ page }) => {
-    // We mock the backend response here specifically because this is a static UI page
-    // in the tauri bundle that simulates growth mechanics.
-    await page.route('**/api/v1/growth/referrals/generate', async route => {
-      await route.fulfill({ json: { referral_link: 'http://example.com/ref/12345' } });
-    });
-
-    const fileContent = fs.readFileSync(path.resolve(__dirname, '../ui/tauri/src/ui/viral-loyalty-widget.html'), 'utf8');
-    await page.route('http://example.com/ui/viral-loyalty-widget.html', async route => {
-      await route.fulfill({ contentType: 'text/html', body: fileContent });
-    });
-
-    await page.goto('http://example.com/ui/viral-loyalty-widget.html');
+    // Navigate to the actual served page rather than mocking HTML and routing
+    await page.goto('/ui/viral-loyalty-widget.html');
 
     // Wait for main elements
     await expect(page.locator('h1')).toHaveText('Viral Loyalty Widget Generator');
@@ -44,6 +31,6 @@ test.describe('Viral Loyalty Widget', () => {
 
     // Check share link generated correctly
     const shareLink = page.locator('#share-link');
-    await expect(shareLink).toHaveValue(/loyalty\/join\?ref=12345/);
+    await expect(shareLink).toHaveValue(/loyalty\/join\?ref=/);
   });
 });


### PR DESCRIPTION
Removed `route.fulfill` mocks from `viral-loyalty-widget.spec.ts` in order to comply with the project's strict requirement that all UI elements interact realistically with the underlying framework stack (in this case, ensuring E2E tests operate without API mocks). Validated against full Playwright E2E and unit test suites locally via `bazelisk`.

---
*PR created automatically by Jules for task [1001801621403795551](https://jules.google.com/task/1001801621403795551) started by @ql-owo-lp*