### PR TITLE
Fix: Remove hardcoded 'test-user' id from frontend components

### DIFF
--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -108,10 +108,14 @@ export default function OnboardingWizard() {
           localStorage.getItem("tenant") ||
           "storefront"
         : "storefront";
-    const userId =
-      typeof localStorage !== "undefined"
-        ? localStorage.getItem("user_id") || "test-user"
-        : "test-user";
+          let userId = "guest";
+      if (typeof localStorage !== "undefined") {
+        userId = localStorage.getItem("user_id") || "";
+        if (!userId) {
+          userId = crypto.randomUUID();
+          localStorage.setItem("user_id", userId);
+        }
+      }
 
     const wizardState = {
       step,
@@ -185,10 +189,14 @@ export default function OnboardingWizard() {
             localStorage.getItem("tenant") ||
             "storefront"
           : "storefront";
-      const userId =
-        typeof localStorage !== "undefined"
-          ? localStorage.getItem("user_id") || "test-user"
-          : "test-user";
+            let userId = "guest";
+      if (typeof localStorage !== "undefined") {
+        userId = localStorage.getItem("user_id") || "";
+        if (!userId) {
+          userId = crypto.randomUUID();
+          localStorage.setItem("user_id", userId);
+        }
+      }
 
       const wizardState = {
         step,
@@ -242,10 +250,14 @@ export default function OnboardingWizard() {
           localStorage.getItem("tenant") ||
           "storefront"
         : "storefront";
-    const userId =
-      typeof localStorage !== "undefined"
-        ? localStorage.getItem("user_id") || "test-user"
-        : "test-user";
+          let userId = "guest";
+      if (typeof localStorage !== "undefined") {
+        userId = localStorage.getItem("user_id") || "";
+        if (!userId) {
+          userId = crypto.randomUUID();
+          localStorage.setItem("user_id", userId);
+        }
+      }
 
     Promise.all([
       fetchWithRetry("/api/onboarding/draft", {
@@ -335,10 +347,14 @@ export default function OnboardingWizard() {
           localStorage.getItem("tenant") ||
           "storefront"
         : "storefront";
-    const userId =
-      typeof localStorage !== "undefined"
-        ? localStorage.getItem("user_id") || "test-user"
-        : "test-user";
+          let userId = "guest";
+      if (typeof localStorage !== "undefined") {
+        userId = localStorage.getItem("user_id") || "";
+        if (!userId) {
+          userId = crypto.randomUUID();
+          localStorage.setItem("user_id", userId);
+        }
+      }
 
     const wizardState = {
       step,
@@ -412,10 +428,14 @@ export default function OnboardingWizard() {
             localStorage.getItem("tenant") ||
             "storefront"
           : "storefront";
-      const userId =
-        typeof localStorage !== "undefined"
-          ? localStorage.getItem("user_id") || "test-user"
-          : "test-user";
+            let userId = "guest";
+      if (typeof localStorage !== "undefined") {
+        userId = localStorage.getItem("user_id") || "";
+        if (!userId) {
+          userId = crypto.randomUUID();
+          localStorage.setItem("user_id", userId);
+        }
+      }
 
       const combinedDescription = `Business Name: ${businessName}\nWhat we sell: ${whatYouSell}\nLocation: ${location}\nTarget Audience: ${targetAudience}`;
       updateState({ bio: combinedDescription });
@@ -550,10 +570,14 @@ export default function OnboardingWizard() {
               localStorage.getItem("tenant") ||
               "storefront"
             : "storefront";
-        const userId =
-          typeof localStorage !== "undefined"
-            ? localStorage.getItem("user_id") || "test-user"
-            : "test-user";
+              let userId = "guest";
+      if (typeof localStorage !== "undefined") {
+        userId = localStorage.getItem("user_id") || "";
+        if (!userId) {
+          userId = crypto.randomUUID();
+          localStorage.setItem("user_id", userId);
+        }
+      }
 
         // Pre-fill state values so we don't need to manually type everything
         updateState({
@@ -681,10 +705,14 @@ export default function OnboardingWizard() {
             localStorage.getItem("tenant") ||
             "storefront"
           : "storefront";
-      const userId =
-        typeof localStorage !== "undefined"
-          ? localStorage.getItem("user_id") || "test-user"
-          : "test-user";
+            let userId = "guest";
+      if (typeof localStorage !== "undefined") {
+        userId = localStorage.getItem("user_id") || "";
+        if (!userId) {
+          userId = crypto.randomUUID();
+          localStorage.setItem("user_id", userId);
+        }
+      }
 
       // Navigate to the loading state immediately
       updateState({ step: 4 });
@@ -794,10 +822,14 @@ export default function OnboardingWizard() {
             localStorage.getItem("tenant") ||
             "storefront"
           : "storefront";
-      const userId =
-        typeof localStorage !== "undefined"
-          ? localStorage.getItem("user_id") || "test-user"
-          : "test-user";
+            let userId = "guest";
+      if (typeof localStorage !== "undefined") {
+        userId = localStorage.getItem("user_id") || "";
+        if (!userId) {
+          userId = crypto.randomUUID();
+          localStorage.setItem("user_id", userId);
+        }
+      }
 
       const startRes = await fetchWithRetry("/api/onboarding/start", {
         method: "POST",

--- a/src/ui/next/src/app/storefront-builder/page.tsx
+++ b/src/ui/next/src/app/storefront-builder/page.tsx
@@ -55,7 +55,11 @@ export default function StorefrontBuilderPage() {
     // Only save to server if there's actual state to save that deviates from idle
     if (status !== 'idle' || bio !== '' || blocks.length > 0) {
       const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'storefront';
-      const userId = localStorage.getItem('user_id') || 'test-user';
+            let userId = typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') || '' : '';
+      if (!userId && typeof localStorage !== 'undefined') {
+        userId = crypto.randomUUID();
+        localStorage.setItem('user_id', userId);
+      }
 
       const payload = {
         builderState: { bio, blocks, status }
@@ -87,7 +91,11 @@ export default function StorefrontBuilderPage() {
   // Read state from server on mount
   useEffect(() => {
     const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'storefront';
-    const userId = localStorage.getItem('user_id') || 'test-user';
+          let userId = typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') || '' : '';
+      if (!userId && typeof localStorage !== 'undefined') {
+        userId = crypto.randomUUID();
+        localStorage.setItem('user_id', userId);
+      }
     fetch('/api/onboarding/state', {
       headers: { 'X-Tenant-ID': tenantId, 'X-User-ID': userId }
     })

--- a/src/ui/next/src/app/website-builder/page.tsx
+++ b/src/ui/next/src/app/website-builder/page.tsx
@@ -45,7 +45,11 @@ export default function WebsiteBuilderPage() {
     try {
       const state = useWebsiteBuilderStore.getState();
       const tenant = typeof localStorage !== 'undefined' ? localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'storefront' : 'storefront';
-      const user = typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') || 'test-user' : 'test-user';
+            let user = typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') || '' : '';
+      if (!user && typeof localStorage !== 'undefined') {
+        user = crypto.randomUUID();
+        localStorage.setItem('user_id', user);
+      }
 
       const res = await fetch('/api/onboarding/draft', {
         method: 'POST',
@@ -89,7 +93,11 @@ export default function WebsiteBuilderPage() {
   useEffect(() => {
     const tenantIdStr = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'storefront';
     setTenantId(tenantIdStr);
-    const userId = localStorage.getItem('user_id') || 'test-user';
+          let userId = typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') || '' : '';
+      if (!userId && typeof localStorage !== 'undefined') {
+        userId = crypto.randomUUID();
+        localStorage.setItem('user_id', userId);
+      }
 
     Promise.all([
       fetch('/api/onboarding/draft', { headers: { 'X-Tenant-ID': tenantIdStr, 'X-User-ID': userId } })
@@ -156,7 +164,11 @@ export default function WebsiteBuilderPage() {
     // Only save if there's actual state
     if (wizardStep !== 0 || bio !== '' || blocks.length > 0 || businessName !== '') {
       const tenantIdStr = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'storefront';
-      const userId = localStorage.getItem('user_id') || 'test-user';
+            let userId = typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') || '' : '';
+      if (!userId && typeof localStorage !== 'undefined') {
+        userId = crypto.randomUUID();
+        localStorage.setItem('user_id', userId);
+      }
 
       const wizardState = {
         step: wizardStep,
@@ -612,7 +624,11 @@ export default function WebsiteBuilderPage() {
                       onClick={async () => {
                         setStatus('generating');
                         const tenantIdStr = typeof localStorage !== 'undefined' ? localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'storefront' : 'storefront';
-                        const userIdStr = typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') || 'test-user' : 'test-user';
+                                                let userIdStr = typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') || '' : '';
+                        if (!userIdStr && typeof localStorage !== 'undefined') {
+                            userIdStr = crypto.randomUUID();
+                            localStorage.setItem('user_id', userIdStr);
+                        }
                         try {
                             const startRes = await fetch('/api/onboarding/start', {
                               method: 'POST',
@@ -688,7 +704,11 @@ export default function WebsiteBuilderPage() {
                         const controller = new AbortController();
                         const abortTimeout = window.setTimeout(() => controller.abort(), 4500);
                         const tenantIdStr = typeof localStorage !== 'undefined' ? localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'storefront' : 'storefront';
-                        const userIdStr = typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') || 'test-user' : 'test-user';
+                                                let userIdStr = typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') || '' : '';
+                        if (!userIdStr && typeof localStorage !== 'undefined') {
+                            userIdStr = crypto.randomUUID();
+                            localStorage.setItem('user_id', userIdStr);
+                        }
                         try {
 
                           const res = await fetch('/api/onboarding/intake', {


### PR DESCRIPTION
Replaces fallback logic in the frontend that generated 'test-user' with dynamic `crypto.randomUUID()` to prevent data collision. E2E tests have been correctly scoped to test actual business logic by maintaining the expected fallback states instead of generating unique UUIDs during their context execution.

---
*PR created automatically by Jules for task [7917059967977430681](https://jules.google.com/task/7917059967977430681) started by @ql-owo-lp*