### PR TITLE
🛡️ Sentry: [reliability fix] ensure db executes strictly up to 3 attempts

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -52,7 +52,7 @@ macro_rules! validate_tenant_id_sqlx {
 static GLOBAL_POOL: OnceLock<PgPool> = OnceLock::new();
 const POSTGRES_MIGRATION_LOCK_KEY: i64 = 0x4f48_435f_4d49_4752;
 
-pub const MAX_DB_RETRY_ATTEMPTS: u32 = 3;
+pub const MAX_DB_RETRY_ATTEMPTS: u32 = 2;
 
 pub fn secure_pg_pool_options() -> sqlx::postgres::PgPoolOptions {
     sqlx::postgres::PgPoolOptions::new()

--- a/src/server/orchestration/state/parity_test.rs
+++ b/src/server/orchestration/state/parity_test.rs
@@ -816,8 +816,8 @@ mod parity_tests {
 
         assert!(res.is_err());
         assert!(res.unwrap_err().contains("Database retry exhausted"));
-        // execute_with_retry makes 1 initial attempt + 2 retries (max_attempts = 3)
-        assert_eq!(*attempts.lock().unwrap(), 4);
+        // execute_with_retry makes 1 initial attempt + 2 retries (max_attempts = 2)
+        assert_eq!(*attempts.lock().unwrap(), 3);
 
         let pg_db = setup_postgres_db().await;
         if let Some(db) = pg_db {
@@ -835,7 +835,7 @@ mod parity_tests {
 
             assert!(res.is_err());
             assert!(res.unwrap_err().contains("Database retry exhausted"));
-            assert_eq!(*attempts.lock().unwrap(), 4);
+            assert_eq!(*attempts.lock().unwrap(), 3);
         }
     }
 


### PR DESCRIPTION
# Spec: ML-Resilience 60-Second Timeout Rule
The ML-Resilience rules require that AI agent jobs have a 60-second timeout with automatic retry (max 3 attempts). 
This PR changes `MAX_DB_RETRY_ATTEMPTS` to `2` to ensure a total of exactly 3 attempts (1 initial + 2 retries) are made for database operation failures. It also updates the corresponding assertions in `src/server/orchestration/state/parity_test.rs` to reflect this count.

Superpowers loaded: none required beyond standard testing practices.

Product-use evidence: I manually audited the ML-Resilience spec which explicitly stated that max 3 attempts should be utilized. I observed that `MAX_DB_RETRY_ATTEMPTS` was 3 causing a total of 4 attempts (1 initial + 3 retries). I addressed this to match the spec and ensured tests reflect this behaviour accurately.

Tests successfully pass.

---
*PR created automatically by Jules for task [9760144153369450469](https://jules.google.com/task/9760144153369450469) started by @ql-owo-lp*