### PR TITLE
Fix tooltip registry schema bug

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -118,7 +118,7 @@ pub async fn update_tooltip(headers: axum::http::HeaderMap, axum::extract::Json(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("default");
     let pool = crate::db::get_pool();
-    match sqlx::query("INSERT INTO tooltips (id, tenant_id, text) VALUES ($1, $2, $3) ON CONFLICT (id) DO UPDATE SET text = EXCLUDED.text").bind(payload.id).bind(tenant_id).bind(payload.text)
+    match sqlx::query("INSERT INTO tooltips (id, tenant_id, text) VALUES ($1, $2, $3) ON CONFLICT (tenant_id, id) DO UPDATE SET text = EXCLUDED.text").bind(payload.id).bind(tenant_id).bind(payload.text)
         .execute(&pool)
         .await
     {

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -2607,11 +2607,12 @@ CREATE TABLE IF NOT EXISTS omni_inbox_messages (
                     );
 
                     CREATE TABLE IF NOT EXISTS tooltips (
-                        id TEXT PRIMARY KEY,
+                        id TEXT NOT NULL,
                         tenant_id TEXT NOT NULL,
                         text TEXT NOT NULL,
                         created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+                        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        PRIMARY KEY (tenant_id, id)
                     );
 
                     CREATE TABLE IF NOT EXISTS unified_messages (

--- a/src/server/db/migrations/130_documentation_schema.sql
+++ b/src/server/db/migrations/130_documentation_schema.sql
@@ -27,11 +27,12 @@ CREATE INDEX IF NOT EXISTS idx_video_tutorials_tenant_id ON video_tutorials(tena
 
 -- Create Tooltips Table
 CREATE TABLE IF NOT EXISTS tooltips (
-    id VARCHAR(255) PRIMARY KEY,
+    id VARCHAR(255) NOT NULL,
     tenant_id VARCHAR(255) NOT NULL,
     text TEXT NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_tooltips_tenant_id ON tooltips(tenant_id);


### PR DESCRIPTION
Fixes a schema bug in the `tooltips` table where `id` was the only primary key, causing conflicts between tenants using the same tooltip element ID. A composite primary key `(tenant_id, id)` is now used to properly scope tooltips per tenant. UPSERT logic in the API has been updated to reflect this change.

---
*PR created automatically by Jules for task [5606336939353247148](https://jules.google.com/task/5606336939353247148) started by @ql-owo-lp*