### PR TITLE
Refactor Twilio Webhook URL Decode and Tests

### DIFF
--- a/src/server/api/twilio_voice.rs
+++ b/src/server/api/twilio_voice.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 use std::collections::HashMap;
 
 use crate::db::DB;
+use ::server_utils::url::url_decode;
 use crate::orchestration::departments::orchestrator::DepartmentOrchestrator;
 use crate::hub::Hub;
 use crate::orchestration::identity_resolution::IdentityResolver;
@@ -291,47 +292,9 @@ fn parse_form_urlencoded(input: &str) -> HashMap<String, String> {
     params
 }
 
-fn url_decode(input: &str) -> String {
-    let mut decoded = String::new();
-    let mut chars = input.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '+' {
-            decoded.push(' ');
-        } else if c == '%' {
-            let mut hex = String::new();
-            if let Some(h1) = chars.next() {
-                hex.push(h1);
-                if let Some(h2) = chars.next() {
-                    hex.push(h2);
-                    if let Ok(byte) = u8::from_str_radix(&hex, 16) {
-                        decoded.push(byte as char);
-                    } else {
-                        decoded.push('%');
-                        decoded.push_str(&hex);
-                    }
-                } else {
-                    decoded.push('%');
-                    decoded.push(h1);
-                }
-            } else {
-                decoded.push('%');
-            }
-        } else {
-            decoded.push(c);
-        }
-    }
-    decoded
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_url_decode_voice() {
-        assert_eq!(url_decode("Hello+World"), "Hello World");
-        assert_eq!(url_decode("whatsapp%3A%2B1234567890"), "whatsapp:+1234567890");
-    }
 
     #[test]
     fn test_parse_form_urlencoded() {

--- a/src/server/api/twilio_webhook.rs
+++ b/src/server/api/twilio_webhook.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 use std::collections::HashMap;
 
 use crate::db::DB;
+use ::server_utils::url::url_decode;
 use crate::orchestration::departments::orchestrator::DepartmentOrchestrator;
 use crate::hub::Hub;
 use crate::orchestration::identity_resolution::IdentityResolver;
@@ -404,49 +405,4 @@ pub async fn twilio_voice_webhook_handler(
     );
 
     ([(axum::http::header::CONTENT_TYPE, "text/xml")], twiml).into_response()
-}
-
-// Basic URL decode
-fn url_decode(input: &str) -> String {
-    let mut decoded = String::new();
-    let mut chars = input.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '+' {
-            decoded.push(' ');
-        } else if c == '%' {
-            let mut hex = String::new();
-            if let Some(h1) = chars.next() {
-                hex.push(h1);
-                if let Some(h2) = chars.next() {
-                    hex.push(h2);
-                    if let Ok(byte) = u8::from_str_radix(&hex, 16) {
-                        decoded.push(byte as char);
-                    } else {
-                        decoded.push('%');
-                        decoded.push_str(&hex);
-                    }
-                } else {
-                    decoded.push('%');
-                    decoded.push(h1);
-                }
-            } else {
-                decoded.push('%');
-            }
-        } else {
-            decoded.push(c);
-        }
-    }
-    decoded
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_url_decode() {
-        assert_eq!(url_decode("Hello+World"), "Hello World");
-        assert_eq!(url_decode("Hello%20World"), "Hello World");
-        assert_eq!(url_decode("whatsapp%3A%2B1234567890"), "whatsapp:+1234567890");
-    }
 }

--- a/src/server/api/twilio_webhook_test.rs
+++ b/src/server/api/twilio_webhook_test.rs
@@ -50,7 +50,19 @@ async fn test_twilio_webhook_post_handler_success() {
         .body(body)
         .unwrap();
 
-    let response = app.oneshot(request).await.unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
+
+    // Test with media
+    let body_media = Body::from("From=whatsapp%3A%2B14155238886&To=whatsapp%3A%2B1234567890&Body=Check+out+this+cake&NumMedia=1&MediaUrl0=https%3A%2F%2Fexample.com%2Fimage.jpg&MediaContentType0=image%2Fjpeg");
+    let request_media = Request::builder()
+        .method("POST")
+        .uri("/api/v1/webhooks/twilio")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body_media)
+        .unwrap();
+
+    let response_media = app.oneshot(request_media).await.unwrap();
+    assert_eq!(response_media.status(), StatusCode::OK);
 }

--- a/src/server/utils/BUILD.bazel
+++ b/src/server/utils/BUILD.bazel
@@ -17,6 +17,7 @@ rust_library(
         "tier_middleware.rs",
         "edge_caching_middleware.rs",
         "tenant_middleware.rs",
+        "url.rs",
     ],
     crate_root = "mod.rs",
     edition = "2024",

--- a/src/server/utils/mod.rs
+++ b/src/server/utils/mod.rs
@@ -16,3 +16,4 @@ pub mod payload_validator;
 
 pub mod edge_caching_middleware;
 pub mod payload_shaper;
+pub mod url;

--- a/src/server/utils/url.rs
+++ b/src/server/utils/url.rs
@@ -1,0 +1,43 @@
+pub fn url_decode(input: &str) -> String {
+    let mut decoded = String::new();
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '+' {
+            decoded.push(' ');
+        } else if c == '%' {
+            let mut hex = String::new();
+            if let Some(h1) = chars.next() {
+                hex.push(h1);
+                if let Some(h2) = chars.next() {
+                    hex.push(h2);
+                    if let Ok(byte) = u8::from_str_radix(&hex, 16) {
+                        decoded.push(byte as char);
+                    } else {
+                        decoded.push('%');
+                        decoded.push_str(&hex);
+                    }
+                } else {
+                    decoded.push('%');
+                    decoded.push(h1);
+                }
+            } else {
+                decoded.push('%');
+            }
+        } else {
+            decoded.push(c);
+        }
+    }
+    decoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_url_decode() {
+        assert_eq!(url_decode("Hello+World"), "Hello World");
+        assert_eq!(url_decode("Hello%20World"), "Hello World");
+        assert_eq!(url_decode("whatsapp%3A%2B1234567890"), "whatsapp:+1234567890");
+    }
+}


### PR DESCRIPTION
Resolves #32985

The requested feature (Twilio WhatsApp integration) was already fully implemented in the codebase (including mapping numbers, Work Triage, AI drafting, inbound UI, outbound sender, and E2E test coverage). As mandated by the proactive optimization protocol, I extracted the manual `url_decode` logic into `src/server/utils/url.rs` and added unit test coverage for media payloads in the `twilio_webhook_test.rs` to leave the repository in a better state.

---
*PR created automatically by Jules for task [7821076837674011842](https://jules.google.com/task/7821076837674011842) started by @ql-owo-lp*