### PR TITLE
🛡️ Sentry: [reliability fix] Add exponential backoff retry to DB timeouts

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -764,10 +764,24 @@ impl DB {
 
             match timeout_res {
                 Err(_) => {
-                    return Err(E::from(format!(
-                        "Database operation '{}' timed out",
-                        operation
-                    )));
+                    attempt += 1;
+                    if attempt > max_attempts {
+                        let _ = ::server_telemetry::record_sqlite_retry_exhausted(
+                            &self.pool, operation,
+                        )
+                        .await;
+                        return Err(E::from(format!(
+                            "Database operation '{}' timed out",
+                            operation
+                        )));
+                    }
+                    let jitter_factor = 1.0 + (rand::random::<f64>() * 0.5); // Up to 50% extra
+                    let jittered_backoff = std::time::Duration::from_secs_f64(
+                        backoff.as_secs_f64() * jitter_factor,
+                    );
+                    tokio::time::sleep(jittered_backoff).await;
+                    backoff *= 2;
+                    continue;
                 }
                 Ok(Ok(val)) => return Ok(val),
                 Ok(Err(err)) => {


### PR DESCRIPTION
Added retry and exponential backoff jitter on timeout inside `src/server/db.rs` `execute_with_retry`. Before this, if the execution timed out it would incorrectly abort immediately instead of properly executing retries, breaking the ML-Resilience fallback parity and the Code Auditor specifications for Sentry Chaos tests. Now it perfectly passes all tests with jitter and max retries correctly checked upon `Err(_)` from the timeout duration.

Superpowers skills used:
- test-driven-development
- subagent-driven-development

---
*PR created automatically by Jules for task [2659481001943496924](https://jules.google.com/task/2659481001943496924) started by @ql-owo-lp*