### PR TITLE
Fix UI files to have border-radius 16px as per UX standards

### DIFF
--- a/src/ui/tauri/src/ui/affiliate-dashboard.html
+++ b/src/ui/tauri/src/ui/affiliate-dashboard.html
@@ -64,7 +64,8 @@
         .glassmorphism {
           background: rgba(22, 22, 26, 0.7);
           border: 1px solid rgba(255, 255, 255, 0.1);
-        }
+          border-radius: 16px;
+      }
         body {
             background: #111111;
             color: #f5f5f7;

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1148,7 +1148,8 @@
           backdrop-filter: blur(30px) saturate(210%) !important;
           -webkit-backdrop-filter: blur(30px) saturate(210%) !important;
           border: 1px solid rgba(255, 255, 255, 0.1) !important;
-        }
+          border-radius: 16px;
+      }
         .context-card:hover {
           background: rgba(40, 40, 45, 0.7) !important;
         }

--- a/src/ui/tauri/src/ui/weekly-snapshot-share.html
+++ b/src/ui/tauri/src/ui/weekly-snapshot-share.html
@@ -51,6 +51,7 @@
       .glassmorphism {
         background: rgba(22, 22, 26, 0.7);
         border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 16px;
       }
       body {
         color: #ffffff;


### PR DESCRIPTION
Adding border-radius: 16px; directly to all instances of .glassmorphism in the Tauri UI html files to match the OHC Premium Standard.

---
*PR created automatically by Jules for task [14521572118359655625](https://jules.google.com/task/14521572118359655625) started by @ql-owo-lp*