### PR TITLE
💰 Miser: Fixed storage limit asserting for Free tier

### DIFF
--- a/src/e2e/tests/cost_dashboard.spec.ts
+++ b/src/e2e/tests/cost_dashboard.spec.ts
@@ -11,9 +11,9 @@ test.describe('Cost Transparency Dashboard CUJ', () => {
         // 3. Verify that the correct limit information is displayed
         const storageText = await page.locator('#storage-text').innerText();
 
-        // As a seeded Free tenant, the limit should be 2048 MB.
-        // Wait until it appears (we expect it to be 2 GB because 2048 MB = 2 GB or 2048MB depending on formatting)
-        // formatBytes converts 2048 MB (2147483648 bytes) -> 2 GB
-        expect(storageText).toContain('2 GB');
+        // As a seeded Free tenant, the limit should be 500 MB.
+        // Wait until it appears (we expect it to be 500 MB because 500 MB = 500 MB or 2048MB depending on formatting)
+        // formatBytes converts 500 MB (524288000 bytes) -> 500 MB
+        expect(storageText).toContain('500 MB');
     });
 });


### PR DESCRIPTION
This commit resolves an issue in the `src/e2e/tests/cost_dashboard.spec.ts` where the free tier's storage limit was erroneously asserted as 2 GB instead of the correct backend-configured 500 MB. All related UI verification and automated E2E tests, including 'Cost Transparency Dashboard CUJ' and 'Miser Cost Features E2E', were manually tested and shown to correctly mirror the soft limits configured by the product specifications.

---
*PR created automatically by Jules for task [11614327162094658123](https://jules.google.com/task/11614327162094658123) started by @ql-owo-lp*