### PR TITLE
fix: explicit type inference for HybridCache in onboarding agent

### DIFF
--- a/src/server/services/onboarding/onboarding_agent.rs
+++ b/src/server/services/onboarding/onboarding_agent.rs
@@ -338,14 +338,14 @@ Your response:",
         tx.commit().await.map_err(|e| e.to_string())?;
 
         let cache_key = format!("agent_onboarding_state_{}_{}", tenant_id, user_id);
-        let cache = ONBOARDING_STATE_AGENT_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(self.hub.redis_client.clone()));
+        let cache = ONBOARDING_STATE_AGENT_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::<serde_json::Value>::new(self.hub.redis_client.clone()));
         tracing::info!("Onboarding cache invalidated for tenant_id={} user_id={}", tenant_id, user_id);
         tracing::debug!("Invalidating onboarding state cache for key: {}", cache_key); // pii-safe
         cache.invalidate(&cache_key).await;
 
         // Invalidate the Dashboard cache as well
         let dashboard_cache_key = format!("onboarding_state_{}", tenant_id);
-        let dashboard_cache = crate::services::dashboard::service::ONBOARDING_STATE_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(self.hub.redis_client.clone()));
+        let dashboard_cache = crate::services::dashboard::service::ONBOARDING_STATE_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::<::server_ohc::app::GetOnboardingStateResponse>::new(self.hub.redis_client.clone()));
         tracing::debug!("Invalidating dashboard onboarding state cache for key: {}", dashboard_cache_key); // pii-safe
         dashboard_cache.invalidate(&dashboard_cache_key).await;
 
@@ -354,7 +354,7 @@ Your response:",
 
     pub async fn get_onboarding_state(&self, tenant_id: &str, user_id: &str) -> Result<serde_json::Value, String> {
         let cache_key = format!("agent_onboarding_state_{}_{}", tenant_id, user_id);
-        let cache = ONBOARDING_STATE_AGENT_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(self.hub.redis_client.clone()));
+        let cache = ONBOARDING_STATE_AGENT_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::<serde_json::Value>::new(self.hub.redis_client.clone()));
         tracing::debug!("Attempting to get onboarding state from cache for key: {}", cache_key); // pii-safe
         if let Some(cached_state) = cache.get(&cache_key).await {
             tracing::info!("Onboarding cache hit for tenant_id={} user_id={}", tenant_id, user_id);
@@ -2955,7 +2955,7 @@ mod tests {
 
         // Prime the agent cache
         let agent_cache_key = format!("agent_onboarding_state_{}_{}", tenant_id, user_id);
-        let agent_cache = ONBOARDING_STATE_AGENT_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::new(hub.redis_client.clone()));
+        let agent_cache = ONBOARDING_STATE_AGENT_CACHE.get_or_init(|| ::server_utils::cache::HybridCache::<serde_json::Value>::new(hub.redis_client.clone()));
         agent_cache.set(&agent_cache_key, state1.clone(), std::time::Duration::from_secs(3600)).await;
 
         // Verify caches are primed


### PR DESCRIPTION
Explicitly parameterize `HybridCache::new()` generic types in onboarding module to resolve a rustc compilation inference error blocking the system build.

Fixes inference ambiguity by explicitly adding type generics like `HybridCache::<serde_json::Value>::new(...)`. Tests ran cleanly afterwards.

---
*PR created automatically by Jules for task [3116069333249113766](https://jules.google.com/task/3116069333249113766) started by @ql-owo-lp*