### PR TITLE
🗺️ Guide: Fix Instant Build button UI breakage

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1308,7 +1308,6 @@
 
         <div class="btn-group" style="margin-top: 16px">
           <button
-            class="next-step-btn"
             id="generate-storefront-btn"
             data-testid="generate-storefront-btn"
             style="width: 100%; min-height: 44px; border-radius: 8px; background: #0066FF; color: white; font-weight: 600; border: none; font-size: 16px; box-shadow: 0 4px 14px 0 rgba(0, 102, 255, 0.39);"


### PR DESCRIPTION
🗺️ Guide: Fix Instant Build button

**Product-use evidence:**
- **Persona:** Maya (Home Baker) seeking a fast AI-powered store creation.
- **Attempted flow:** Navigated to `setup.html`, filled out the Instant Build `textarea` and clicked the `Generate My Workspace` button.
- **Observed gap:** The UI breaks to a blank screen instead of initiating the AI flow because a generic `next-step-btn` event listener intercepts the click, looks for a non-existent `data-next` attribute, and calls `goToStep(null)`, breaking the display state.
- **Reason for fix:** A non-technical owner using the conversational AI flow expects it to work instantly. Failing to a blank page breaks trust on Day One.
- **Post-fix UI flow:** Filling out the `textarea` and clicking the button now triggers the correct AI job, advancing to the loading state and generating the site successfully.

**Loaded Superpowers Skills:**
- `using-superpowers`, `subagent-driven-development`, `test-driven-development` (via manual python-playwright verification prior to applying the fix).

**Interaction Audit Table:**
| Element | Designed Purpose | Observed Result | Fix |
|---|---|---|---|
| `#generate-storefront-btn` | Trigger AI generation and go to loading state | UI breaks to blank state (goToStep null) | Removed conflicting `next-step-btn` class |

---
*PR created automatically by Jules for task [15059326515678989588](https://jules.google.com/task/15059326515678989588) started by @ql-owo-lp*