### PR TITLE
test(e2e): Fix quoting feed e2e test expectations to match updated UI

### DIFF
--- a/src/e2e/e2e_quoting_feed.spec.ts
+++ b/src/e2e/e2e_quoting_feed.spec.ts
@@ -21,12 +21,12 @@ test.describe('Quote Feed e2e', () => {
 
     await expect(page).toHaveURL(/\/quoting\?id=.*/);
 
-    await expect(page.getByText('Quote Details')).toBeVisible();
+    await expect(page.getByText('Quote Summary')).toBeVisible();
 
     // Tap approve on the quoting page
-    await page.getByRole('button', { name: 'Pay Deposit with Pay' }).click();
+    await page.getByRole('button', { name: 'Approve & Send' }).click();
 
     // Assert quote is accepted
-    await expect(page.getByText('Deposit Paid')).toBeVisible();
+    await expect(page.getByText('Proposal Accepted')).toBeVisible();
   });
 });


### PR DESCRIPTION
test(e2e): Fix quoting feed e2e test expectations to match updated UI

The text labels in the quoting component were updated ("Quote Summary", "Approve & Send", and "Proposal Accepted"), which caused the E2E test `e2e_quoting_feed.spec.ts` to fail because it was still asserting the old text strings. This commit updates the assertions to match the current UI.

---
*PR created automatically by Jules for task [12296754853489017081](https://jules.google.com/task/12296754853489017081) started by @ql-owo-lp*