### PR TITLE
🛡️ Sentry: [reliability fix] Fix network chaos test duplicate & build isolation

### DIFF
--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -12,6 +12,7 @@ SERVER_RS_SRCS = [
     "cart_recovery.rs",
     "chaos.rs",
     "chaos_db_test.rs",
+    "chaos_network_test.rs",
     "crypto.rs",
     "db.rs",
     "hub.rs",

--- a/src/server/chaos_network_test.rs
+++ b/src/server/chaos_network_test.rs
@@ -120,7 +120,7 @@ mod additional_network_chaos {
     }
 
     #[tokio::test]
-    async fn test_sentry_chaos_network_partition() {
+    async fn test_sentry_chaos_network_partition_thin_client_sim() {
         // Condition: SQLite fallback mode encounters invalid remote sync endpoints.
         // Verification: Missions correctly persist as PENDING rather than erroring out and dropping data.
         let sync_endpoint = "http://invalid-endpoint.local";

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -7083,3 +7083,5 @@ async fn test_api_settings_voice() {
 #[cfg(test)]
 mod health_test;
 // optimization done
+#[cfg(test)]
+pub mod chaos_network_test;


### PR DESCRIPTION
This PR resolves testing integration issues involving `chaos_network_test.rs`. It ensures that tests are accurately evaluated in the build system while preserving the strict "no deletion without replacement" rule, renaming an existing test instead. It also rectifies test environment leakage into the production application binary by encapsulating the module within a `#[cfg(test)]` flag.

---
*PR created automatically by Jules for task [16361791739453545758](https://jules.google.com/task/16361791739453545758) started by @ql-owo-lp*