### PR TITLE
fix(telemetry): Add missing telemetry check to track_onboarding_step

### DIFF
--- a/src/server/telemetry/mod.rs
+++ b/src/server/telemetry/mod.rs
@@ -1493,6 +1493,7 @@ pub fn get_onboarding_duration_histogram() -> &'static Histogram<u64> {
 }
 
 pub fn track_onboarding_step(tenant_id: &str, step: &str, duration_ms: u64) {
+    if !::server_config::get().telemetry_enabled { return; }
     let histogram = get_onboarding_duration_histogram();
     histogram.record(
         duration_ms,


### PR DESCRIPTION
Fixes an issue where `track_onboarding_step` could execute without checking if `telemetry_enabled` was opted-in. This commit ensures full local sovereignty by returning early if telemetry is disabled, matching the established pattern in other `record_*` and `buffer_metric*` functions in `src/server/telemetry/mod.rs`.

**Product-use evidence:**
A standalone operator running OHC locally without explicitly enabling telemetry should not have any onboarding metric payloads tracked or cached. This ensures compliance with the strict local sovereignty guarantees of the Standalone deployment mode.

---
*PR created automatically by Jules for task [3606628319431680972](https://jules.google.com/task/3606628319431680972) started by @ql-owo-lp*