### PR TITLE
feat: extract WhatsApp image captions via Meta webhook

### DIFF
--- a/src/server/api/meta_webhook.rs
+++ b/src/server/api/meta_webhook.rs
@@ -122,7 +122,14 @@ pub async fn meta_webhook_post_handler(
                              for message in messages {
                                   let sender_id = message.get("from").and_then(|f| f.as_str()).unwrap_or("unknown");
                                   let display_phone_number = value.get("metadata").and_then(|m| m.get("display_phone_number")).and_then(|p| p.as_str()).unwrap_or("test_tenant");
-                                  let text = message.get("text").and_then(|t| t.get("body")).and_then(|b| b.as_str()).unwrap_or("");
+                                  let mut text = message.get("text").and_then(|t| t.get("body")).and_then(|b| b.as_str()).unwrap_or("").to_string();
+                                  if text.is_empty() {
+                                      if let Some(image) = message.get("image") {
+                                          let img_id = image.get("id").and_then(|i| i.as_str()).unwrap_or("unknown");
+                                          let caption = image.get("caption").and_then(|c| c.as_str()).unwrap_or("");
+                                          text = format!("![Image]({}) {}", img_id, caption).trim().to_string();
+                                      }
+                                  }
 
                                   let pool = &state.db.pool;
                                   let resolved_tenant_id = match &state.db.store {


### PR DESCRIPTION
Adds support to the Meta incoming webhook handler (`src/server/api/meta_webhook.rs`) to detect WhatsApp messages containing an `image` payload. When an image is present, the handler retrieves the `id` and `caption` (if available), formatting them as a markdown string.

This enables the system to correctly handle visual inputs seamlessly in the unified inbox, allowing the AI to draft replies that acknowledge user-provided photos (e.g. "Can you make a cake like this?").

All `bazelisk test` test targets pass successfully, including the existing Playwright E2E coverage for WhatsApp image flows.

Superpowers loaded: `bazel_test`, `playwright_e2e_tests`.

---
*PR created automatically by Jules for task [6181525151101669125](https://jules.google.com/task/6181525151101669125) started by @ql-owo-lp*

Resolves #32828