### PR TITLE
chore: enforce tenant_id validation against claims

### DIFF
--- a/src/server/api/inbox/customer_memory.rs
+++ b/src/server/api/inbox/customer_memory.rs
@@ -1,4 +1,5 @@
 use axum::{
+    extract::Extension,
     extract::{State, Json, Path},
     http::StatusCode,
     routing::{post, get},
@@ -30,8 +31,12 @@ pub struct IngestEventResponse {
 
 pub async fn ingest_event(
     State(state): State<CustomerMemoryState>,
+    Extension(claims): Extension<::server_common::Claims>,
     Json(payload): Json<IngestEventPayload>,
 ) -> Result<Json<IngestEventResponse>, StatusCode> {
+    if claims.organization_id.as_deref() != Some(&payload.tenant_id) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
     let service = CustomerMemoryGraphService::new(state.db.pool.clone());
 
     match service.ingest_interaction(&payload.tenant_id, &payload.customer_id, &payload.channel, &payload.raw_content).await {
@@ -45,8 +50,12 @@ pub async fn ingest_event(
 
 pub async fn get_profile_summary(
     State(state): State<CustomerMemoryState>,
+    Extension(claims): Extension<::server_common::Claims>,
     Path((tenant_id, customer_id)): Path<(String, String)>,
 ) -> Result<Json<CustomerProfileSummary>, StatusCode> {
+    if claims.organization_id.as_deref() != Some(&tenant_id) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
     let service = CustomerMemoryGraphService::new(state.db.pool.clone());
 
     match service.get_profile_summary(&tenant_id, &customer_id).await {

--- a/src/server/api/inbox/webhook.rs
+++ b/src/server/api/inbox/webhook.rs
@@ -1,4 +1,5 @@
 use axum::{
+    extract::Extension,
     extract::{State, Json},
     response::IntoResponse,
     http::StatusCode,
@@ -71,8 +72,12 @@ where
 
 pub async fn get_conversations(
     State(state): State<OmnichannelWebhookState>,
+    Extension(claims): Extension<::server_common::Claims>,
     axum::extract::Path(tenant_id): axum::extract::Path<String>,
 ) -> impl IntoResponse {
+    if claims.organization_id.as_deref() != Some(&tenant_id) {
+        return (StatusCode::UNAUTHORIZED, Json(Vec::<ConversationResponse>::new())).into_response();
+    }
     match &state.db.store {
         crate::db::DbStore::Postgres => {
             let query = "SELECT id, tenant_id, customer_id, channel, status, CAST(created_at AS text) as created_at FROM unified_threads WHERE tenant_id = $1 ORDER BY created_at DESC";
@@ -119,8 +124,12 @@ pub async fn get_conversations(
 
 pub async fn get_messages(
     State(state): State<OmnichannelWebhookState>,
+    Extension(claims): Extension<::server_common::Claims>,
     axum::extract::Path((tenant_id, conversation_id)): axum::extract::Path<(String, String)>,
 ) -> impl IntoResponse {
+    if claims.organization_id.as_deref() != Some(&tenant_id) {
+        return (StatusCode::UNAUTHORIZED, Json(Vec::<MessageResponse>::new())).into_response();
+    }
     match &state.db.store {
         crate::db::DbStore::Postgres => {
             let query = "SELECT id, tenant_id, source, original_content, translated_content, draft_reply, status, sender_id, CAST(created_at AS text) as created_at FROM omni_inbox_messages WHERE tenant_id = $1 AND customer_id = (SELECT customer_id FROM unified_threads WHERE id = $2) ORDER BY created_at ASC";

--- a/src/server/api/ledger.rs
+++ b/src/server/api/ledger.rs
@@ -1,4 +1,5 @@
 use axum::{
+    extract::Extension,
     extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
@@ -67,9 +68,13 @@ pub fn router() -> Router<AppState> {
 
 async fn get_invoice(
     State(state): State<AppState>,
+    Extension(claims): Extension<::server_common::Claims>,
     Path(id): Path<String>,
     axum::extract::Query(query): axum::extract::Query<GetInvoiceQuery>,
 ) -> impl IntoResponse {
+    if claims.organization_id.as_deref() != Some(&query.tenant_id) {
+        return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
+    }
     let repo = LedgerRepository::new(state.db);
     match repo.get_invoice(&query.tenant_id, &id).await {
         Ok(Some(invoice)) => (StatusCode::OK, Json(invoice)).into_response(),
@@ -80,8 +85,12 @@ async fn get_invoice(
 
 async fn create_invoice_draft(
     State(state): State<AppState>,
+    Extension(claims): Extension<::server_common::Claims>,
     Json(payload): Json<CreateInvoiceDraftRequest>,
 ) -> impl IntoResponse {
+    if claims.organization_id.as_deref() != Some(&payload.tenant_id) {
+        return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
+    }
     let repo = LedgerRepository::new(state.db);
 
     let invoice_id = Uuid::new_v4().to_string();
@@ -126,9 +135,13 @@ async fn create_invoice_draft(
 
 async fn update_invoice_status(
     State(state): State<AppState>,
+    Extension(claims): Extension<::server_common::Claims>,
     Path(id): Path<String>,
     Json(payload): Json<UpdateInvoiceStatusRequest>,
 ) -> impl IntoResponse {
+    if claims.organization_id.as_deref() != Some(&payload.tenant_id) {
+        return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
+    }
     let repo = LedgerRepository::new(state.db);
     match repo.update_invoice_status(&payload.tenant_id, &id, &payload.status).await {
         Ok(_) => StatusCode::OK.into_response(),
@@ -138,8 +151,12 @@ async fn update_invoice_status(
 
 async fn apply_payment(
     State(state): State<AppState>,
+    Extension(claims): Extension<::server_common::Claims>,
     Json(payload): Json<ApplyPaymentRequest>,
 ) -> impl IntoResponse {
+    if claims.organization_id.as_deref() != Some(&payload.tenant_id) {
+        return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
+    }
     let repo = LedgerRepository::new(state.db);
     let event = PaymentEvent {
         id: Uuid::new_v4().to_string(),
@@ -159,8 +176,12 @@ async fn apply_payment(
 
 async fn get_ledger_entries(
     State(state): State<AppState>,
+    Extension(claims): Extension<::server_common::Claims>,
     Path(tenant_id): Path<String>,
 ) -> impl IntoResponse {
+    if claims.organization_id.as_deref() != Some(&tenant_id) {
+        return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
+    }
     let repo = LedgerRepository::new(state.db);
     match repo.get_ledger_entries(&tenant_id).await {
         Ok(entries) => (StatusCode::OK, Json(entries)).into_response(),


### PR DESCRIPTION
🧹 Cleaner: Enforce multi-tenant safety across API routes by validating `tenant_id` against claims.

Superpowers skills loaded: multi-tenant-safety-check.

Product-use evidence:
Persona: Nora, Agency Principal
Issue: If a malicious user intercepted an API request to `ledger`, `inbox`, or `customer_memory` routes, they could potentially supply another tenant's ID in the request body/path and access/modify resources belonging to that tenant.
Fix: Extract `Claims` via Axum's `Extension` and verify that `claims.organization_id` exactly matches the `tenant_id` supplied in the request. Return `401 Unauthorized` if they do not match.

Interaction Audit Table:
| Element | Designed Purpose | Observed Result | Fix |
|---|---|---|---|
| Axum Handlers (Ledger/Inbox/Memory) | Provide API access restricted to the user's organization | Did not validate `tenant_id` against session claims | Added `Extension(claims): Extension<::server_common::Claims>` and verified `claims.organization_id == requested tenant_id` |

---
*PR created automatically by Jules for task [14192069807219067260](https://jules.google.com/task/14192069807219067260) started by @ql-owo-lp*