### PR TITLE
🚀 Nova: [viral product widget tests and giveaway conflict fix]

### DIFF
--- a/src/e2e/viral_giveaway.spec.ts
+++ b/src/e2e/viral_giveaway.spec.ts
@@ -136,8 +136,6 @@ test.describe('Viral Giveaway Loop', () => {
 
     await publicPage.close();
   });
-<<<<<<< HEAD
-=======
   test('should dismiss soft paywall when Maybe Later is clicked', async ({ page }) => {
     await page.goto('/giveaway');
     await page.evaluate(() => {
@@ -159,5 +157,4 @@ test.describe('Viral Giveaway Loop', () => {
     // Verify "Powered by OHC" footer is not present
     await expect(page.locator('a', { hasText: '⚡ Powered by OHC' })).not.toBeVisible();
   });
->>>>>>> 6fa2c4b4 (feat: Add pro soft paywall to viral giveaway generator)
 });

--- a/src/e2e/viral_product_widget.spec.ts
+++ b/src/e2e/viral_product_widget.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from './fixtures';
+
+test.describe('Viral Product Widget', () => {
+  test('should allow owner to configure the product widget, view preview and trigger paywall', async ({ page, context }) => {
+    // 1. Navigate to dashboard
+    await page.goto('/dashboard');
+
+    // 2. Find and click the Viral Product Widget link in GrowBusinessCard
+    const widgetLink = page.locator('a[href="/viral-product-widget"]');
+    await expect(widgetLink).toBeVisible();
+    await widgetLink.click();
+
+    // Verify page content
+    await expect(page.getByRole('heading', { name: 'Viral Product Widget' })).toBeVisible();
+
+    // Wait to ensure client-side hydration doesn't interrupt filling
+    await page.waitForTimeout(500);
+
+    // 3. Configure the widget
+    const titleInput = page.getByRole('textbox').first();
+    await titleInput.fill('Amazing New Coffee');
+
+    const themeSelect = page.getByRole('combobox');
+    await themeSelect.selectOption('dark');
+
+    // Check that the preview URL has been updated
+    const previewIframe = page.locator('iframe[title="Preview"]');
+    await expect(previewIframe).toHaveAttribute('src', /theme=dark/);
+    await expect(previewIframe).toHaveAttribute('src', /productName=Amazing%20New%20Coffee/);
+
+    // 4. Try to remove branding, expect paywall
+    const removeBrandingCheckbox = page.getByRole('checkbox', { name: /Remove Branding/i });
+    await removeBrandingCheckbox.click();
+
+    await expect(page.getByRole('heading', { name: 'Upgrade to Pro' })).toBeVisible();
+
+    // Close the paywall by clicking "Keep Branding"
+    await page.getByRole('button', { name: 'Keep Branding' }).click();
+
+    // Ensure paywall is gone
+    await expect(page.getByRole('heading', { name: 'Upgrade to Pro' })).toBeHidden();
+
+    // The checkbox should still be unchecked because we didn't upgrade
+    await expect(removeBrandingCheckbox).not.toBeChecked();
+
+    // 5. Copy the embed code
+    const copyButton = page.getByRole('button', { name: 'Copy Code' });
+    // Make the button visible by hovering over the parent
+    await page.locator('.relative.group').hover();
+    await expect(copyButton).toBeVisible();
+
+    // Note: Clipboard operations in headless mode might fail, but we check if the button text updates
+    await copyButton.click();
+    await expect(page.getByText('Copied!')).toBeVisible();
+  });
+
+  test('should remove branding when Pro is available', async ({ page, context }) => {
+    await page.goto('/viral-product-widget');
+    await page.evaluate(() => {
+        localStorage.setItem('tenant', 'e2e-test-store');
+        localStorage.setItem('has_pro', 'true');
+    });
+    await page.reload();
+
+    const removeBrandingCheckbox = page.getByRole('checkbox', { name: /Remove Branding/i });
+    await removeBrandingCheckbox.click();
+
+    // Soft paywall should not appear
+    await expect(page.getByRole('heading', { name: 'Upgrade to Pro' })).not.toBeVisible();
+
+    // The checkbox should be checked
+    await expect(removeBrandingCheckbox).toBeChecked();
+
+    // Check that the preview URL has been updated
+    const previewIframe = page.locator('iframe[title="Preview"]');
+    await expect(previewIframe).toHaveAttribute('src', /branding=false/);
+  });
+});

--- a/src/ui/next/src/app/dashboard/GrowBusinessCard.test.tsx
+++ b/src/ui/next/src/app/dashboard/GrowBusinessCard.test.tsx
@@ -19,8 +19,11 @@ describe('GrowBusinessCard', () => {
     const groupBuyLink = screen.getByRole('link', { name: /Group Buy/i });
     expect(groupBuyLink).toHaveAttribute('href', '/group-buy-widget');
 
-    const widgetLink = screen.getByRole('link', { name: /Viral Widget/i });
+    const widgetLink = screen.getByRole('link', { name: 'Viral Widget' });
     expect(widgetLink).toHaveAttribute('href', '/viral-powered-by-ohc-widget');
+
+    const productWidgetLink = screen.getByRole('link', { name: 'Viral Product Widget' });
+    expect(productWidgetLink).toHaveAttribute('href', '/viral-product-widget');
 
     const bizCardLink = screen.getByRole('link', { name: /Digital Business Card/i });
     expect(bizCardLink).toHaveAttribute('href', '/digital-business-card');

--- a/src/ui/next/src/app/dashboard/GrowBusinessCard.tsx
+++ b/src/ui/next/src/app/dashboard/GrowBusinessCard.tsx
@@ -48,6 +48,13 @@ export function GrowBusinessCard() {
               Viral Widget
             </Link>
             <Link
+              id="viral-product-widget-btn"
+              href="/viral-product-widget"
+              className="px-4 py-2 bg-indigo-50 hover:bg-indigo-100 text-indigo-700 rounded-lg text-sm font-medium transition-colors whitespace-nowrap"
+            >
+              Viral Product Widget
+            </Link>
+            <Link
               id="digital-business-card-btn"
               href="/digital-business-card"
               className="px-4 py-2 bg-pink-50 hover:bg-pink-100 text-pink-700 rounded-lg text-sm font-medium transition-colors whitespace-nowrap"

--- a/src/ui/next/src/app/viral-powered-by-ohc-widget/page.tsx
+++ b/src/ui/next/src/app/viral-powered-by-ohc-widget/page.tsx
@@ -11,6 +11,7 @@ export default function ViralPoweredByOHCWidgetPage() {
   const [copied, setCopied] = useState(false);
   const [hasPro, setHasPro] = useState(false);
   const [showPaywall, setShowPaywall] = useState(false);
+  const [hideBranding, setHideBranding] = useState(false);
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
@@ -27,10 +28,12 @@ export default function ViralPoweredByOHCWidgetPage() {
     if (!hasPro) {
       e.preventDefault();
       setShowPaywall(true);
+      return;
     }
+    setHideBranding(e.target.checked);
   };
 
-  const embedUrl = `https://ohc.app/api/v1/growth/viral-widget/embed?tenant=${tenant}&theme=${theme}&title=${encodeURIComponent(title)}&branding=${!hasPro}`;
+  const embedUrl = `https://ohc.app/api/v1/growth/viral-widget/embed?tenant=${tenant}&theme=${theme}&title=${encodeURIComponent(title)}&branding=${!hideBranding}`;
   const embedCode = `<iframe src="${embedUrl}" width="100%" height="400" frameborder="0" scrolling="no" style="border:none; overflow:hidden; border-radius:16px;"></iframe>`;
 
   const handleCopy = () => {
@@ -62,7 +65,7 @@ export default function ViralPoweredByOHCWidgetPage() {
                 <input
                     type="checkbox"
                     id="removeBranding"
-                    checked={hasPro}
+                    checked={hideBranding}
                     onChange={handleRemoveBranding}
                     className="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
                 />
@@ -87,7 +90,7 @@ export default function ViralPoweredByOHCWidgetPage() {
         <div className="flex-1 flex flex-col p-8">
            <h2 className="text-xl font-semibold font-outfit text-gray-900 mb-4">Live Preview</h2>
            <div className="flex-1 bg-gray-100 rounded-2xl shadow-inner border-2 border-dashed border-gray-300 relative overflow-hidden flex items-center justify-center p-6 min-h-[400px]">
-              <iframe src={`/api/v1/growth/viral-widget/embed?tenant=${tenant}&theme=${theme}&title=${encodeURIComponent(title)}&branding=${!hasPro}`} className="w-full h-full border-none rounded-xl" />
+              <iframe src={`/api/v1/growth/viral-widget/embed?tenant=${tenant}&theme=${theme}&title=${encodeURIComponent(title)}&branding=${!hideBranding}`} className="w-full h-full border-none rounded-xl" />
            </div>
         </div>
       </div>


### PR DESCRIPTION
This PR accomplishes the following:
- Resolves an unhandled git conflict marker block within `viral_giveaway.spec.ts`.
- Introduces E2E tests for the `viral-product-widget` in `viral_product_widget.spec.ts`.
- Updates `GrowBusinessCard.tsx` and related tests to link to the new `viral-product-widget` via the dashboard.
- Updates the soft paywall logic in `viral-powered-by-ohc-widget/page.tsx` to handle the `hideBranding` state correctly.

## Product-use evidence
- **Persona:** Nova, Lead Engineer.
- **Workflow attempted:**
  - I observed a missing Playwright E2E test file (`viral_product_widget.spec.ts`) that matches the product capabilities listed for the Growth loops.
  - Furthermore, `viral_giveaway.spec.ts` contained unfixed Git merge conflict blocks (`<<<<<<< HEAD`).
  - `GrowBusinessCard.tsx` did not feature a link to the `viral-product-widget`.
  - The check-box state tracking inside `viral-powered-by-ohc-widget/page.tsx` was inaccurately bound directly to `hasPro` instead of `hideBranding`.
- **Why owner needs it:** Testing the platform effectively guarantees owner-led stability. Linking to the product widget allows owners to natively click through from the growth dashboard.
- **Result after fix:** The Playwright tests have been introduced and properly hooked in. The `viral-product-widget` widget properly interacts under the test harness, and `bazel test //...` along with `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"` executes with all tests passing. The git conflict was effectively resolved.

---
*PR created automatically by Jules for task [10284386187212057725](https://jules.google.com/task/10284386187212057725) started by @ql-owo-lp*