### PR TITLE
🗺️ Guide: [Fix Glassmorphism Constraints for Onboarding UI]

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -691,7 +691,7 @@ html.dark .glass-card {
 }
 
 .glass-control {
-  border-radius: 8px;
+  border-radius: 8px !important;
   background: rgba(255, 255, 255, 0.65);
   backdrop-filter: blur(30px) saturate(210%);
   border: 1px solid rgba(255, 255, 255, 0.4);
@@ -699,7 +699,7 @@ html.dark .glass-card {
 
 @media (prefers-color-scheme: dark) {
   .glass-control {
-    border-radius: 8px;
+    border-radius: 8px !important;
     background: rgba(22, 22, 26, 0.7);
     backdrop-filter: blur(30px) saturate(210%);
     border: 1px solid rgba(255, 255, 255, 0.1);
@@ -707,7 +707,7 @@ html.dark .glass-card {
 }
 
 html.dark .glass-control {
-  border-radius: 8px;
+  border-radius: 8px !important;
   background: rgba(22, 22, 26, 0.7);
   backdrop-filter: blur(30px) saturate(210%);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -776,13 +776,13 @@ input[type="url"],
 input[type="search"],
 textarea,
 select {
-  border-radius: 8px;
+  border-radius: 8px !important;
 }
 
 button,
 .app-button,
 .charge-btn {
-  border-radius: 8px;
+  border-radius: 8px !important;
 }
 
 
@@ -974,7 +974,7 @@ button,
 
 .setup-page #setup-screen button {
   min-height: 44px;
-  border-radius: 8px;
+  border-radius: 8px !important;
   cursor: pointer;
 }
 
@@ -1028,7 +1028,7 @@ button,
   min-height: 44px;
   padding: 12px 14px;
   border: 1px solid #cfd8e3;
-  border-radius: 8px;
+  border-radius: 8px !important;
   background: #ffffff;
   color: #18212f;
   font: inherit;

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -123,7 +123,7 @@
       }
       /* Added missing glass-control definition */
       .glass-control {
-        border-radius: 8px;
+        border-radius: 8px !important;
         background: rgba(255, 255, 255, 0.65);
         backdrop-filter: blur(40px) saturate(220%);
         -webkit-backdrop-filter: blur(40px) saturate(220%);


### PR DESCRIPTION
This pull request fixes a visual UX constraint violation identified in `docs/business/market_research/ux_analysis_onboarding.md`. Specifically, it enforces the "Translucent Glass Mandate" by explicitly ensuring controls (`.glass-control`) maintain a strict `8px` rounded corner radius (via `!important`) across both the legacy Next.js builder (`globals.css`) and the desktop Tauri UI (`setup.html`), keeping the parent container cards cleanly at `16px`.

## User Persona & CUJ
- **Persona:** Maya, Home Baker (Small business owner)
- **CUJ:** Completing the Day-One Onboarding Setup Flow across Web/Desktop environments.
- **Observed Gap:** The `glassmorphism` styling inconsistently or loosely defined the border radiuses for standard nested `.glass-control` components (like buttons, select menus, and inputs). A lack of specificity could lead to sub-optimal aesthetics, violating the macOS translucent glass requirement. 
- **The Fix:** Ensuring `.glass-control` has an overriding `border-radius: 8px !important;` rule.

## Verification
- All layout changes have been visually analyzed against the constraints.
- `bazel test //...` run has passed.
- `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"` run has completed cleanly.
- `bazel test //src/ui/next:next_vitest` run has successfully passed.

---
*PR created automatically by Jules for task [16251967025133641437](https://jules.google.com/task/16251967025133641437) started by @ql-owo-lp*