### PR TITLE
🧙 Wizard: Fix back button step navigation in setup UI

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2378,7 +2378,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-assistant"
+            data-prev="step-admin"
           >
             Back
           </button>
@@ -2426,7 +2426,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-admin"
+            data-prev="step-offer"
           >
             Back
           </button>
@@ -2473,7 +2473,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-offer"
+            data-prev="step-location"
           >
             Back
           </button>
@@ -2520,7 +2520,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-location"
+            data-prev="step-target-audience"
           >
             Back
           </button>
@@ -2579,7 +2579,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-target-audience"
+            data-prev="step-domain"
           >
             Back
           </button>


### PR DESCRIPTION
The back button on multiple steps of the onboarding wizard navigated to the wrong previous step. This commit fixes that issue by linking them properly matching the expected linear process.

---
*PR created automatically by Jules for task [6619893066491148033](https://jules.google.com/task/6619893066491148033) started by @ql-owo-lp*