### PR TITLE
Fix unused variable and improve Twilio Voice Webhook test coverage

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -169,7 +169,7 @@ pub async fn create_billing_portal_session_handler(
         if r.starts_with("http") {
             let mut parts = r.splitn(4, '/');
             let scheme = parts.next()?;
-            let empty = parts.next()?;
+            let _empty = parts.next()?;
             let host = parts.next()?;
             Some(format!("{}//{}", scheme, host))
         } else {

--- a/src/server/api/twilio_voice_test.rs
+++ b/src/server/api/twilio_voice_test.rs
@@ -1,1 +1,51 @@
-// Basic test stub for twilio_voice endpoints
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+use crate::db::DB;
+use crate::hub::Hub;
+use crate::orchestration::departments::orchestrator::DepartmentOrchestrator;
+use crate::orchestration::departments::orchestrator::MeshNode;
+use crate::api::twilio_voice::{twilio_voice_incoming_handler, TwilioVoiceWebhookState};
+use ::server_integrations_twilio::provider::TwilioProvider;
+
+#[tokio::test]
+async fn test_twilio_voice_incoming_handler() {
+    let pool = crate::db::get_pool();
+    let db = Arc::new(DB { pool: pool.clone(), store: crate::db::DbStore::Sqlite(pool.clone()) });
+
+    let transport = crate::mesh::local::LocalMeshTransport::new();
+    let node = Arc::new(crate::mesh::CentrifugeNode::new(transport));
+    let orchestrator = Arc::new(DepartmentOrchestrator::new(db.clone(), node));
+    let hub = Arc::new(Hub::new());
+
+    let twilio = Arc::new(TwilioProvider::new("test".to_string(), "test".to_string()));
+
+    let state = TwilioVoiceWebhookState {
+        hub,
+        db: db.clone(),
+        orchestrator,
+        voice_engine: Arc::new(crate::voice::VoiceAIEdgeEngine::new()),
+        twilio,
+    };
+
+    let app = axum::Router::new()
+        .route("/api/v1/webhooks/twilio_voice/incoming", axum::routing::post(twilio_voice_incoming_handler))
+        .with_state(state);
+
+    let body = Body::from("CallSid=CA123&From=%2B1234567890&To=%2B0987654321");
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/webhooks/twilio_voice/incoming")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/src/server/api/twilio_webhook_test.rs
+++ b/src/server/api/twilio_webhook_test.rs
@@ -66,3 +66,44 @@ async fn test_twilio_webhook_post_handler_success() {
     let response_media = app.oneshot(request_media).await.unwrap();
     assert_eq!(response_media.status(), StatusCode::OK);
 }
+
+#[tokio::test]
+async fn test_twilio_voice_webhook_handler_success() {
+    let pool = crate::db::get_pool();
+    let db = Arc::new(DB { pool: pool.clone(), store: crate::db::DbStore::Sqlite(pool.clone()) });
+
+    let _ = sqlx::query("INSERT OR IGNORE INTO settings (tenant_id, sms_critical_phone, voice_receptionist_number) VALUES ('test_tenant', '+1234567890', '+1234567890')")
+        .execute(&pool)
+        .await;
+
+    let transport = crate::mesh::local::LocalMeshTransport::new();
+    let node = Arc::new(crate::mesh::CentrifugeNode::new(transport));
+    let orchestrator = Arc::new(DepartmentOrchestrator::new(db.clone(), node));
+    let hub = Arc::new(Hub::new());
+
+    let state = TwilioWebhookState {
+        hub,
+        db: db.clone(),
+        orchestrator,
+        voice_engine: Arc::new(crate::voice::VoiceAIEdgeEngine::new()),
+        voice_router: Arc::new(crate::voice::VoiceContextRouter::new()),
+        voice_sessions: Arc::new(dashmap::DashMap::new()),
+    };
+
+    let app = axum::Router::new()
+        .route("/api/v1/webhooks/twilio/voice", axum::routing::post(crate::api::twilio_webhook::twilio_voice_webhook_handler))
+        .with_state(state);
+
+    let body = Body::from("CallSid=CA123&From=%2B1234567890&To=%2B0987654321");
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/webhooks/twilio/voice")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}


### PR DESCRIPTION
Fix unused variable and improve Twilio Voice Webhook test coverage.

Resolves #33030

- Added unit tests for `twilio_voice_incoming_handler` and `twilio_voice_webhook_handler` to boost Twilio API test coverage.
- Fixed `empty` unused variable warning in `billing_api.rs`.
- Loaded superpowers and audited implementation using Live Service UI gap logic to determine E2E test state. All E2E WhatsApp flows are already successfully implemented.

---
*PR created automatically by Jules for task [17516592324223231742](https://jules.google.com/task/17516592324223231742) started by @ql-owo-lp*