### PR TITLE
Implement Multi-Tenant Local Edge Caching for Dynamic Storefronts

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -365,7 +365,7 @@ services:
           memory: 256M
 
   edge-cache:
-    image: nginx:alpine
+    image: openresty/openresty:alpine
     ports:
       - "80:80"
     volumes:

--- a/deploy/docker/nginx/nginx.conf
+++ b/deploy/docker/nginx/nginx.conf
@@ -42,6 +42,34 @@ http {
             add_header X-Proxy-Cache $upstream_cache_status;
         }
 
+        location /purge {
+            allow 127.0.0.1;
+            allow 10.0.0.0/8;
+            allow 172.16.0.0/12;
+            allow 192.168.0.0/16;
+            deny all;
+
+            content_by_lua_block {
+                ngx.req.read_body()
+                local tag = ngx.req.get_body_data()
+                if tag and tag ~= "" then
+                    -- Sanitize tag to prevent command injection
+                    local sanitized_tag = string.gsub(tag, "[^%w%-_:]", "")
+                    if sanitized_tag ~= tag then
+                        ngx.status = 400
+                        ngx.say("Invalid tag format")
+                        return
+                    end
+                    local cmd = 'grep -rl "Surrogate-Key: .*' .. sanitized_tag .. '.*" /var/cache/nginx | xargs -r rm -f'
+                    os.execute(cmd)
+                    ngx.say("Purged " .. sanitized_tag)
+                else
+                    ngx.status = 400
+                    ngx.say("No tag provided")
+                end
+            }
+        }
+
         # Handle custom domains mapping to storefront resolution endpoint if not localhost
         location / {
             # For local E2E testing, we allow requests directly passing through Nginx.

--- a/src/server/api/storefront_delivery.rs
+++ b/src/server/api/storefront_delivery.rs
@@ -107,8 +107,20 @@ async fn invalidate_cache_webhook(
     let tags_to_invalidate = payload.tags;
     tokio::spawn(async move {
         let cdn = crate::utils::edge_caching_middleware::get_cdn_cache();
+        let client = reqwest::Client::new();
         for tag in tags_to_invalidate {
             cdn.invalidate_by_tag(&tag).await;
+
+            // Send purge request to NGINX Edge Cache
+            if let Err(e) = client.post("http://edge-cache/purge")
+                .body(tag.clone())
+                .send()
+                .await
+            {
+                tracing::warn!("Failed to send purge request to NGINX for tag {}: {}", tag, e);
+            } else {
+                tracing::info!("Successfully sent purge request to NGINX for tag {}", tag);
+            }
         }
     });
 
@@ -201,18 +213,19 @@ fn set_storefront_headers(response: &mut axum::response::Response, html: &str, t
     let result = hasher.finalize();
     let etag = format!("\"{:x}\"", result);
 
-    let mut cache_tag = format!("tenant-id:{}", tenant_id);
-    if let Some(tags) = custom_tags {
-        if !tags.is_empty() {
-            cache_tag = tags.join(", ");
-        }
+    let mut tags = vec![format!("tenant-id:{}", tenant_id)];
+    if let Some(mut ct) = custom_tags {
+        tags.append(&mut ct);
     }
 
-    if let Ok(val) = cache_tag.parse() {
+    let cache_tag_comma = tags.join(", ");
+    let surrogate_key_space = tags.join(" ");
+
+    if let Ok(val) = cache_tag_comma.parse() {
         response.headers_mut().insert("Cache-Tag", val);
     }
 
-    if let Ok(val) = cache_tag.parse() {
+    if let Ok(val) = surrogate_key_space.parse() {
         response.headers_mut().insert("Surrogate-Key", val);
     }
 

--- a/src/server/services/cache_invalidator.rs
+++ b/src/server/services/cache_invalidator.rs
@@ -59,6 +59,7 @@ pub async fn start_cache_invalidator(pool: sqlx::PgPool) {
                 let mut tenant_id_str = None;
                 let mut product_id_str = None;
 
+                let client = reqwest::Client::new();
                 for tag in &event.tags {
                     info!("Invalidating cache for tag: {}", tag);
                     if tag.starts_with("tenant-id:") {
@@ -69,6 +70,17 @@ pub async fn start_cache_invalidator(pool: sqlx::PgPool) {
                     edge_cache.invalidate_by_tag(tag).await;
                     let cdn_cache = crate::utils::edge_caching_middleware::get_cdn_cache();
                     cdn_cache.invalidate_by_tag(tag).await;
+
+                    // Send purge request to NGINX Edge Cache
+                    if let Err(e) = client.post("http://edge-cache/purge")
+                        .body(tag.clone())
+                        .send()
+                        .await
+                    {
+                        warn!("Failed to send purge request to NGINX for tag {}: {}", tag, e);
+                    } else {
+                        info!("Successfully sent purge request to NGINX for tag {}", tag);
+                    }
                 }
 
                 if let (Some(t_str), Some(p_str)) = (tenant_id_str, product_id_str) {


### PR DESCRIPTION
Resolves #33193

This pull request implements the requested multi-tenant local edge caching for storefronts without utilizing an external proprietary CDN. It achieves this by configuring the pre-existing edge-cache service (now switched from standard NGINX to OpenResty) to support caching and targeted invalidation.

**Changes:**
1. Modified `storefront_delivery.rs` to structure `Cache-Tag` and `Surrogate-Key` properly to include the `tenant-id`. This header setup ensures cache files can be individually traced per tenant/product.
2. Updated `nginx.conf` and `docker-compose.yml` to switch the edge proxy from `nginx:alpine` to `openresty/openresty:alpine`. Configured a `/purge` endpoint leveraging a custom Lua block which securely runs regex against cache files to purge by `Surrogate-Key`.
3. Updated cache invalidation routines in `src/server/services/cache_invalidator.rs` and webhook deliveries in `storefront_delivery.rs`. Now, standard backend invalidation events correctly send an `HTTP POST /purge` request directly to the local edge-cache service.

**Verification:**
- Ran `bazelisk test //src/server/...` -> All tests pass (100% green).
- Ran `bazelisk test //src/e2e:playwright` -> All E2E functionalities pass without regression.
- Superpowers skills `test-driven-development`, `systematic-debugging`, `verification-before-completion`, and `writing-plans` influenced the plan, implementation, security mitigation and verification.

---
*PR created automatically by Jules for task [5084123598932796991](https://jules.google.com/task/5084123598932796991) started by @ql-owo-lp*