### PR TITLE
✍️ Scribe: Fix Help Button Accessibility Label

### DIFF
--- a/src/ui/next/src/components/help.test.tsx
+++ b/src/ui/next/src/components/help.test.tsx
@@ -90,7 +90,7 @@ describe('HelpWidget', () => {
 
   it('renders the help widget', async () => {
     render(<TooltipProvider><WalkthroughProvider><HelpWidget /></WalkthroughProvider></TooltipProvider>);
-    expect(screen.getByRole('button', { name: 'Help' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open help chat' })).toBeInTheDocument();
   });
 
   it('fetches dynamic walkthroughs when clicked and handles fallback data', async () => {
@@ -111,7 +111,7 @@ describe('HelpWidget', () => {
       </div>
     );
 
-    const helpBtn = screen.getByRole('button', { name: 'Help' });
+    const helpBtn = screen.getByRole('button', { name: 'Open help chat' });
     await user.click(helpBtn);
 
     const tourBtn = screen.getByText('Tour: Set up your store');
@@ -136,7 +136,7 @@ describe('HelpWidget', () => {
     const user = userEvent.setup();
     render(<div><TooltipProvider><WalkthroughProvider><HelpWidget /></WalkthroughProvider></TooltipProvider></div>);
 
-    const helpBtn = screen.getByRole('button', { name: 'Help' });
+    const helpBtn = screen.getByRole('button', { name: 'Open help chat' });
     await user.click(helpBtn);
 
     const chatTab = screen.getByText('Ask anything');
@@ -160,7 +160,7 @@ describe('HelpWidget', () => {
     const user = userEvent.setup();
     render(<div><TooltipProvider><WalkthroughProvider><HelpWidget /></WalkthroughProvider></TooltipProvider></div>);
 
-    const helpBtn = screen.getByRole('button', { name: 'Help' });
+    const helpBtn = screen.getByRole('button', { name: 'Open help chat' });
     await user.click(helpBtn);
 
     const chatTab = screen.getByText('Ask anything');
@@ -174,7 +174,7 @@ describe('HelpWidget', () => {
     const user = userEvent.setup();
     render(<div><TooltipProvider><WalkthroughProvider><HelpWidget /></WalkthroughProvider></TooltipProvider></div>);
 
-    const helpBtn = screen.getByRole('button', { name: 'Help' });
+    const helpBtn = screen.getByRole('button', { name: 'Open help chat' });
     await user.click(helpBtn);
 
     const videosTab = screen.getByText('Videos');
@@ -204,7 +204,7 @@ describe('HelpWidget', () => {
     const user = userEvent.setup();
     render(<div><TooltipProvider><WalkthroughProvider><HelpWidget /></WalkthroughProvider></TooltipProvider></div>);
 
-    const helpBtn = screen.getByRole('button', { name: 'Help' });
+    const helpBtn = screen.getByRole('button', { name: 'Open help chat' });
     await user.click(helpBtn);
 
     const videosTab = screen.getByText('Videos');
@@ -233,7 +233,7 @@ describe('HelpWidget', () => {
     const user = userEvent.setup();
     render(<div><TooltipProvider><WalkthroughProvider><HelpWidget /></WalkthroughProvider></TooltipProvider></div>);
 
-    const helpBtn = screen.getByRole('button', { name: 'Help' });
+    const helpBtn = screen.getByRole('button', { name: 'Open help chat' });
     await user.click(helpBtn);
 
     const videosTab = screen.getByText('Videos');
@@ -262,7 +262,7 @@ describe('HelpWidget', () => {
     const user = userEvent.setup();
     render(<div><TooltipProvider><WalkthroughProvider><HelpWidget /></WalkthroughProvider></TooltipProvider></div>);
 
-    const helpBtn = screen.getByRole('button', { name: 'Help' });
+    const helpBtn = screen.getByRole('button', { name: 'Open help chat' });
     await user.click(helpBtn);
 
     const newTab = screen.getByText('New');
@@ -278,7 +278,7 @@ describe('HelpWidget', () => {
     const user = userEvent.setup();
     render(<div><TooltipProvider><WalkthroughProvider><HelpWidget /></WalkthroughProvider></TooltipProvider></div>);
 
-    const helpBtn = screen.getByRole('button', { name: 'Help' });
+    const helpBtn = screen.getByRole('button', { name: 'Open help chat' });
     await user.click(helpBtn);
 
     await waitFor(() => {
@@ -299,7 +299,7 @@ describe('HelpWidget', () => {
     const user = userEvent.setup();
     render(<div><TooltipProvider><WalkthroughProvider><HelpWidget /></WalkthroughProvider></TooltipProvider></div>);
 
-    const helpBtn = screen.getByRole('button', { name: 'Help' });
+    const helpBtn = screen.getByRole('button', { name: 'Open help chat' });
     await user.click(helpBtn);
 
     const closeBtn = screen.getByLabelText('Close Help Widget');
@@ -332,7 +332,7 @@ describe('HelpWidget', () => {
     const user = userEvent.setup();
     render(<div><TooltipProvider><WalkthroughProvider><HelpWidget /></WalkthroughProvider></TooltipProvider></div>);
 
-    const helpBtn = screen.getByRole('button', { name: 'Help' });
+    const helpBtn = screen.getByRole('button', { name: 'Open help chat' });
     await user.click(helpBtn);
 
     const chatTab = screen.getByText('Ask anything');

--- a/src/ui/next/src/components/help.tsx
+++ b/src/ui/next/src/components/help.tsx
@@ -219,7 +219,7 @@ export function HelpWidget() {
             id="ohc-floating-help-btn"
             onClick={() => setOpen(!open)}
             className="w-14 h-14 bg-blue-600/90 backdrop-blur-[20px] saturate-200 text-white rounded-full shadow-[0_8px_32px_rgba(37,99,235,0.3)] flex items-center justify-center hover:bg-blue-700/90 active:scale-95 transition-all min-h-[44px] min-w-[44px]"
-            aria-label="Help"
+            aria-label="Open help chat"
           >
             <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />


### PR DESCRIPTION
This PR fixes an issue where the E2E tests expected the floating help button to have `aria-label="Open help chat"`, but the UI component used `aria-label="Help"`. By fixing this label mismatch in `help.tsx` and `help.test.tsx`, all E2E tests for the documentation workflow now pass perfectly, helping the scribe functionality shine.

---
*PR created automatically by Jules for task [13330991815160100414](https://jules.google.com/task/13330991815160100414) started by @ql-owo-lp*