### PR TITLE
🤖 Implementer: Harness Upgrade - Anthropic 3-Tier Memory in SQLite FTS5 store

### DIFF
--- a/src/agents/builtin/sqlite_memory.rs
+++ b/src/agents/builtin/sqlite_memory.rs
@@ -1,5 +1,6 @@
-/// Master Catalog B.3. Memory: Long-term (OpenAI/LangGraph): Sessions backed by SQLite/Redis, or namespace-organized JSON Stores. Hermes Agent Unique Harness Innovations: FTS5 session search: Cross-session recall with LLM summarization.
 use crate::memory_store::LongTermMemory;
+/// Master Catalog B.3. Memory: Long-term (OpenAI/LangGraph): Sessions backed by SQLite/Redis, or namespace-organized JSON Stores. Hermes Agent Unique Harness Innovations: FTS5 session search: Cross-session recall with LLM summarization.
+
 use async_trait::async_trait;
 use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
 
@@ -45,6 +46,16 @@ impl SqliteMemoryStore {
                 role UNINDEXED,
                 content,
                 timestamp UNINDEXED
+            )",
+        )
+        .execute(&pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS topics (
+                topic_name TEXT PRIMARY KEY,
+                content TEXT,
+                updated_at INTEGER
             )",
         )
         .execute(&pool)
@@ -272,16 +283,35 @@ impl LongTermMemory for SqliteMemoryStore {
 
 #[async_trait]
 impl crate::tools::anthropic_memory::MemoryAccessor for SqliteMemoryStore {
-    async fn retrieve_topic(&self, _topic_name: &str) -> Result<String, String> {
-        Err("Topic retrieval not supported in SQLite FTS5 store directly.".to_string())
+    async fn retrieve_topic(&self, topic_name: &str) -> Result<String, String> {
+        let row = sqlx::query_as::<_, (String,)>("SELECT content FROM topics WHERE topic_name = ?")
+            .bind(topic_name)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        match row {
+            Some((content,)) => Ok(content),
+            None => Err(format!("Topic '{}' not found", topic_name)),
+        }
     }
 
-    async fn search_transcripts(&self, _query: &str, _limit: usize) -> Result<Vec<String>, String> {
-        // Fallback to cross-session search
-        <Self as crate::memory_store::LongTermMemory>::search_cross_session_messages(
-            self, _query, _limit, false,
-        )
-        .await
+    async fn search_transcripts(&self, query: &str, limit: usize) -> Result<Vec<String>, String> {
+        let search_pattern = format!("\"{}\"", query);
+
+        let rows = sqlx::query_as::<_, (String, String, String)>("SELECT session_id, role, content FROM session_messages_fts WHERE session_messages_fts MATCH ? ORDER BY rank LIMIT ?")
+            .bind(&search_pattern)
+            .bind(limit as i64)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let results: Vec<String> = rows
+            .into_iter()
+            .map(|(sid, role, content)| format!("[Session: {}] {}: {}", sid, role, content))
+            .collect();
+
+        Ok(results)
     }
 
     async fn search_cross_session_messages(
@@ -296,14 +326,120 @@ impl crate::tools::anthropic_memory::MemoryAccessor for SqliteMemoryStore {
         .await
     }
 
-    async fn write_topic(&self, _topic_name: &str, _content: &str) -> Result<(), String> {
-        Err("Topic writing not supported in SQLite FTS5 store directly.".to_string())
+    async fn write_topic(&self, topic_name: &str, content: &str) -> Result<(), String> {
+        let timestamp = chrono::Utc::now().timestamp();
+        sqlx::query("INSERT INTO topics (topic_name, content, updated_at) VALUES (?, ?, ?) ON CONFLICT(topic_name) DO UPDATE SET content=excluded.content, updated_at=excluded.updated_at")
+            .bind(topic_name)
+            .bind(content)
+            .bind(timestamp)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn test_sqlite_memory_topics() {
+        use crate::tools::anthropic_memory::MemoryAccessor;
+        use std::sync::Arc;
+
+        struct MockLlm;
+        #[async_trait::async_trait]
+        impl crate::llm::LlmClient for MockLlm {
+            async fn chat(
+                &self,
+                _req: crate::types::ChatRequest,
+            ) -> Result<crate::types::ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(crate::types::ChatResponse {
+                    message: crate::types::Message::assistant("Summary"),
+                    usage: crate::types::Usage::default(),
+                    stop_reason: "stop".to_string(),
+                    response_id: None,
+                })
+            }
+            async fn generate_embedding(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.1; 1536])
+            }
+        }
+
+        let store = SqliteMemoryStore::new("sqlite::memory:", Arc::new(MockLlm))
+            .await
+            .unwrap();
+
+        // Topic should not exist initially
+        let res = MemoryAccessor::retrieve_topic(&store, "architecture").await;
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("not found"));
+
+        // Write a new topic
+        MemoryAccessor::write_topic(&store, "architecture", "We use Rust and Axum").await.unwrap();
+
+        // Retrieve the topic
+        let content = MemoryAccessor::retrieve_topic(&store, "architecture").await.unwrap();
+        assert_eq!(content, "We use Rust and Axum");
+
+        // Update the topic
+        MemoryAccessor::write_topic(&store, "architecture", "We use Rust, Axum, and Postgres").await.unwrap();
+
+        // Retrieve updated content
+        let updated_content = MemoryAccessor::retrieve_topic(&store, "architecture").await.unwrap();
+        assert_eq!(updated_content, "We use Rust, Axum, and Postgres");
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_search_transcripts() {
+
+        use crate::tools::anthropic_memory::MemoryAccessor;
+        use std::sync::Arc;
+
+        struct MockLlm;
+        #[async_trait::async_trait]
+        impl crate::llm::LlmClient for MockLlm {
+            async fn chat(
+                &self,
+                _req: crate::types::ChatRequest,
+            ) -> Result<crate::types::ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(crate::types::ChatResponse {
+                    message: crate::types::Message::assistant("Summary"),
+                    usage: crate::types::Usage::default(),
+                    stop_reason: "stop".to_string(),
+                    response_id: None,
+                })
+            }
+            async fn generate_embedding(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.1; 1536])
+            }
+        }
+
+        let store = SqliteMemoryStore::new("sqlite::memory:", Arc::new(MockLlm))
+            .await
+            .unwrap();
+
+        store.store_session_message("s1", "user", "How do I configure the bazel build?").await.unwrap();
+        store.store_session_message("s1", "assistant", "Use the BUILD.bazel file in the root.").await.unwrap();
+        store.store_session_message("s2", "user", "Why does bazel fail on mac?").await.unwrap();
+
+        let transcripts = MemoryAccessor::search_transcripts(&store, "bazel", 10).await.unwrap();
+
+        // Assert we got raw transcripts instead of just snippets
+        assert_eq!(transcripts.len(), 3);
+
+        let combined = transcripts.join("\n");
+        assert!(combined.contains("[Session: s1] user: How do I configure the bazel build?"));
+        assert!(combined.contains("[Session: s1] assistant: Use the BUILD.bazel file in the root."));
+        assert!(combined.contains("[Session: s2] user: Why does bazel fail on mac?"));
+    }
 
     #[tokio::test]
     async fn test_sqlite_memory_store() {


### PR DESCRIPTION
Implemented the Anthropic 3-Tier Memory mechanic from the Master Catalog in the `SqliteMemoryStore`:
- Added a `topics` table for explicit topic file storage and retrieval
- Implemented `write_topic` and `retrieve_topic`
- Updated `search_transcripts` to perform FTS5 MATCH queries against `session_messages_fts`
- Added comprehensive unit tests in `src/agents/builtin/sqlite_memory.rs`

---
*PR created automatically by Jules for task [11319622945927962648](https://jules.google.com/task/11319622945927962648) started by @ql-owo-lp*