### PR TITLE
feat(help): Video Tutorials Mobile Optimization

### DIFF
--- a/src/e2e/help-walkthrough.spec.ts
+++ b/src/e2e/help-walkthrough.spec.ts
@@ -25,4 +25,28 @@ test.describe('Help Walkthrough', () => {
     await page.locator('#wt-close').click();
     await expect(overlay).not.toBeVisible();
   });
+
+  test('should open and play video tutorial', async ({ page }) => {
+    await adminPage(page);
+    await page.goto('/help');
+
+    // Wait for the video tutorial cards to be visible
+    const videoCard = page.getByText('How to set up your first store easily');
+    await videoCard.waitFor({ state: 'visible' });
+
+    // Click the video card to open the player modal
+    await videoCard.click();
+
+    // Assert that the video player modal is visible
+    const videoPlayer = page.locator('video');
+    await expect(videoPlayer).toBeVisible();
+
+    // Assert that the close button is visible and click it to close the modal
+    const closeBtn = page.getByLabel('Close video');
+    await expect(closeBtn).toBeVisible();
+    await closeBtn.click();
+
+    // Assert that the modal is no longer visible
+    await expect(closeBtn).not.toBeVisible();
+  });
 });

--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -254,21 +254,14 @@ pub async fn list_videos(Query(query): Query<DocsQuery>) -> Json<Vec<serde_json:
 
     let mobile_optimized = query.mobile_optimized.unwrap_or(false);
 
+    let _ = mobile_optimized; // Keep parameter for future use
     let json_videos = videos.into_iter().map(|v| {
-        if mobile_optimized {
-            serde_json::json!({
-                "id": v.id,
-                "title": v.title,
-                "video_url": v.video_url
-            })
-        } else {
-            serde_json::json!({
-                "id": v.id,
-                "title": v.title,
-                "duration": v.duration,
-                "video_url": v.video_url
-            })
-        }
+        serde_json::json!({
+            "id": v.id,
+            "title": v.title,
+            "duration": v.duration,
+            "video_url": v.video_url
+        })
     }).collect();
     Json(json_videos)
 }


### PR DESCRIPTION
Fixes the video tutorials section of the help center to properly display video lengths on mobile devices by retaining the duration field from the backend API. Also adds an E2E test to ensure the video modal renders correctly and can be closed.

---
*PR created automatically by Jules for task [1236930293823422554](https://jules.google.com/task/1236930293823422554) started by @ql-owo-lp*