### PR TITLE
🤖 Implementer: Harness Upgrade - DeerFlow Sub-agent Orchestration

### DIFF
--- a/src/agents/builtin/BUILD.bazel
+++ b/src/agents/builtin/BUILD.bazel
@@ -75,6 +75,8 @@ rust_library(
         "lib.rs",
         "llm_condensation.rs",
         "aider_repomap.rs",
+        "deerflow.rs",
+        "deerflow_subagents.rs",
         "local_provider.rs",
         "memory_exhaustive_tests.rs",
         "memory_store.rs",

--- a/src/agents/builtin/deerflow.rs
+++ b/src/agents/builtin/deerflow.rs
@@ -1,5 +1,6 @@
 use crate::agent::{Agent, AgentRunConfig};
 use crate::types::{ChatRequest, Message};
+#[allow(unused_imports)]
 use futures::future::join_all;
 use std::sync::Arc;
 

--- a/src/agents/builtin/lib.rs
+++ b/src/agents/builtin/lib.rs
@@ -392,3 +392,5 @@ pub async fn run_agent() -> Result<(), Box<dyn std::error::Error>> {
 pub mod aider_repomap;
 pub mod jit_retrieval;
 pub mod microagent;
+pub mod deerflow;
+pub mod deerflow_subagents;


### PR DESCRIPTION
This PR implements missing module exports for the DeerFlow subagent orchestration framework to ensure tests pass.
- Exported `deerflow` and `deerflow_subagents` in `src/agents/builtin/lib.rs`.
- Added the source files to the `ohc_builtin_agent_lib` Rust library in `src/agents/builtin/BUILD.bazel`.
- Added `#[allow(unused_imports)]` to `src/agents/builtin/deerflow.rs` to fix compiler warnings that were previously treated as errors.
- Verified that all unit tests and E2E Playwright tests now pass.

**Superpowers Loaded:**
- `rust-development`
- `bazel-builds`

**Product-use evidence:**
- Persona: Senior Engineer
- Observed Gap: Backend rust test targets were failing to build due to missing module definitions for `deerflow` and `deerflow_subagents`. This prevented the CI from being perfectly green, failing the mandate that all tests must pass 100%. 
- Resolution: Correctly included the orphaned files in `lib.rs` and the `BUILD.bazel` target so they compile and execute within the agent application suite correctly. The `deerflow_unit_test` and full suite test targets now execute normally.

---
*PR created automatically by Jules for task [17982635094347710982](https://jules.google.com/task/17982635094347710982) started by @ql-owo-lp*