### PR TITLE
fix: Redact sensitive payload information from action router tracing logs

### DIFF
--- a/src/server/domain/action_router.rs
+++ b/src/server/domain/action_router.rs
@@ -21,8 +21,8 @@ pub async fn dispatch_action(
         "supply_order" => {
             tracing::info!("Approved and dispatched supply order via Quartermaster Agent for tenant: {}", tenant_id); // pii-safe
             // Simulating outbound communication to vendor via omnichannel dispatcher
-            if let Some(msg) = payload.get("draft_message").and_then(|v| v.as_str()) {
-                tracing::info!("Omnichannel Dispatcher sent: {}", msg);
+            if let Some(_msg) = payload.get("draft_message").and_then(|v| v.as_str()) {
+                tracing::info!("Omnichannel Dispatcher sent: [REDACTED]");
             }
         }
         "social_post_draft" => {
@@ -46,16 +46,16 @@ pub async fn dispatch_action(
                 .map_err(|e| e.to_string())?;
         }
         "lead_recovery" => {
-            tracing::info!("Approved and recovered lead for tenant: {}", tenant_id);
-            if let Some(msg) = payload.get("draft_reply").and_then(|v| v.as_str()) {
-                tracing::info!("Lead Recovery Engine sent reply: {}", msg);
+            tracing::info!("Approved and recovered lead for tenant: {}", tenant_id); // pii-safe
+            if let Some(_msg) = payload.get("draft_reply").and_then(|v| v.as_str()) {
+                tracing::info!("Lead Recovery Engine sent reply: [REDACTED]");
             }
         }
         "dispute_resolution" => {
 
             tracing::info!("Approved and resolved dispute for tenant: {}", tenant_id); // pii-safe
-            if let Some(msg) = payload.get("generated_response").and_then(|v| v.as_str()) {
-                tracing::info!("Dispute Resolution Engine sent reply: {}", msg);
+            if let Some(_msg) = payload.get("generated_response").and_then(|v| v.as_str()) {
+                tracing::info!("Dispute Resolution Engine sent reply: [REDACTED]");
             }
             if let Some(refund) = payload.get("refund_amount").and_then(|v| v.as_f64()) {
                 tracing::info!("Dispute Resolution Engine processed simulated refund: ${}", refund);


### PR DESCRIPTION
**Hybrid Privacy Audit (PII Leakage in Multi-Tenant Environments)**

This pull request implements the required automated compliance guardrails to prevent Personally Identifiable Information (PII) leakage in multi-tenant environments.

### Changes
- Updated the tracing logs in `src/server/domain/action_router.rs` to replace potentially sensitive user-generated payload contents (`draft_message`, `draft_reply`, `generated_response`) with `[REDACTED]`.
- Prevented potential compiler warnings by renaming unused matched variables to `_msg`.
- Resolved failures detected by the `src/server/pii_leakage_check.sh` validation suite.

### Verifications Completed
- Executed local sovereignty validation tests (`telemetry_test.rs`).
- The `pii_leakage_check_test` suite now successfully passes.

---
*PR created automatically by Jules for task [5723605543775063398](https://jules.google.com/task/5723605543775063398) started by @ql-owo-lp*