### PR TITLE
✍️ Scribe: add missing tooltips to registry defaults

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -87,6 +87,9 @@ pub async fn get_tooltips(headers: axum::http::HeaderMap) -> Json<std::collectio
         tooltips.insert("kairos-nav-link-tooltip".to_string(), "Click here to see what your AI helpers are working on and how they plan.".to_string());
         tooltips.insert("generate-link-btn".to_string(), "Click here to share access with a team member.".to_string());
         tooltips.insert("ask-ai-tooltip".to_string(), "Open AI Help Chat to get answers instantly.".to_string());
+        tooltips.insert("settings-delivery-tooltip".to_string(), "Turn this on to offer local delivery to your customers.".to_string());
+        tooltips.insert("help-btn-tooltip".to_string(), "Need help? Click here to access our Help Center, Ask AI, Video Tutorials, and Release Notes.".to_string());
+        tooltips.insert("help-search-tooltip".to_string(), "Search for help articles and videos...".to_string());
     }
 
     Json(tooltips)


### PR DESCRIPTION
The `tooltips.spec.ts` test was checking for `settings-delivery-tooltip`, `help-btn-tooltip`, and `help-search-tooltip` which were not present in the default tooltips registry fallback returned by `src/server/api/docs.rs:get_tooltips` when the database was empty, but were being used by the components (and the components tests verified they load if they exist in the registry). I added them to the default list so they'll work properly out-of-the-box. Tests pass.

---
*PR created automatically by Jules for task [201530490484301368](https://jules.google.com/task/201530490484301368) started by @ql-owo-lp*