### PR TITLE
⚡ Bolt: Mobile Payload Optimization for UI Triage feed

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -4798,11 +4798,26 @@ async fn load_ui_triage_from_db(db: &crate::db::DB, tenant_id: &str, mobile_opti
             let mut legacy_rows_json = Vec::new();
             match &db1.store {
                 crate::db::DbStore::Postgres => {
-                    let query_str = "SELECT id, tenant_id, customer_id, source, priority, context, status, CAST(created_at AS text) AS created_at, action_type, action_payload FROM (SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.context, t.status, t.created_at, a.action_type, a.payload AS action_payload FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id UNION ALL SELECT a.id, a.tenant_id, t.customer_id, t.channel AS source, 'normal' AS priority, (SELECT content FROM unified_messages WHERE thread_id = t.id ORDER BY created_at DESC LIMIT 1) AS context, a.status, a.created_at, a.action_type, a.action_payload FROM unified_triage_actions a JOIN unified_threads t ON a.thread_id = t.id) sub WHERE tenant_id = $1 AND status != 'resolved' AND status != 'dismissed' ORDER BY created_at DESC LIMIT 50";
-                    if let Ok(rows) = sqlx::query(query_str).bind(&t_id1).fetch_all(&db1.pool).await {
-                        for row in rows {
-                            use sqlx::Row;
-                            let item = serde_json::json!({
+                    if mobile_optimized {
+                        let query_str = "SELECT id, status, CAST(created_at AS text) AS created_at, action_type FROM (SELECT t.id, t.tenant_id, t.status, t.created_at, a.action_type FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id UNION ALL SELECT a.id, a.tenant_id, a.status, a.created_at, a.action_type FROM unified_triage_actions a JOIN unified_threads t ON a.thread_id = t.id) sub WHERE tenant_id = $1 AND status != 'resolved' AND status != 'dismissed' ORDER BY created_at DESC LIMIT 50";
+                        if let Ok(rows) = sqlx::query(query_str).bind(&t_id1).fetch_all(&db1.pool).await {
+                            for row in rows {
+                                use sqlx::Row;
+                                let item = serde_json::json!({
+                                    "id": row.get::<String, _>("id"),
+                                    "status": row.try_get::<String, _>("status").unwrap_or_default(),
+                                    "created_at": match row.try_get::<chrono::DateTime<chrono::Utc>, _>("created_at") { Ok(dt) => dt.to_rfc3339(), Err(_) => "".to_string() },
+                                    "action_type": row.try_get::<String, _>("action_type").unwrap_or_default(),
+                                });
+                                legacy_rows_json.push(item);
+                            }
+                        }
+                    } else {
+                        let query_str = "SELECT id, tenant_id, customer_id, source, priority, context, status, CAST(created_at AS text) AS created_at, action_type, action_payload FROM (SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.context, t.status, t.created_at, a.action_type, a.payload AS action_payload FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id UNION ALL SELECT a.id, a.tenant_id, t.customer_id, t.channel AS source, 'normal' AS priority, (SELECT content FROM unified_messages WHERE thread_id = t.id ORDER BY created_at DESC LIMIT 1) AS context, a.status, a.created_at, a.action_type, a.action_payload FROM unified_triage_actions a JOIN unified_threads t ON a.thread_id = t.id) sub WHERE tenant_id = $1 AND status != 'resolved' AND status != 'dismissed' ORDER BY created_at DESC LIMIT 50";
+                        if let Ok(rows) = sqlx::query(query_str).bind(&t_id1).fetch_all(&db1.pool).await {
+                            for row in rows {
+                                use sqlx::Row;
+                                let item = serde_json::json!({
                                     "id": row.get::<String, _>("id"),
                                     "tenant_id": row.get::<String, _>("tenant_id"),
                                     "customer_id": row.try_get::<String, _>("customer_id").unwrap_or_default(),
@@ -4813,17 +4828,33 @@ async fn load_ui_triage_from_db(db: &crate::db::DB, tenant_id: &str, mobile_opti
                                     "created_at": match row.try_get::<chrono::DateTime<chrono::Utc>, _>("created_at") { Ok(dt) => dt.to_rfc3339(), Err(_) => "".to_string() },
                                     "action_type": row.try_get::<String, _>("action_type").unwrap_or_default(),
                                     "action_payload": row.try_get::<String, _>("action_payload").unwrap_or_default(),
-                            });
-                            legacy_rows_json.push(item);
+                                });
+                                legacy_rows_json.push(item);
+                            }
                         }
                     }
                 }
                 crate::db::DbStore::Sqlite(pool) => {
-                    let query_str = "SELECT id, tenant_id, customer_id, source, priority, context, status, CAST(created_at AS TEXT) AS created_at, action_type, action_payload FROM (SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.context, t.status, t.created_at, a.action_type, a.payload AS action_payload FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id UNION ALL SELECT a.id, a.tenant_id, t.customer_id, t.channel AS source, 'normal' AS priority, (SELECT content FROM unified_messages WHERE thread_id = t.id ORDER BY created_at DESC LIMIT 1) AS context, a.status, a.created_at, a.action_type, a.action_payload FROM unified_triage_actions a JOIN unified_threads t ON a.thread_id = t.id) sub WHERE tenant_id = ? AND status != 'resolved' AND status != 'dismissed' ORDER BY created_at DESC LIMIT 50";
-                    if let Ok(rows) = sqlx::query(query_str).bind(&t_id1).fetch_all(pool).await {
-                        for row in rows {
-                            use sqlx::Row;
-                            let item = serde_json::json!({
+                    if mobile_optimized {
+                        let query_str = "SELECT id, status, CAST(created_at AS TEXT) AS created_at, action_type FROM (SELECT t.id, t.tenant_id, t.status, t.created_at, a.action_type FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id UNION ALL SELECT a.id, a.tenant_id, a.status, a.created_at, a.action_type FROM unified_triage_actions a JOIN unified_threads t ON a.thread_id = t.id) sub WHERE tenant_id = ? AND status != 'resolved' AND status != 'dismissed' ORDER BY created_at DESC LIMIT 50";
+                        if let Ok(rows) = sqlx::query(query_str).bind(&t_id1).fetch_all(pool).await {
+                            for row in rows {
+                                use sqlx::Row;
+                                let item = serde_json::json!({
+                                    "id": row.get::<String, _>("id"),
+                                    "status": row.try_get::<String, _>("status").unwrap_or_default(),
+                                    "created_at": match row.try_get::<chrono::DateTime<chrono::Utc>, _>("created_at") { Ok(dt) => dt.to_rfc3339(), Err(_) => "".to_string() },
+                                    "action_type": row.try_get::<String, _>("action_type").unwrap_or_default(),
+                                });
+                                legacy_rows_json.push(item);
+                            }
+                        }
+                    } else {
+                        let query_str = "SELECT id, tenant_id, customer_id, source, priority, context, status, CAST(created_at AS TEXT) AS created_at, action_type, action_payload FROM (SELECT t.id, t.tenant_id, t.customer_id, t.source, t.priority, t.context, t.status, t.created_at, a.action_type, a.payload AS action_payload FROM triage_items t LEFT JOIN triage_proposed_actions a ON t.id = a.triage_item_id UNION ALL SELECT a.id, a.tenant_id, t.customer_id, t.channel AS source, 'normal' AS priority, (SELECT content FROM unified_messages WHERE thread_id = t.id ORDER BY created_at DESC LIMIT 1) AS context, a.status, a.created_at, a.action_type, a.action_payload FROM unified_triage_actions a JOIN unified_threads t ON a.thread_id = t.id) sub WHERE tenant_id = ? AND status != 'resolved' AND status != 'dismissed' ORDER BY created_at DESC LIMIT 50";
+                        if let Ok(rows) = sqlx::query(query_str).bind(&t_id1).fetch_all(pool).await {
+                            for row in rows {
+                                use sqlx::Row;
+                                let item = serde_json::json!({
                                     "id": row.get::<String, _>("id"),
                                     "tenant_id": row.get::<String, _>("tenant_id"),
                                     "customer_id": row.try_get::<String, _>("customer_id").unwrap_or_default(),
@@ -4834,8 +4865,9 @@ async fn load_ui_triage_from_db(db: &crate::db::DB, tenant_id: &str, mobile_opti
                                     "created_at": match row.try_get::<chrono::DateTime<chrono::Utc>, _>("created_at") { Ok(dt) => dt.to_rfc3339(), Err(_) => "".to_string() },
                                     "action_type": row.try_get::<String, _>("action_type").unwrap_or_default(),
                                     "action_payload": row.try_get::<String, _>("action_payload").unwrap_or_default(),
-                            });
-                            legacy_rows_json.push(item);
+                                });
+                                legacy_rows_json.push(item);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This commit addresses a mobile payload optimization opportunity in `load_ui_triage_from_db`.

When `mobile_optimized=true` is requested via query string, the handler now executes a slimmed-down SQL query (in both PostgreSQL and SQLite implementations) fetching only `id, status, created_at, action_type`, instead of the full unified thread context, `action_payload`, and other details.

This minimizes over-fetching for mobile connections, saving bandwidth and lowering DB query processing times. Verified locally through `server_benchmarks_unit_test`.

---
*PR created automatically by Jules for task [3336514939327934384](https://jules.google.com/task/3336514939327934384) started by @ql-owo-lp*