### PR TITLE
fix: Use Next.js route for Cost Dashboard in E2E Tests

### DIFF
--- a/src/e2e/cost_dashboard_ui.spec.ts
+++ b/src/e2e/cost_dashboard_ui.spec.ts
@@ -5,7 +5,7 @@ test.describe('Cost Dashboard & Plan Limits UI', () => {
     await loginAs(page, adminUser);
 
     // Navigate to the Cost Dashboard directly
-    await page.goto('/ui/cost-dashboard.html');
+    await page.goto('/cost-dashboard');
 
     // Wait for the main heading to be visible
     await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' }).first()).toBeVisible({ timeout: 15000 });
@@ -32,7 +32,7 @@ test.describe('Cost Dashboard & Plan Limits UI', () => {
     // Set viewport to 375px width (iPhone SE size)
     await page.setViewportSize({ width: 375, height: 667 });
 
-    await page.goto('/ui/cost-dashboard.html');
+    await page.goto('/cost-dashboard');
 
     // Verify main widget renders
     await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' }).first()).toBeVisible({ timeout: 15000 });
@@ -146,8 +146,8 @@ test.describe('Cost Dashboard & Plan Limits UI', () => {
     await viewDetailedCostsBtn.click();
 
     // Wait for URL to update
-    await page.waitForURL('**/ui/cost-dashboard.html');
-    expect(page.url()).toContain('/ui/cost-dashboard.html');
+    await page.waitForURL('**/cost-dashboard');
+    expect(page.url()).toContain('/cost-dashboard');
 
     // Now Cost Dashboard is visible
     await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' }).first()).toBeVisible({ timeout: 15000 });

--- a/src/e2e/miser_cost_features.spec.ts
+++ b/src/e2e/miser_cost_features.spec.ts
@@ -6,7 +6,7 @@ test.describe('Miser Cost Features E2E', () => {
     await loginAs(page, adminUser);
 
     // Navigate to the Cost Dashboard
-    await page.goto('/ui/cost-dashboard.html');
+    await page.goto('/cost-dashboard');
 
     // Wait for the main headings
     await expect(page.locator('text=Cost Transparency Dashboard')).toBeVisible({ timeout: 15000 });
@@ -154,7 +154,7 @@ test.describe('Miser Cost Features E2E', () => {
         }
     });
 
-    await page.goto('/ui/cost-dashboard.html');
+    await page.goto('/cost-dashboard');
 
     // The threshold should trigger given a $2,000 spend on the Starter plan.
     await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' })).toBeVisible({ timeout: 15000 });

--- a/src/e2e/my_plan_dashboard.spec.ts
+++ b/src/e2e/my_plan_dashboard.spec.ts
@@ -24,13 +24,13 @@ test.describe('My Plan and Cost Dashboard Screens', () => {
     const detailedCostsButton = page.locator('button', { hasText: 'View Detailed Costs' });
     await expect(detailedCostsButton).toBeVisible();
     await detailedCostsButton.click();
-    await page.waitForURL('**/ui/cost-dashboard.html');
-    await expect(page.url()).toContain('/ui/cost-dashboard.html');
+    await page.waitForURL('**/cost-dashboard');
+    await expect(page.url()).toContain('/cost-dashboard');
   });
 
   test('Cost Dashboard screen metrics are visible', async ({ page }) => {
     // Go directly to Cost Dashboard
-    await page.goto('/ui/cost-dashboard.html');
+    await page.goto('/cost-dashboard');
 
     // Check core metric elements visibility
     await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' })).toBeVisible({ timeout: 10000 });

--- a/src/e2e/tauri_billing.spec.ts
+++ b/src/e2e/tauri_billing.spec.ts
@@ -13,7 +13,7 @@ test.describe('Tauri Billing & Pricing UI', () => {
       localStorage.setItem('token', 'e2e-dummy-token');
     });
 
-    await page.goto(`/ui/cost-dashboard.html`);
+    await page.goto(`/cost-dashboard`);
 
     await expect(page.locator('h1', { hasText: 'My Plan' }).first()).toBeVisible({ timeout: 10000 });
     await expect(page.locator('h2', { hasText: 'Your Current Usage' })).toBeVisible();

--- a/src/e2e/test_billing_limits.spec.ts
+++ b/src/e2e/test_billing_limits.spec.ts
@@ -13,7 +13,7 @@ test('Cost Soft Limit friendly prompt shows', async ({ page, loginAs, unlimitedA
       }
   });
 
-  await page.goto('/ui/cost-dashboard.html', { waitUntil: 'load' });
+  await page.goto('/cost-dashboard', { waitUntil: 'load' });
 
   // Wait for a core UI element proving the page actually mounted
   await expect(page.locator('h1', { hasText: 'Cost Transparency Dashboard' })).toBeVisible({ timeout: 25000 });

--- a/src/e2e/test_services_billing.spec.ts
+++ b/src/e2e/test_services_billing.spec.ts
@@ -35,10 +35,10 @@ test.describe('Billing Services & Plan Limits E2E', () => {
     await page.goto('/plan');
     // await page.waitForLoadState('networkidle'); // Removed due to timeout in mock server env
 
-    // 4. Click View Detailed Costs and assert navigation to /ui/cost-dashboard.html
+    // 4. Click View Detailed Costs and assert navigation to /cost-dashboard
     await page.getByRole('button', { name: 'View Detailed Costs' }).click();
     // await page.waitForLoadState('networkidle'); // Removed due to timeout in mock server env
-    await expect(page).toHaveURL(/\/ui\/cost-dashboard\.html/);
+    await expect(page).toHaveURL(/\/cost-dashboard/);
     await expect(page.getByRole('button', { name: 'Download Invoice' })).toBeVisible({ timeout: 10000 });
   });
 
@@ -69,7 +69,7 @@ test.describe('Billing Services & Plan Limits E2E', () => {
   test('Cost Dashboard renders core metrics and handles interactions', async ({ page, adminUser, loginAs }) => {
     await loginAs(page, adminUser);
 
-    await page.goto('/ui/cost-dashboard.html');
+    await page.goto('/cost-dashboard');
     // await page.waitForLoadState('networkidle'); // Removed due to timeout in mock server env
 
     // Set viewport to a mobile size

--- a/src/e2e/tests/cost_dashboard.spec.ts
+++ b/src/e2e/tests/cost_dashboard.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '../fixtures';
 test.describe('Cost Transparency Dashboard CUJ', () => {
     test('owner can view their tier limits and storage usage', async ({ page }) => {
         // 1. Navigate to cost dashboard
-        await page.goto('/ui/cost-dashboard.html');
+        await page.goto('/cost-dashboard');
 
         // 2. Wait for the billing summary to load
         await expect(page.locator('#cost-dashboard-plan-name')).not.toHaveText('--', { timeout: 10000 });


### PR DESCRIPTION
The Playwright E2E test files were referencing a deprecated HTML path \`/ui/cost-dashboard.html\` instead of the actual dynamic route \`/cost-dashboard\`. NextJS routes do not have the `.html` extension, causing connection refused and 404 failures. This patch updates all tests to navigate and assert the correct URL.

---
*PR created automatically by Jules for task [2399947660569327677](https://jules.google.com/task/2399947660569327677) started by @ql-owo-lp*