### PR TITLE
fix(db): Do not retry on non-retryable syntax errors

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -772,6 +772,11 @@ impl DB {
                 Ok(Ok(val)) => return Ok(val),
                 Ok(Err(err)) => {
                     let err_str = err.to_string().to_lowercase();
+
+                    if err_str.contains("syntax error") || err_str.contains("42601") {
+                        return Err(err);
+                    }
+
                     let is_sqlite_lock = self.is_sqlite()
                         && (err_str.contains("database is locked")
                             || err_str.contains("sqlite_busy"));


### PR DESCRIPTION
The system was retrying on syntax errors, which are inherently non-retryable. This commit introduces fail-fast behavior when `err.to_string()` contains "syntax error" or "42601" (the Postgres error code for syntax errors), preventing pointless retries and aligning with the chaos testing expected behaviors.

---
*PR created automatically by Jules for task [5196333738858979354](https://jules.google.com/task/5196333738858979354) started by @ql-owo-lp*