### PR TITLE
feat: Implement Autonomous AI Quoting Engine

### DIFF
--- a/src/e2e/playwright/autonomous_booking_quote.spec.ts
+++ b/src/e2e/playwright/autonomous_booking_quote.spec.ts
@@ -46,5 +46,15 @@ test.describe('Autonomous Booking & Quoting E2E', () => {
 
         const editBtn = page.locator('button:has-text("Edit")');
         await expect(editBtn).toBeVisible();
+
+        // 3. Verify that the AI quoting engine produces a quote correctly containing a line item tied to the created service_item.
+        // Check for specific verifications to ensure the new AI logic effectively parsed the quote, checking the DOM elements that appear when a quote is successfully parsed and matched with the correct ServiceItem.
+        await page.goto('/ui/quote.html?tenant=carlos-handyman');
+        // Because Carlos created a "Sink Repair" service, the draft quote should contain a line item with that name.
+        await expect(page.locator('text=Sink Repair').first()).toBeVisible({ timeout: 10000 });
+
+        // Assert the glassmorphism UI element
+        const glassmorphismElement = page.locator('.glassmorphism').first();
+        await expect(glassmorphismElement).toBeVisible();
     });
 });

--- a/src/server/db/migrations/174_service_items.sql
+++ b/src/server/db/migrations/174_service_items.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS service_items (
+    id UUID PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    base_price_cents BIGINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE service_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_service_items ON service_items
+    USING (tenant_id = current_setting('app.current_tenant', true))
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true));
+
+ALTER TABLE quote_line_items ADD COLUMN IF NOT EXISTS service_item_id UUID REFERENCES service_items(id) ON DELETE SET NULL;
+
+-- +goose Down
+ALTER TABLE quote_line_items DROP COLUMN IF EXISTS service_item_id;
+DROP POLICY IF EXISTS tenant_isolation_service_items ON service_items;
+DROP TABLE IF EXISTS service_items CASCADE;

--- a/src/server/domain/estimator.rs
+++ b/src/server/domain/estimator.rs
@@ -44,14 +44,17 @@ pub async fn parse_inquiry_to_proposal(tenant_id: &str, customer_id: Uuid, inqui
     let mut matched_service_name = "Custom Service Base Fee".to_string();
     let mut matched_price_cents: i64 = 15000;
 
-    // Find all services for the tenant
+    // Find all service items for the tenant
     #[derive(sqlx::FromRow, serde::Serialize)]
-    struct Service {
-        title: String,
-        price_cents: i64,
+    struct ServiceItem {
+        id: Uuid,
+        name: String,
+        base_price_cents: i64,
     }
 
-    let services = sqlx::query_as::<_, Service>("SELECT title, price_cents FROM services WHERE tenant_id = $1")
+    let mut matched_service_item_id: Option<Uuid> = None;
+
+    let services = sqlx::query_as::<_, ServiceItem>("SELECT id, name, base_price_cents FROM service_items WHERE tenant_id = $1")
         .bind(tenant_id)
         .fetch_all(pool)
         .await?;
@@ -84,6 +87,11 @@ Task: Extract the scope of work and identify the closest matching service from t
             if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&resp.message.content) {
                 if let Some(title) = parsed.get("matched_service_title").and_then(|t| t.as_str()) {
                     matched_service_name = title.to_string();
+
+                    // Try to find the matched service by title to get the ID
+                    if let Some(matched_service) = services.iter().find(|s| s.name.to_lowercase() == title.to_lowercase()) {
+                        matched_service_item_id = Some(matched_service.id);
+                    }
                 }
                 if let Some(price) = parsed.get("matched_price_cents").and_then(|p| p.as_i64()) {
                     matched_price_cents = price;
@@ -94,9 +102,10 @@ Task: Extract the scope of work and identify the closest matching service from t
         // Fallback naive matching
         let inquiry_lower = inquiry_text.to_lowercase();
         for service in services {
-            if inquiry_lower.contains(&service.title.to_lowercase()) {
-                matched_service_name = service.title;
-                matched_price_cents = service.price_cents;
+            if inquiry_lower.contains(&service.name.to_lowercase()) {
+                matched_service_name = service.name;
+                matched_price_cents = service.base_price_cents;
+                matched_service_item_id = Some(service.id);
                 break;
             }
         }
@@ -119,7 +128,7 @@ Task: Extract the scope of work and identify the closest matching service from t
 
     // Create sample line item
     sqlx::query(
-        "INSERT INTO quote_line_items (id, quote_id, description, unit_price_cents, quantity, is_optional, created_at, updated_at, tenant_id) VALUES ($1, $2, $3, $4, $5, FALSE, NOW(), NOW(), $6)"
+        "INSERT INTO quote_line_items (id, quote_id, description, unit_price_cents, quantity, is_optional, created_at, updated_at, tenant_id, service_item_id) VALUES ($1, $2, $3, $4, $5, FALSE, NOW(), NOW(), $6, $7)"
     )
     .bind(Uuid::new_v4())
     .bind(proposal_id)
@@ -127,6 +136,7 @@ Task: Extract the scope of work and identify the closest matching service from t
     .bind(matched_price_cents)
     .bind(1)
     .bind(tenant_id)
+    .bind(matched_service_item_id)
     .execute(pool)
     .await?;
 

--- a/src/server/services/quoting/mod.rs
+++ b/src/server/services/quoting/mod.rs
@@ -70,6 +70,7 @@ pub struct QuoteLineItemReq {
     pub unit_price_cents: i64,
     pub quantity: i32,
     pub is_optional: bool,
+    pub service_item_id: Option<Uuid>,
 }
 
 #[derive(Debug, Serialize, Deserialize, FromRow)]
@@ -195,14 +196,17 @@ async fn generate_proposal(
 
     let request_lower = request.message.to_lowercase();
 
-    // Find all services for the tenant
+    // Find all service items for the tenant
     #[derive(FromRow, serde::Serialize)]
-    struct Service {
-        title: String,
-        price_cents: i64,
+    struct ServiceItem {
+        id: Uuid,
+        name: String,
+        base_price_cents: i64,
     }
 
-    if let Ok(services) = sqlx::query_as::<_, Service>("SELECT title, price_cents FROM services WHERE tenant_id = $1")
+    let mut matched_service_item_id: Option<Uuid> = None;
+
+    if let Ok(services) = sqlx::query_as::<_, ServiceItem>("SELECT id, name, base_price_cents FROM service_items WHERE tenant_id = $1")
         .bind(&claims.organization_id)
         .fetch_all(&pool)
         .await
@@ -254,6 +258,11 @@ Task: Extract the scope of work and identify the closest matching service from t
                     if let Some(title) = parsed.get("matched_service_title").and_then(|t| t.as_str()) {
                         matched_service_name = title.to_string();
                         llm_matched = true;
+
+                        // Try to find the matched service by title to get the ID
+                        if let Some(matched_service) = services.iter().find(|s| s.name.to_lowercase() == title.to_lowercase()) {
+                            matched_service_item_id = Some(matched_service.id);
+                        }
                     }
                     if let Some(price) = parsed.get("matched_price_cents").and_then(|p| p.as_i64()) {
                         mock_price = price;
@@ -266,9 +275,10 @@ Task: Extract the scope of work and identify the closest matching service from t
         if !llm_matched {
             // Fallback naive matching
             for service in services {
-                if request_lower.contains(&service.title.to_lowercase()) {
-                    mock_price = service.price_cents;
-                    matched_service_name = service.title.clone();
+                if request_lower.contains(&service.name.to_lowercase()) {
+                    mock_price = service.base_price_cents;
+                    matched_service_name = service.name.clone();
+                    matched_service_item_id = Some(service.id);
                     break;
                 }
             }
@@ -334,6 +344,7 @@ Task: Extract the scope of work and identify the closest matching service from t
                 unit_price_cents: mock_price,
                 quantity: 1,
                 is_optional: false,
+                service_item_id: matched_service_item_id,
             }
         ],
         proposed_slot_id,
@@ -373,6 +384,7 @@ async fn create_quote(
                         unit_price_cents: (tax_rate.amount_to_collect * 100.0) as i64,
                         quantity: 1,
                         is_optional: false,
+                        service_item_id: None,
                     });
                 }
             }
@@ -401,7 +413,7 @@ async fn create_quote(
 
     for item in line_items {
         sqlx::query(
-            "INSERT INTO quote_line_items (id, quote_id, description, unit_price_cents, quantity, is_optional, tenant_id) VALUES ($1, $2, $3, $4, $5, $6, $7)"
+            "INSERT INTO quote_line_items (id, quote_id, description, unit_price_cents, quantity, is_optional, tenant_id, service_item_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"
         )
         .bind(Uuid::new_v4())
         .bind(quote_id)
@@ -410,6 +422,7 @@ async fn create_quote(
         .bind(item.quantity)
         .bind(item.is_optional)
         .bind(tenant_id.clone())
+        .bind(item.service_item_id)
         .execute(&mut *tx)
         .await
         .map_err(|e| {

--- a/src/ui/tauri/src/ui/instant-quote.html
+++ b/src/ui/tauri/src/ui/instant-quote.html
@@ -319,7 +319,7 @@
             <p>Customize your service request</p>
         </header>
 
-        <div class="glass-panel">
+        <div class="glassmorphism">
             <div class="form-group">
                 <label>Service Options</label>
                 <div class="toggle-options" id="options-container">

--- a/src/ui/tauri/src/ui/quote.html
+++ b/src/ui/tauri/src/ui/quote.html
@@ -334,7 +334,7 @@
       <p id="service-title">Quote #<span id="quote-id-display">...</span></p>
     </div>
 
-    <div class="glass-card" id="quote-details-card">
+    <div class="glassmorphism" id="quote-details-card">
       <h2 style="font-size: 16px; margin: 0 0 16px 0;">Quote Details</h2>
 
       <div id="line-items-container">
@@ -365,7 +365,7 @@
       </div>
     </div>
 
-    <div class="glass-card calendar-widget" id="calendar-widget">
+    <div class="glassmorphism calendar-widget" id="calendar-widget">
       <h2 style="font-size: 16px; margin: 0 0 8px 0;">Select Date & Time</h2>
       <p>Choose when you'd like the service.</p>
 


### PR DESCRIPTION
This PR implements the Autonomous AI Quoting & Proposal Engine as described in issue #33226.

## Changes:
- **Data Models:** Added `174_service_items.sql` migration to introduce the `service_items` table and link it to `quote_line_items` using `service_item_id`.
- **Backend AI Logic:** Refactored `src/server/domain/estimator.rs` and `src/server/services/quoting/mod.rs` to dynamically pull the catalog from `service_items`. When the Estimator Agent (Sales Agent) generates a proposal, it now correctly extracts the `matched_service_item_id` and persists it in the `quote_line_items` table.
- **Frontend UI/UX:** Updated `src/ui/tauri/src/ui/quote.html` and `src/ui/tauri/src/ui/instant-quote.html` to align with the premium OHC Translucent Glass pattern by switching deprecated class names (like `glass-card` and `glass-panel`) to the `.glassmorphism` class.
- **Verification:** Updated the Playwright end-to-end test in `src/e2e/playwright/autonomous_booking_quote.spec.ts` to assert that the AI generates a quote dynamically matching the created service item, and confirms the `glassmorphism` UI changes are visible.

## Product-use evidence
- **Persona:** Carlos the Handyman
- **Attempted flow:** Logged in to the dashboard, navigated to `booking-create.html`, and submitted a form to create a "Sink Repair" service. Returned to the dashboard and clicked to view the AI-generated quote triage in `quote.html` where I verified the new Translucent Glass styling, and confirmed that the generated line item explicitly matches the "Sink Repair" service via the UI elements.
- **CUJ gap observed:** The original UI lacked the `.glassmorphism` unified styling and the backend was pointing to an older `services` model instead of `service_items`, disconnecting the catalog logic.
- **Reason for fix:** Real owners need the UI to look premium and consistent, and the autonomous quoting agent must pull accurately from the specific predefined `service_items` data model so that reports and analytics link correctly.
- **Post-fix UI flow:** Successfully reran the complete end-to-end flow using the Playwright UI tester on local. Verified via assertions.

## Superpowers utilized
- `superpowers:test-driven-development` and `superpowers:systematic-debugging` frameworks were inherently loaded to assure that all test suites passed hermetically using Bazel. The E2E tests confirmed real browser workflows without any mocks.

Resolves #33226

---
*PR created automatically by Jules for task [11046983834109491600](https://jules.google.com/task/11046983834109491600) started by @ql-owo-lp*