### PR TITLE
fix: agent queue resilience fallback to paused state

### DIFF
--- a/src/server/orchestration/queue/ohc_job_queue.rs
+++ b/src/server/orchestration/queue/ohc_job_queue.rs
@@ -215,6 +215,12 @@ impl OHCJobQueue {
                 .execute(&mut *tx)
                 .await;
 
+                sqlx::query("UPDATE agents SET status = 'PAUSED' WHERE tenant_id = $1 AND status != 'PAUSED'")
+                    .bind(&tenant_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| e.to_string())?;
+
                 sqlx::query("UPDATE ohc_job_queue SET status = 'FAILED', retry_count = $1, failed_reason = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $3")
                     .bind(next_retry)
                     .bind(reason)

--- a/src/server/orchestration/queue/pg_queue.rs
+++ b/src/server/orchestration/queue/pg_queue.rs
@@ -200,6 +200,13 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
                     .execute(&mut *tx)
                     .await
                     .map_err(|e| e.to_string())?;
+
+                sqlx::query("UPDATE agents SET status = 'PAUSED' WHERE tenant_id = $1 AND status != 'PAUSED'")
+                    .bind(&tenant_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| e.to_string())?;
+
                 sqlx::query("UPDATE ohc_job_queue SET status = 'FAILED', retry_count = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2")
                     .bind(next_attempt)
                     .bind(job_id)

--- a/src/server/orchestration/queue/pg_queue_test.rs
+++ b/src/server/orchestration/queue/pg_queue_test.rs
@@ -71,6 +71,8 @@ async fn test_pg_fail_max_retries_dead_letter() {
     // Ensure tables are clean for tests
     sqlx::query("DELETE FROM ohc_job_queue").execute(&pool).await.unwrap();
     sqlx::query("DELETE FROM department_dead_letters").execute(&pool).await.unwrap();
+    sqlx::query("DELETE FROM agents WHERE id = 'agent-1'").execute(&pool).await.unwrap();
+    sqlx::query("INSERT INTO agents (id, tenant_id, name, role, status) VALUES ('agent-1', 'test_org', 'test', 'test', 'ACTIVE')").execute(&pool).await.unwrap();
 
     let job = Job {
         id: "job-fail-pg-dead".to_string(),
@@ -111,6 +113,10 @@ async fn test_pg_fail_max_retries_dead_letter() {
     assert_eq!(dl_department, "job_queue");
     assert_eq!(dl_payload, "{\"test\":\"payload\"}");
     assert_eq!(dl_error_message, "test reason");
+
+    let agent_row = sqlx::query("SELECT status FROM agents WHERE id = 'agent-1'").fetch_one(&pool).await.unwrap();
+    let agent_status: String = agent_row.get("status");
+    assert_eq!(agent_status, "PAUSED");
 }
 
 #[tokio::test]

--- a/src/server/orchestration/queue/queue_test.rs
+++ b/src/server/orchestration/queue/queue_test.rs
@@ -180,6 +180,18 @@ async fn test_sqlite_fail_max_retries_dead_letter() {
         )"
     ).execute(&pool).await.unwrap();
 
+    sqlx::query(
+        "CREATE TABLE agents (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            role TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'ACTIVE'
+        )"
+    ).execute(&pool).await.unwrap();
+
+    sqlx::query("INSERT INTO agents (id, tenant_id, name, role, status) VALUES ('agent-1', 'test_org', 'test', 'test', 'ACTIVE')").execute(&pool).await.unwrap();
+
     let queue = super::SQLiteTaskQueue::new(std::sync::Arc::new(pool.clone()));
 
     let job = super::Job {

--- a/src/server/orchestration/queue/sqlite_queue.rs
+++ b/src/server/orchestration/queue/sqlite_queue.rs
@@ -233,6 +233,13 @@ async fn enqueue_batch(&self, jobs: Vec<Job>) -> Result<(), String> {
                     .execute(&mut *tx)
                     .await
                     .map_err(|e| e.to_string())?;
+
+                sqlx::query("UPDATE agents SET status = 'PAUSED' WHERE tenant_id = ? AND status != 'PAUSED'")
+                    .bind(&tenant_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| e.to_string())?;
+
                 sqlx::query("UPDATE ohc_job_queue SET status = 'FAILED', retry_count = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?")
                     .bind(next_attempt)
                     .bind(job_id)


### PR DESCRIPTION
Fixes a bug where agent jobs failing and hitting max retries failed to put active agents into a paused state as mandated by ML-resilience rules. Added fallback updates to `ohc_job_queue`, `pg_queue`, and `sqlite_queue` along with the required test fixes.

---
*PR created automatically by Jules for task [14627842448154270481](https://jules.google.com/task/14627842448154270481) started by @ql-owo-lp*