### PR TITLE
🔗 Link: [Architecture] Implement Universal Edge-Cached Dynamic Storefront for SEO

### DIFF
--- a/docs/architecture/cdn_integration_pattern.md
+++ b/docs/architecture/cdn_integration_pattern.md
@@ -1,0 +1,8 @@
+# CDN Integration Pattern
+
+The OneHumanCorp (OHC) platform utilizes an edge caching mechanism for high-performance storefront delivery. To facilitate this:
+- The system employs an `edge_caching_middleware` to simulate CDN functionality locally (for standalone or docker-compose environments).
+- The middleware supports caching based on `Cache-Tag` or `Surrogate-Key` HTTP headers.
+- When dynamic resources (like product pricing, inventory levels, or SEO metadata) are updated, the backend services invalidate the affected content by emitting specific cache tags using the `invalidate_by_tag` method or publishing to the `cache_invalidation_events` Pub/Sub topic via Redis.
+
+This enables the application to automatically scale its storefront delivery while keeping the edge caches consistent with the central PostgreSQL datastore.

--- a/src/e2e/tests/storefront_edge_seo.spec.ts
+++ b/src/e2e/tests/storefront_edge_seo.spec.ts
@@ -39,6 +39,6 @@ test.describe('Storefront Edge SEO and Caching', () => {
         await expect(page.locator('#copy-link-btn')).toBeVisible({ timeout: 10000 });
 
         // Assert cache was successfully invalidated internally by our webhook above
-        expect(true).toBe(true);
+        await expect(frame.locator('body')).toContainText('Original SEO Name');
     });
 });

--- a/src/server/orchestration/departments/marketing_agent.rs
+++ b/src/server/orchestration/departments/marketing_agent.rs
@@ -280,6 +280,9 @@ impl Department for MarketingAgent {
                                 let cache = crate::builder::edge::get_edge_cache();
                                 cache.invalidate_by_tag(&format!("tenant-id:{}", tenant_id_str)).await;
                                 cache.invalidate_by_tag(&format!("entity:product:{}", product_id_str)).await;
+                                let cdn_cache = crate::utils::edge_caching_middleware::get_cdn_cache();
+                                cdn_cache.invalidate_by_tag(&format!("tenant-id:{}", tenant_id_str)).await;
+                                cdn_cache.invalidate_by_tag(&format!("entity:product:{}", product_id_str)).await;
 
                                 // Trigger site publish job for all sites for the tenant
                                 if let Ok(sites) = crate::builder::db::list_sites(&pool, tenant_id).await {


### PR DESCRIPTION
This PR addresses the architecture gap where the dynamic storefronts do not actively purge Edge CDN cache states on SEO changes.

### Changes
- **Marketing Agent CDN Cache Invalidation**: Now triggers invalidation on `cdn_cache` alongside `edge_cache` upon product SEO schema updates to ensure global caches (via edge-caching-middleware) purge accurately. 
- **Documentation**: Formally documented the CDN Integration Pattern in `docs/architecture/cdn_integration_pattern.md`.
- **E2E Stability**: Updated `storefront_edge_seo.spec.ts` which previously contained an empty `expect(true).toBe(true)` to actually verify the storefront iframe UI updates and hydrates the SEO content accurately.

### Testing
- `bazelisk test //...` verified.
- Playwright E2E suites validated using `await expect(frame.locator('body')).toContainText('Original SEO Name');`. 

*Superpowers used: `browser/Playwright` for E2E validation. `Codebase Audit` & `Design Docs Research` to identify cache-invalidation mismatches.*

Resolves #32845

---
*PR created automatically by Jules for task [6495419312520923427](https://jules.google.com/task/6495419312520923427) started by @ql-owo-lp*