### PR TITLE
fix: add missing closing brace to CSS rule in setup.html

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -116,6 +116,7 @@
         min-height: 44px;
         min-width: 44px;
         box-sizing: border-box;
+      }
       /* Added missing glass-control definition */
       .glass-control {
         border-radius: 8px;


### PR DESCRIPTION
Fixes a malformed CSS block in `src/ui/tauri/src/ui/setup.html` by adding a missing closing brace to a CSS rule. This ensures the rest of the styles in the file are parsed and applied correctly.

---
*PR created automatically by Jules for task [1644670018693789434](https://jules.google.com/task/1644670018693789434) started by @ql-owo-lp*