### PR TITLE
🔨 Forge: Universal Edge-Cached Dynamic Storefront for SEO

### DIFF
--- a/src/e2e/tests/storefront_edge_seo.spec.ts
+++ b/src/e2e/tests/storefront_edge_seo.spec.ts
@@ -21,14 +21,24 @@ test.describe('Storefront Edge SEO and Caching', () => {
         });
 
         // Hit the edge cache endpoint via request
+        let initialRes = await request.get(`http://127.0.0.1:18789/api/v1/storefront/${tenantId}/44444444-4444-4444-4444-444444444444`);
+        expect(initialRes.status()).toBe(200);
+        expect(initialRes.headers()['x-cache']).toBe('MISS');
+
         let res = await request.get(`http://127.0.0.1:18789/api/v1/storefront/${tenantId}/44444444-4444-4444-4444-444444444444`);
         expect(res.status()).toBe(200);
+        expect(res.headers()['x-cache']).toBe('HIT');
 
         // Update the product, forcing an invalidation
         const invalidateRes = await request.post('http://127.0.0.1:18789/api/v1/storefront/webhook/invalidate', {
             data: { tags: [`entity:product:44444444-4444-4444-4444-444444444444`] }
         });
         expect(invalidateRes.status()).toBe(200);
+        await page.waitForTimeout(100);
+
+        let postInvalidateRes = await request.get(`http://127.0.0.1:18789/api/v1/storefront/${tenantId}/44444444-4444-4444-4444-444444444444`);
+        expect(postInvalidateRes.status()).toBe(200);
+        expect(postInvalidateRes.headers()['x-cache']).toBe('MISS');
 
         // Access the UI file
         const htmlPath = path.resolve(__dirname, '../../../src/ui/tauri/src/ui/storefront.html');

--- a/src/server/api/catalog.rs
+++ b/src/server/api/catalog.rs
@@ -293,6 +293,14 @@ async fn handle_create_product(
     let cache = CATALOG_CACHE.get_or_init(|| HybridCache::new(None));
     cache.invalidate(&tenant_id).await;
 
+    // Edge Cache Invalidation
+    let edge_cache = crate::builder::edge::get_edge_cache();
+    edge_cache.invalidate_by_tag(&format!("tenant-id:{}", tenant_id)).await;
+    edge_cache.invalidate_by_tag(&format!("entity:product:{}", product_id)).await;
+    let cdn_cache = crate::utils::edge_caching_middleware::get_cdn_cache();
+    cdn_cache.invalidate_by_tag(&format!("tenant-id:{}", tenant_id)).await;
+    cdn_cache.invalidate_by_tag(&format!("entity:product:{}", product_id)).await;
+
     if let Err(e) = hub.tracker().record_product_added(&tenant_id).await {
         tracing::warn!(
             "Failed to update product usage counter for tenant {}: {}",

--- a/src/server/orchestration/departments/marketing_agent.rs
+++ b/src/server/orchestration/departments/marketing_agent.rs
@@ -281,6 +281,10 @@ impl Department for MarketingAgent {
                                 cache.invalidate_by_tag(&format!("tenant-id:{}", tenant_id_str)).await;
                                 cache.invalidate_by_tag(&format!("entity:product:{}", product_id_str)).await;
 
+                                let cdn = crate::utils::edge_caching_middleware::get_cdn_cache();
+                                cdn.invalidate_by_tag(&format!("tenant-id:{}", tenant_id_str)).await;
+                                cdn.invalidate_by_tag(&format!("entity:product:{}", product_id_str)).await;
+
                                 // Trigger site publish job for all sites for the tenant
                                 if let Ok(sites) = crate::builder::db::list_sites(&pool, tenant_id).await {
                                     for site in sites {

--- a/src/server/workers/pos_sync_worker.rs
+++ b/src/server/workers/pos_sync_worker.rs
@@ -316,6 +316,9 @@ impl crate::queue::TaskJobHandler for PosSyncWorker {
                 let cache = crate::builder::edge::get_edge_cache();
                 let _ = cache.invalidate_by_tag(&format!("entity:product:{}", product_id)).await;
                 let _ = cache.invalidate_by_tag(&format!("tenant-id:{}", job.tenant_id)).await;
+                let cdn = crate::utils::edge_caching_middleware::get_cdn_cache();
+                cdn.invalidate_by_tag(&format!("entity:product:{}", product_id)).await;
+                cdn.invalidate_by_tag(&format!("tenant-id:{}", job.tenant_id)).await;
 
                 let pool_clone = self.db.pool.clone();
                 let tenant_id_clone = uuid::Uuid::parse_str(&job.tenant_id).unwrap_or_default();
@@ -543,6 +546,9 @@ impl crate::queue::TaskJobHandler for PosSyncWorker {
                             let cache = crate::builder::edge::get_edge_cache();
                             let _ = cache.invalidate_by_tag(&format!("entity:product:{}", product_id)).await;
                             let _ = cache.invalidate_by_tag(&format!("tenant-id:{}", job.tenant_id)).await;
+                            let cdn = crate::utils::edge_caching_middleware::get_cdn_cache();
+                            cdn.invalidate_by_tag(&format!("entity:product:{}", product_id)).await;
+                            cdn.invalidate_by_tag(&format!("tenant-id:{}", job.tenant_id)).await;
 
                             let pool_clone = self.db.pool.clone();
                             let tenant_id_clone = uuid::Uuid::parse_str(&job.tenant_id).unwrap_or_default();


### PR DESCRIPTION
This pull request addresses the architectural gap of missing edge caching invalidation for dynamic storefronts.

**Product Use Evidence:**
As an owner (e.g. Maya the Baker), when I update my storefront's product offerings or inventory, those changes should immediately reflect on the public, SEO-optimized Edge storefronts without waiting for long cache expiries.

**Changes:**
- `src/server/api/catalog.rs`: Now correctly publishes cache invalidation events (both `edge_cache` and `cdn_cache` tags) when a product is created or updated.
- `src/server/workers/pos_sync_worker.rs`: Ensured offline POS syncing invalidates both edge cache and cdn cache so that the storefront mirrors real-time inventory adjustments.
- `src/server/orchestration/departments/marketing_agent.rs`: Handled invalidations similarly on marketing actions such as SEO data generation.

**Tests:**
- E2E Playwright tests (`bazelisk test //src/e2e:playwright`) have been fully run and verified the storefront edge logic and cache HIT/MISS dynamics correctly.
- Ensured unit testing passes.

**Superpowers used:**
No particular external superpowers used. Evaluated code via deep CLI search for invalidation behavior and E2E test execution.

---
*PR created automatically by Jules for task [14596311881075394659](https://jules.google.com/task/14596311881075394659) started by @ql-owo-lp*

Resolves #32845