### PR TITLE
feat: add WithTooltip wrapper to in-app help center elements

### DIFF
--- a/src/ui/next/src/app/help/page.tsx
+++ b/src/ui/next/src/app/help/page.tsx
@@ -137,7 +137,12 @@ export default function HelpCenterPage() {
 
             {advancedArticles.length > 0 && (
               <div className="pt-8">
-                <div className="border-t border-gray-200/50 pt-8 mt-4"><button onClick={() => setIsAdvancedOpen(!isAdvancedOpen)} className="flex items-center text-gray-500 hover:text-gray-900 transition-colors duration-200"><span className="text-lg font-bold font-outfit mr-2">Advanced</span><svg className={`w-5 h-5 transform transition-transform duration-200 ${isAdvancedOpen ? 'rotate-180' : ' '}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg></button>{isAdvancedOpen && (<motion.div className="pt-6" initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.3 }}><ArticleSections articles={advancedArticles} hoverBg="hover:bg-white/80" /></motion.div>)}</div>
+                <div className="border-t border-gray-200/50 pt-8 mt-4">
+                  <WithTooltip id="help-advanced-toggle-tooltip" defaultText="Show advanced developer options">
+                    <button onClick={() => setIsAdvancedOpen(!isAdvancedOpen)} className="flex items-center text-gray-500 hover:text-gray-900 transition-colors duration-200"><span className="text-lg font-bold font-outfit mr-2">Advanced</span><svg className={`w-5 h-5 transform transition-transform duration-200 ${isAdvancedOpen ? 'rotate-180' : ' '}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg></button>
+                  </WithTooltip>
+                  {isAdvancedOpen && (<motion.div className="pt-6" initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.3 }}><ArticleSections articles={advancedArticles} hoverBg="hover:bg-white/80" /></motion.div>)}
+                </div>
               </div>
             )}
           </div>

--- a/src/ui/next/src/components/VideoTutorialList.test.tsx
+++ b/src/ui/next/src/components/VideoTutorialList.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { VideoTutorialList } from './VideoTutorialList';
+import { TooltipProvider } from './TooltipRegistry';
 
 describe('VideoTutorialList', () => {
   beforeEach(() => {
@@ -126,7 +127,11 @@ describe('VideoTutorialList', () => {
       ])
     });
 
-    render(<VideoTutorialList />);
+    render(
+      <TooltipProvider>
+        <VideoTutorialList />
+      </TooltipProvider>
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Modal Video')).toBeInTheDocument();

--- a/src/ui/next/src/components/VideoTutorialList.tsx
+++ b/src/ui/next/src/components/VideoTutorialList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from 'react';
+import { WithTooltip } from './TooltipRegistry';
 
 type VideoTutorial = {
   id: number;
@@ -130,9 +131,11 @@ export function VideoTutorialList({
             {/* Header */}
             <div className="absolute top-0 left-0 right-0 p-4 bg-gradient-to-b from-black/90 to-transparent z-10 flex justify-between items-start pt-6">
               <h3 className="text-white font-bold font-outfit text-base pr-4 line-clamp-2 drop-shadow-md leading-tight">{activeVideo.title}</h3>
-              <button onClick={() => setActiveVideo(null)} className="text-white/80 hover:text-white bg-white/20 hover:bg-white/30 backdrop-blur-[30px] saturate-[210%] border border-white/20 rounded-full p-2 transition-all min-h-[44px] min-w-[44px] flex items-center justify-center flex-shrink-0" aria-label="Close video">
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
-              </button>
+              <WithTooltip id="video-close-btn-tooltip" defaultText="Close video player">
+                <button onClick={() => setActiveVideo(null)} className="text-white/80 hover:text-white bg-white/20 hover:bg-white/30 backdrop-blur-[30px] saturate-[210%] border border-white/20 rounded-full p-2 transition-all min-h-[44px] min-w-[44px] flex items-center justify-center flex-shrink-0" aria-label="Close video">
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+                </button>
+              </WithTooltip>
             </div>
 
             {/* Real Video Player area */}

--- a/src/ui/next/src/components/help.tsx
+++ b/src/ui/next/src/components/help.tsx
@@ -417,13 +417,15 @@ export function HelpWidget() {
             {/* Header */}
             <div className="absolute top-0 left-0 right-0 p-4 bg-gradient-to-b from-black/90 to-transparent z-10 flex justify-between items-start pt-6">
               <h3 className="text-white font-bold font-outfit text-base pr-4 line-clamp-2 drop-shadow-md leading-tight">{activeVideo.title}</h3>
-              <button
-                onClick={() => setActiveVideo(null)}
-                className="text-white/80 hover:text-white bg-white/20 hover:bg-white/30 backdrop-blur-3xl saturate-[210%] border border-white/20 rounded-full p-2 transition-all min-h-[44px] min-w-[44px] flex items-center justify-center flex-shrink-0"
-                aria-label="Close video"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
-              </button>
+              <WithTooltip id="video-close-btn-tooltip" defaultText="Close video player">
+                <button
+                  onClick={() => setActiveVideo(null)}
+                  className="text-white/80 hover:text-white bg-white/20 hover:bg-white/30 backdrop-blur-3xl saturate-[210%] border border-white/20 rounded-full p-2 transition-all min-h-[44px] min-w-[44px] flex items-center justify-center flex-shrink-0"
+                  aria-label="Close video"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+                </button>
+              </WithTooltip>
             </div>
 
             {/* Real Video Player area */}


### PR DESCRIPTION
Adds `WithTooltip` to missing interactive elements across the help center documentation components (`app/help/page.tsx`, `components/VideoTutorialList.tsx`, `components/help.tsx`) to adhere to the mandate that non-obvious UI elements must have tooltips. Tests updated to match changes.

---
*PR created automatically by Jules for task [17177455097328379720](https://jules.google.com/task/17177455097328379720) started by @ql-owo-lp*