### PR TITLE
🛡️ Sentry: [reliability fix] Fix `test_network_packet_drops_with_retry` failure

### DIFF
--- a/src/server/chaos_network_test.rs
+++ b/src/server/chaos_network_test.rs
@@ -55,18 +55,23 @@ mod chaos_network_tests {
         let res: Result<(), String> = db.execute_with_retry("network_test", move || {
             let counter = counter_clone.clone();
             async move {
-                counter.fetch_add(1, Ordering::SeqCst);
+                let attempts = counter.fetch_add(1, Ordering::SeqCst);
+
+                // Simulate connection closed only on the first attempt so that retry loop takes effect.
+                if attempts == 0 {
+                    return Err("connection reset".to_string());
+                }
 
                 match tokio::net::TcpStream::connect(addr).await {
                     Ok(mut stream) => {
                         let msg = b"hello";
                         if let Err(_) = stream.write_all(msg).await {
-                             return Err("network drop on write".to_string());
+                             return Err("broken pipe".to_string());
                         }
 
                         let mut buf = vec![0; 5];
                         if let Err(_) = stream.read_exact(&mut buf).await {
-                             return Err("network drop on read".to_string());
+                             return Err("connection reset".to_string());
                         }
 
                         if &buf == msg {
@@ -75,7 +80,7 @@ mod chaos_network_tests {
                             Err("data mismatch".to_string())
                         }
                     }
-                    Err(_) => Err("network drop on connect".to_string()),
+                    Err(_) => Err("connection refused".to_string()),
                 }
             }
         }).await;


### PR DESCRIPTION
The chaos engineering tests for ML-Resilience include `test_network_packet_drops_with_retry` which was failing because the simulated network drops were returning generic string errors like "network drop on connect". These errors did not match the connection error patterns checked by `is_connection_err` in `db.rs` (`"connection refused"`, `"connection reset"`, `"connection closed"`, `"broken pipe"`).

This PR fixes the test by:
1. Updating the mocked errors to use realistic string patterns (e.g. `"connection reset"`, `"broken pipe"`).
2. Simulating the connection drop only on the first attempt, allowing the retry logic to correctly recover and verify the fallback mechanisms.

Verified by running `bazel test //...` which resulted in 100% green status.

---
*PR created automatically by Jules for task [11996464022806002037](https://jules.google.com/task/11996464022806002037) started by @ql-owo-lp*