### PR TITLE
🧙 Wizard: Improve onboarding domain validation and resolve compiler warning

### DIFF
--- a/src/e2e/tests/setup_wizard_optimization.spec.ts
+++ b/src/e2e/tests/setup_wizard_optimization.spec.ts
@@ -25,6 +25,16 @@ test.describe('Onboarding Wizard Optimization', () => {
     await expect(page.locator('#domain-error')).toBeVisible();
     await expect(page.locator('#domain-error')).toContainText('contain only lowercase letters');
 
+    await domainInput.fill('-invalid-leading-hyphen');
+    await page.locator('#step-domain .next-step-btn').click();
+    await expect(page.locator('#domain-error')).toBeVisible();
+    await expect(page.locator('#domain-error')).toContainText('cannot start or end with a hyphen');
+
+    await domainInput.fill('invalid-trailing-hyphen-');
+    await page.locator('#step-domain .next-step-btn').click();
+    await expect(page.locator('#domain-error')).toBeVisible();
+    await expect(page.locator('#domain-error')).toContainText('cannot start or end with a hyphen');
+
     await domainInput.fill('valid-domain-123');
     await page.locator('#step-domain .next-step-btn').click();
 

--- a/src/server/api/assistant.rs
+++ b/src/server/api/assistant.rs
@@ -1912,8 +1912,6 @@ mod real_feature_state_tests {
         crate::db::secure_pg_pool_options()
             .before_acquire(|conn, _meta| {
                 Box::pin(async move {
-                    use sqlx::Executor;
-
                     ::server_common::auth_utils::set_org_context(&mut *conn, "").await?;
                     Ok(true)
                 })
@@ -1921,7 +1919,6 @@ mod real_feature_state_tests {
             .after_release(|conn, _meta| {
                 Box::pin(async move {
                     use sqlx::Executor;
-
                     conn.execute("DISCARD ALL").await?;
                     Ok(true)
                 })

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -3312,9 +3312,9 @@
             state.target_audience = inputs.target_audience.value.trim();
           }
         } else if (stepId === "step-domain") {
-          const domainRegex = /^[a-z0-9-]+$/;
+          const domainRegex = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
           if (inputs.domain_name.value.trim().length < 3 || !domainRegex.test(inputs.domain_name.value.trim())) {
-            document.getElementById("domain-error").innerText = "Domain must be at least 3 characters and contain only lowercase letters, numbers, and hyphens.";
+            document.getElementById("domain-error").innerText = "Domain must be at least 3 characters, contain only lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen.";
             document.getElementById("domain-error").style.display = "flex";
             inputs.domain_name.classList.add("invalid-input");
             isValid = false;


### PR DESCRIPTION
This PR addresses an issue where the domain name validation in the onboarding wizard allowed domains with leading or trailing hyphens. The regex was updated to prevent this and tests were added to ensure the validation works correctly. It also fixes a Rust compiler warning caused by an unused import in the backend codebase.

---
*PR created automatically by Jules for task [698100001526565036](https://jules.google.com/task/698100001526565036) started by @ql-owo-lp*