### PR TITLE
🎥 Lens Audit: fix missing glassmorphism styles to dashboard panels and cards

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -717,8 +717,32 @@ html.dark .glass-control {
 .app-shell .app-card,
 .app-shell .app-panel,
 .app-shell .glassmorphism,
-.app-shell .glass-card,
+.app-shell .glass-card {
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(30px) saturate(210%);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
 
+@media (prefers-color-scheme: dark) {
+  .app-shell .app-card,
+  .app-shell .app-panel,
+  .app-shell .glassmorphism,
+  .app-shell .glass-card {
+    background: rgba(22, 22, 26, 0.7);
+    backdrop-filter: blur(30px) saturate(210%);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+}
+
+html.dark .app-shell .app-card,
+html.dark .app-shell .app-panel,
+html.dark .app-shell .glassmorphism,
+html.dark .app-shell .glass-card {
+  background: rgba(22, 22, 26, 0.7);
+  backdrop-filter: blur(30px) saturate(210%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
 
 .app-shell [class*="bg-gradient"] {
   background-image: none !important;


### PR DESCRIPTION
This PR applies the required premium macOS-style translucent "Glass" materials to the dashboard panels and cards across the application. It ensures that `.app-shell .app-card`, `.app-shell .app-panel`, `.app-shell .glassmorphism`, and `.app-shell .glass-card` classes utilize the correct `backdrop-filter`, `background`, `border`, and `border-radius` styles for both light mode and dark mode variants, complying directly with the OHC Premium Design Standards. This visual regression fix also enables the Playwright E2E tests for these visual contracts (`login_lens.spec.ts`) to successfully pass.

---
*PR created automatically by Jules for task [18430322848067797570](https://jules.google.com/task/18430322848067797570) started by @ql-owo-lp*