### PR TITLE
Enforce RLS on embedding_cache and telemetry_buffer

### DIFF
--- a/src/server/migrations/999_missing_rls.sql
+++ b/src/server/migrations/999_missing_rls.sql
@@ -140,3 +140,14 @@ CREATE POLICY tenant_isolation_epics ON epics USING (tenant_id = current_setting
 ALTER TABLE IF EXISTS incidents ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS tenant_isolation_incidents ON incidents;
 CREATE POLICY tenant_isolation_incidents ON incidents USING (tenant_id::text = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id::text = current_setting('app.current_tenant', true));
+
+-- Missing Policies added by cleanup script
+DROP POLICY IF EXISTS tenant_isolation_embedding_cache ON embedding_cache;
+CREATE POLICY tenant_isolation_embedding_cache ON embedding_cache USING (tenant_id = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id = current_setting('app.current_tenant', true));
+
+DROP POLICY IF EXISTS tenant_isolation_telemetry_buffer ON telemetry_buffer;
+CREATE POLICY tenant_isolation_telemetry_buffer ON telemetry_buffer USING (tenant_id = current_setting('app.current_tenant', true)) WITH CHECK (tenant_id = current_setting('app.current_tenant', true));
+
+-- Missing RLS Enablement added by cleanup script
+ALTER TABLE IF EXISTS embedding_cache ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS telemetry_buffer ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Added missing Row Level Security (RLS) policies and enablement statements for the `embedding_cache` and `telemetry_buffer` tables to ensure full multi-tenant data isolation.

---
*PR created automatically by Jules for task [4780075156482032112](https://jules.google.com/task/4780075156482032112) started by @ql-owo-lp*