### PR TITLE
fix: fix onboarding wizard cross-device resume and health check

### DIFF
--- a/src/server/api/onboarding/mod.rs
+++ b/src/server/api/onboarding/mod.rs
@@ -35,7 +35,12 @@ async fn setup_health_check(
     let is_cloud = query.mode.as_deref() == Some("cloud");
     match crate::services::onboarding::provisioner::check_environment(is_cloud) {
         Ok(_) => Ok(Json(serde_json::json!({ "status": "ready" }))),
-        Err(e) => Ok(Json(serde_json::json!({ "status": "error", "message": e }))),
+        Err(_) => {
+            match crate::services::onboarding::provisioner::provision_environment(is_cloud) {
+                Ok(_) => Ok(Json(serde_json::json!({ "status": "ready" }))),
+                Err(e) => Ok(Json(serde_json::json!({ "status": "error", "message": e }))),
+            }
+        }
     }
 }
 

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -51,6 +51,9 @@
         border: 1px solid rgba(255, 255, 255, 0.4);
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
       }
+      .glass-control {
+        border-radius: 8px !important;
+      }
       @media (prefers-color-scheme: dark) {
         .container, .glassmorphism {
           background: rgba(22, 22, 26, 0.7);
@@ -2805,9 +2808,11 @@
           }
         }
 
-        // Merge backend state, taking priority
+        // Merge backend state, taking priority if it has advanced further or exists
         if (loadedState && Object.keys(loadedState).length > 0) {
-          state = { ...state, ...loadedState };
+          if (!state.step || (loadedState.step && loadedState.step >= state.step)) {
+              state = { ...state, ...loadedState };
+          }
           if (loadedState.businessName && !loadedState.business_name) {
              state.business_name = loadedState.businessName;
           }
@@ -3066,12 +3071,12 @@
 
         clearTimeout(saveStateTimer);
         saveStateTimer = setTimeout(async () => {
+          localStorage.setItem("onboardingState", JSON.stringify(state));
           if (window.__TAURI__ && window.__TAURI__.core) {
             window.__TAURI__.core
               .invoke("save_onboarding_state", { state, tenantId, userId })
               .catch((err) => console.warn("Tauri save_onboarding_state failed, using offline fallback:", err));
           } else {
-            localStorage.setItem("onboardingState", JSON.stringify(state));
             const backendUrl =
               window.location.protocol === "file:" ||
               ["1420", "3000", "8081"].includes(window.location.port)


### PR DESCRIPTION
- Fixed health check to automatically provision environment.
- Enforced 8px border-radius for `.glass-control` inputs according to premium UI guidelines.
- Fixed cross-device state resume logic to properly merge and prioritize offline and backend states.

---
*PR created automatically by Jules for task [14958667428566484375](https://jules.google.com/task/14958667428566484375) started by @ql-owo-lp*