### PR TITLE
🛡️ Sentinel: [Hybrid Security Fix] Enforce Secure File Permissions on SQLite Auxiliary Files

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -3116,7 +3116,7 @@
           "REPO_MAPPING:rules_rust+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_rust+,rules_cc rules_cc+",
           "REPO_MAPPING:rules_rust+,rules_rust rules_rust+",
-          "FILE:@@//Cargo.lock aa79d9ec2d57e32b685d7a075246d16af2d394d2a4710d9354867a81540d417a",
+          "FILE:@@//Cargo.lock 006cbf12f921620970e319d195592ce14b620677862edb2cf6734c606794ab73",
           "FILE:@@//Cargo.toml 2de1afce2ac14e121c86a31947a790a00324b05067f1a346ab8613b888c6f6c4",
           "FILE:@@//src/server/integrations/twilio/Cargo.toml 0b844e21da462f26931e5cd748780679576031f13904526d0aae009774abba03",
           "FILE:@@//src/server/integrations/core/Cargo.toml eafe72b50cce37ffa026a47a89e02d1ea7a64cfe9d5fdc7cfb0dea8d3cbcbfbf",

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -332,6 +332,23 @@ impl DB {
                                 return Err(e.into());
                             }
                         }
+
+                        // Pre-create SQLite auxiliary files (-wal and -shm) with secure permissions
+                        // to prevent them from inheriting the default umask (e.g. 0644).
+                        let wal_path = format!("{}-wal", db_path.display());
+                        let shm_path = format!("{}-shm", db_path.display());
+
+                        for ext_path in [&wal_path, &shm_path] {
+                            if let Ok(file) = opts.open(ext_path) {
+                                if let Ok(metadata) = file.metadata() {
+                                    let mut p = metadata.permissions();
+                                    if (p.mode() & 0o777) != 0o600 {
+                                        p.set_mode(0o600);
+                                        let _ = file.set_permissions(p);
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
                 #[cfg(not(unix))]


### PR DESCRIPTION
This PR hardens the Standalone Mode SQLite configuration by preemptively enforcing `0o600` permissions on the `-wal` and `-shm` files. Previously, SQLite would create these files implicitly, which bypassed the main `.db` file's `0o600` permission and fell back to the system's potentially less secure `umask` (e.g. `0644`). The changes have been verified with `db_unit_test` and E2E playwright tests.

---
*PR created automatically by Jules for task [9223459312164640783](https://jules.google.com/task/9223459312164640783) started by @ql-owo-lp*