### PR TITLE
feat: improve zero-click onboarding glassmorphism and fix test selector

### DIFF
--- a/src/e2e/tests/zero_click_onboarding.spec.ts
+++ b/src/e2e/tests/zero_click_onboarding.spec.ts
@@ -58,7 +58,7 @@ test.describe('Zero-Click Onboarding to Agent Feed', () => {
     const chatInput = page.locator('input[placeholder*="e.g. I am a home baker"]');
     await expect(chatInput).toBeVisible();
     await chatInput.fill('');
-    await page.locator('button[type="submit"]').click();
+    await page.locator('#chat-send-btn').click();
 
     // Message shouldn't appear in chat history
     const userMessages = page.locator('.chat-message.user');
@@ -97,7 +97,7 @@ test.describe('Zero-Click Onboarding to Agent Feed', () => {
     const chatInput = page.locator('input[placeholder*="e.g. I am a home baker"]');
     await expect(chatInput).toBeVisible();
     await chatInput.fill('This is a test message to ensure history persistence.');
-    await page.locator('button[type="submit"]').click();
+    await page.locator('#chat-send-btn').click();
 
     // Wait for the message to appear
     const userMessages = page.locator('.chat-message.user');
@@ -126,7 +126,7 @@ test.describe('Zero-Click Onboarding to Agent Feed', () => {
     const chatInput = page.locator('input[placeholder*="e.g. I am a home baker"]');
     await expect(chatInput).toBeVisible();
     await chatInput.fill('Testing chat bubble formatting');
-    await page.locator('button[type="submit"]').click();
+    await page.locator('#chat-send-btn').click();
 
     // Check message wrapper layout
     const lastUserMessage = page.locator('.chat-message.user').last();

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -463,25 +463,30 @@
         font-size: 14px;
         line-height: 1.5;
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+        border-radius: 16px;
       }
       .chat-message.assistant .chat-bubble {
         background: rgba(255, 255, 255, 0.65);
         border: 1px solid rgba(255, 255, 255, 0.6);
-        border-bottom-left-radius: 4px;
         color: #1d1d1f;
+        border-radius: 16px;
+        border-bottom-left-radius: 4px;
       }
       @media (prefers-color-scheme: dark) {
         .chat-message.assistant .chat-bubble {
           background: rgba(40, 40, 45, 0.8);
           border: 1px solid rgba(255, 255, 255, 0.1);
           color: #f5f5f7;
-        }
+          border-radius: 16px;
+          border-bottom-left-radius: 4px;
+      }
       }
       .chat-message.user .chat-bubble {
         background: #0066FF;
         border: 1px solid #0052cc;
-        border-bottom-right-radius: 4px;
         color: white;
+        border-radius: 16px;
+        border-bottom-right-radius: 4px;
       }
       .chat-sender {
         font-size: 11px;


### PR DESCRIPTION
This commit addresses the issue where zero-click onboarding E2E tests were failing because the `button[type="submit"]` was ambiguous or non-functional in the modified context. It updates the test to use the specific `#chat-send-btn` ID.

It also updates `src/ui/tauri/src/ui/setup.html` to align with the OHC Premium Glassmorphism styling requirements (using `border-radius: 16px` on the containers and `.chat-bubble` elements, while preserving the conversational "tail" look via `border-bottom-*-radius: 4px`). All tests have been verified to pass successfully.

---
*PR created automatically by Jules for task [13034339321445722139](https://jules.google.com/task/13034339321445722139) started by @ql-owo-lp*