### PR TITLE
fix: improve stuck queue dead-letter routing and K8s resource scaling

### DIFF
--- a/deploy/helm/ohc/values.yaml
+++ b/deploy/helm/ohc/values.yaml
@@ -16,8 +16,8 @@ backend:
       cpu: 1000m
       memory: 1Gi
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 50m
+      memory: 128Mi
   service:
     port: 8080
   vpa:
@@ -115,8 +115,8 @@ ohcCore:
       cpu: 1000m
       memory: 1Gi
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 50m
+      memory: 128Mi
   service:
     port: 18789
   vpa:

--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -452,7 +452,9 @@ impl HybridSyncDaemon {
         let pg_update = format!("UPDATE agent_missions SET status = 'FAILED' WHERE {}", PG_WHERE_CLAUSE);
 
         // SQLite
-        let _ = sqlx::query(&sqlite_insert).execute(&self.sqlite_pool).await;
+        if let Err(e) = sqlx::query(&sqlite_insert).execute(&self.sqlite_pool).await {
+            warn!("Failed to insert dead letter for SQLite agent missions: {}", e);
+        }
         if let Ok(res) = sqlx::query(&sqlite_update).execute(&self.sqlite_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck agent missions from SQLite", res.rows_affected());
@@ -460,7 +462,9 @@ impl HybridSyncDaemon {
         }
 
         // PG
-        let _ = sqlx::query(&pg_insert).execute(&self.pg_pool).await;
+        if let Err(e) = sqlx::query(&pg_insert).execute(&self.pg_pool).await {
+            warn!("Failed to insert dead letter for PostgreSQL agent missions: {}", e);
+        }
         if let Ok(res) = sqlx::query(&pg_update).execute(&self.pg_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck agent missions from PostgreSQL", res.rows_affected());
@@ -476,22 +480,29 @@ impl HybridSyncDaemon {
         const PG_RUNNING_WHERE: &str = "status = 'RUNNING' AND updated_at < NOW() - INTERVAL '1 hour'";
         const PG_QUEUED_WHERE: &str = "status = 'QUEUED' AND created_at < NOW() - INTERVAL '24 hours'";
 
+        let sqlite_running_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'job_stuck', 'sub_agent_queue', json_object('id', id, 'payload', json(COALESCE(payload, '{{}}'))), '[cleanup] Stagnant backlog item stuck in RUNNING for > 1 hour' FROM sub_agent_queue WHERE {}", SQLITE_RUNNING_WHERE);
         let sqlite_running_update = format!("UPDATE sub_agent_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE {}", SQLITE_RUNNING_WHERE);
         let sqlite_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'job_failed', 'sub_agent_queue', json_object('id', id, 'payload', json(COALESCE(payload, '{{}}'))), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE {}", SQLITE_QUEUED_WHERE);
         let sqlite_queued_delete = format!("DELETE FROM sub_agent_queue WHERE {}", SQLITE_QUEUED_WHERE);
 
+        let pg_running_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'job_stuck', 'sub_agent_queue', json_build_object('id', id, 'payload', COALESCE(payload::jsonb, '{{}}'::jsonb))::text, '[cleanup] Stagnant backlog item stuck in RUNNING for > 1 hour' FROM sub_agent_queue WHERE {}", PG_RUNNING_WHERE);
         let pg_running_update = format!("UPDATE sub_agent_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE {}", PG_RUNNING_WHERE);
         let pg_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'job_failed', 'sub_agent_queue', json_build_object('id', id, 'payload', COALESCE(payload::jsonb, '{{}}'::jsonb))::text, '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE {}", PG_QUEUED_WHERE);
         let pg_queued_delete = format!("DELETE FROM sub_agent_queue WHERE {}", PG_QUEUED_WHERE);
 
         // SQLite queue
+        if let Err(e) = sqlx::query(&sqlite_running_insert).execute(&self.sqlite_pool).await {
+            warn!("Failed to insert dead letter for SQLite RUNNING jobs: {}", e);
+        }
         if let Ok(res) = sqlx::query(&sqlite_running_update).execute(&self.sqlite_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck RUNNING jobs from SQLite sub_agent_queue", res.rows_affected());
             }
         }
 
-        let _ = sqlx::query(&sqlite_queued_insert).execute(&self.sqlite_pool).await;
+        if let Err(e) = sqlx::query(&sqlite_queued_insert).execute(&self.sqlite_pool).await {
+            warn!("Failed to insert dead letter for SQLite QUEUED jobs: {}", e);
+        }
         if let Ok(res) = sqlx::query(&sqlite_queued_delete).execute(&self.sqlite_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck QUEUED jobs from SQLite sub_agent_queue", res.rows_affected());
@@ -499,13 +510,18 @@ impl HybridSyncDaemon {
         }
 
         // PG queue
+        if let Err(e) = sqlx::query(&pg_running_insert).execute(&self.pg_pool).await {
+            warn!("Failed to insert dead letter for PostgreSQL RUNNING jobs: {}", e);
+        }
         if let Ok(res) = sqlx::query(&pg_running_update).execute(&self.pg_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck RUNNING jobs from PostgreSQL sub_agent_queue", res.rows_affected());
             }
         }
 
-        let _ = sqlx::query(&pg_queued_insert).execute(&self.pg_pool).await;
+        if let Err(e) = sqlx::query(&pg_queued_insert).execute(&self.pg_pool).await {
+            warn!("Failed to insert dead letter for PostgreSQL QUEUED jobs: {}", e);
+        }
         if let Ok(res) = sqlx::query(&pg_queued_delete).execute(&self.pg_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck QUEUED jobs from PostgreSQL sub_agent_queue", res.rows_affected());

--- a/src/server/orchestration/hybrid_sync/daemon_test.rs
+++ b/src/server/orchestration/hybrid_sync/daemon_test.rs
@@ -646,22 +646,47 @@ async fn test_hybrid_sync_pos_offline_transactions() {
         sqlx::query("CREATE TABLE IF NOT EXISTS department_dead_letters (id VARCHAR PRIMARY KEY, tenant_id VARCHAR, event_type VARCHAR, department VARCHAR, payload TEXT, error_message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)").execute(&pg_pool).await.unwrap();
 
         // Insert stuck queued tasks
-        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, created_at, payload) VALUES ('stuck_queued_sqlite', 'tenant1', 'QUEUED', datetime('now', '-25 hour'), '{}')")
+        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, created_at, updated_at, payload) VALUES ('stuck_queued_sqlite', 'tenant1', 'QUEUED', datetime('now', '-25 hour'), datetime('now', '-25 hour'), '{}')")
             .execute(&sqlite_pool).await.unwrap();
 
-        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, created_at, payload) VALUES ('stuck_queued_pg', 'tenant1', 'QUEUED', NOW() - INTERVAL '25 hours', '{}')")
+        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, created_at, updated_at, payload) VALUES ('stuck_queued_pg', 'tenant1', 'QUEUED', NOW() - INTERVAL '25 hours', NOW() - INTERVAL '25 hours', '{}')")
+            .execute(&pg_pool).await.unwrap();
+
+        // Insert stuck running tasks
+        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, updated_at, payload) VALUES ('stuck_running_sqlite', 'tenant1', 'RUNNING', datetime('now', '-2 hour'), '{}')")
+            .execute(&sqlite_pool).await.unwrap();
+
+        sqlx::query("INSERT INTO sub_agent_queue (id, tenant_id, status, updated_at, payload) VALUES ('stuck_running_pg', 'tenant1', 'RUNNING', NOW() - INTERVAL '2 hours', '{}')")
             .execute(&pg_pool).await.unwrap();
 
         let daemon = super::daemon::HybridSyncDaemon::new(sqlite_pool.clone(), pg_pool.clone());
         daemon.prune_stuck_sub_agent_queue().await.unwrap();
 
-        // Verify SQLite queue is failed
+        // Verify SQLite queue is failed (deleted)
         let row_queue_sqlite = sqlx::query("SELECT status FROM sub_agent_queue WHERE id = \'stuck_queued_sqlite\'").fetch_optional(&sqlite_pool).await.unwrap();
         assert!(row_queue_sqlite.is_none());
 
-        // Verify PG queue is failed
+        // Verify PG queue is failed (deleted)
         let row_queue = sqlx::query("SELECT status FROM sub_agent_queue WHERE id = \'stuck_queued_pg\'").fetch_optional(&pg_pool).await.unwrap();
         assert!(row_queue.is_none());
+
+        // Verify SQLite running is failed
+        use sqlx::Row;
+        let row_running_sqlite = sqlx::query("SELECT status FROM sub_agent_queue WHERE id = \'stuck_running_sqlite\'").fetch_one(&sqlite_pool).await.unwrap();
+        assert_eq!(row_running_sqlite.get::<String, _>("status"), "FAILED");
+
+        // Verify PG running is failed
+        let row_running = sqlx::query("SELECT status FROM sub_agent_queue WHERE id = \'stuck_running_pg\'").fetch_one(&pg_pool).await.unwrap();
+        assert_eq!(row_running.get::<String, _>("status"), "FAILED");
+
+        // Verify dead letters were created for running jobs
+        let dl_sqlite: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE payload LIKE '%stuck_running_sqlite%'")
+            .fetch_one(&sqlite_pool).await.unwrap();
+        assert_eq!(dl_sqlite.0, 1);
+
+        let dl_pg: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE payload LIKE '%stuck_running_pg%'")
+            .fetch_one(&pg_pool).await.unwrap();
+        assert_eq!(dl_pg.0, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR implements key SRE/infrastructure improvements:

1. **Hybrid Sync Daemon Queue Hygiene**: Stuck `RUNNING` tasks were previously being marked `FAILED` without being logged to the `department_dead_letters` table, resulting in lost payloads. We now correctly insert these into the DLQ before marking them failed. Also replaced silent `let _ = sqlx::query` failures with `warn!` logs.
2. **Test Coverage**: Added test coverage in `daemon_test.rs` to assert that stuck `RUNNING` tasks create the required dead letter queue rows.
3. **K8s Optimization**: Updated the Helm chart `values.yaml` to optimize `backend` and `ohcCore` requests down to `50m` CPU and `128Mi` memory, allowing higher multi-tenant scaling density while maintaining high resource limits.

---
*PR created automatically by Jules for task [8932304448461242708](https://jules.google.com/task/8932304448461242708) started by @ql-owo-lp*