### PR TITLE
feat: Agentic Subscription Retention & Churn Prediction System

### DIFF
--- a/src/e2e/e2e-seed.sql
+++ b/src/e2e/e2e-seed.sql
@@ -737,3 +737,20 @@ INSERT INTO tooltips (id, tenant_id, text) VALUES ('api-docs-tooltip', 'e2e-tena
 INSERT INTO tooltips (id, tenant_id, text) VALUES ('kairos-nav-link-tooltip', 'e2e-tenant', 'Click here to see what your AI helpers are working on and how they plan.') ON CONFLICT DO NOTHING;
 INSERT INTO tooltips (id, tenant_id, text) VALUES ('generate-link-btn', 'e2e-tenant', 'Click here to share access with a team member.') ON CONFLICT DO NOTHING;
 INSERT INTO tooltips (id, tenant_id, text) VALUES ('ask-ai-tooltip', 'e2e-tenant', 'Open AI Help Chat to get answers instantly.') ON CONFLICT DO NOTHING;
+
+-- Add subscription churn risk seed data
+INSERT INTO customers (id, tenant_id, name, email)
+VALUES ('c_churn_1', 'e2e-tenant', 'Alex the Churner', 'alex@example.com')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO products (id, tenant_id, title, price_cents, status)
+VALUES ('p_churn_1', 'e2e-tenant', 'Music Lessons Weekly', 5000, 'active')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO subscription_plans (id, tenant_id, product_id, name, price_cents, interval, frequency)
+VALUES ('plan_churn_1', 'e2e-tenant', 'p_churn_1', 'Music Lessons Weekly', 5000, 'weekly', 'weekly')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO subscribers (id, tenant_id, customer_id, subscription_plan_id, status, health_score, last_engagement_at)
+VALUES ('sub_churn_1', 'e2e-tenant', 'c_churn_1', 'plan_churn_1', 'ACTIVE', 30, NOW() - INTERVAL '31 days')
+ON CONFLICT DO NOTHING;

--- a/src/server/db/migrations/205_subscription_health_score.sql
+++ b/src/server/db/migrations/205_subscription_health_score.sql
@@ -1,14 +1,42 @@
 -- +goose Up
 -- Add health_score and last_engagement_at to subscriptions
-ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS health_score INTEGER DEFAULT 100;
-ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+DO $$
+BEGIN
+    IF to_regclass('subscriptions') IS NOT NULL THEN
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='subscriptions' AND column_name='health_score') THEN
+            ALTER TABLE subscriptions ADD COLUMN health_score INTEGER DEFAULT 100;
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='subscriptions' AND column_name='last_engagement_at') THEN
+            ALTER TABLE subscriptions ADD COLUMN last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+        END IF;
+    END IF;
+END
+$$;
 
 -- Add health_score and last_engagement_at to subscribers
-ALTER TABLE subscribers ADD COLUMN IF NOT EXISTS health_score INTEGER DEFAULT 100;
-ALTER TABLE subscribers ADD COLUMN IF NOT EXISTS last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+DO $$
+BEGIN
+    IF to_regclass('subscribers') IS NOT NULL THEN
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='subscribers' AND column_name='health_score') THEN
+            ALTER TABLE subscribers ADD COLUMN health_score INTEGER DEFAULT 100;
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='subscribers' AND column_name='last_engagement_at') THEN
+            ALTER TABLE subscribers ADD COLUMN last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+        END IF;
+    END IF;
+END
+$$;
 
 -- +goose Down
-ALTER TABLE subscriptions DROP COLUMN IF EXISTS health_score;
-ALTER TABLE subscriptions DROP COLUMN IF EXISTS last_engagement_at;
-ALTER TABLE subscribers DROP COLUMN IF EXISTS health_score;
-ALTER TABLE subscribers DROP COLUMN IF EXISTS last_engagement_at;
+DO $$
+BEGIN
+    IF to_regclass('subscriptions') IS NOT NULL THEN
+        ALTER TABLE subscriptions DROP COLUMN IF EXISTS health_score;
+        ALTER TABLE subscriptions DROP COLUMN IF EXISTS last_engagement_at;
+    END IF;
+    IF to_regclass('subscribers') IS NOT NULL THEN
+        ALTER TABLE subscribers DROP COLUMN IF EXISTS health_score;
+        ALTER TABLE subscribers DROP COLUMN IF EXISTS last_engagement_at;
+    END IF;
+END
+$$;

--- a/src/server/db/migrations/205_subscription_health_score.sql
+++ b/src/server/db/migrations/205_subscription_health_score.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- Add health_score and last_engagement_at to subscriptions
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS health_score INTEGER DEFAULT 100;
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+
+-- Add health_score and last_engagement_at to subscribers
+ALTER TABLE subscribers ADD COLUMN IF NOT EXISTS health_score INTEGER DEFAULT 100;
+ALTER TABLE subscribers ADD COLUMN IF NOT EXISTS last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+
+-- +goose Down
+ALTER TABLE subscriptions DROP COLUMN IF EXISTS health_score;
+ALTER TABLE subscriptions DROP COLUMN IF EXISTS last_engagement_at;
+ALTER TABLE subscribers DROP COLUMN IF EXISTS health_score;
+ALTER TABLE subscribers DROP COLUMN IF EXISTS last_engagement_at;

--- a/src/server/migrations/205_subscription_health_score.sql
+++ b/src/server/migrations/205_subscription_health_score.sql
@@ -1,14 +1,42 @@
 -- +goose Up
 -- Add health_score and last_engagement_at to subscriptions
-ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS health_score INTEGER DEFAULT 100;
-ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+DO $$
+BEGIN
+    IF to_regclass('subscriptions') IS NOT NULL THEN
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='subscriptions' AND column_name='health_score') THEN
+            ALTER TABLE subscriptions ADD COLUMN health_score INTEGER DEFAULT 100;
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='subscriptions' AND column_name='last_engagement_at') THEN
+            ALTER TABLE subscriptions ADD COLUMN last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+        END IF;
+    END IF;
+END
+$$;
 
 -- Add health_score and last_engagement_at to subscribers
-ALTER TABLE subscribers ADD COLUMN IF NOT EXISTS health_score INTEGER DEFAULT 100;
-ALTER TABLE subscribers ADD COLUMN IF NOT EXISTS last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+DO $$
+BEGIN
+    IF to_regclass('subscribers') IS NOT NULL THEN
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='subscribers' AND column_name='health_score') THEN
+            ALTER TABLE subscribers ADD COLUMN health_score INTEGER DEFAULT 100;
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='subscribers' AND column_name='last_engagement_at') THEN
+            ALTER TABLE subscribers ADD COLUMN last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+        END IF;
+    END IF;
+END
+$$;
 
 -- +goose Down
-ALTER TABLE subscriptions DROP COLUMN IF EXISTS health_score;
-ALTER TABLE subscriptions DROP COLUMN IF EXISTS last_engagement_at;
-ALTER TABLE subscribers DROP COLUMN IF EXISTS health_score;
-ALTER TABLE subscribers DROP COLUMN IF EXISTS last_engagement_at;
+DO $$
+BEGIN
+    IF to_regclass('subscriptions') IS NOT NULL THEN
+        ALTER TABLE subscriptions DROP COLUMN IF EXISTS health_score;
+        ALTER TABLE subscriptions DROP COLUMN IF EXISTS last_engagement_at;
+    END IF;
+    IF to_regclass('subscribers') IS NOT NULL THEN
+        ALTER TABLE subscribers DROP COLUMN IF EXISTS health_score;
+        ALTER TABLE subscribers DROP COLUMN IF EXISTS last_engagement_at;
+    END IF;
+END
+$$;

--- a/src/server/migrations/205_subscription_health_score.sql
+++ b/src/server/migrations/205_subscription_health_score.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- Add health_score and last_engagement_at to subscriptions
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS health_score INTEGER DEFAULT 100;
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+
+-- Add health_score and last_engagement_at to subscribers
+ALTER TABLE subscribers ADD COLUMN IF NOT EXISTS health_score INTEGER DEFAULT 100;
+ALTER TABLE subscribers ADD COLUMN IF NOT EXISTS last_engagement_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
+
+-- +goose Down
+ALTER TABLE subscriptions DROP COLUMN IF EXISTS health_score;
+ALTER TABLE subscriptions DROP COLUMN IF EXISTS last_engagement_at;
+ALTER TABLE subscribers DROP COLUMN IF EXISTS health_score;
+ALTER TABLE subscribers DROP COLUMN IF EXISTS last_engagement_at;

--- a/src/server/workers/subscription_churn_prediction_job.rs
+++ b/src/server/workers/subscription_churn_prediction_job.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+use crate::db::DB;
+use std::time::Duration;
+use uuid::Uuid;
+
+pub struct SubscriptionChurnPredictionJob {
+    pub db: Arc<DB>,
+}
+
+impl SubscriptionChurnPredictionJob {
+    pub fn new(db: Arc<DB>) -> Self {
+        Self { db }
+    }
+
+    pub fn start(&self) {
+        let db = self.db.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(3600 * 24)); // Run daily
+            loop {
+                interval.tick().await;
+
+                match &db.store {
+                    crate::db::DbStore::Postgres => {
+                        let rows = sqlx::query(
+                            r#"
+                            SELECT id, tenant_id, customer_id, health_score
+                            FROM subscribers
+                            WHERE status = 'ACTIVE'
+                            AND (health_score < 50 OR last_engagement_at <= NOW() - INTERVAL '30 days')
+                            "#
+                        )
+                        .fetch_all(&db.pool)
+                        .await
+                        .unwrap_or_default();
+
+                        for row in rows {
+                            use sqlx::Row;
+                            let subscriber_id: String = row.get("id");
+                            let tenant_id: String = row.get("tenant_id");
+                            let customer_id: String = row.get("customer_id");
+                            let health_score: i32 = row.get("health_score");
+
+                            let payload = serde_json::json!({
+                                "subscriber_id": subscriber_id,
+                                "customer_id": customer_id,
+                                "health_score": health_score,
+                                "reason": if health_score < 50 { "low_health_score" } else { "low_engagement" }
+                            });
+
+                            let _ = sqlx::query(
+                                "INSERT INTO ohc_job_queue (id, tenant_id, job_type, payload, status, next_retry_at) VALUES ($1, $2, 'subscription_churn_risk', $3, 'PENDING', NOW()) ON CONFLICT DO NOTHING"
+                            )
+                            .bind(Uuid::new_v4().to_string())
+                            .bind(tenant_id)
+                            .bind(payload.to_string())
+                            .execute(&db.pool)
+                            .await;
+                        }
+                    },
+                    crate::db::DbStore::Sqlite(sqlite_pool) => {
+                         let rows = sqlx::query(
+                            r#"
+                            SELECT id, tenant_id, customer_id, health_score
+                            FROM subscribers
+                            WHERE status = 'ACTIVE'
+                            AND (health_score < 50 OR datetime(last_engagement_at) <= datetime('now', '-30 days'))
+                            "#
+                        )
+                        .fetch_all(sqlite_pool)
+                        .await
+                        .unwrap_or_default();
+
+                        for row in rows {
+                            use sqlx::Row;
+                            let subscriber_id: String = row.get("id");
+                            let tenant_id: String = row.get("tenant_id");
+                            let customer_id: String = row.get("customer_id");
+                            let health_score: i32 = row.get("health_score");
+
+                            let payload = serde_json::json!({
+                                "subscriber_id": subscriber_id,
+                                "customer_id": customer_id,
+                                "health_score": health_score,
+                                "reason": if health_score < 50 { "low_health_score" } else { "low_engagement" }
+                            });
+
+                            let _ = sqlx::query(
+                                "INSERT INTO ohc_job_queue (id, tenant_id, job_type, payload, status, next_retry_at) VALUES (?, ?, 'subscription_churn_risk', ?, 'PENDING', CURRENT_TIMESTAMP) ON CONFLICT DO NOTHING"
+                            )
+                            .bind(Uuid::new_v4().to_string())
+                            .bind(tenant_id)
+                            .bind(payload.to_string())
+                            .execute(sqlite_pool)
+                            .await;
+                        }
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/server/workers/subscription_churn_prediction_worker.rs
+++ b/src/server/workers/subscription_churn_prediction_worker.rs
@@ -1,0 +1,153 @@
+use std::sync::Arc;
+use tokio::time::Duration;
+use crate::db::DB;
+use sqlx::Row;
+use crate::orchestration::departments::{DepartmentEvent, DepartmentOrchestrator};
+use uuid::Uuid;
+
+pub struct SubscriptionChurnPredictionWorker {
+    db: Arc<DB>,
+    orchestrator: Arc<DepartmentOrchestrator>,
+}
+
+impl SubscriptionChurnPredictionWorker {
+    pub fn new(db: Arc<DB>, orchestrator: Arc<DepartmentOrchestrator>) -> Self {
+        Self { db, orchestrator }
+    }
+
+    pub fn start(self: Arc<Self>) {
+        tokio::spawn(async move {
+            loop {
+                match self.poll().await {
+                    Ok(true) => {
+                        // Processed a job, continue immediately
+                        continue;
+                    }
+                    Ok(false) => {
+                        // No jobs, sleep
+                        tokio::time::sleep(Duration::from_millis(5000)).await;
+                    }
+                    Err(e) => {
+                        tracing::error!("SubscriptionChurnPredictionWorker error: {}", e);
+                        tokio::time::sleep(Duration::from_millis(5000)).await;
+                    }
+                }
+            }
+        });
+    }
+
+    pub async fn poll(&self) -> Result<bool, String> {
+        let job = match &self.db.store {
+            crate::db::DbStore::Postgres => {
+                let mut tx = self.db.pool.begin().await.map_err(|e| e.to_string())?;
+                let row = sqlx::query(
+                    r#"
+                    SELECT id, tenant_id, payload
+                    FROM ohc_job_queue
+                    WHERE status = 'PENDING' AND next_retry_at <= NOW() AND job_type = 'subscription_churn_risk'
+                    ORDER BY next_retry_at ASC, created_at ASC
+                    FOR UPDATE SKIP LOCKED
+                    LIMIT 1
+                    "#
+                )
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| e.to_string())?;
+
+                if let Some(r) = row {
+                    let id: String = r.get("id");
+                    let tenant_id: String = r.get("tenant_id");
+                    let payload: serde_json::Value = serde_json::from_str(r.get("payload")).unwrap_or_else(|_| serde_json::json!({}));
+
+                    sqlx::query("UPDATE ohc_job_queue SET status = 'PROCESSING', updated_at = NOW() WHERE id = $1")
+                        .bind(&id)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|e| e.to_string())?;
+
+                    tx.commit().await.map_err(|e| e.to_string())?;
+                    Some((id, tenant_id, payload))
+                } else {
+                    tx.rollback().await.map_err(|e| e.to_string())?;
+                    None
+                }
+            },
+            crate::db::DbStore::Sqlite(sqlite_pool) => {
+                let mut tx = sqlite_pool.begin().await.map_err(|e| e.to_string())?;
+                let row = sqlx::query(
+                    r#"
+                    SELECT id, tenant_id, payload
+                    FROM ohc_job_queue
+                    WHERE status = 'PENDING' AND next_retry_at <= CURRENT_TIMESTAMP AND job_type = 'subscription_churn_risk'
+                    ORDER BY next_retry_at ASC, created_at ASC
+                    LIMIT 1
+                    "#
+                )
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| e.to_string())?;
+
+                if let Some(r) = row {
+                    let id: String = r.get("id");
+                    let tenant_id: String = r.get("tenant_id");
+                    let payload_str: String = r.get("payload");
+                    let payload: serde_json::Value = serde_json::from_str(&payload_str).unwrap_or_else(|_| serde_json::json!({}));
+
+                    sqlx::query("UPDATE ohc_job_queue SET status = 'PROCESSING', updated_at = CURRENT_TIMESTAMP WHERE id = ?")
+                        .bind(&id)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|e| e.to_string())?;
+
+                    tx.commit().await.map_err(|e| e.to_string())?;
+                    Some((id, tenant_id, payload))
+                } else {
+                    tx.rollback().await.map_err(|e| e.to_string())?;
+                    None
+                }
+            }
+        };
+
+        if let Some((job_id, tenant_id, payload)) = job {
+            if let Some(customer_id) = payload.get("customer_id").and_then(|v| v.as_str()) {
+                let subscriber_id = payload.get("subscriber_id").and_then(|v| v.as_str()).unwrap_or("");
+                let health_score = payload.get("health_score").and_then(|v| v.as_i64()).unwrap_or(0);
+
+                let event = DepartmentEvent {
+                    id: Uuid::new_v4().to_string(),
+                    tenant_id: tenant_id.clone(),
+                    event_type: "tenant.subscription.churn_risk".to_string(),
+                    payload: serde_json::json!({
+                        "customer_id": customer_id,
+                        "subscriber_id": subscriber_id,
+                        "health_score": health_score,
+                    }),
+                };
+
+                let _ = self.orchestrator.dispatch_event(event).await;
+            }
+
+            // Mark job as completed
+            match &self.db.store {
+                crate::db::DbStore::Postgres => {
+                    sqlx::query("UPDATE ohc_job_queue SET status = 'COMPLETED', updated_at = NOW() WHERE id = $1")
+                        .bind(&job_id)
+                        .execute(&self.db.pool)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                },
+                crate::db::DbStore::Sqlite(sqlite_pool) => {
+                    sqlx::query("UPDATE ohc_job_queue SET status = 'COMPLETED', updated_at = CURRENT_TIMESTAMP WHERE id = ?")
+                        .bind(&job_id)
+                        .execute(sqlite_pool)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                }
+            }
+
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/ui/next/src/e2e/subscription_churn_retention.spec.ts
+++ b/src/ui/next/src/e2e/subscription_churn_retention.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Agentic Subscription Retention & Churn Prediction Feed E2E', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test('should display subscription churn win-back recommendation in the feed and allow approval', async ({ page }) => {
+    test.setTimeout(180000);
+
+    // 1. Log in as Leo
+    await page.goto('/login');
+    await page.getByPlaceholder('Email or Username').fill('leo@example.com');
+    await page.getByPlaceholder('Password').fill('password123');
+    await page.getByRole('button', { name: 'Log In' }).click();
+    await expect(page.locator('h1', { hasText: 'Dashboard' }).first()).toBeVisible({ timeout: 25000 });
+
+    // Navigate to the unified agent feed
+    await page.goto('/feed');
+
+    // Wait for the feed items to populate
+    await expect(page.getByTestId('agent-feed').first()).toBeVisible({ timeout: 25000 });
+
+    // Assert that we see a churn risk Action Card
+    const churnCard = page.locator('div', { hasText: 'at risk of churning' }).first();
+    await expect(churnCard).toBeVisible({ timeout: 15000 });
+
+    const approveBtn = churnCard.locator('button', { hasText: 'Approve' }).first();
+    await expect(approveBtn).toBeVisible({ timeout: 15000 });
+
+    await approveBtn.click();
+
+    // Assert that the card is removed after approval
+    await expect(approveBtn).not.toBeVisible({ timeout: 15000 });
+  });
+});


### PR DESCRIPTION
feat: Agentic Subscription Retention & Churn Prediction System
Resolves #32790

Added health_score and last_engagement_at metrics to subscriptions and subscribers. Implemented a SubscriptionChurnPredictionWorker that periodically checks for users with a low health score or prolonged inactivity, emitting a churn_risk event. Extended the CustomerSuccessAgent to listen for this event and automatically draft a personalized win-back offer using the LLM. The offer appears in the owner's Action Feed for final review.

---
*PR created automatically by Jules for task [3438697788255708491](https://jules.google.com/task/3438697788255708491) started by @ql-owo-lp*