### PR TITLE
🤖 Implementer: Harness Upgrade - Fix Autodream Compilation Error

### DIFF
--- a/src/agents/builtin/autodream/mod.rs
+++ b/src/agents/builtin/autodream/mod.rs
@@ -114,7 +114,6 @@ impl AutoDreamWorker {
                 }
              };
 
-             db.inject_truth("system", &format!("session-summary-{}", id), &summary, &embedding).await?;
 
              db.insert_autodream_memory(&format!("session-summary-{}", id), "system", "system_agent", &id, &summary, &embedding, "SESSION_SUMMARY").await?;
 


### PR DESCRIPTION
Removed an invalid method call (`db.inject_truth(...)`) in `src/agents/builtin/autodream/mod.rs` that was causing compilation errors. The subsequent line correctly stores the data using `insert_autodream_memory`. Tested and built successfully.

---
*PR created automatically by Jules for task [4917280606911823469](https://jules.google.com/task/4917280606911823469) started by @ql-owo-lp*