### PR TITLE
fix(onboarding): show correct Draft Saved text

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -4121,7 +4121,7 @@
             window.__TAURI__.core
               .invoke("save_onboarding_state", { state, tenantId, userId })
               .then(() => {
-                e.target.innerText = "Saved!";
+                e.target.innerText = "Draft Saved!";
                 setTimeout(() => {
                   e.target.innerText = originalText;
                   e.target.disabled = false;
@@ -4147,7 +4147,7 @@
             })
               .then((res) => {
                 if (res.ok) {
-                  e.target.innerText = "Saved!";
+                  e.target.innerText = "Draft Saved!";
                   setTimeout(() => {
                     e.target.innerText = originalText;
                     e.target.disabled = false;


### PR DESCRIPTION
## Problem
The `setup.spec.ts` test was failing because it expected the `save-draft-btn` text to change to `"Draft Saved!"` upon saving, but it was being set to `"Saved!"` in `setup.html`.

## Solution
Updated the `save_onboarding_state` success handlers in `setup.html` (both Tauri backend and fallback paths) to set the button text to `"Draft Saved!"`.

## Evidence
`npx playwright test src/e2e/setup.spec.ts` now passes smoothly.

---
*PR created automatically by Jules for task [11521260522020729375](https://jules.google.com/task/11521260522020729375) started by @ql-owo-lp*