### PR TITLE
feat: implement agentic SEO pre-rendering and edge cache warming

### DIFF
--- a/src/server/api/storefront_delivery.rs
+++ b/src/server/api/storefront_delivery.rs
@@ -92,7 +92,7 @@ async fn get_storefront_product(
                 let cache_key_clone = cache_key.clone();
                 let cache_clone = cache.clone();
                 tokio::spawn(async move {
-                    let _ = regenerate_storefront_product(pool_clone, tenant_id, product_id, cache_key_clone.clone(), cache_clone).await;
+                    let _ = crate::builder::edge::regenerate_product_cache(pool_clone, tenant_id, product_id, cache_key_clone.clone(), cache_clone).await;
                     let ongoing = get_ongoing_generation();
                     ongoing.lock().await.remove(&cache_key_clone);
                 });
@@ -122,7 +122,7 @@ async fn get_storefront_product(
         }
     }
 
-    let result = regenerate_storefront_product(state.pool.clone(), tenant_id, product_id, cache_key.clone(), cache.clone()).await;
+    let result = crate::builder::edge::regenerate_product_cache(state.pool.clone(), tenant_id, product_id, cache_key.clone(), cache.clone()).await;
 
     {
         let ongoing = get_ongoing_generation();
@@ -143,87 +143,6 @@ async fn get_storefront_product(
     Ok(response)
 }
 
-async fn regenerate_storefront_product(
-    pool: PgPool,
-    tenant_id: Uuid,
-    product_id: Uuid,
-    cache_key: String,
-    cache: std::sync::Arc<crate::utils::cache::HybridCache<String>>,
-) -> Result<(String, Vec<String>), StatusCode> {
-    #[derive(sqlx::FromRow)]
-    struct ProductSeoRow {
-        seo_title: Option<String>,
-        seo_description: Option<String>,
-        seo_schema_json: Option<sqlx::types::Json<serde_json::Value>>,
-    }
-
-    let pool1 = pool.clone();
-    let pool2 = pool.clone();
-    let (site_id_res, seo_res) = tokio::join!(
-        async move {
-            sqlx::query_scalar::<_, Uuid>(
-                "SELECT id FROM builder_sites WHERE tenant_id = $1 ORDER BY created_at ASC LIMIT 1"
-            )
-            .bind(tenant_id)
-            .fetch_one(&pool1)
-            .await
-        },
-        async move {
-            sqlx::query_as::<_, ProductSeoRow>(
-                "SELECT seo_title, seo_description, seo_schema_json FROM products WHERE id = $1 AND tenant_id = $2"
-            )
-            .bind(product_id.to_string())
-            .bind(tenant_id.to_string())
-            .fetch_optional(&pool2)
-            .await
-        }
-    );
-
-    if let Ok(site_id) = site_id_res {
-        // Just call regenerate_cache from builder edge
-        if let Ok((mut html, tags)) = regenerate_cache(pool.clone(), tenant_id, site_id, cache_key.clone(), cache.clone()).await {
-
-            if let Ok(Some(row)) = seo_res {
-                if let Some(seo_title) = row.seo_title {
-                    if let Some(start) = html.find("<title>") {
-                        if let Some(end) = html[start..].find("</title>") {
-                            let end = start + end + "</title>".len();
-                            html.replace_range(start..end, &format!("<title>{}</title>\n<meta name=\"title\" content=\"{}\">", seo_title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"), seo_title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")));
-                        }
-                    }
-                }
-
-                if let Some(seo_desc) = row.seo_description {
-                    if let Some(start) = html.find("<meta name=\"description\"") {
-                        if let Some(end) = html[start..].find(">") {
-                            let end = start + end + ">".len();
-                            html.replace_range(start..end, &format!("<meta name=\"description\" content=\"{}\">", seo_desc.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")));
-                        }
-                    } else if let Some(head_end) = html.find("</head>") {
-                        html.insert_str(head_end, &format!("<meta name=\"description\" content=\"{}\">\n", seo_desc.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")));
-                    }
-                }
-
-                if let Some(seo_schema) = row.seo_schema_json {
-                    if let Some(start) = html.find("<script type=\"application/ld+json\">") {
-                        if let Some(end) = html[start..].find("</script>") {
-                            let end = start + end + "</script>".len();
-                            html.replace_range(start..end, &format!("<script type=\"application/ld+json\">\n{}\n</script>", serde_json::to_string(&seo_schema.0).unwrap_or_default()));
-                        }
-                    } else if let Some(head_end) = html.find("</head>") {
-                        html.insert_str(head_end, &format!("<script type=\"application/ld+json\">\n{}\n</script>\n", serde_json::to_string(&seo_schema.0).unwrap_or_default()));
-                    }
-                }
-            }
-
-            // Pre-warm the cache since SWR or cache miss just resolved
-            cache.set_with_tags(&cache_key, html.clone(), tags.clone(), std::time::Duration::from_secs(3600)).await;
-
-            return Ok((html, tags));
-        }
-    }
-    Err(StatusCode::NOT_FOUND)
-}
 
 
 fn set_storefront_headers(response: &mut axum::response::Response, html: &str, tenant_id: Uuid, custom_tags: Option<Vec<String>>) {

--- a/src/server/builder/edge.rs
+++ b/src/server/builder/edge.rs
@@ -231,6 +231,88 @@ pub async fn handle_edge_request_impl(
     Ok(response)
 }
 
+pub async fn regenerate_product_cache(
+    pool: PgPool,
+    tenant_id: Uuid,
+    product_id: Uuid,
+    cache_key: String,
+    cache: std::sync::Arc<crate::utils::cache::HybridCache<String>>,
+) -> Result<(String, Vec<String>), axum::http::StatusCode> {
+    #[derive(sqlx::FromRow)]
+    struct ProductSeoRow {
+        seo_title: Option<String>,
+        seo_description: Option<String>,
+        seo_schema_json: Option<sqlx::types::Json<serde_json::Value>>,
+    }
+
+    let pool1 = pool.clone();
+    let pool2 = pool.clone();
+    let (site_id_res, seo_res) = tokio::join!(
+        async move {
+            sqlx::query_scalar::<_, Uuid>(
+                "SELECT id FROM builder_sites WHERE tenant_id = $1 ORDER BY created_at ASC LIMIT 1"
+            )
+            .bind(tenant_id)
+            .fetch_one(&pool1)
+            .await
+        },
+        async move {
+            sqlx::query_as::<_, ProductSeoRow>(
+                "SELECT seo_title, seo_description, seo_schema_json FROM products WHERE id = $1 AND tenant_id = $2"
+            )
+            .bind(product_id.to_string())
+            .bind(tenant_id.to_string())
+            .fetch_optional(&pool2)
+            .await
+        }
+    );
+
+    if let Ok(site_id) = site_id_res {
+        // Just call regenerate_cache from builder edge
+        if let Ok((mut html, tags)) = regenerate_cache(pool.clone(), tenant_id, site_id, cache_key.clone(), cache.clone()).await {
+
+            if let Ok(Some(row)) = seo_res {
+                if let Some(seo_title) = row.seo_title {
+                    if let Some(start) = html.find("<title>") {
+                        if let Some(end) = html[start..].find("</title>") {
+                            let end = start + end + "</title>".len();
+                            html.replace_range(start..end, &format!("<title>{}</title>\n<meta name=\"title\" content=\"{}\">", seo_title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"), seo_title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")));
+                        }
+                    }
+                }
+
+                if let Some(seo_desc) = row.seo_description {
+                    if let Some(start) = html.find("<meta name=\"description\"") {
+                        if let Some(end) = html[start..].find(">") {
+                            let end = start + end + ">".len();
+                            html.replace_range(start..end, &format!("<meta name=\"description\" content=\"{}\">", seo_desc.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")));
+                        }
+                    } else if let Some(head_end) = html.find("</head>") {
+                        html.insert_str(head_end, &format!("<meta name=\"description\" content=\"{}\">\n", seo_desc.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")));
+                    }
+                }
+
+                if let Some(seo_schema) = row.seo_schema_json {
+                    if let Some(start) = html.find("<script type=\"application/ld+json\">") {
+                        if let Some(end) = html[start..].find("</script>") {
+                            let end = start + end + "</script>".len();
+                            html.replace_range(start..end, &format!("<script type=\"application/ld+json\">\n{}\n</script>", serde_json::to_string(&seo_schema.0).unwrap_or_default()));
+                        }
+                    } else if let Some(head_end) = html.find("</head>") {
+                        html.insert_str(head_end, &format!("<script type=\"application/ld+json\">\n{}\n</script>\n", serde_json::to_string(&seo_schema.0).unwrap_or_default()));
+                    }
+                }
+            }
+
+            // Pre-warm the cache since SWR or cache miss just resolved
+            cache.set_with_tags(&cache_key, html.clone(), tags.clone(), std::time::Duration::from_secs(3600)).await;
+
+            return Ok((html, tags));
+        }
+    }
+    Err(axum::http::StatusCode::NOT_FOUND)
+}
+
 pub async fn regenerate_cache(
     pool: PgPool,
     tenant_id: Uuid,

--- a/src/server/orchestration/departments/marketing_agent.rs
+++ b/src/server/orchestration/departments/marketing_agent.rs
@@ -288,6 +288,12 @@ impl Department for MarketingAgent {
                                 cdn.invalidate_by_tag(&format!("tenant-id:{}", tenant_id_str)).await;
                                 cdn.invalidate_by_tag(&format!("entity:product:{}", product_id_str)).await;
 
+                                // Proactively pre-render the product cache
+                                if let Ok(product_uuid) = uuid::Uuid::parse_str(&product_id_str) {
+                                    let cache_key = format!("storefront:product:{}:{}", tenant_id, product_uuid);
+                                    let _ = crate::builder::edge::regenerate_product_cache(pool.clone(), tenant_id, product_uuid, cache_key, cache.clone()).await;
+                                }
+
                                 // Trigger site publish job for all sites for the tenant
                                 if let Ok(sites) = crate::builder::db::list_sites(&pool, tenant_id).await {
                                     for site in sites {

--- a/src/server/orchestration/departments/marketing_seo.rs
+++ b/src/server/orchestration/departments/marketing_seo.rs
@@ -10,7 +10,23 @@ pub struct RuntimeSeoClient;
 #[async_trait::async_trait]
 impl SeoClient for RuntimeSeoClient {
     async fn generate_seo_metadata(&self, name: &str, description: &str, item_type: &str, price: f64) -> Result<(String, String, serde_json::Value), String> {
-        // Mock SEO generation
+        let api_key = std::env::var("MINIMAX_API_KEY").unwrap_or_default();
+        if !api_key.is_empty() {
+            let minimax = crate::minimax::MinimaxClient::new(api_key);
+            let prompt = format!("You are an expert SEO AI. Generate SEO metadata for a {item_type} named '{name}' with description '{description}' priced at {price}. Return a JSON object with 'title', 'description', and a 'schema' object containing valid JSON-LD for schema.org/{item_type}. Only return the JSON object without markdown formatting blocks.");
+
+            if let Ok(res) = minimax.reason(&prompt).await {
+                let cleaned = res.trim().trim_start_matches("```json").trim_start_matches("```").trim_end_matches("```").trim();
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(cleaned) {
+                    let title = json.get("title").and_then(|v| v.as_str()).unwrap_or(name).to_string();
+                    let desc = json.get("description").and_then(|v| v.as_str()).unwrap_or(description).to_string();
+                    let schema = json.get("schema").cloned().unwrap_or_else(|| json!({}));
+                    return Ok((title, desc, schema));
+                }
+            }
+        }
+
+        // Fallback to basic SEO generation
         let title = format!("{} | Buy Online", name);
         let desc = format!("Purchase {} online. {}", name, description);
         let schema = json!({

--- a/src/server/services/cache_invalidator.rs
+++ b/src/server/services/cache_invalidator.rs
@@ -80,10 +80,10 @@ pub async fn start_cache_invalidator(pool: sqlx::PgPool) {
                         .fetch_one(&pool)
                         .await;
 
-                        if let Ok(site_id) = site_id_res {
+                        if let Ok(_site_id) = site_id_res {
                             info!("Pre-warming cache for product: {} tenant: {}", product_id, tenant_id);
                             let cache_key = format!("storefront:product:{}:{}", tenant_id, product_id);
-                            let _ = crate::builder::edge::regenerate_cache(pool.clone(), tenant_id, site_id, cache_key, edge_cache.clone()).await;
+                            let _ = crate::builder::edge::regenerate_product_cache(pool.clone(), tenant_id, product_id, cache_key, edge_cache.clone()).await;
                         }
                     }
                 }


### PR DESCRIPTION
Implemented Agentic SEO Pre-rendering and proactive Edge cache warming for products as requested in #33027.

- The `MarketingAgent` now generates SEO metadata using an LLM instead of using hardcoded mock values.
- `regenerate_product_cache` has been exposed to allow proactive pre-rendering of products.
- `MarketingAgent` and `CacheInvalidator` now call `regenerate_product_cache` immediately when a product is updated or created to ensure the fully rendered HTML (with injected SEO) is warmed up at the edge globally.

Resolves #33027.

---
*PR created automatically by Jules for task [7483043706311747605](https://jules.google.com/task/7483043706311747605) started by @ql-owo-lp*