### PR TITLE
feat: use proper approval draft string

### DIFF
--- a/src/e2e/playwright/ambassador.spec.ts
+++ b/src/e2e/playwright/ambassador.spec.ts
@@ -48,7 +48,7 @@ test.describe('Ambassador Agent Workflow', () => {
 
     // 5. Click 'Approve & Send Draft'
     const approveBtn = feedCard.getByTestId('feed-approve-btn');
-    await expect(approveBtn).toContainText('Send Draft');
+    await expect(approveBtn).toContainText('✨ Approve & Send Draft');
     await approveBtn.click();
 
   });

--- a/src/ui/next/src/app/dashboard/AmbassadorReplyCard.tsx
+++ b/src/ui/next/src/app/dashboard/AmbassadorReplyCard.tsx
@@ -74,9 +74,9 @@ export const AmbassadorReplyCard: React.FC<AmbassadorReplyCardProps> = ({ approv
               onApprove();
             }}
             className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all duration-200 shadow-md flex items-center justify-center"
-            aria-label="Send Draft" data-testid="feed-approve-btn"
+            aria-label="✨ Approve & Send Draft" data-testid="feed-approve-btn"
           >
-            Send Draft
+            ✨ Approve & Send Draft
           </button>
         )}
         {onDismiss && (

--- a/src/ui/next/src/components/feed/AgentActionCard.tsx
+++ b/src/ui/next/src/components/feed/AgentActionCard.tsx
@@ -1977,7 +1977,7 @@ export const AgentActionCard: React.FC<AgentActionCardProps> = ({
                 aria-label="Approve & Send Draft"
                 data-testid="approve-ambassador-reply"
               >
-                Send Draft
+                ✨ Approve & Send Draft
               </button>
               <button
                 onClick={() => {


### PR DESCRIPTION
Resolves #33146 by using the `✨ Approve & Send Draft` string for ambassador reply feature according to design wireframes. Evaluated with test simulation tools locally to ensure selector correctly matches. E2E tests have been updated with this string.

---
*PR created automatically by Jules for task [14371263187378372376](https://jules.google.com/task/14371263187378372376) started by @ql-owo-lp*