### PR TITLE
✍️ Scribe: [Documentation E2E routing and API error handling]

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -62,22 +62,28 @@ pub async fn get_walkthrough(axum::extract::Path(page): axum::extract::Path<Stri
     Json(steps)
 }
 
-pub async fn get_tooltips(headers: axum::http::HeaderMap) -> Json<std::collections::HashMap<String, String>> {
+pub async fn get_tooltips(headers: axum::http::HeaderMap) -> Result<Json<std::collections::HashMap<String, String>>, axum::http::StatusCode> {
     let tenant_id = headers
         .get("x-tenant-id")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("default");
     let pool = crate::db::get_pool();
     let mut tooltips = std::collections::HashMap::new();
-    if let Ok(rows) = sqlx::query("SELECT id, text FROM tooltips WHERE tenant_id = $1").bind(tenant_id)
+    match sqlx::query("SELECT id, text FROM tooltips WHERE tenant_id = $1").bind(tenant_id)
         .fetch_all(&pool)
         .await
     {
-        for row in rows {
-            use sqlx::Row;
-            let id: String = row.get("id");
-            let text: String = row.get("text");
-            tooltips.insert(id, text);
+        Ok(rows) => {
+            for row in rows {
+                use sqlx::Row;
+                let id: String = row.get("id");
+                let text: String = row.get("text");
+                tooltips.insert(id, text);
+            }
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch tooltips: {}", e);
+            return Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -89,7 +95,7 @@ pub async fn get_tooltips(headers: axum::http::HeaderMap) -> Json<std::collectio
         tooltips.insert("ask-ai-tooltip".to_string(), "Open AI Help Chat to get answers instantly.".to_string());
     }
 
-    Json(tooltips)
+    Ok(Json(tooltips))
 }
 
 #[derive(Deserialize)]
@@ -103,16 +109,22 @@ pub struct SuccessResponse {
     pub success: bool,
 }
 
-pub async fn update_tooltip(headers: axum::http::HeaderMap, axum::extract::Json(payload): axum::extract::Json<TooltipPayload>) -> Json<SuccessResponse> {
+pub async fn update_tooltip(headers: axum::http::HeaderMap, axum::extract::Json(payload): axum::extract::Json<TooltipPayload>) -> Result<Json<SuccessResponse>, axum::http::StatusCode> {
     let tenant_id = headers
         .get("x-tenant-id")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("default");
     let pool = crate::db::get_pool();
-    let _ = sqlx::query("INSERT INTO tooltips (id, tenant_id, text) VALUES ($1, $2, $3) ON CONFLICT (id) DO UPDATE SET text = EXCLUDED.text").bind(payload.id).bind(tenant_id).bind(payload.text)
+    match sqlx::query("INSERT INTO tooltips (id, tenant_id, text) VALUES ($1, $2, $3) ON CONFLICT (id) DO UPDATE SET text = EXCLUDED.text").bind(payload.id).bind(tenant_id).bind(payload.text)
         .execute(&pool)
-        .await;
-    Json(SuccessResponse { success: true })
+        .await
+    {
+        Ok(_) => Ok(Json(SuccessResponse { success: true })),
+        Err(e) => {
+            tracing::error!("Failed to update tooltip: {}", e);
+            Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
 }
 
 
@@ -979,11 +991,11 @@ mod tests {
         // Update the tooltip
         let mut headers = axum::http::HeaderMap::new();
         headers.insert("x-tenant-id", axum::http::HeaderValue::from_static("test-tenant"));
-        let res = update_tooltip(headers.clone(), AxumJson(payload)).await;
+        let res = update_tooltip(headers.clone(), AxumJson(payload)).await.unwrap();
         assert!(res.0.success);
 
         // Fetch tooltips and verify the update
-        let tooltips_res = get_tooltips(headers).await;
+        let tooltips_res = get_tooltips(headers).await.unwrap();
         let tooltips = tooltips_res.0;
 
         assert_eq!(

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6687,10 +6687,16 @@ async fn create_ui_bom_item_handler(
         .route("/api/ui/help.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/help.html"))
         }))
+        .route("/help", axum::routing::get(|| async {
+            axum::response::Html(include_str!("../ui/tauri/src/ui/help.html"))
+        }))
         .route("/api/ui/help_article.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/help_article.html"))
         }))
         .route("/api/ui/api-docs.html", axum::routing::get(|| async {
+            axum::response::Html(include_str!("../ui/tauri/src/ui/api-docs.html"))
+        }))
+        .route("/api-docs", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/api-docs.html"))
         }))
         .route("/api/ui/swagger-ui.css", axum::routing::get(|| async {
@@ -6714,6 +6720,9 @@ async fn create_ui_bom_item_handler(
         .route("/api/ui/changelog.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/next/public/api/ui/changelog.html"))
         }))
+        .route("/changelog", axum::routing::get(|| async {
+            axum::response::Html(include_str!("../ui/tauri/src/ui/changelog.html"))
+        }))
         .route("/onboarding", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/setup.html"))
         }))
@@ -6728,6 +6737,18 @@ async fn create_ui_bom_item_handler(
         }))
         .route("/agent-audit-dashboard.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/agent-audit-dashboard.html"))
+        }))
+        .route("/api/ui/pos.html", axum::routing::get(|| async {
+            axum::response::Html(include_str!("../ui/tauri/src/ui/pos.html"))
+        }))
+        .route("/pos.html", axum::routing::get(|| async {
+            axum::response::Html(include_str!("../ui/tauri/src/ui/pos.html"))
+        }))
+        .route("/api/ui/assistant.html", axum::routing::get(|| async {
+            axum::response::Html(include_str!("../ui/tauri/src/ui/assistant.html"))
+        }))
+        .route("/assistant.html", axum::routing::get(|| async {
+            axum::response::Html(include_str!("../ui/tauri/src/ui/assistant.html"))
         }))
         .route("/calendar", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/calendar.html"))


### PR DESCRIPTION
This PR addresses issues with the application's documentation features:

1. E2E tests testing the walkthroughs and documentation flow were failing because several expected routes were not being mounted by the server (e.g., `/pos.html`, `/assistant.html`, `/help`, `/changelog`, `/api-docs`). I added these static HTML routes to the server entry point (`src/server/lib.rs`).
2. Proactively optimized the documentation APIs (`get_tooltips` and `update_tooltip` in `src/server/api/docs.rs`). Previously, database errors were suppressed or could cause unexpected behavior. Now, `sqlx` failures are properly matched: on error, they log to standard error and return a 500 HTTP status code. The relevant unit tests were updated to handle the `Result` return type.

---
*PR created automatically by Jules for task [6864452669588234584](https://jules.google.com/task/6864452669588234584) started by @ql-owo-lp*