### PR TITLE
Optimize docs and dashboard API response payloads for mobile

### DIFF
--- a/src/proto/app.proto
+++ b/src/proto/app.proto
@@ -191,6 +191,7 @@ message VideoMetadata {
 }
 
 message GetVideoTutorialsRequest {
+  bool mobile_optimized = 1;
 }
 
 message GetVideoTutorialsResponse {

--- a/src/proto/docs.proto
+++ b/src/proto/docs.proto
@@ -22,6 +22,7 @@ message GetHelpArticleResponse {
 message SearchHelpArticlesRequest {
   string query = 1;
   string topic_filter = 2; // optional
+  bool mobile_optimized = 3;
 }
 
 message SearchHelpArticlesResponse {
@@ -49,7 +50,9 @@ message VideoTutorial {
   string video_url = 4;
 }
 
-message GetVideoTutorialsRequest {}
+message GetVideoTutorialsRequest {
+  bool mobile_optimized = 1;
+}
 
 message GetVideoTutorialsResponse {
   repeated VideoTutorial tutorials = 1;

--- a/src/server/services/dashboard/service.rs
+++ b/src/server/services/dashboard/service.rs
@@ -727,9 +727,10 @@ impl DashboardService for MyDashboardService {
 
     async fn get_video_tutorials(
         &self,
-        _request: Request<GetVideoTutorialsRequest>,
+        request: Request<GetVideoTutorialsRequest>,
     ) -> Result<Response<GetVideoTutorialsResponse>, Status> {
-        let videos = vec![
+        let req = request.into_inner();
+        let mut videos = vec![
             VideoMetadata {
                 title: "How to add your first product".to_string(),
                 description: "A quick 60-second guide to listing items in your store.".to_string(),
@@ -748,6 +749,13 @@ impl DashboardService for MyDashboardService {
                     .to_string(),
             },
         ];
+
+        if req.mobile_optimized {
+            for video in videos.iter_mut() {
+                video.description = String::new();
+                video.duration_sec = 0;
+            }
+        }
 
         Ok(Response::new(GetVideoTutorialsResponse { videos }))
     }
@@ -1074,6 +1082,17 @@ mod tests {
         assert!(res.is_err());
         assert_eq!(res.unwrap_err().code(), tonic::Code::InvalidArgument);
     }
-}
 
-// Parallel Execution Optimization verified
+    #[tokio::test]
+    async fn test_get_video_tutorials_mobile_optimized() {
+        let service = setup_test_dashboard_service().await;
+        let request = Request::new(::server_ohc::app::GetVideoTutorialsRequest {
+            mobile_optimized: true,
+        });
+
+        let response = service.get_video_tutorials(request).await.unwrap().into_inner();
+        assert!(!response.videos.is_empty());
+        assert_eq!(response.videos[0].description, ""); // Omitted for mobile
+        assert_eq!(response.videos[0].duration_sec, 0); // Omitted for mobile
+    }
+}

--- a/src/server/services/docs/service.rs
+++ b/src/server/services/docs/service.rs
@@ -122,8 +122,14 @@ impl DocsService for MyDocsService {
             .cloned()
             .collect();
 
+        let mut final_articles = filtered;
+        if req.mobile_optimized {
+            for article in final_articles.iter_mut() {
+                article.content_markdown = String::new();
+            }
+        }
         Ok(Response::new(SearchHelpArticlesResponse {
-            articles: filtered,
+            articles: final_articles,
         }))
     }
 
@@ -144,11 +150,19 @@ impl DocsService for MyDocsService {
 
     async fn get_video_tutorials(
         &self,
-        _request: Request<GetVideoTutorialsRequest>,
+        request: Request<GetVideoTutorialsRequest>,
     ) -> Result<Response<GetVideoTutorialsResponse>, Status> {
-        let tutorials = get_video_tutorials();
+        let req = request.into_inner();
+        let mut tutorials = get_video_tutorials().clone();
+
+        if req.mobile_optimized {
+            for tutorial in tutorials.iter_mut() {
+                tutorial.duration = String::new();
+            }
+        }
+
         Ok(Response::new(GetVideoTutorialsResponse {
-            tutorials: tutorials.clone(),
+            tutorials,
         }))
     }
 }

--- a/src/server/services/docs/service_tests.rs
+++ b/src/server/services/docs/service_tests.rs
@@ -27,7 +27,7 @@
         let service = MyDocsService::new();
 
         // Test 1: Empty query, empty topic (should return all)
-        let request = Request::new(SearchHelpArticlesRequest {
+        let request = Request::new(SearchHelpArticlesRequest { mobile_optimized: false,
             query: "".to_string(),
             topic_filter: "".to_string(),
         });
@@ -35,7 +35,7 @@
         assert_eq!(response.articles.len(), 6);
 
         // Test 2: Search by query "payment"
-        let request = Request::new(SearchHelpArticlesRequest {
+        let request = Request::new(SearchHelpArticlesRequest { mobile_optimized: false,
             query: "payment".to_string(),
             topic_filter: "".to_string(),
         });
@@ -44,7 +44,7 @@
         assert!(response.articles.iter().any(|a| a.topic == "Getting Started")); // "accept payments"
 
         // Test 3: Search by topic "AI Agents"
-        let request = Request::new(SearchHelpArticlesRequest {
+        let request = Request::new(SearchHelpArticlesRequest { mobile_optimized: false,
             query: "".to_string(),
             topic_filter: "AI Agents".to_string(),
         });
@@ -53,7 +53,7 @@
         assert_eq!(response.articles[0].topic, "AI Agents");
 
         // Test 4: Search by query and topic
-        let request = Request::new(SearchHelpArticlesRequest {
+        let request = Request::new(SearchHelpArticlesRequest { mobile_optimized: false,
             query: "support".to_string(),
             topic_filter: "AI Agents".to_string(),
         });
@@ -102,7 +102,7 @@
         ];
 
         for (query, topic, expected) in cases {
-            let request = Request::new(SearchHelpArticlesRequest {
+            let request = Request::new(SearchHelpArticlesRequest { mobile_optimized: false,
                 query: query.to_string(),
                 topic_filter: topic.to_string(),
             });
@@ -405,7 +405,7 @@
         ];
 
         for (query, expected) in test_cases {
-            let request = Request::new(SearchHelpArticlesRequest {
+            let request = Request::new(SearchHelpArticlesRequest { mobile_optimized: false,
                 query: query.to_string(),
                 topic_filter: "".to_string(),
             });
@@ -728,7 +728,7 @@
         ];
 
         for (topic, expected) in test_cases {
-            let request = Request::new(SearchHelpArticlesRequest {
+            let request = Request::new(SearchHelpArticlesRequest { mobile_optimized: false,
                 query: "".to_string(),
                 topic_filter: topic.to_string(),
             });
@@ -998,11 +998,37 @@
         ];
 
         for (query, topic, expected) in test_cases {
-            let request = Request::new(SearchHelpArticlesRequest {
+            let request = Request::new(SearchHelpArticlesRequest { mobile_optimized: false,
                 query: query.to_string(),
                 topic_filter: topic.to_string(),
             });
             let response = service.search_help_articles(request).await.unwrap().into_inner();
             assert_eq!(response.articles.len(), expected, "Failed for query '{}', topic '{}'", query, topic);
         }
+    }
+    #[tokio::test]
+    async fn test_search_help_articles_mobile_optimized() {
+        let service = MyDocsService::new();
+        let request = Request::new(SearchHelpArticlesRequest {
+            query: "welcome".to_string(),
+            topic_filter: "".to_string(),
+            mobile_optimized: true,
+        });
+
+        let response = service.search_help_articles(request).await.unwrap().into_inner();
+        assert_eq!(response.articles.len(), 1);
+        assert_eq!(response.articles[0].id, "getting-started-1");
+        assert_eq!(response.articles[0].content_markdown, ""); // Omitted for mobile
+    }
+
+    #[tokio::test]
+    async fn test_get_video_tutorials_mobile_optimized() {
+        let service = MyDocsService::new();
+        let request = Request::new(GetVideoTutorialsRequest {
+            mobile_optimized: true,
+        });
+
+        let response = service.get_video_tutorials(request).await.unwrap().into_inner();
+        assert!(!response.tutorials.is_empty());
+        assert_eq!(response.tutorials[0].duration, ""); // Omitted for mobile
     }


### PR DESCRIPTION
- Add `mobile_optimized` field in `GetVideoTutorialsRequest` in `app.proto` and `docs.proto`.
- Add `mobile_optimized` field in `SearchHelpArticlesRequest` in `docs.proto`.
- Clear `description`, `duration_sec`, and `content_markdown` in response messages when `mobile_optimized` is set.
- Add unit tests for `DocsService` and `DashboardService` to ensure correct mobile payload optimization.

---
*PR created automatically by Jules for task [4687003684599517157](https://jules.google.com/task/4687003684599517157) started by @ql-owo-lp*