### PR TITLE
UI: Apply macOS glassmorphism styling to setup wizard toggles

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -29,7 +29,7 @@
         backdrop-filter: blur(30px) saturate(210%);
         -webkit-backdrop-filter: blur(30px) saturate(210%);
         padding: 20px;
-        padding-bottom: 80px;
+        padding-bottom: 24px;
         border-radius: 16px;
         box-shadow:
           0 4px 6px -1px rgba(0, 0, 0, 0.1),
@@ -39,7 +39,7 @@
         max-width: 480px;
         border: 1px solid rgba(255, 255, 255, 0.4);
         box-sizing: border-box;
-        max-height: calc(100vh - 40px);
+        max-height: 90vh;
         overflow-y: auto;
       }
       /* OHC Premium Glassmorphism */
@@ -1023,7 +1023,7 @@
       @media (max-width: 768px) {
         .container {
           padding: 20px;
-          padding-bottom: 80px;
+          padding-bottom: 24px;
           width: 100%;
           border: none;
         }
@@ -2002,7 +2002,7 @@
         </div>
 
         <div class="capability-toggles">
-          <label tabindex="0" class="toggle-row">
+          <label tabindex="0" class="toggle-row glass-control glassmorphism">
             <div class="toggle-info">
               <span class="toggle-title">Draft Replies</span>
               <span class="toggle-desc"
@@ -2019,7 +2019,7 @@
               <span class="slider"></span>
             </div>
           </label>
-          <label tabindex="0" class="toggle-row">
+          <label tabindex="0" class="toggle-row glass-control glassmorphism">
             <div class="toggle-info">
               <span class="toggle-title">Schedule Meetings</span>
               <span class="toggle-desc"
@@ -2036,7 +2036,7 @@
               <span class="slider"></span>
             </div>
           </label>
-          <label tabindex="0" class="toggle-row">
+          <label tabindex="0" class="toggle-row glass-control glassmorphism">
             <div class="toggle-info">
               <span class="toggle-title">Manage Inventory</span>
               <span class="toggle-desc"
@@ -2326,7 +2326,7 @@
         </div>
 
         <div style="padding-top: 8px">
-          <label tabindex="0" class="toggle-row" style="cursor: pointer">
+          <label tabindex="0" class="toggle-row glass-control glassmorphism" style="cursor: pointer">
             <div class="toggle-info">
               <span class="toggle-title">Allow AI to Auto-Respond</span>
             </div>


### PR DESCRIPTION
This PR improves the visual appearance of the setup wizard by applying macOS translucent glassmorphism styling to the capability toggle controls. It also fixes a layout clipping issue by adjusting the `.container` max-height and padding.

---
*PR created automatically by Jules for task [2972941570527808048](https://jules.google.com/task/2972941570527808048) started by @ql-owo-lp*