### PR TITLE
🤖 Implementer: Harness Upgrade - Subagent Orchestration: Worktree isolation

### DIFF
--- a/src/agents/builtin/claude_subagents.rs
+++ b/src/agents/builtin/claude_subagents.rs
@@ -123,6 +123,7 @@ impl ClaudeSubagentSpawner {
                 ));
                 sub_config.developer_instructions = worktree_instructions;
                 sub_config.project_trusted = true; // Typically worktrees require trust to commit.
+                sub_config.workspace_path = Some(worktree_dir.to_string_lossy().to_string());
 
                 let result = self.execute_and_summarize(task, &sub_config).await?;
 


### PR DESCRIPTION
🤖 Implementer: Harness Upgrade - Subagent Orchestration: Worktree isolation

**Issue:**
When a subagent is spawned using `ClaudeSubagentMode::Worktree`, a new isolated git worktree is created and instructions are appended to the subagent's prompt to use that directory. However, the subagent's execution tools (e.g., `bash`, `read_file`, `grep`) were continuing to execute inside the parent agent's default workspace path because `sub_config.workspace_path` was not being overridden to point to the newly created worktree.

**Fix:**
This PR explicitly sets `sub_config.workspace_path = Some(worktree_dir.to_string_lossy().to_string());` inside the `Worktree` configuration block of `ClaudeSubagentSpawner::run_subagent`. This guarantees the isolated subagent actually executes its tools physically within the provisioned worktree, properly enforcing the industry standard "Subagent Orchestration: Worktree execution model".

**Verification:**
- Ran `bazelisk test //...` (101 tests passed)
- Executed `bazelisk test //src/agents/builtin/...` which passed all 9 target tests (including `test_claude_subagent_worktree_isolation`).

**Loaded Superpowers Skills:**
- No particular external superpower skill script was required for this specific single-line architectural alignment.

**Code Review Status:**
- Approved locally.

---
*PR created automatically by Jules for task [689254471278417163](https://jules.google.com/task/689254471278417163) started by @ql-owo-lp*