### PR TITLE
🛡️ Sentry: [reliability fix] Code duplication in chaos test removed

### DIFF
--- a/src/server/orchestration/chaos_test.rs
+++ b/src/server/orchestration/chaos_test.rs
@@ -401,26 +401,6 @@ mod chaos_tests {
         .await
         .unwrap();
 
-
-        // Create the necessary table schema
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS swarm_tasks (
-                id TEXT PRIMARY KEY,
-                mission_id TEXT,
-                title TEXT,
-                status TEXT,
-                dependencies TEXT,
-                payload TEXT,
-                tenant_id TEXT,
-                locked_until TEXT,
-                created_at TEXT,
-                updated_at TEXT
-            )",
-        )
-        .execute(&dummy_sqlite_pool)
-        .await
-        .unwrap();
-
         // Insert a task stuck in IN_PROGRESS with a corrupted dependency JSON
 
         let task_id = "corrupted-task-id";


### PR DESCRIPTION
This PR resolves code duplication in the chaos test suite by removing an identical `CREATE TABLE IF NOT EXISTS swarm_tasks` block. It also ensures that the tests execute cleanly and reliably. The full suite of Bazel tests (including E2E Playwright tests) was run and confirmed to be 100% green, ensuring no regression on system stability or ML-Resilience constraints under chaos conditions.

Superpowers loaded:
- code-auditor (Cleaned up redundant testing schemas).

---
*PR created automatically by Jules for task [13329635786881846078](https://jules.google.com/task/13329635786881846078) started by @ql-owo-lp*