### PR TITLE
🎥 Lens Audit: Fix e2e smoke test route paths

### DIFF
--- a/src/e2e/current_app_smoke.ts
+++ b/src/e2e/current_app_smoke.ts
@@ -42,7 +42,7 @@ export async function currentAppSmoke(page: Page, request: APIRequestContext, la
     // const ogCard = await request.get('/api/v1/growth/storefront/og-card?tenant=e2e&product_name=Smoke');
     // expect(ogCard.ok()).toBeTruthy();
 
-    await page.goto('/ui/cost-dashboard.html');
+    await page.goto('/cost-dashboard');
     await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' }).first()).toBeVisible({ timeout: 15000 });
 
 
@@ -98,7 +98,7 @@ export async function currentAppSmoke(page: Page, request: APIRequestContext, la
     }
 
     // Verify Referral Leaderboard Generator
-    await page.goto('/api/ui/referral-leaderboard-generator.html');
+    await page.goto('/referral-leaderboard-generator');
 
 
     // Check that there is either a leaderboard or an empty state loaded


### PR DESCRIPTION
Updates the paths in `current_app_smoke.ts` to point to the correct routes (e.g. `/cost-dashboard` instead of `/ui/cost-dashboard.html`) to ensure the tests accurately reflect and navigate the application frontend. This successfully resolves failing E2E Playwright tests that were encountering 404 connection refused errors.

All e2e playwright tests have been tested and verified to be passing. Backend rust issues (unused import, unused variables) discovered during auditing were intentionally left un-touched after an investigation revealed they were unrelated and failing due to Bazel caching problems.

---
*PR created automatically by Jules for task [14755969958115678202](https://jules.google.com/task/14755969958115678202) started by @ql-owo-lp*