### PR TITLE
fix: proxy safe-to-spend to backend to fix CFOAgentCard

### DIFF
--- a/src/e2e/tests/cfo_agent_card.spec.ts
+++ b/src/e2e/tests/cfo_agent_card.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('CFOAgentCard Integration', () => {
+  test('should load safe-to-spend data correctly on the dashboard', async ({ page }) => {
+    // Navigate to the dashboard. The stack (frontend and backend) should be running,
+    // so we should not mock anything here and rely on the actual response.
+    // Explicitly add baseURL from environment or hardcode to 8080 if not set,
+    // as it seems Playwright baseURL is somehow not picked up in this standalone test.
+    const baseUrl = process.env.BASE_URL || 'http://127.0.0.1:8080';
+    await page.goto(`${baseUrl}/dashboard`);
+
+    // Wait for the page to load the component title
+    await page.waitForSelector('text=Profit & Tax Card', { timeout: 10000 });
+
+    // Verify the structure of the CFOAgentCard
+    await expect(page.locator('text=Money In')).toBeVisible();
+    await expect(page.locator('text=Money Out')).toBeVisible();
+    await expect(page.locator('text=Estimated Tax Safe')).toBeVisible();
+
+    // Verify there are $ figures present
+    const moneyMatch = page.locator('text=/\\$\\d+\\.\\d{2}/');
+    await expect(moneyMatch.first()).toBeVisible();
+  });
+});

--- a/src/ui/next/src/app/api/finance/safe-to-spend/route.test.ts
+++ b/src/ui/next/src/app/api/finance/safe-to-spend/route.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+describe("GET /api/finance/safe-to-spend", () => {
+  beforeEach(() => {
+    vi.stubEnv("BACKEND_URL", "http://backend.internal");
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("forwards the request to the Rust backend", async () => {
+    const backendResponse = {
+      money_in: 500,
+      money_out: 100,
+      tax_safe: 50,
+    };
+    (global.fetch as any).mockResolvedValueOnce({
+      status: 200,
+      json: async () => backendResponse,
+    });
+
+    const request = new Request("http://localhost/api/finance/safe-to-spend");
+    const response = await GET(request);
+    expect(response.status).toBe(200);
+
+    const json = await response.json();
+    expect(json).toEqual(backendResponse);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://backend.internal/api/v1/payments/ledger/api/finance/safe-to-spend",
+      expect.objectContaining({
+        method: "GET",
+      })
+    );
+  });
+});

--- a/src/ui/next/src/app/api/finance/safe-to-spend/route.ts
+++ b/src/ui/next/src/app/api/finance/safe-to-spend/route.ts
@@ -1,0 +1,5 @@
+import { proxyBackendGet } from "../../ui/backendProxy";
+
+export async function GET(req: Request) {
+  return proxyBackendGet(req, "/api/v1/payments/ledger/api/finance/safe-to-spend");
+}

--- a/src/ui/next/src/app/dashboard/CFOAgentCard.test.tsx
+++ b/src/ui/next/src/app/dashboard/CFOAgentCard.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { CFOAgentCard } from "./CFOAgentCard";
+
+describe("CFOAgentCard", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  it("renders safe to spend data", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        money_in: 500,
+        money_out: 100,
+        tax_safe: 50,
+      }),
+    });
+
+    render(<CFOAgentCard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Profit & Tax Card")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("$500.00")).toBeInTheDocument();
+    expect(screen.getByText("$100.00")).toBeInTheDocument();
+    expect(screen.getByText("$50.00")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
The `CFOAgentCard` component tried to fetch safe-to-spend data from `/api/finance/safe-to-spend`, which was returning a 404 since the route didn't exist in the Next.js API router.

This adds a Next.js proxy route under `src/app/api/finance/safe-to-spend/route.ts` that points to the correct Rust backend URL `/api/v1/payments/ledger/api/finance/safe-to-spend` established via `.nest` and `.route`.

Also added:
- Unit test for the new proxy route
- Unit test for the `CFOAgentCard` component
- End-to-end (E2E) Playwright test for `CFOAgentCard` to verify the page layout values load correctly on the dashboard.

---
*PR created automatically by Jules for task [1270994933249443860](https://jules.google.com/task/1270994933249443860) started by @ql-owo-lp*