### PR TITLE
style: optimize glassmorphism classes to enforce OHC standards

### DIFF
--- a/src/ui/next/src/app/agent-marketplace/publish/page.tsx
+++ b/src/ui/next/src/app/agent-marketplace/publish/page.tsx
@@ -62,7 +62,7 @@ export default function PublishAgentPage() {
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="glassmorphism p-8 rounded-[16px] border border-white/40 shadow-sm backdrop-blur-[30px] saturate-[210%] bg-white/65">
+        <form onSubmit={handleSubmit} className="glassmorphism p-8  border border-white/40 shadow-sm backdrop-blur-[30px] saturate-[210%] bg-white/65">
           <div className="mb-6">
             <label htmlFor="name" className="block text-[#18212f] font-semibold mb-2">Agent Name</label>
             <input

--- a/src/ui/next/src/app/api/v1/growth/storefront/og-card/route.tsx
+++ b/src/ui/next/src/app/api/v1/growth/storefront/og-card/route.tsx
@@ -1,49 +1,49 @@
 export const runtime = 'edge';
 
 export async function GET(request: Request) {
-  try {
-    const { searchParams } = new URL(request.url);
+ try {
+  const { searchParams } = new URL(request.url);
 
-    const escapeHtml = (unsafe: string) => {
-      return unsafe
-          .replace(/&/g, "&amp;")
-          .replace(/</g, "&lt;")
-          .replace(/>/g, "&gt;")
-          .replace(/"/g, "&quot;")
-          .replace(/'/g, "&#039;");
-    };
-    const tenantRaw = escapeHtml(searchParams.get('tenant') || 'my-store');
-    const productName = escapeHtml(searchParams.get('product_name') || 'Product');
+  const escapeHtml = (unsafe: string) => {
+   return unsafe
+     .replace(/&/g, "&amp;")
+     .replace(/</g, "&lt;")
+     .replace(/>/g, "&gt;")
+     .replace(/"/g, "&quot;")
+     .replace(/'/g, "&#039;");
+  };
+  const tenantRaw = escapeHtml(searchParams.get('tenant') || 'my-store');
+  const productName = escapeHtml(searchParams.get('product_name') || 'Product');
 
-    const svg = `
+  const svg = `
 <svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="1200" height="630" fill="#111827"/>
-  <text fill="#ffffff" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="80" font-weight="bold" letter-spacing="0em">
-    <tspan x="600" y="250" text-anchor="middle">${productName}</tspan>
-  </text>
-  <text fill="#9ca3af" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="40" letter-spacing="0em">
-    <tspan x="600" y="320" text-anchor="middle">Discover our exclusive, high-quality products.</tspan>
-  </text>
-  <text fill="#9ca3af" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="40" letter-spacing="0em">
-    <tspan x="600" y="380" text-anchor="middle">Buy directly from ${tenantRaw} storefront!</tspan>
-  </text>
-  <rect x="400" y="450" width="400" height="80" rx="30" fill="#1f2937" stroke="#374151" stroke-width="2"/>
-  <text fill="#d1d5db" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="24" font-weight="bold" letter-spacing="0em">
-    <tspan x="600" y="500" text-anchor="middle">⚡ Powered by OHC</tspan>
-  </text>
+ <rect width="1200" height="630" fill="#111827"/>
+ <text fill="#ffffff" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="80" font-weight="bold" letter-spacing="0em">
+  <tspan x="600" y="250" text-anchor="middle">${productName}</tspan>
+ </text>
+ <text fill="#9ca3af" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="40" letter-spacing="0em">
+  <tspan x="600" y="320" text-anchor="middle">Discover our exclusive, high-quality products.</tspan>
+ </text>
+ <text fill="#9ca3af" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="40" letter-spacing="0em">
+  <tspan x="600" y="380" text-anchor="middle">Buy directly from ${tenantRaw} storefront!</tspan>
+ </text>
+ <rect x="400" y="450" width="400" height="80" rx="30" fill="#1f2937" stroke="#374151" stroke-width="2"/>
+ <text fill="#d1d5db" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="24" font-weight="bold" letter-spacing="0em">
+  <tspan x="600" y="500" text-anchor="middle">⚡ Powered by OHC</tspan>
+ </text>
 </svg>`;
 
-    return new Response(svg.trim(), {
-      status: 200,
-      headers: {
-        'Content-Type': 'image/svg+xml',
-        'Cache-Control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=300'
-      }
-    });
-  } catch (e: any) {
-    console.error(`${e.message}`);
-    return new Response(`Failed to generate the image`, {
-      status: 500,
-    });
-  }
+  return new Response(svg.trim(), {
+   status: 200,
+   headers: {
+    'Content-Type': 'image/svg+xml',
+    'Cache-Control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=300'
+   }
+  });
+ } catch (e: any) {
+  console.error(`${e.message}`);
+  return new Response(`Failed to generate the image`, {
+   status: 500,
+  });
+ }
 }

--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -1205,3 +1205,10 @@ html.dark .glass-panel {
     border: 1px solid rgba(255, 255, 255, 0.4);
   }
 }
+/* Global border radius to fix UI regression */
+.glassmorphism, .glass-card {
+  border-radius: 16px;
+}
+.glass-control {
+  border-radius: 8px;
+}

--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -966,7 +966,7 @@ export default function OnboardingWizard() {
     <div className="setup-page min-h-screen w-full bg-[#F5F5F7] dark:bg-[#16161a] flex items-center justify-center sm:p-4 font-inter overflow-x-hidden">
       <div
         id="setup-screen"
-        className="w-full max-w-[375px] sm:max-w-md lg:max-w-lg xl:max-w-2xl mx-auto overflow-hidden flex flex-col min-h-[100vh] sm:min-h-[812px] relative bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border-0 sm:border sm:rounded-[16px] border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-none sm:shadow-[0_18px_44px_rgba(15,23,42,0.12)] glassmorphism sm:rounded-[16px]"
+        className="w-full max-w-[375px] sm:max-w-md lg:max-w-lg xl:max-w-2xl mx-auto overflow-hidden flex flex-col min-h-[100vh] sm:min-h-[812px] relative bg-[rgba(255,255,255,0.65)] dark:bg-[rgba(22,22,26,0.7)] backdrop-blur-[30px] backdrop-saturate-[210%] border-0 sm:border  border-[rgba(255,255,255,0.4)] dark:border-[rgba(255,255,255,0.1)] shadow-none sm:shadow-[0_18px_44px_rgba(15,23,42,0.12)] glassmorphism "
       >
         <div className="px-6 pt-5 text-center">
           <div className="setup-header-main">
@@ -1088,7 +1088,7 @@ export default function OnboardingWizard() {
           )}
 
           {step === 0 && (
-            <div className="flex flex-col flex-1 animate-fade-in w-full h-full max-h-full glassmorphism sm:rounded-[16px] p-4">
+            <div className="flex flex-col flex-1 animate-fade-in w-full h-full max-h-full glassmorphism  p-4">
               <button
                 onClick={() => {
                   updateState({ step: -2 });
@@ -2349,7 +2349,7 @@ export default function OnboardingWizard() {
           {step === 4 && (
             <div
               aria-live="polite"
-              className="flex flex-col flex-1 justify-center items-center text-center animate-fade-in glass-card rounded-[16px] shadow-2xl p-4 sm:p-8"
+              className="flex flex-col flex-1 justify-center items-center text-center animate-fade-in glass-card  shadow-2xl p-4 sm:p-8"
             >
               <div className="w-24 h-24 relative mb-8">
                 <div className="absolute inset-0 border-4 border-[#0066FF]/20 rounded-full"></div>
@@ -2480,7 +2480,7 @@ export default function OnboardingWizard() {
               </p>
 
               <div className="w-full space-y-3 mt-auto">
-                <div className="p-3 glass-card rounded-[16px] flex flex-col items-center mb-6">
+                <div className="p-3 glass-card  flex flex-col items-center mb-6">
                   <p className="text-xs text-gray-500 dark:text-[#A1A1A6] uppercase font-bold tracking-wider mb-2">
                     Your Shareable Link
                   </p>

--- a/src/ui/next/src/app/onboarding/zero-click/page.tsx
+++ b/src/ui/next/src/app/onboarding/zero-click/page.tsx
@@ -44,7 +44,7 @@ export default function ZeroClickBuilderPage() {
         {!generatedStore ? (
           <OnboardingChatAgent onComplete={handleChatComplete} />
         ) : (
-          <div className="glassmorphism sm:rounded-[16px] p-8 mb-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
+          <div className="glassmorphism  p-8 mb-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
             <div className="text-center mb-8">
               <div className="inline-flex items-center justify-center w-16 h-16 bg-green-100 dark:bg-green-900/30 text-green-600 rounded-full mb-4">
                 <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/ui/next/src/app/zero-click-builder/page.tsx
+++ b/src/ui/next/src/app/zero-click-builder/page.tsx
@@ -48,7 +48,7 @@ export default function ZeroClickBuilderPage() {
           .page-bg { background-color: #000000; }
         }
       `}} />
-      <div className="w-full max-w-[375px] mx-auto glassmorphism p-6 rounded-[16px] border border-white/40 dark:border-white/10 relative overflow-hidden">
+      <div className="w-full max-w-[375px] mx-auto glassmorphism p-6  border border-white/40 dark:border-white/10 relative overflow-hidden">
 
         {builderState === 'idle' && (
           <div className="flex flex-col gap-6 relative z-10">

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -26,8 +26,8 @@
       }
       .container {
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         padding: 20px;
         padding-bottom: 24px;
         border-radius: 16px;
@@ -46,8 +46,8 @@
       .glassmorphism {
         border-radius: 16px;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
       }
@@ -57,8 +57,8 @@
       @media (prefers-color-scheme: dark) {
         .container, .glassmorphism {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
-          -webkit-backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
+          -webkit-backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
           border-radius: 16px;
         }
@@ -87,8 +87,8 @@
         box-sizing: border-box;
         font-size: 16px;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         transition:
           border-color 0.2s,
           background 0.2s,
@@ -125,8 +125,8 @@
       .glass-control {
         border-radius: 8px;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
       }
       textarea.glass-control, input.glass-control, select.glass-control, button.glass-control {
@@ -255,8 +255,8 @@
         align-items: center;
         justify-content: space-between;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 12px 16px;
         box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.05);
@@ -319,15 +319,15 @@
       @media (prefers-color-scheme: dark) {
         .container {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
           border-radius: 16px;
         }
         .context-card,
         .toggle-row {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
-          -webkit-backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
+          -webkit-backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .context-card:hover {
@@ -350,8 +350,8 @@
         }
         .container {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
-          -webkit-backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
+          -webkit-backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
           box-shadow:
             0 4px 6px -1px rgba(0, 0, 0, 0.1),
@@ -543,8 +543,8 @@
         align-items: center;
         justify-content: space-between;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 12px 16px;
         box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.05);
@@ -607,15 +607,15 @@
       @media (prefers-color-scheme: dark) {
         .container {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
           border-radius: 16px;
         }
         .context-card,
         .toggle-row {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
-          -webkit-backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
+          -webkit-backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .context-card:hover {
@@ -689,8 +689,8 @@
           Helvetica,
           Arial,
           sans-serif;
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         transition:
           border-color 0.2s,
           background 0.2s,
@@ -715,8 +715,8 @@
       .context-card {
         min-height: 44px;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 16px;
         cursor: pointer;
@@ -770,8 +770,8 @@
         align-items: center;
         gap: 10px;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 12px 16px;
         min-height: 44px;
@@ -812,7 +812,7 @@
         min-height: 44px;
       }
       .btn-secondary:hover {
-        background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(40px) saturate(220%); -webkit-backdrop-filter: blur(40px) saturate(220%);
+        background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(30px) saturate(210%); -webkit-backdrop-filter: blur(30px) saturate(210%);
         color: #1d1d1f;
       }
       .btn-group {
@@ -882,8 +882,8 @@
         align-items: center;
         justify-content: space-between;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 12px 16px;
         box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.05);
@@ -946,15 +946,15 @@
       @media (prefers-color-scheme: dark) {
         .container {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
           border-radius: 16px;
         }
         .context-card,
         .toggle-row {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
-          -webkit-backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
+          -webkit-backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .context-card:hover {
@@ -990,8 +990,8 @@
           min-width: 44px;
           box-sizing: border-box;
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
-          -webkit-backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
+          -webkit-backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .radio-option:hover {
@@ -1210,8 +1210,8 @@
         align-items: center;
         justify-content: space-between;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 12px 16px;
         box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.05);
@@ -1274,15 +1274,15 @@
       @media (prefers-color-scheme: dark) {
         .container {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
           border-radius: 16px;
         }
         .context-card,
         .toggle-row {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
-          -webkit-backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
+          -webkit-backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .context-card:hover {
@@ -4415,8 +4415,8 @@
         .ohc-tooltip {
             position: fixed;
             background: rgba(255, 255, 255, 0.65);
-            backdrop-filter: blur(40px) saturate(220%);
-            -webkit-backdrop-filter: blur(40px) saturate(220%);
+            backdrop-filter: blur(30px) saturate(210%);
+            -webkit-backdrop-filter: blur(30px) saturate(210%);
             border: 1px solid rgba(255, 255, 255, 0.4);
             padding: 12px 16px;
             color: #1d1d1f;
@@ -4450,8 +4450,8 @@
         align-items: center;
         justify-content: space-between;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         padding: 12px 16px;
         box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.05);
@@ -4514,13 +4514,13 @@
       @media (prefers-color-scheme: dark) {
         .container {
             background: rgba(22, 22, 26, 0.7);
-            backdrop-filter: blur(40px) saturate(220%);
+            backdrop-filter: blur(30px) saturate(210%);
             border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .context-card, .toggle-row {
           background: rgba(22, 22, 26, 0.7);
-          backdrop-filter: blur(40px) saturate(220%);
-          -webkit-backdrop-filter: blur(40px) saturate(220%);
+          backdrop-filter: blur(30px) saturate(210%);
+          -webkit-backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .context-card:hover {
@@ -4679,8 +4679,8 @@
       .ohc-tooltip {
         position: fixed;
         background: rgba(255, 255, 255, 0.65);
-        backdrop-filter: blur(40px) saturate(220%);
-        -webkit-backdrop-filter: blur(40px) saturate(220%);
+        backdrop-filter: blur(30px) saturate(210%);
+        -webkit-backdrop-filter: blur(30px) saturate(210%);
         border: 1px solid rgba(255, 255, 255, 0.4);
         color: #1d1d1f;
         padding: 8px 12px;
@@ -4811,7 +4811,7 @@
           bubble.classList.add("ohc-walkthrough-bubble");
           bubble.setAttribute("role", "dialog");
           bubble.style.cssText =
-            "position: fixed; background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(40px) saturate(220%); -webkit-backdrop-filter: blur(40px) saturate(220%); border: 1px solid rgba(255, 255, 255, 0.4); border-radius: 16px; padding: 16px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); z-index: 99999; max-width: 300px; display: flex; flex-direction: column; gap: 8px; font-family: Outfit, sans-serif;";
+            "position: fixed; background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(30px) saturate(210%); -webkit-backdrop-filter: blur(30px) saturate(210%); border: 1px solid rgba(255, 255, 255, 0.4); border-radius: 16px; padding: 16px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); z-index: 99999; max-width: 300px; display: flex; flex-direction: column; gap: 8px; font-family: Outfit, sans-serif;";
           document.body.appendChild(bubble);
 
           function renderStep() {
@@ -4938,7 +4938,7 @@
     font-size: 14px;
     font-weight: 600;
     background: rgba(255, 255, 255, 0.65);
-    backdrop-filter: blur(40px) saturate(220%);
+    backdrop-filter: blur(30px) saturate(210%);
     border-top: 1px solid rgba(255, 255, 255, 0.4);
     border-radius: 16px;
     width: 100%;


### PR DESCRIPTION
This PR enforces OHC premium design standards for glassmorphism components. It moves `border-radius` assignments for `.glassmorphism` and `.glass-card` into `globals.css`, and selectively removes redundant `rounded-[16px]` hardcoded classes only when they accompany those glassmorphism styles, preserving rounded borders elsewhere to avoid sharp-corner regressions. It also updates the `backdrop-filter` in the Tauri setup HTML template to match the desired standard.

---
*PR created automatically by Jules for task [15414787141460367287](https://jules.google.com/task/15414787141460367287) started by @ql-owo-lp*