### PR TITLE
fix: Resolve single-flight race condition in `get_or_fetch_with_swr`

### DIFF
--- a/src/server/utils/cache.rs
+++ b/src/server/utils/cache.rs
@@ -144,10 +144,17 @@ where
             }
         };
 
+        {
+            let val = rx.borrow().clone();
+            if val.is_some() {
+                return val;
+            }
+        }
+
         if rx.changed().await.is_ok() {
             rx.borrow().clone()
         } else {
-            None
+            rx.borrow().clone()
         }
     }
 
@@ -203,10 +210,17 @@ where
             }
         };
 
+        {
+            let val = rx.borrow().clone();
+            if val.is_some() {
+                return val;
+            }
+        }
+
         if rx.changed().await.is_ok() {
             rx.borrow().clone()
         } else {
-            None
+            rx.borrow().clone()
         }
     }
 


### PR DESCRIPTION
Fixes a critical concurrency bug in the SWR caching utility which caused background requests and benchmarks to hang.
- Checked `rx.borrow().clone()` before awaiting `rx.changed().await`.
- Both `get_or_fetch_with_swr` and `get_or_fetch_with_tags_swr` were patched.
- Verified backend and e2e testing passes correctly.

---
*PR created automatically by Jules for task [3000646402907254842](https://jules.google.com/task/3000646402907254842) started by @ql-owo-lp*