### PR TITLE
🎥 Lens Audit: Restore OHC Translucent Glass Tokens in Owner Feed UI

### DIFF
--- a/src/ui/tauri/src/components/AgentFeedCard.tsx
+++ b/src/ui/tauri/src/components/AgentFeedCard.tsx
@@ -25,12 +25,12 @@ export const AgentFeedCard: React.FC<AgentFeedCardProps> = ({ draft, onApprove, 
                 <div className="text-sm font-medium text-[#1D1D1F] dark:text-[#F5F5F7]">
                     Message from {draft.customer_name || 'Unknown User'}
                 </div>
-                <div className="text-xs text-gray-500 uppercase">
+                <div className="text-xs text-[#1D1D1F]/60 dark:text-[#F5F5F7]/60 uppercase">
                     {draft.source}
                 </div>
             </div>
 
-            <div className="text-sm text-gray-800 dark:text-gray-200 bg-white/40 dark:bg-black/20 p-3 rounded-lg">
+            <div className="text-sm text-[#1D1D1F]/80 dark:text-[#F5F5F7]/80 bg-white/40 dark:bg-black/20 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10 p-3 rounded-[8px]">
                 {draft.response}
             </div>
 
@@ -43,7 +43,7 @@ export const AgentFeedCard: React.FC<AgentFeedCardProps> = ({ draft, onApprove, 
                 </button>
                 <button
                     onClick={() => onEdit(draft.draft_id)}
-                    className="w-full min-h-[44px] bg-gray-200 hover:bg-gray-300 dark:bg-gray-800 dark:hover:bg-gray-700 text-[#1D1D1F] dark:text-[#F5F5F7] rounded-[8px] font-medium transition-colors"
+                    className="w-full min-h-[44px] bg-white/50 dark:bg-gray-800/50 hover:bg-white/80 dark:hover:bg-gray-700/50 text-[#1D1D1F] dark:text-[#F5F5F7] rounded-[8px] border border-white/40 dark:border-white/10 font-medium transition-colors"
                 >
                     Edit Draft
                 </button>

--- a/src/ui/tauri/src/components/owner_feed/PayoutSummaryCard.tsx
+++ b/src/ui/tauri/src/components/owner_feed/PayoutSummaryCard.tsx
@@ -16,16 +16,16 @@ export const PayoutSummaryCard: React.FC<PayoutSummaryCardProps> = ({
   return (
     <div className="bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] rounded-[16px] p-4 shadow-sm border border-white/40 dark:border-white/10">
       <div className="flex justify-between items-start mb-2">
-        <h3 className="text-lg font-semibold text-gray-900">Your Payout Summary is ready.</h3>
-        <span className="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-700/10">Pending</span>
+        <h3 className="text-lg font-semibold text-[#1D1D1F] dark:text-[#F5F5F7]">Your Payout Summary is ready.</h3>
+        <span className="inline-flex items-center rounded-[8px] bg-[#34C759]/10 px-2 py-1 text-xs font-medium text-[#34C759] ring-1 ring-inset ring-[#34C759]/20">Pending</span>
       </div>
-      <p className="text-sm text-gray-600 mb-4">
+      <p className="text-sm text-[#1D1D1F]/80 dark:text-[#F5F5F7]/80 mb-4">
         You earned ${(totalUsdEarned / 100).toFixed(2)} USD and €{(totalEurEarned / 100).toFixed(2)} EUR this week. After conversion and fees, ${(totalUsdPayout / 100).toFixed(2)} USD will hit your Chase account tomorrow.
       </p>
 
       <button
         onClick={onViewDetails}
-        className="w-full bg-blue-600 text-white min-h-[44px] px-4 rounded-[8px] text-sm font-medium hover:bg-blue-700 transition-colors"
+        className="w-full bg-[#0066FF] text-white min-h-[44px] px-4 rounded-[8px] text-sm font-medium hover:bg-blue-600 transition-colors"
       >
         View Details
       </button>

--- a/src/ui/tauri/src/components/owner_feed/ReviewDraftQuoteCard.tsx
+++ b/src/ui/tauri/src/components/owner_feed/ReviewDraftQuoteCard.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 
 interface ReviewDraftQuoteCardProps {
@@ -19,34 +18,34 @@ export const ReviewDraftQuoteCard: React.FC<ReviewDraftQuoteCardProps> = ({
   return (
     <div className="bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] rounded-[16px] p-4 shadow-sm border border-white/40 dark:border-white/10">
       <div className="flex justify-between items-start mb-2">
-        <h3 className="text-lg font-semibold text-gray-900">Draft Quote Ready</h3>
-        <span className="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10">Action Required</span>
+        <h3 className="text-lg font-semibold text-[#1D1D1F] dark:text-[#F5F5F7]">Draft Quote Ready</h3>
+        <span className="inline-flex items-center rounded-[8px] bg-[#FF9500]/10 px-2 py-1 text-xs font-medium text-[#FF9500] ring-1 ring-inset ring-[#FF9500]/20">Action Required</span>
       </div>
-      <p className="text-sm text-gray-600 mb-4">
+      <p className="text-sm text-[#1D1D1F]/80 dark:text-[#F5F5F7]/80 mb-4">
         {projectDescription} for {customerName}
       </p>
 
-      <div className="bg-gray-50 rounded-[8px] p-3 mb-4 border border-gray-100">
+      <div className="bg-white/40 dark:bg-black/20 backdrop-blur-[30px] saturate-[210%] rounded-[8px] p-3 mb-4 border border-white/40 dark:border-white/10">
         <div className="flex justify-between text-sm">
-          <span className="text-gray-500">Total Cost:</span>
-          <span className="font-medium">${(totalCost / 100).toFixed(2)}</span>
+          <span className="text-[#1D1D1F]/70 dark:text-[#F5F5F7]/70">Total Cost:</span>
+          <span className="font-medium text-[#1D1D1F] dark:text-[#F5F5F7]">${(totalCost / 100).toFixed(2)}</span>
         </div>
         <div className="flex justify-between text-sm mt-1">
-          <span className="text-gray-500">Deposit Required (33%):</span>
-          <span className="font-medium">${((totalCost / 3) / 100).toFixed(2)}</span>
+          <span className="text-[#1D1D1F]/70 dark:text-[#F5F5F7]/70">Deposit Required (33%):</span>
+          <span className="font-medium text-[#1D1D1F] dark:text-[#F5F5F7]">${((totalCost / 3) / 100).toFixed(2)}</span>
         </div>
       </div>
 
       <div className="flex space-x-3">
         <button
           onClick={onApprove}
-          className="flex-1 bg-blue-600 text-white min-h-[44px] px-4 rounded-[8px] text-sm font-medium hover:bg-blue-700 transition-colors"
+          className="flex-1 bg-[#0066FF] text-white min-h-[44px] px-4 rounded-[8px] text-sm font-medium hover:bg-blue-600 transition-colors"
         >
           Approve & Send
         </button>
         <button
           onClick={onEdit}
-          className="flex-1 bg-white text-gray-700 min-h-[44px] px-4 rounded-[8px] text-sm font-medium border border-gray-300 hover:bg-gray-50 transition-colors"
+          className="flex-1 bg-white/50 dark:bg-gray-800/50 text-[#1D1D1F] dark:text-[#F5F5F7] min-h-[44px] px-4 rounded-[8px] text-sm font-medium border border-white/40 dark:border-white/10 hover:bg-white/80 dark:hover:bg-gray-700/50 transition-colors"
         >
           Edit
         </button>

--- a/src/ui/tauri/src/components/owner_feed/__tests__/PayoutSummaryCard.test.tsx
+++ b/src/ui/tauri/src/components/owner_feed/__tests__/PayoutSummaryCard.test.tsx
@@ -1,3 +1,5 @@
+/** @vitest-environment jsdom */
+
 import React from 'react';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';

--- a/src/ui/tauri/src/components/owner_feed/__tests__/ReviewDraftQuoteCard.test.tsx
+++ b/src/ui/tauri/src/components/owner_feed/__tests__/ReviewDraftQuoteCard.test.tsx
@@ -1,3 +1,5 @@
+/** @vitest-environment jsdom */
+
 import React from 'react';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';


### PR DESCRIPTION
- Added `@vitest-environment jsdom` to `PayoutSummaryCard.test.tsx` and `ReviewDraftQuoteCard.test.tsx` to fix Vitest failures.
- Updated styling on `PayoutSummaryCard.tsx`, `ReviewDraftQuoteCard.tsx`, and `AgentFeedCard.tsx` to adhere to the OHC Premium Token Library.
  - Used translucent glass layers (`bg-white/65 dark:bg-[#16161a]/70`, `backdrop-blur-[30px] saturate-[210%]`).
  - Used canonical colors for headers, text, success statuses (`#34C759`), warnings (`#FF9500`), and buttons (`#0066FF`).
  - Corrected corner rounding to 16px for exterior containers and 8px for internal cards/buttons.

---
*PR created automatically by Jules for task [18279909691694897793](https://jules.google.com/task/18279909691694897793) started by @ql-owo-lp*