### PR TITLE
🗺️ Guide: Seamless Day One Onboarding Flow to Command Center

### DIFF
--- a/src/e2e/setup_onboarding.spec.ts
+++ b/src/e2e/setup_onboarding.spec.ts
@@ -102,4 +102,8 @@ test('setup onboarding mobile-first inputs and logic', async ({ page }) => {
   await page.selectOption('#template-selection', { label: 'Modern' });
   const finishBtn = page.locator('#finish-btn');
   await expect(finishBtn).toBeVisible();
+
+  await finishBtn.click();
+  await page.waitForURL('**/dashboard.html*');
+  await expect(page.url()).toContain('dashboard.html');
 });

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -3765,7 +3765,7 @@
                   delete window.generateStorefrontLoadingInterval;
               }
 
-              window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
+              window.location.href = "dashboard.html#unified-agent-feed-section";
               return;
             }
 
@@ -3829,7 +3829,7 @@
                 delete window.generateStorefrontLoadingInterval;
             }
 
-            window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
+            window.location.href = "dashboard.html#unified-agent-feed-section";
           }
         } catch (e) {
           chatMessagesEl.innerHTML += `<div style="margin-bottom: 10px; color: #FF3B30;"><strong>Error:</strong> Failed to connect.</div>`;
@@ -3894,7 +3894,7 @@
               localStorage.removeItem("onboardingState");
               localStorage.setItem("has_onboarded", "true");
 
-              window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
+              window.location.href = "dashboard.html#unified-agent-feed-section";
               return;
             }
 
@@ -3938,7 +3938,7 @@
               localStorage.removeItem("onboardingState");
               localStorage.setItem("has_onboarded", "true");
 
-              window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
+              window.location.href = "dashboard.html#unified-agent-feed-section";
             } else {
               const errData = await response.json().catch(() => ({}));
               throw new Error(
@@ -4247,7 +4247,7 @@
                   localStorage.removeItem("onboardingState");
                   localStorage.setItem("has_onboarded", "true");
 
-                  window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
+                  window.location.href = "dashboard.html#unified-agent-feed-section";
                 })
                 .catch((err) => {
                   console.error(err);
@@ -4289,7 +4289,7 @@
                     }
                     localStorage.removeItem("onboardingState");
                     localStorage.setItem("has_onboarded", "true");
-                    window.location.href = "success.html?tenant=" + encodeURIComponent(localStorage.getItem("tenant_id") || "e2e-tenant");
+                    window.location.href = "dashboard.html#unified-agent-feed-section";
                   } else {
                     const errData = await response.json().catch(() => ({}));
                     throw new Error(


### PR DESCRIPTION
Optimized the "Day One" onboarding experience by removing the intermediate `success.html` step. When an owner completes the 8-step setup wizard, they are now directly routed to `dashboard.html#unified-agent-feed-section`. This removes friction and fulfills the promise of immediately dropping the owner into a useful work context where they can see pending tasks, drafts, and business signals. E2E tests have been updated and verified to assert the new routing behavior.

---
*PR created automatically by Jules for task [16454284957146883825](https://jules.google.com/task/16454284957146883825) started by @ql-owo-lp*