### PR TITLE
Fix PII leakage in telemetry

### DIFF
--- a/src/server/analytics.rs
+++ b/src/server/analytics.rs
@@ -31,7 +31,7 @@ impl Tracker {
         let sanitized_props = self.sanitize_props(props);
 
         // Use a generic log statement to avoid test violations for exact property matching
-        tracing::info!("Event tracked: {}, props count: {}", name, sanitized_props.len());
+        tracing::info!("Event tracked: {}, props count: {}", name, sanitized_props.len()); // pii-safe
     }
 }
 

--- a/src/server/pii_leakage_check.sh
+++ b/src/server/pii_leakage_check.sh
@@ -44,7 +44,7 @@ def main():
         for file in files:
             if file.endswith('.rs'):
                 filepath = os.path.join(root, file)
-                if 'telemetry' in filepath or 'analytics.rs' in filepath or '_test.rs' in filepath:
+                if '_test.rs' in filepath:
                     continue
 
                 matches = check_file(filepath)

--- a/src/server/telemetry/mod.rs
+++ b/src/server/telemetry/mod.rs
@@ -1384,6 +1384,7 @@ pub fn is_sensitive_key(key: &str) -> bool {
         || k.contains("ipaddress")
         || k.contains("macaddress")
         || k.contains("creditcard") || k.contains("deviceid") || k.contains("gps") || k.contains("latitude") || k.contains("longitude")
+        || (k.contains("tenant") && k != "tenantid")
 }
 
 pub fn is_email(s: &str) -> bool {


### PR DESCRIPTION
This PR implements the Hybrid Privacy Audit and Compliance Guardrails requirements by fixing PII leakage in telemetry logs.
It adds `tenant` to the `is_sensitive_key` function while correctly excluding `tenant_id` and `organization_id` as they are internal partitions and not PII. 
Additionally, it patches `analytics.rs` which was logging without `// pii-safe` flag, and ensures the bash script (`pii_leakage_check.sh`) doesn't silently bypass `telemetry` or `analytics.rs`.

---
*PR created automatically by Jules for task [10570280498339628899](https://jules.google.com/task/10570280498339628899) started by @ql-owo-lp*