### PR TITLE
🔗 Link: Offline-Tolerant Agentic POS & Tap-to-Pay System

### DIFF
--- a/src/server/api/terminal_api.rs
+++ b/src/server/api/terminal_api.rs
@@ -318,6 +318,9 @@ pub struct PosOfflineTransaction {
     pub payload: String,
     pub timestamp: Option<String>,
     pub device_signature: Option<String>,
+    pub terminal_id: Option<String>,
+    pub offline_queued: Option<bool>,
+    pub sync_timestamp: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
@@ -422,7 +425,7 @@ pub async fn sync_offline_transactions_handler(
         }
 
         let mut query_builder = sqlx::QueryBuilder::new(
-            "INSERT INTO pos_offline_transactions (id, tenant_id, client_id, amount_cents, currency, payload, status, _sync_status, device_signature) "
+            "INSERT INTO pos_offline_transactions (id, tenant_id, client_id, amount_cents, currency, payload, status, _sync_status, device_signature, terminal_id, offline_queued, sync_timestamp) "
         );
 
         let tenant_id_clone = tenant_id.clone();
@@ -433,6 +436,13 @@ pub async fn sync_offline_transactions_handler(
             let currency = tx.currency.clone();
             let payload_str = tx.payload.clone();
             let device_signature = tx.device_signature.clone();
+            let terminal_id = tx.terminal_id.clone();
+            let offline_queued = tx.offline_queued.unwrap_or(false);
+
+            // Convert timestamp string to chrono DateTime if available
+            let sync_timestamp: Option<chrono::DateTime<chrono::Utc>> = tx.sync_timestamp.as_ref().and_then(|ts| {
+                chrono::DateTime::parse_from_rfc3339(ts).map(|dt| dt.with_timezone(&chrono::Utc)).ok()
+            });
 
             b.push_bind(tx_id)
              .push_bind(tenant_id_clone.clone())
@@ -442,7 +452,10 @@ pub async fn sync_offline_transactions_handler(
              .push_bind(sqlx::types::Json(serde_json::from_str::<serde_json::Value>(&payload_str).unwrap_or(serde_json::json!({}))))
              .push_bind("PENDING")
              .push_bind("pending")
-             .push_bind(device_signature);
+             .push_bind(device_signature)
+             .push_bind(terminal_id)
+             .push_bind(offline_queued)
+             .push_bind(sync_timestamp);
         });
 
         query_builder.push(" ON CONFLICT (id) DO NOTHING RETURNING id, client_id, amount_cents, currency, payload");
@@ -511,6 +524,52 @@ pub async fn sync_offline_transactions_handler(
                          .push_bind("offline_pos_sync")
                          .push_bind(sqlx::types::Json(serde_json::from_str::<serde_json::Value>(&job_payload).unwrap_or(serde_json::json!({}))));
                     });
+
+                    for tx in &req_data.transactions {
+                        if let Ok(payload_val) = serde_json::from_str::<serde_json::Value>(&tx.payload) {
+                            if let Some(items) = payload_val.as_array() {
+                                for item in items {
+                                    if let (Some(product_id), Some(quantity)) = (
+                                        item.get("product_id").and_then(|v| v.as_str()),
+                                        item.get("quantity").and_then(|v| v.as_i64()),
+                                    ) {
+                                        let sales_req_id = uuid::Uuid::new_v4().to_string();
+                                        let sales_payload = serde_json::json!({
+                                            "source": "terminal",
+                                            "event": "pos_transaction_completed",
+                                            "agent_type": "sales_and_revenue",
+                                            "product_id": product_id,
+                                            "quantity": quantity,
+                                            "amount_cents": tx.amount_cents,
+                                        });
+                                        let _ = sqlx::query("INSERT INTO agent_action_requests (id, tenant_id, action_type, status, product_id, payload) VALUES ($1, $2, 'record_pos_transaction', 'pending', $3, $4)")
+                                            .bind(&sales_req_id)
+                                            .bind(&tenant_id)
+                                            .bind(&product_id)
+                                            .bind(sqlx::types::Json(sales_payload))
+                                            .execute(&mut *db_tx)
+                                            .await;
+
+                                        let ops_req_id = uuid::Uuid::new_v4().to_string();
+                                        let ops_payload = serde_json::json!({
+                                            "source": "terminal",
+                                            "event": "pos_transaction_completed",
+                                            "agent_type": "operations",
+                                            "product_id": product_id,
+                                            "quantity": quantity,
+                                        });
+                                        let _ = sqlx::query("INSERT INTO agent_action_requests (id, tenant_id, action_type, status, product_id, payload) VALUES ($1, $2, 'record_pos_transaction', 'pending', $3, $4)")
+                                            .bind(&ops_req_id)
+                                            .bind(&tenant_id)
+                                            .bind(&product_id)
+                                            .bind(sqlx::types::Json(ops_payload))
+                                            .execute(&mut *db_tx)
+                                            .await;
+                                    }
+                                }
+                            }
+                        }
+                    }
 
                     if let Err(e) = job_query_builder.build().execute(&mut *db_tx).await {
                         tracing::error!("Failed to enqueue jobs: {}", e);

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -1171,7 +1171,10 @@ CREATE TABLE IF NOT EXISTS omni_inbox_messages (
                         subscription_frequency TEXT,
                         subscription_discount_percent INTEGER DEFAULT 0,
                         _sync_status TEXT DEFAULT 'pending',
-                        version INTEGER DEFAULT 1
+                        version INTEGER DEFAULT 1,
+                        terminal_id TEXT,
+                        offline_queued BOOLEAN DEFAULT FALSE,
+                        sync_timestamp TIMESTAMP
                     );
 
                     CREATE TABLE IF NOT EXISTS orders (
@@ -1187,7 +1190,10 @@ CREATE TABLE IF NOT EXISTS omni_inbox_messages (
                         subscription_frequency TEXT,
                         subscription_discount_percent INTEGER DEFAULT 0,
                         _sync_status TEXT DEFAULT 'pending',
-                        version INTEGER DEFAULT 1
+                        version INTEGER DEFAULT 1,
+                        terminal_id TEXT,
+                        offline_queued BOOLEAN DEFAULT FALSE,
+                        sync_timestamp TIMESTAMP
                     );
                     CREATE TABLE IF NOT EXISTS order_items (
                         id TEXT PRIMARY KEY,

--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -101,6 +101,9 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
              type: 'tap_to_pay',
              product_id: item.product.id,
              quantity: item.quantity,
+             terminal_id: localStorage.getItem('ohc_pos_device_id') || 'local_device',
+             offline_queued: true,
+             sync_timestamp: new Date().toISOString(),
              payload: { amount_cents: item.product.price_cents * item.quantity }
           });
        });


### PR DESCRIPTION
### Problem Statement

Physical and mobile operators operating in flaky network environments needed the ability to accept Tap-to-Pay without hardware reliance, but transactions required proper online tracking for inventory and revenue summaries through AI agents.

### Changes Made

- **Data Models**: Added `terminal_id`, `offline_queued`, and `sync_timestamp` to the `pos_offline_transactions` and `orders` PostgreSQL schema definition and migrations.
- **Frontend POS (`StripeTerminalClient.tsx`)**: The offline tap-to-pay payload to the sync manager now records `terminal_id`, sets `offline_queued` to true, and sets `sync_timestamp`.
- **Backend API (`terminal_api.rs`)**: Processed these fields in `PosOfflineTransaction` parsing, persisting them in the backend database. Furthermore, triggered `agent_action_requests` dynamically for `sales_and_revenue` and `operations` agents mirroring the online flow so the system can resolve inventory locks and calculate metrics during the eventual edge synchronization.
- All tests fully pass, including E2E UI Playwright and backend unit tests.

### Product-use Evidence

- **Persona**: Field Ops and Standalone Tap-to-pay users.
- **CUJ**: Process payment in an offline-only mode via terminal; queue and sync the payload to correctly emit an agent action to update total cart and inventory operations.
- The UI properly routes the offline payload including the device identifier to trigger the corresponding backend jobs when the device reconnects.
- Loaded Superpowers Skills (Verified locally against `test` suite standards, `git`, and UI paths)

---
*PR created automatically by Jules for task [4567712385221080969](https://jules.google.com/task/4567712385221080969) started by @ql-owo-lp*

Resolves #33305