### PR TITLE
Fix expert team api route fault injection logic and SyncManager enqueue method call

### DIFF
--- a/src/ui/next/src/app/api/expert-team/route.ts
+++ b/src/ui/next/src/app/api/expert-team/route.ts
@@ -48,6 +48,9 @@ export async function POST(req: Request) {
   } catch (error: any) {
     // Check if the fault is from fetch_after where it was converted to an Error
     if (error.message && error.message.includes('Fault Injected')) {
+        if (error.message.includes('expert_team_api_start')) {
+            return NextResponse.json({ error: error.message }, { status: 500 });
+        }
         if (error.message.includes('expert_team_api_fetch_after') || error.message.includes('expert_team_api_fetch_before')) {
             return NextResponse.json({ error: "Backend service unavailable" }, { status: 503 });
         }

--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -97,7 +97,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
        if (onOptimisticReserve) onOptimisticReserve();
 
        cart?.forEach(item => {
-          syncManager.enqueueAction({
+           SyncManager.getInstance().enqueue({
              type: 'tap_to_pay',
              product_id: item.product.id,
              quantity: item.quantity,
@@ -149,7 +149,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
      if (onOptimisticReserve) onOptimisticReserve();
 
      cart?.forEach(item => {
-        syncManager.enqueueAction({
+           SyncManager.getInstance().enqueue({
            type: 'cash_sale',
            product_id: item.product.id,
            quantity: item.quantity,


### PR DESCRIPTION
Fix expert team api route fault injection logic and SyncManager enqueue method call

This commit fixes the chaotic test suite `route.chaos.test.ts` where injecting a fault at the `expert_team_api_start` stage resulted in an incorrect fallback. It correctly maps the target string and allows the exact error to fall through to a 500 response. Furthermore, it fixes the `StripeTerminalClient` compile failure in `next build` that occurred during testing (updating `enqueueAction` to the proper `enqueue` definition).

---
*PR created automatically by Jules for task [1764961601647962034](https://jules.google.com/task/1764961601647962034) started by @ql-owo-lp*