### PR TITLE
fix(queue): resolve job queue test timeouts and dead-letter cleanup logic

### DIFF
--- a/src/server/orchestration/queue/ohc_job_queue.rs
+++ b/src/server/orchestration/queue/ohc_job_queue.rs
@@ -142,12 +142,12 @@ impl OHCJobQueue {
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
              SELECT lower(hex(randomblob(16))), tenant_id, 'job_failed', 'job_queue', COALESCE(CAST(payload AS TEXT), '{}'), '[cleanup] Stagnant backlog item stuck in PENDING for > 24 hours'
              FROM ohc_job_queue
-             WHERE status = 'PENDING' AND updated_at < datetime('now', '-24 hours')"
+             WHERE status = 'PENDING' AND created_at < datetime('now', '-24 hours')"
         } else {
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
              SELECT gen_random_uuid()::text, tenant_id, 'job_failed', 'job_queue', COALESCE(payload::text, '{}'), '[cleanup] Stagnant backlog item stuck in PENDING for > 24 hours'
              FROM ohc_job_queue
-             WHERE status = 'PENDING' AND updated_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
+             WHERE status = 'PENDING' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
         };
 
         sqlx::query(query_str)
@@ -157,10 +157,10 @@ impl OHCJobQueue {
 
         let query_str = if is_standalone {
             "DELETE FROM ohc_job_queue
-             WHERE status = 'PENDING' AND updated_at < datetime('now', '-24 hours')"
+             WHERE status = 'PENDING' AND created_at < datetime('now', '-24 hours')"
         } else {
             "DELETE FROM ohc_job_queue
-             WHERE status = 'PENDING' AND updated_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
+             WHERE status = 'PENDING' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
         };
 
         let stagnant_result = sqlx::query(query_str)

--- a/src/server/orchestration/queue/worker_pool.rs
+++ b/src/server/orchestration/queue/worker_pool.rs
@@ -30,6 +30,7 @@ impl WorkerPool {
 
             let handle = tokio::spawn(async move {
                 tracing::info!("Worker {} started listening for {:?}", i, types_clone);
+                let mut current_sleep_ms = 10;
 
                 loop {
                     tokio::select! {
@@ -39,10 +40,11 @@ impl WorkerPool {
                         }
 
                         // Wait a bit before polling again to avoid busy-waiting loop without jobs
-                        _ = tokio::time::sleep(Duration::from_millis(500)) => {
+                        _ = tokio::time::sleep(Duration::from_millis(current_sleep_ms)) => {
                             let type_strs: Vec<&str> = types_clone.iter().map(AsRef::as_ref).collect();
                             match queue_clone.dequeue(type_strs).await {
                                 Ok(Some(job)) => {
+                                    current_sleep_ms = 10;
                                     tracing::debug!("Worker {} processing job {}", i, job.id);
                                     let job_id = job.id.clone();
 
@@ -85,11 +87,13 @@ impl WorkerPool {
                                     }
                                 }
                                 Ok(None) => {
-                                    // No jobs, loop back and sleep
+                                    // No jobs, loop back and sleep with backoff
+                                    current_sleep_ms = std::cmp::min(current_sleep_ms * 2, 500);
                                 }
                                 Err(e) => {
                                     ::server_telemetry::record_error_signal("[bug] Worker failed to dequeue");
                                     tracing::trace!("Worker {} failed to dequeue: {}", i, e);
+                                    current_sleep_ms = std::cmp::min(current_sleep_ms * 2, 500);
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes failing tests in `server_orchestration_queue_test`:
- `test_worker_pool_chaos_timeout`: Replaced a static 500ms `tokio::time::sleep` in the `worker_pool.rs` with an exponential backoff polling strategy (10ms to 500ms max). This significantly improves worker responsiveness under high load, resolving lock contention and test timeout issues without burning CPU.
- `test_cleanup_stagnant_pending_jobs`: Updated `cleanup_stale_jobs` in `ohc_job_queue.rs` to query `created_at` instead of `updated_at` when searching for stagnant 24-hour-old jobs, properly catching stalled backlog items and making tests pass.

Both targets were verified via `bazel test //...` and target-specific commands.

---
*PR created automatically by Jules for task [6497774864902807507](https://jules.google.com/task/6497774864902807507) started by @ql-owo-lp*