### PR TITLE
💰 Miser: [Add budget-health-alert-text ID to cost dashboard]

### DIFF
--- a/src/ui/next/src/app/cost-dashboard/page.tsx
+++ b/src/ui/next/src/app/cost-dashboard/page.tsx
@@ -326,7 +326,7 @@ export default function CostDashboardPage() {
                 </svg>
                 <div>
                     <h3 className="text-sm font-semibold text-amber-800">Budget Alert</h3>
-                    <p className="text-sm text-amber-700 mt-1">Heads up! Your projected monthly cost ({formatCurrency(data.projected_monthly_cost)}) is reaching your plan's soft limit. Soft Limit Approaching. Upgrade to a higher tier to avoid disruption and secure better bulk rates!</p>
+                    <p id="budget-health-alert-text" className="text-sm text-amber-700 mt-1">Heads up! Your projected monthly cost ({formatCurrency(data.projected_monthly_cost)}) is reaching your plan's soft limit. Soft Limit Approaching. Upgrade to a higher tier to avoid disruption and secure better bulk rates!</p>
                 </div>
             </div>
         )}


### PR DESCRIPTION
Added the `budget-health-alert-text` ID to the `<p>` element containing the budget health alert in the Next.js `cost-dashboard/page.tsx` component. This resolves Playwright E2E test failures that expected this selector to be present when the projected costs exceed the soft limit threshold.

---
*PR created automatically by Jules for task [17112482022717175510](https://jules.google.com/task/17112482022717175510) started by @ql-owo-lp*