### PR TITLE
💰 Miser: Fix budget health alert visibility and dashboard cache invalidation

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -115,6 +115,13 @@ pub async fn report_cost_handler(
     if req.metric_name == "ohc_llm_cost_total_cents" {
         let agent_id = req.labels.get("agent_id").map(|s| s.as_str()).unwrap_or("unknown_agent");
         hub.get_cost_auditor().record_manual_cost(agent_id, &tenant_id, req.value);
+        if let Some(cache) = COST_DASHBOARD_CACHE.get() {
+            let cache_clone = cache.clone();
+            let tenant_id_clone = tenant_id.clone();
+            tokio::spawn(async move {
+                cache_clone.invalidate(&tenant_id_clone).await;
+            });
+        }
     }
 
     let pool = crate::db::get_pool();

--- a/src/ui/tauri/src/ui/cost-dashboard.html
+++ b/src/ui/tauri/src/ui/cost-dashboard.html
@@ -323,7 +323,7 @@
                </div>
             </div>
 
-            <div class="glassmorphism" id="budget-health-alert" style="display: flex; margin-top: 20px; padding: 16px; background: rgba(254, 252, 232, 0.65); border: 1px solid rgba(253, 230, 138, 0.5); align-items: flex-start; gap: 12px;">
+            <div class="glassmorphism" id="budget-health-alert" style="display: none; margin-top: 20px; padding: 16px; background: rgba(254, 252, 232, 0.65); border: 1px solid rgba(253, 230, 138, 0.5); align-items: flex-start; gap: 12px;">
                 <svg style="width: 24px; height: 24px; color: #d97706; flex-shrink: 0; margin-top: 2px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>


### PR DESCRIPTION
💰 Miser: Fix budget health alert visibility and dashboard cache invalidation

* Hide `budget-health-alert` element by default in `src/ui/tauri/src/ui/cost-dashboard.html`. The element is properly set to display `flex` by javascript when `budget_health_alert` boolean in response is true.
* Invalidate `COST_DASHBOARD_CACHE` upon reporting manual costs via `/api/billing/report-cost` endpoint. This guarantees accurate display when soft limits are tested in E2E tests and production usage.

---
*PR created automatically by Jules for task [7763096471754773419](https://jules.google.com/task/7763096471754773419) started by @ql-owo-lp*