### PR TITLE
fix: securely resolve tenant_id from authenticated session in dynamic_workflows API

### DIFF
--- a/src/server/api/dynamic_workflows.rs
+++ b/src/server/api/dynamic_workflows.rs
@@ -23,6 +23,7 @@ where
 
 async fn start_workflow(
     State(manager): State<Arc<DynamicWorkflowManager>>,
+    axum::extract::Extension(auth_info): axum::extract::Extension<::server_auth::orchestration::AuthInfo>,
     Json(mut request): Json<DynamicWorkflowRequest>,
 ) -> axum::response::Response {
     if request.prompt.trim().is_empty() {
@@ -32,8 +33,17 @@ async fn start_workflow(
         )
             .into_response();
     }
-    if request.tenant_id.trim().is_empty() {
-        request.tenant_id = "default".to_string();
+
+    // OVERRIDE the request body's tenant_id with the one from the authenticated session
+    // to prevent multi-tenant safety issue where tenant_id is read from request body
+    if !auth_info.spiffe_id.is_empty() {
+        request.tenant_id = auth_info.spiffe_id;
+    } else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({ "error": "missing tenant identity in session" })),
+        )
+            .into_response();
     }
 
     match manager.start_workflow(request).await {


### PR DESCRIPTION
This PR fixes a multi-tenant safety vulnerability where `tenant_id` was read directly from an incoming HTTP request body instead of being securely derived from a trusted, authenticated session. 

**Changes:**
- In `src/server/api/dynamic_workflows.rs`, `start_workflow` now accepts `axum::extract::Extension<::server_auth::orchestration::AuthInfo>` as a parameter.
- It overrides the incoming `request.tenant_id` with `auth_info.spiffe_id` (representing the authenticated tenant identity).
- Added a fallback block that returns `StatusCode::UNAUTHORIZED` if the `spiffe_id` is somehow empty.

**Verification (Superpowers Skills applied: rigorous end-to-end testing):**
- ✅ `bazelisk build //src/server/...` passed successfully without compile errors.
- ✅ `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"` passed successfully.
- Code has been fully reviewed.

---
*PR created automatically by Jules for task [7119498646338687478](https://jules.google.com/task/7119498646338687478) started by @ql-owo-lp*