### PR TITLE
💰 Miser: Fix Cost Soft Limit mapping for PlanTier in Billing API

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -625,8 +625,12 @@ pub async fn cost_dashboard_handler(
     let projected_cents = ::server_pricing::calculator::calculate_projected_monthly_cost_cents(total_costs_f64, elapsed_days, 30);
 
     // For free tier, base_price is 0, so any cost > 0 might trigger it, but let's say the budget is $10 for free, $50 for starter, $150 for pro, $500 for business
-    let budget_limit = tier.base_price();
-    let budget_limit = if budget_limit <= 0.0 { 10.0 } else { budget_limit };
+    let budget_limit = match tier {
+        ::server_pricing::rate_limit::PlanTier::Free => 10.0,
+        ::server_pricing::rate_limit::PlanTier::Starter => 50.0,
+        ::server_pricing::rate_limit::PlanTier::Pro => 150.0,
+        ::server_pricing::rate_limit::PlanTier::Business => 500.0,
+    };
 
     let budget_manager = ::server_pricing::budget::BudgetManager::new(budget_limit);
     let budget_health_alert = budget_manager.is_projected_cost_over_threshold(projected_cents);


### PR DESCRIPTION
This PR addresses a bug where the `budget_limit` for cost soft limits erroneously fell back to `tier.base_price()`, which would wrongly trigger cost soft limit health alerts (especially since the Free tier has a base price of 0.0).

By correcting the `budget_limit` to explicitly map to the per-tier soft limits (`$10` for Free, `$50` for Starter, `$150` for Pro, and `$500` for Business), it restores the appropriate health alert thresholds on the Cost Transparency Dashboard.

Targeted UI E2E tests (`test_billing_limits.spec.ts`) and pricing unit tests run fully green with this fix.

---
*PR created automatically by Jules for task [6458737869247674437](https://jules.google.com/task/6458737869247674437) started by @ql-owo-lp*