### PR TITLE
🗺️ Guide: [Premium Onboarding Action Buttons]

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -146,7 +146,7 @@
           border-radius: 8px !important;
         }
       }
-      button {
+      button, .btn-primary {
         min-width: 44px;
         background-color: #0066FF;
         color: white;
@@ -161,10 +161,10 @@
         transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
         box-shadow: 0 4px 14px 0 rgba(0, 102, 255, 0.39);
       }
-      button:hover {
+      button:hover, .btn-primary:hover {
         background-color: #0052cc;
       }
-      button:active {
+      button:active, .btn-primary:active {
         transform: scale(0.98);
       }
 
@@ -1056,7 +1056,7 @@
         }
         h1 { font-size: 20px; }
         p { font-size: 13px; }
-        select, textarea, input, button {
+        select, textarea, input, button, .btn-primary {
           font-size: 14px;
         }
       }
@@ -1369,7 +1369,7 @@
           <button
             id="generate-storefront-btn"
             data-testid="generate-storefront-btn"
-            style="width: 100%; min-height: 44px; border-radius: 8px; background: #0066FF; color: white; font-weight: 600; border: none; font-size: 16px; box-shadow: 0 4px 14px 0 rgba(0, 102, 255, 0.39);"
+            class="btn-primary" style="width: 100%;"
             disabled
           >
             Generate My Workspace
@@ -1391,7 +1391,7 @@
           </button>
           <button
             type="button"
-            class="btn-secondary next-step-btn"
+            class="btn-primary next-step-btn"
             data-testid="next-step-btn"
             data-next="step-context"
             style="width: 100%;"
@@ -1821,7 +1821,7 @@
         </div>
         <div class="btn-group">
           <button
-            class="next-step-btn"
+            class="btn-primary next-step-btn"
             aria-label="Next Step"
             title="Next Step"
             data-testid="next-step-btn"
@@ -1857,7 +1857,7 @@
         </div>
         <div class="btn-group">
           <button
-            class="next-step-btn"
+            class="btn-primary next-step-btn"
             aria-label="Next Step"
             title="Next Step"
             data-testid="next-step-btn"
@@ -1918,7 +1918,7 @@
 
         <div class="btn-group">
           <button
-            class="next-step-btn"
+            class="btn-primary next-step-btn"
             aria-label="Next Step"
             title="Next Step"
             data-testid="next-step-btn"
@@ -2051,7 +2051,7 @@
 
         <div class="btn-group">
           <button
-            class="next-step-btn"
+            class="btn-primary next-step-btn"
             aria-label="Next Step"
             title="Next Step"
             data-testid="next-step-btn"
@@ -2339,7 +2339,7 @@
 
         <div class="btn-group">
           <button
-            class="next-step-btn"
+            class="btn-primary next-step-btn"
             aria-label="Next Step"
             title="Next Step"
             data-testid="next-step-btn"
@@ -2387,7 +2387,7 @@
         </div>
         <div class="btn-group">
           <button
-            class="next-step-btn"
+            class="btn-primary next-step-btn"
             aria-label="Next Step"
             title="Next Step"
             data-testid="next-step-btn"
@@ -2435,7 +2435,7 @@
         </div>
         <div class="btn-group">
           <button
-            class="next-step-btn"
+            class="btn-primary next-step-btn"
             aria-label="Next Step"
             title="Next Step"
             data-testid="next-step-btn"
@@ -2483,7 +2483,7 @@
         </div>
         <div class="btn-group">
           <button
-            class="next-step-btn"
+            class="btn-primary next-step-btn"
             aria-label="Next Step"
             title="Next Step"
             data-testid="next-step-btn"
@@ -2557,7 +2557,7 @@
         </div>
         <div class="btn-group" style="margin-top: 20px">
           <button
-            class="next-step-btn"
+            class="btn-primary next-step-btn"
             aria-label="Next Step"
             title="Next Step"
             data-testid="next-step-btn"


### PR DESCRIPTION
I have introduced a `.btn-primary` class and applied it to all primary forward-moving buttons (like "Step-by-Step Setup", "Generate My Workspace", and "Next") in the Tauri setup UI (`src/ui/tauri/src/ui/setup.html`).

Product-use evidence: 
- Persona: Maya - Home Baker
- Browser/Playwright flow attempted: Starting the onboarding wizard via 'Instant Build' or 'Step-by-Step Setup', navigating through the intake steps, observing the styling of the Next buttons.
- CUJ gap observed: Primary action buttons were missing the distinct premium visual branding (e.g., `#0066FF` blue), instead relying on inline styles or falling back to generic button styles, creating an inconsistent UI hierarchy.
- Fix: Extracted inline styles and updated the base `button` styling to include a specific `.btn-primary` class.
- Post-fix UI flow: Visually verified via Playwright screenshot that the `.btn-primary` class appropriately renders the primary action buttons with the premium blue style and retains the mandatory minimum 44px mobile touch targets. All Playwright tests completed successfully.

---
*PR created automatically by Jules for task [1761788529522560972](https://jules.google.com/task/1761788529522560972) started by @ql-owo-lp*