### PR TITLE
🧙 Wizard: Removed mock loading delays from setup.html

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -3564,7 +3564,7 @@
           btn.disabled = true;
 
           // Add a small delay to allow browser to render "Saving..."
-          await new Promise((r) => setTimeout(r, 100));
+
 
           saveCurrentState();
 
@@ -3761,9 +3761,7 @@
                   delete window.generateStorefrontLoadingInterval;
               }
 
-              setTimeout(() => {
-                window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
-              }, 1500);
+              window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
               return;
             }
 
@@ -3816,9 +3814,7 @@
                 delete window.generateStorefrontLoadingInterval;
             }
 
-            setTimeout(() => {
-              window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
-            }, 1500);
+            window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
           }
         } catch (e) {
           chatMessagesEl.innerHTML += `<div style="margin-bottom: 10px; color: #FF3B30;"><strong>Error:</strong> Failed to connect.</div>`;
@@ -4031,9 +4027,7 @@
                   delete window.generateStorefrontLoadingInterval;
               }
 
-              setTimeout(() => {
-                window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
-              }, 1500);
+              window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
               return;
             }
 
@@ -4085,9 +4079,7 @@
                 delete window.generateStorefrontLoadingInterval;
             }
 
-            setTimeout(() => {
-              window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
-            }, 1500);
+            window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
           } catch (err) {
             console.error(err);
             goToStep("step-initial");


### PR DESCRIPTION
Removed mock `setTimeout` loading delays from `setup.html` that artificially delayed UI navigation (such as the 1.5-second wait before redirecting to `success.html` and the 100ms fake rendering delay when saving drafts).

- Removed `setTimeout` wraps around `window.location.href` to allow immediate progression.
- Removed fake async pause logic (`await new Promise((r) => setTimeout(r, 100));`).
- Evaluated end-to-end paths manually, then ran full Playwright and Bazel test suites to ensure logic holds up without the artificial delays.

These codebase optimizations follow the mandate to remove mock UI loading data and improve perceived speed for non-technical users in the setup wizard.

---
*PR created automatically by Jules for task [17402912439419947047](https://jules.google.com/task/17402912439419947047) started by @ql-owo-lp*