### PR TITLE
fix: SRE Queue Pruning and Chaos Report Visual Excellence

### DIFF
--- a/deploy/docker/grafana/provisioning/dashboards/ohc-hybrid-telemetry.json
+++ b/deploy/docker/grafana/provisioning/dashboards/ohc-hybrid-telemetry.json
@@ -3301,6 +3301,17 @@
           "legendFormat": "{{error}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ohc_error_signals_total[5m])) by (category)",
+          "legendFormat": "Error Signal: {{category}}",
+          "range": true,
+          "refId": "B"
         }
       ]
     },
@@ -3830,6 +3841,17 @@
           "legendFormat": "{{error}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ohc_error_signals_total[5m])) by (category)",
+          "legendFormat": "Error Signal: {{category}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "options": {

--- a/deploy/grafana/dashboards/ohc-hybrid-telemetry.json
+++ b/deploy/grafana/dashboards/ohc-hybrid-telemetry.json
@@ -3301,6 +3301,17 @@
           "legendFormat": "{{error}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ohc_error_signals_total[5m])) by (category)",
+          "legendFormat": "Error Signal: {{category}}",
+          "range": true,
+          "refId": "B"
         }
       ]
     },
@@ -3830,6 +3841,17 @@
           "legendFormat": "{{error}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ohc_error_signals_total[5m])) by (category)",
+          "legendFormat": "Error Signal: {{category}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "options": {

--- a/deploy/helm/ohc/dashboards/ohc-hybrid-telemetry.json
+++ b/deploy/helm/ohc/dashboards/ohc-hybrid-telemetry.json
@@ -3301,6 +3301,17 @@
           "legendFormat": "{{error}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ohc_error_signals_total[5m])) by (category)",
+          "legendFormat": "Error Signal: {{category}}",
+          "range": true,
+          "refId": "B"
         }
       ]
     },
@@ -3830,6 +3841,17 @@
           "legendFormat": "{{error}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ohc_error_signals_total[5m])) by (category)",
+          "legendFormat": "Error Signal: {{category}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "options": {

--- a/src/e2e/chaos_report_ui.spec.ts
+++ b/src/e2e/chaos_report_ui.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Chaos Report UI', () => {
+  test('should render properly and handle dark mode toggle', async ({ page }) => {
+    // Navigate to the Chaos Report page
+    await page.goto('/chaos-report');
+
+    // Verify header exists
+    await expect(page.getByRole('heading', { name: 'System Reliability Report' })).toBeVisible();
+
+    // Verify sections have the premium-glass class
+    const firstSection = page.locator('section').first();
+    await expect(firstSection).toHaveClass(/premium-glass/);
+
+    // Initial state (assuming light mode defaults) or whatever system preference is.
+    // Let's ensure the wrapper changes classes appropriately when toggled.
+    const wrapperDiv = page.locator('.min-h-screen');
+    const isInitiallyDark = await wrapperDiv.evaluate(el => el.classList.contains('dark'));
+
+    // Find and click the toggle button
+    const toggleButton = page.getByRole('button', { name: /Toggle .* Mode/ });
+    await expect(toggleButton).toBeVisible();
+    await toggleButton.click();
+
+    // Verify the class changes on the wrapper
+    const isNowDark = await wrapperDiv.evaluate(el => el.classList.contains('dark'));
+    expect(isNowDark).toBe(!isInitiallyDark);
+
+    // Toggle back
+    await toggleButton.click();
+    const isFinallyDark = await wrapperDiv.evaluate(el => el.classList.contains('dark'));
+    expect(isFinallyDark).toBe(isInitiallyDark);
+  });
+});

--- a/src/server/monitoring/dashboards/ohc-hybrid-telemetry.json
+++ b/src/server/monitoring/dashboards/ohc-hybrid-telemetry.json
@@ -3301,6 +3301,17 @@
           "legendFormat": "{{error}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ohc_error_signals_total[5m])) by (category)",
+          "legendFormat": "Error Signal: {{category}}",
+          "range": true,
+          "refId": "B"
         }
       ]
     },
@@ -3830,6 +3841,17 @@
           "legendFormat": "{{error}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ohc_error_signals_total[5m])) by (category)",
+          "legendFormat": "Error Signal: {{category}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "options": {

--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -483,12 +483,12 @@ impl HybridSyncDaemon {
         let sqlite_running_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'job_stuck', 'sub_agent_queue', json_object('id', id, 'payload', json(COALESCE(payload, '{{}}'))), '[cleanup] Stagnant backlog item stuck in RUNNING for > 1 hour' FROM sub_agent_queue WHERE {}", SQLITE_RUNNING_WHERE);
         let sqlite_running_update = format!("UPDATE sub_agent_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE {}", SQLITE_RUNNING_WHERE);
         let sqlite_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'job_failed', 'sub_agent_queue', json_object('id', id, 'payload', json(COALESCE(payload, '{{}}'))), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE {}", SQLITE_QUEUED_WHERE);
-        let sqlite_queued_delete = format!("DELETE FROM sub_agent_queue WHERE {}", SQLITE_QUEUED_WHERE);
+        let sqlite_queued_delete = format!("UPDATE sub_agent_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE {}", SQLITE_QUEUED_WHERE);
 
         let pg_running_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'job_stuck', 'sub_agent_queue', json_build_object('id', id, 'payload', COALESCE(payload::jsonb, '{{}}'::jsonb))::text, '[cleanup] Stagnant backlog item stuck in RUNNING for > 1 hour' FROM sub_agent_queue WHERE {}", PG_RUNNING_WHERE);
         let pg_running_update = format!("UPDATE sub_agent_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE {}", PG_RUNNING_WHERE);
         let pg_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'job_failed', 'sub_agent_queue', json_build_object('id', id, 'payload', COALESCE(payload::jsonb, '{{}}'::jsonb))::text, '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM sub_agent_queue WHERE {}", PG_QUEUED_WHERE);
-        let pg_queued_delete = format!("DELETE FROM sub_agent_queue WHERE {}", PG_QUEUED_WHERE);
+        let pg_queued_delete = format!("UPDATE sub_agent_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE {}", PG_QUEUED_WHERE);
 
         // SQLite queue
         if let Err(e) = sqlx::query(&sqlite_running_insert).execute(&self.sqlite_pool).await {

--- a/src/server/orchestration/queue/ohc_job_queue.rs
+++ b/src/server/orchestration/queue/ohc_job_queue.rs
@@ -156,10 +156,10 @@ impl OHCJobQueue {
         .map_err(|e| e.to_string())?;
 
         let query_str = if is_standalone {
-            "DELETE FROM ohc_job_queue
+            "UPDATE ohc_job_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP
              WHERE status = 'PENDING' AND created_at < datetime('now', '-24 hours')"
         } else {
-            "DELETE FROM ohc_job_queue
+            "UPDATE ohc_job_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP
              WHERE status = 'PENDING' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
         };
 

--- a/src/server/queue.rs
+++ b/src/server/queue.rs
@@ -434,7 +434,7 @@ impl TaskQueue for PostgresTaskQueue {
         .map_err(|e| e.to_string())?;
 
         let stagnant_result = sqlx::query(
-            "DELETE FROM sub_agent_queue
+            "UPDATE sub_agent_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP
              WHERE status = 'QUEUED' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
         )
         .execute(&mut *tx)
@@ -1157,7 +1157,7 @@ impl TaskQueue for SqliteTaskQueue {
         .await;
 
         let stagnant_result = sqlx::query(
-            "DELETE FROM sub_agent_queue
+            "UPDATE sub_agent_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP
              WHERE status = 'QUEUED' AND created_at < datetime('now', '-24 hour')"
         )
         .execute(&self.pool)

--- a/src/ui/next/src/app/chaos-report/page.tsx
+++ b/src/ui/next/src/app/chaos-report/page.tsx
@@ -23,18 +23,9 @@ export default function ChaosReportPage() {
       });
   }, []);
 
-  const glassStyle = isDarkMode ? {
-    background: 'rgba(22, 22, 26, 0.7)',
-    backdropFilter: 'blur(30px) saturate(210%)',
-    border: '1px solid rgba(255, 255, 255, 0.1)',
-  } : {
-    background: 'rgba(255, 255, 255, 0.65)',
-    backdropFilter: 'blur(30px) saturate(210%)',
-    border: '1px solid rgba(255, 255, 255, 0.4)',
-  };
 
   return (
-    <div className={`min-h-screen ${isDarkMode ? 'bg-gray-900 text-white' : 'bg-[#F5F5F7] text-[#1D1D1F]'} p-8 font-inter transition-colors duration-300`}>
+    <div className={`min-h-screen ${isDarkMode ? 'dark bg-gray-900 text-white' : 'bg-[#F5F5F7] text-[#1D1D1F]'} p-8 font-inter transition-colors duration-300`}>
       <header className="mb-10 max-w-6xl mx-auto flex justify-between items-center">
         <div>
           <h1 className="text-4xl font-bold font-outfit tracking-tight">System Reliability Report</h1>
@@ -49,7 +40,7 @@ export default function ChaosReportPage() {
       </header>
 
       <main className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-8">
-        <section className="col-span-1 lg:col-span-2 mb-8 p-6 rounded-2xl shadow-lg transition-all duration-300 relative overflow-hidden" style={glassStyle}>
+        <section className={"premium-glass col-span-1 lg:col-span-2 mb-8 p-6 rounded-2xl shadow-lg transition-all duration-300 relative overflow-hidden"}>
             <h2 className="text-xl font-bold mb-4 tracking-tight">Chaos Resilience Metrics</h2>
             <div className="space-y-3 font-mono text-sm opacity-90">
                 <div className="flex items-center gap-2">
@@ -68,8 +59,7 @@ export default function ChaosReportPage() {
         </section>
 
         <section
-          className="p-8 rounded-3xl shadow-lg transition-all duration-300 relative overflow-hidden"
-          style={glassStyle}
+          className={"premium-glass p-8 rounded-3xl shadow-lg transition-all duration-300 relative overflow-hidden"}
         >
           <div className="absolute top-0 right-0 p-6 opacity-20">
             <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -105,8 +95,7 @@ export default function ChaosReportPage() {
         </section>
 
         <section
-          className="p-8 rounded-3xl shadow-lg transition-all duration-300 relative overflow-hidden"
-          style={glassStyle}
+          className={"premium-glass p-8 rounded-3xl shadow-lg transition-all duration-300 relative overflow-hidden"}
         >
           <div className="absolute top-0 right-0 p-6 opacity-20">
             <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -1181,3 +1181,16 @@ html.dark .glass-panel {
     border: 1px solid rgba(255, 255, 255, 0.4);
   }
 }
+@layer utilities {
+  .premium-glass {
+    background: rgba(255, 255, 255, 0.65) !important;
+    backdrop-filter: blur(30px) saturate(210%) !important;
+    border: 1px solid rgba(255, 255, 255, 0.4) !important;
+  }
+  .dark .premium-glass,
+  .premium-glass.dark {
+    background: rgba(22, 22, 26, 0.7) !important;
+    backdrop-filter: blur(30px) saturate(210%) !important;
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
+  }
+}


### PR DESCRIPTION
- **Queue Refactor**: Changes stagnant queued job cleanup from `DELETE` to `UPDATE SET status='FAILED'` to leave an audit trail across `sub_agent_queue` and `ohc_job_queue`.
- **Grafana Updates**: Injects `ohc_error_signals_total` metric accurately in JSON dashboard templates.
- **Visual Excellence (UI)**: Standardizes macOS Translucent Glass `.premium-glass` in `globals.css` and updates `chaos-report/page.tsx` to utilize standard Tailwind `dark` class container context rather than hardcoding colors.
- **E2E Testing**: Adds missing `chaos_report_ui.spec.ts` script to test interactions and rendering for the visual upgrades. Tested with Bazel, Vitest, and Playwright resulting in 100% test completion.

---
*PR created automatically by Jules for task [10344505118033689742](https://jules.google.com/task/10344505118033689742) started by @ql-owo-lp*