### PR TITLE
chore: Remove unused import Arc from AgentMemoryService

### DIFF
--- a/src/server/services/agent_memory/service.rs
+++ b/src/server/services/agent_memory/service.rs
@@ -3,7 +3,7 @@ use dashmap::DashMap;
 use tokio::sync::OnceCell;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+
 use sqlx::PgPool;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]


### PR DESCRIPTION
This PR resolves the `unused import: std::sync::Arc` warning that was emitted by the Rust compiler in `src/server/services/agent_memory/service.rs`. 

The original request (viral loyalty widget implementation) was already present on `main`, so no changes were needed to the frontend. All tests have passed successfully.

---
*PR created automatically by Jules for task [12979839910546311604](https://jules.google.com/task/12979839910546311604) started by @ql-owo-lp*