### PR TITLE
fix: enforce 44px minimum touch targets in setup UI

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2530,7 +2530,7 @@
             enterkeyhint="next"
             autocapitalize="none"
             autocorrect="off"
-            style="flex: 1; border: none; background: transparent; outline: none; margin-bottom: 0; padding: 0; font-size: 16px; font-family: inherit; color: inherit; text-align: right; min-width: 0; appearance: none; box-shadow: none;"
+            style="flex: 1; border: none; background: transparent; outline: none; margin-bottom: 0; padding: 0; font-size: 16px; font-family: inherit; color: inherit; text-align: right; min-width: 0; min-height: 44px; appearance: none; box-shadow: none;"
             enterkeyhint="next"
           />
           <span style="font-size: 16px; font-weight: 500; color: #1d1d1f; opacity: 0.8; padding-left: 4px; white-space: nowrap; flex-shrink: 0;">.ohc.app</span>
@@ -2582,6 +2582,7 @@
           id="template-selection"
           data-testid="template-selection"
           class="glass-control glassmorphism"
+          style="min-height: 44px;"
         >
           <option value="" disabled selected>Select a template...</option>
           <option value="Modern">Modern</option>


### PR DESCRIPTION
Added `min-height: 44px` to `#domain-name` input and `#template-selection` dropdown in `setup.html` to align with the Mobile-First Non-Negotiables regarding touch targets size.

---
*PR created automatically by Jules for task [16658432492349342728](https://jules.google.com/task/16658432492349342728) started by @ql-owo-lp*