### PR TITLE
fix(db): ensure correct tokio::time trackings in execute_with_retry loop timeouts

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -689,15 +689,12 @@ impl DB {
         let mut backoff = std::time::Duration::from_millis(1);
 
         // Enforce the 60-second ML-Resilience rule for database operations
-        #[cfg(test)]
-        let start_time = tokio::time::Instant::now(); // use simulated time for tests
-        #[cfg(not(test))]
-        let start_time = std::time::Instant::now(); // use real time for prod
+        // Use tokio::time::Instant everywhere so that time paused in tests (like via tokio::time::advance)
+        // accurately increments the clock to simulate delays.
+        let start_time = tokio::time::Instant::now();
         let timeout_duration = std::time::Duration::from_secs(60);
 
         loop {
-            // Note: Since tokio::time::Instant does not interact with paused time during tests,
-            // it accurately tracks real elapsed time without causing false timeouts in simulated time tests.
             if start_time.elapsed() >= timeout_duration {
                 return Err(E::from(format!(
                     "Database operation '{}' timed out",
@@ -705,12 +702,7 @@ impl DB {
                 )));
             }
 
-            // In tests we want tokio::time::timeout to handle paused time cleanly.
-            let remaining_time = if cfg!(test) {
-                timeout_duration
-            } else {
-                timeout_duration.saturating_sub(start_time.elapsed())
-            };
+            let remaining_time = timeout_duration.saturating_sub(start_time.elapsed());
 
             let timeout_res = tokio::time::timeout(remaining_time, f()).await;
 


### PR DESCRIPTION
This PR fixes an issue where the ML-Resilience timeout tracking mechanism inside `execute_with_retry` loop was using bifurcated test/prod logic for retrieving time that circumvented accurate simulation. Specifically, under test configurations, it used `std::time::Instant` and skipped time advances when calculating the `remaining_time`, which broke testing scenarios intended to simulate latency (e.g. `test_execute_with_retry_sync_lag`). This consolidation uses `tokio::time::Instant::now()` consistently and enforces uniform remaining time calculations across all environments, thus satisfying mode parity rules.

---
*PR created automatically by Jules for task [5433562485715912110](https://jules.google.com/task/5433562485715912110) started by @ql-owo-lp*