### PR TITLE
Fix network parity chaos test unused variable

### DIFF
--- a/src/server/orchestration/chaos_test.rs
+++ b/src/server/orchestration/chaos_test.rs
@@ -679,7 +679,7 @@ mod chaos_tests {
         let standalone_tasks = temp_env::async_with_vars([("OHC_STATE_MANAGER_TIMEOUT_MS", Some("50"))], async {
             tokio::time::timeout(std::time::Duration::from_millis(250), standalone_state_manager.pull_available_tasks(10)).await.expect("Test hung")
         }).await;
-        let elapsed_standalone = start_standalone.elapsed();
+        let _elapsed_standalone = start_standalone.elapsed();
 
         // Parity verification: both should gracefully fallback (likely to empty lists or error, but must not panic)
         // Cloud and Standalone should behave identically at the API boundary


### PR DESCRIPTION
In `src/server/orchestration/chaos_test.rs`, the `test_network_partition_parity` test was failing compilation due to an unused variable (`elapsed_standalone`). To respect Rust's compiler strictness, I changed it to `_elapsed_standalone`. This fix ensures `bazel test //...` fully passes and the build remains green.

---
*PR created automatically by Jules for task [15688422454676827506](https://jules.google.com/task/15688422454676827506) started by @ql-owo-lp*