### PR TITLE
🛡️ Sentry: [reliability fix] ML-Resilience 60-second timeout rule parity

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -52,7 +52,7 @@ macro_rules! validate_tenant_id_sqlx {
 static GLOBAL_POOL: OnceLock<PgPool> = OnceLock::new();
 const POSTGRES_MIGRATION_LOCK_KEY: i64 = 0x4f48_435f_4d49_4752;
 
-pub const MAX_DB_RETRY_ATTEMPTS: u32 = 3;
+pub const MAX_DB_RETRY_ATTEMPTS: u32 = 2;
 
 pub fn secure_pg_pool_options() -> sqlx::postgres::PgPoolOptions {
     sqlx::postgres::PgPoolOptions::new()

--- a/src/server/orchestration/state/parity_test.rs
+++ b/src/server/orchestration/state/parity_test.rs
@@ -889,7 +889,7 @@ mod parity_tests {
         assert!(res.is_err());
         assert!(res.unwrap_err().contains("Database retry exhausted"));
         // execute_with_retry makes 1 initial attempt + 2 retries (max_attempts = 2)
-        assert_eq!(*attempts.lock().unwrap(), 4);
+        assert_eq!(*attempts.lock().unwrap(), 3);
 
         let pg_db = setup_postgres_db().await;
         if let Some(db) = pg_db {
@@ -907,7 +907,7 @@ mod parity_tests {
 
             assert!(res.is_err());
             assert!(res.unwrap_err().contains("Database retry exhausted"));
-            assert_eq!(*attempts.lock().unwrap(), 4);
+            assert_eq!(*attempts.lock().unwrap(), 3);
         }
     }
 


### PR DESCRIPTION
This PR enforces the ML-Resilience 60-second timeout rule by explicitly ensuring `execute_with_retry` respects the maximum 3 attempts rule (1 initial + 2 retries). 

The `MAX_DB_RETRY_ATTEMPTS` constant was reduced to `2` to bring the retry logic back into alignment with ML-Resilience rules and existing comments `// execute_with_retry makes 1 initial attempt + 2 retries (max_attempts = 2)`.

I also updated `test_execute_with_retry_chaos_exhaustion` inside `src/server/orchestration/state/parity_test.rs` to assert 3 total attempts correctly instead of 4, ensuring full parity.

Superpowers skills used: `writing-skills`, `systematic-debugging`.

**Product-use evidence:**
N/A as this was a purely backend change to enforce the retry timeout constraint. 

`bazelisk test //...` verified everything runs correctly and there are no regressions.

---
*PR created automatically by Jules for task [156219812387141764](https://jules.google.com/task/156219812387141764) started by @ql-owo-lp*