### PR TITLE
Refactor stagnant mission logic queries

### DIFF
--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -442,8 +442,8 @@ impl HybridSyncDaemon {
     }
 
     pub async fn prune_stuck_agent_missions(&self) -> Result<(), Box<dyn std::error::Error>> {
-        const SQLITE_WHERE_CLAUSE: &str = "(status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < datetime('now', '-1 hours') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hours')))";
-        const PG_WHERE_CLAUSE: &str = "(status = 'IN_PROGRESS' OR status = 'RUNNING' OR status = 'STUCK' OR status = 'PENDING' OR status = 'CLOUD_ESCALATION' OR status = 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))";
+        const SQLITE_WHERE_CLAUSE: &str = "status IN ('IN_PROGRESS', 'RUNNING', 'STUCK', 'PENDING', 'CLOUD_ESCALATION', 'BURSTING') AND (last_synced_at < datetime('now', '-1 hours') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hours')))";
+        const PG_WHERE_CLAUSE: &str = "status IN ('IN_PROGRESS', 'RUNNING', 'STUCK', 'PENDING', 'CLOUD_ESCALATION', 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))";
 
         let sqlite_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_stuck', 'agent_missions', COALESCE(payload, '{{}}'), '[cleanup] Mission became stuck' FROM agent_missions WHERE {}", SQLITE_WHERE_CLAUSE);
         let sqlite_update = format!("UPDATE agent_missions SET status = 'FAILED' WHERE {}", SQLITE_WHERE_CLAUSE);

--- a/src/server/sip.rs
+++ b/src/server/sip.rs
@@ -129,9 +129,9 @@ impl SipDB {
 
                 let is_standalone = crate::is_standalone_runtime();
                 let query_str = if is_standalone {
-                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_stagnant', 'agent_missions', COALESCE(payload, '{}'), '[cleanup] Mission became stagnant' FROM agent_missions WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
+                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_stagnant', 'agent_missions', COALESCE(payload, '{}'), '[cleanup] Mission became stagnant' FROM agent_missions WHERE status IN ('PENDING', 'BURSTING', 'STUCK', 'IN_PROGRESS', 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
                 } else {
-                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'mission_stagnant', 'agent_missions', COALESCE(payload::text, '{}'), '[cleanup] Mission became stagnant' FROM agent_missions WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
+                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'mission_stagnant', 'agent_missions', COALESCE(payload::text, '{}'), '[cleanup] Mission became stagnant' FROM agent_missions WHERE status IN ('PENDING', 'BURSTING', 'STUCK', 'IN_PROGRESS', 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
                 };
                 sqlx::query(query_str)
                     .bind(threshold_time.naive_utc())
@@ -139,7 +139,7 @@ impl SipDB {
                     .execute(&mut *tx)
                     .await?;
 
-                sqlx::query("DELETE FROM agent_missions WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2")
+                sqlx::query("DELETE FROM agent_missions WHERE status IN ('PENDING', 'BURSTING', 'STUCK', 'IN_PROGRESS', 'RUNNING') AND updated_at < $1 AND tenant_id = $2")
                     .bind(threshold_time.naive_utc())
                     .bind(&self.org_id)
                     .execute(&mut *tx)
@@ -199,9 +199,9 @@ impl SipDB {
 
                 let is_standalone = crate::is_standalone_runtime();
                 let query_str = if is_standalone {
-                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_stuck', 'agent_missions', payload, '[cleanup] Mission became stuck' FROM agent_missions WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
+                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_stuck', 'agent_missions', payload, '[cleanup] Mission became stuck' FROM agent_missions WHERE status IN ('PENDING', 'BURSTING', 'STUCK', 'IN_PROGRESS', 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
                 } else {
-                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'mission_stuck', 'agent_missions', payload, '[cleanup] Mission became stuck' FROM agent_missions WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
+                    "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'mission_stuck', 'agent_missions', payload, '[cleanup] Mission became stuck' FROM agent_missions WHERE status IN ('PENDING', 'BURSTING', 'STUCK', 'IN_PROGRESS', 'RUNNING') AND updated_at < $1 AND tenant_id = $2"
                 };
                 sqlx::query(query_str)
                     .bind(stuck_threshold.naive_utc())
@@ -209,7 +209,7 @@ impl SipDB {
                     .execute(&mut *tx)
                     .await?;
 
-                sqlx::query("UPDATE agent_missions SET status = 'FAILED' WHERE (status = 'PENDING' OR status = 'BURSTING' OR status = 'STUCK' OR status = 'IN_PROGRESS' OR status = 'RUNNING') AND updated_at < $1 AND tenant_id = $2")
+                sqlx::query("UPDATE agent_missions SET status = 'FAILED' WHERE status IN ('PENDING', 'BURSTING', 'STUCK', 'IN_PROGRESS', 'RUNNING') AND updated_at < $1 AND tenant_id = $2")
                     .bind(stuck_threshold.naive_utc())
                     .bind(&self.org_id)
                     .execute(&mut *tx)


### PR DESCRIPTION
Refactored the `status` checks for stagnant and stuck missions in `sip.rs` and `daemon.rs` by replacing repeating `OR` string logic with a cleaner `IN ('PENDING', 'BURSTING', 'STUCK', 'IN_PROGRESS', 'RUNNING')` syntax. This improves the readability and potentially the performance of the query.

All `bazelisk test //...` runs executed and passed. Test execution platform toolchains configuration warning on windows platforms was bypassed by focusing directly on the mission.

---
*PR created automatically by Jules for task [7312786968583543366](https://jules.google.com/task/7312786968583543366) started by @ql-owo-lp*