### PR TITLE
fix: ensure correct dark mode border for glassmorphism containers

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -328,7 +328,7 @@
           background: rgba(22, 22, 26, 0.7);
           backdrop-filter: blur(30px) saturate(210%);
           -webkit-backdrop-filter: blur(30px) saturate(210%);
-          border-color: rgba(255, 255, 255, 0.1);
+          border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .context-card:hover {
           background: rgba(22, 22, 26, 0.7);
@@ -616,7 +616,7 @@
           background: rgba(22, 22, 26, 0.7);
           backdrop-filter: blur(30px) saturate(210%);
           -webkit-backdrop-filter: blur(30px) saturate(210%);
-          border-color: rgba(255, 255, 255, 0.1);
+          border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .context-card:hover {
           background: rgba(22, 22, 26, 0.7);
@@ -955,7 +955,7 @@
           background: rgba(22, 22, 26, 0.7);
           backdrop-filter: blur(30px) saturate(210%);
           -webkit-backdrop-filter: blur(30px) saturate(210%);
-          border-color: rgba(255, 255, 255, 0.1);
+          border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .context-card:hover {
           background: rgba(22, 22, 26, 0.7);
@@ -992,7 +992,7 @@
           background: rgba(22, 22, 26, 0.7);
           backdrop-filter: blur(30px) saturate(210%);
           -webkit-backdrop-filter: blur(30px) saturate(210%);
-          border-color: rgba(255, 255, 255, 0.1);
+          border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .radio-option:hover {
           background: rgba(40, 40, 45, 0.7);
@@ -1016,7 +1016,7 @@
         .chat-bubble {
           background: rgba(22, 22, 26, 0.7);
           color: #f5f5f7;
-          border-color: rgba(255, 255, 255, 0.1);
+          border: 1px solid rgba(255, 255, 255, 0.1);
         }
       }
 
@@ -1147,7 +1147,7 @@
           background: rgba(22, 22, 26, 0.7) !important;
           backdrop-filter: blur(30px) saturate(210%) !important;
           -webkit-backdrop-filter: blur(30px) saturate(210%) !important;
-          border-color: rgba(255, 255, 255, 0.1) !important;
+          border: 1px solid rgba(255, 255, 255, 0.1) !important;
         }
         .context-card:hover {
           background: rgba(40, 40, 45, 0.7) !important;
@@ -1283,7 +1283,7 @@
           background: rgba(22, 22, 26, 0.7);
           backdrop-filter: blur(30px) saturate(210%);
           -webkit-backdrop-filter: blur(30px) saturate(210%);
-          border-color: rgba(255, 255, 255, 0.1);
+          border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .context-card:hover {
           background: rgba(22, 22, 26, 0.7);
@@ -4529,7 +4529,7 @@
           background: rgba(22, 22, 26, 0.7);
           backdrop-filter: blur(30px) saturate(210%);
           -webkit-backdrop-filter: blur(30px) saturate(210%);
-          border-color: rgba(255, 255, 255, 0.1);
+          border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .context-card:hover {
           background: rgba(22, 22, 26, 0.7);
@@ -4542,7 +4542,7 @@
         }
             .ohc-tooltip {
                 background: rgba(22, 22, 26, 0.7);
-                border-color: rgba(255, 255, 255, 0.1);
+                border: 1px solid rgba(255, 255, 255, 0.1);
                 color: #f5f5f7;
             }
         }


### PR DESCRIPTION
Replaces `border-color: rgba(255, 255, 255, 0.1)` with the full CSS shorthand `border: 1px solid rgba(255, 255, 255, 0.1)` in `src/ui/tauri/src/ui/setup.html` to correctly apply the OHC Premium dark mode glassmorphism UI token across relevant `.container`, `.context-card`, `.radio-option`, `.chat-bubble`, and `.ohc-tooltip` classes.

---
*PR created automatically by Jules for task [4038953209914089111](https://jules.google.com/task/4038953209914089111) started by @ql-owo-lp*