### PR TITLE
🔨 Forge: Fix Action Feed empty state and E2E references

### DIFF
--- a/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
+++ b/src/ui/next/src/app/dashboard/UnifiedAgentFeed.tsx
@@ -754,7 +754,7 @@ export function UnifiedAgentFeed({ initialData }: { initialData?: any }) {
               >
                 <div className="text-3xl mb-2">✨</div>
                 <h3 className="text-xl font-bold font-outfit text-[#1D1D1F] dark:text-[#F5F5F7]">
-                  All caught up!
+                  All caught up! Your business is running smoothly.
                 </h3>
                 <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 break-words">
                   Your agents are currently monitoring the business. While

--- a/src/ui/next/src/app/unified-feed/page.tsx
+++ b/src/ui/next/src/app/unified-feed/page.tsx
@@ -118,7 +118,7 @@ export default function UnifiedFeed() {
              <div className="w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
                <svg className="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
              </div>
-            <p className="font-medium text-sm">All caught up.</p>
+            <p className="font-medium text-sm">All caught up! Your business is running smoothly.</p>
           </div>
         ) : (
           feedItems.map((item) => (

--- a/src/ui/next/src/e2e/triage-action-feed.spec.ts
+++ b/src/ui/next/src/e2e/triage-action-feed.spec.ts
@@ -66,13 +66,13 @@ test.describe('Triage Action Feed UI', () => {
       const firstCard = listItems.nth(0);
       const testId = await firstCard.getAttribute('data-testid');
       // Click header to expand
-      await firstCard.locator(`[data-testid="triage-card-header-${itemId}"]`).click();
+      await firstCard.locator(`[data-testid="triage-card-header-${testId?.replace("triage-card-", "")}"]`).click();
       await page.waitForTimeout(500);
 
       // Triage items in the UI are using dynamic IDs
-      const approveBtn = firstCard.locator(`button[data-testid="triage-approve-${itemId}"]`);
-      const reviewBtn = firstCard.locator(`button[data-testid="triage-review-btn-${itemId}"]`);
-      const dismissBtn = firstCard.locator(`button[data-testid="triage-dismiss-${itemId}"]`);
+      const approveBtn = firstCard.locator(`button[data-testid="triage-approve-${testId?.replace("triage-card-", "")}"]`);
+      const reviewBtn = firstCard.locator(`button[data-testid="triage-review-btn-${testId?.replace("triage-card-", "")}"]`);
+      const dismissBtn = firstCard.locator(`button[data-testid="triage-dismiss-${testId?.replace("triage-card-", "")}"]`);
 
       // We will wait for the API response after clicking
       const responsePromise = page.waitForResponse(response =>
@@ -86,7 +86,7 @@ test.describe('Triage Action Feed UI', () => {
         try {
           await reviewBtn.waitFor({ state: 'visible', timeout: 2000 });
           await reviewBtn.click();
-          const saveBtn = firstCard.locator(`button[data-testid="triage-save-btn-${itemId}"]`);
+          const saveBtn = firstCard.locator(`button[data-testid="triage-save-btn-${testId?.replace("triage-card-", "")}"]`);
           await saveBtn.waitFor({ state: 'visible', timeout: 2000 });
           await saveBtn.click();
         } catch (e1) {
@@ -94,7 +94,7 @@ test.describe('Triage Action Feed UI', () => {
             await dismissBtn.waitFor({ state: 'visible', timeout: 2000 });
             await dismissBtn.click();
           } catch (e2) {
-            console.log(`No approve, review, or dismiss button visible for ${itemId}!`);
+            console.log(`No approve, review, or dismiss button visible for ${testId?.replace("triage-card-", "")}!`);
             break;
           }
         }


### PR DESCRIPTION
This PR implements the missing acceptance criteria for issue #32792 (OHC Unified AI Action Feed).

Specifically, it applies the required "All caught up! Your business is running smoothly." empty state text for the Action Feed and fixes a runtime syntax error in the associated E2E test file (`triage-action-feed.spec.ts`) where `itemId` was incorrectly referenced instead of the dynamic `testId`. All tests, including `bazel test //...` and `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"`, pass successfully.

---
*PR created automatically by Jules for task [8403561922606351782](https://jules.google.com/task/8403561922606351782) started by @ql-owo-lp*

Resolves #32792