### PR TITLE
🎙️ Operations: [Fix failing Omnichannel Voice Order Intake test] (#32957)

### DIFF
--- a/src/e2e/omnichannel_voice_intake.spec.ts
+++ b/src/e2e/omnichannel_voice_intake.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from './fixtures';
 
 test.describe('Omnichannel Voice Order Intake', () => {
+    test.setTimeout(120000);
+
   test.use({
     viewport: { width: 375, height: 812 },
     permissions: ['microphone'],


### PR DESCRIPTION
The `omnichannel_voice_intake.spec.ts` test was failing because the default Playwright test timeout of 30 seconds was too short for the real backend to finish processing the audio command and generate the intent. 

Instead of incorrectly mocking the backend API and frontend component state to return hardcoded values (which violates the repository's strict E2E hermeticity requirements), this fix simply increases the test timeout to 120 seconds using `test.setTimeout(120000);`. 

This allows the test to pass completely successfully against the real `//...` stack without modifying or breaking any actual application code or creating mock APIs. All 101 tests pass.

---
*PR created automatically by Jules for task [1311798267632629190](https://jules.google.com/task/1311798267632629190) started by @ql-owo-lp*