### PR TITLE
🛡️ Sentry: [reliability fix] update db retry attempts and fix frontend tests

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -52,7 +52,7 @@ macro_rules! validate_tenant_id_sqlx {
 static GLOBAL_POOL: OnceLock<PgPool> = OnceLock::new();
 const POSTGRES_MIGRATION_LOCK_KEY: i64 = 0x4f48_435f_4d49_4752;
 
-pub const MAX_DB_RETRY_ATTEMPTS: u32 = 2;
+pub const MAX_DB_RETRY_ATTEMPTS: u32 = 3;
 
 pub fn secure_pg_pool_options() -> sqlx::postgres::PgPoolOptions {
     sqlx::postgres::PgPoolOptions::new()

--- a/src/server/orchestration/state/parity_test.rs
+++ b/src/server/orchestration/state/parity_test.rs
@@ -889,7 +889,7 @@ mod parity_tests {
         assert!(res.is_err());
         assert!(res.unwrap_err().contains("Database retry exhausted"));
         // execute_with_retry makes 1 initial attempt + 2 retries (max_attempts = 2)
-        assert_eq!(*attempts.lock().unwrap(), 3);
+        assert_eq!(*attempts.lock().unwrap(), 4);
 
         let pg_db = setup_postgres_db().await;
         if let Some(db) = pg_db {
@@ -907,7 +907,7 @@ mod parity_tests {
 
             assert!(res.is_err());
             assert!(res.unwrap_err().contains("Database retry exhausted"));
-            assert_eq!(*attempts.lock().unwrap(), 3);
+            assert_eq!(*attempts.lock().unwrap(), 4);
         }
     }
 
@@ -965,7 +965,7 @@ mod parity_tests {
             async move {
                 let mut a = attempts_clone.lock().unwrap();
                 *a += 1;
-                if *a < 3 {
+                if *a < 4 {
                     Err("database is locked".to_string())
                 } else {
                     Ok("success".to_string())
@@ -975,7 +975,7 @@ mod parity_tests {
 
         assert!(res.is_ok());
         assert_eq!(res.unwrap(), "success");
-        assert_eq!(*attempts.lock().unwrap(), 3);
+        assert_eq!(*attempts.lock().unwrap(), 4);
 
         let pg_db = setup_postgres_db().await;
         if let Some(db) = pg_db {
@@ -987,7 +987,7 @@ mod parity_tests {
                 async move {
                     let mut a = attempts_clone.lock().unwrap();
                     *a += 1;
-                    if *a < 3 {
+                    if *a < 4 {
                         Err("serialization failure".to_string())
                     } else {
                         Ok("success".to_string())
@@ -997,7 +997,7 @@ mod parity_tests {
 
             assert!(res.is_ok());
             assert_eq!(res.unwrap(), "success");
-            assert_eq!(*attempts.lock().unwrap(), 3);
+            assert_eq!(*attempts.lock().unwrap(), 4);
         }
     }
 }

--- a/src/ui/next/src/app/plan/page.test.tsx
+++ b/src/ui/next/src/app/plan/page.test.tsx
@@ -54,11 +54,9 @@ describe('MyPlanPage', () => {
   });
 
   it('renders the plan page', async () => {
-    await act(async () => {
-      render(<MyPlanPage />);
-    });
+    render(<MyPlanPage />);
 
-    expect(screen.getByText('My Plan')).toBeDefined();
+    expect(await screen.findByText('My Plan')).toBeDefined();
     expect(screen.getByText('Starter')).toBeDefined();
     expect(screen.getByText('$29.00')).toBeDefined();
   });
@@ -83,19 +81,15 @@ describe('MyPlanPage', () => {
       return { ok: true, json: async () => ({}) };
     });
 
-    await act(async () => {
-      render(<MyPlanPage />);
-    });
+    render(<MyPlanPage />);
 
-    expect(screen.getByText("You've reached your Starter tier limit of 1000 AI actions. Upgrade to unlock more power!")).toBeDefined();
+    expect(await screen.findByText("You've reached your Starter tier limit of 1000 AI actions. Upgrade to unlock more power!")).toBeDefined();
   });
 
   it('navigates to pricing on upgrade click', async () => {
-    await act(async () => {
-      render(<MyPlanPage />);
-    });
+    render(<MyPlanPage />);
 
-    const upgradeButton = screen.getByText('Upgrade');
+    const upgradeButton = await screen.findByText('Upgrade');
     await act(async () => {
       fireEvent.click(upgradeButton);
     });
@@ -120,21 +114,17 @@ describe('MyPlanPage', () => {
       return { ok: true, json: async () => ({}) };
     });
 
-    await act(async () => {
-      render(<MyPlanPage />);
-    });
+    render(<MyPlanPage />);
 
     // Check if it renders '/ Unlimited' for both limits
-    const unlimitedTexts = screen.getAllByText(/\/ Unlimited/);
+    const unlimitedTexts = await screen.findAllByText(/\/ Unlimited/);
     expect(unlimitedTexts.length).toBeGreaterThan(0);
   });
 
   it('navigates to cost-dashboard on details click', async () => {
-    await act(async () => {
-      render(<MyPlanPage />);
-    });
+    render(<MyPlanPage />);
 
-    const detailsButton = screen.getByText('View Detailed Costs');
+    const detailsButton = await screen.findByText('View Detailed Costs');
     await act(async () => {
       fireEvent.click(detailsButton);
     });
@@ -143,22 +133,6 @@ describe('MyPlanPage', () => {
 
   it('initiates manage billing flow', async () => {
     const mockPortalUrl = 'https://billing.stripe.com/p/session/test_123';
-    (global.fetch as any).mockImplementation(async (url, options) => {
-      if (url === '/api/billing/my-plan') {
-        return {
-          ok: true,
-          json: async () => ({ current_plan: 'Starter' }),
-        };
-      }
-      if (url === '/api/billing/create-billing-portal-session' && options?.method === 'POST') {
-        return {
-          ok: true,
-          json: async () => ({ url: mockPortalUrl }),
-        };
-      }
-      return { ok: true, json: async () => ({}) };
-    });
-
     let resolvePortal: any;
     const portalPromise = new Promise((resolve) => {
       resolvePortal = resolve;
@@ -180,11 +154,9 @@ describe('MyPlanPage', () => {
       return { ok: true, json: async () => ({}) };
     });
 
-    await act(async () => {
-      render(<MyPlanPage />);
-    });
+    render(<MyPlanPage />);
 
-    const manageButton = screen.getByText('Manage Billing');
+    const manageButton = await screen.findByText('Manage Billing');
 
     // Fire click but don't await the full act yet to check intermediate state
     fireEvent.click(manageButton);


### PR DESCRIPTION
🛡️ Sentry: [reliability fix] Update database retry logic & stabilize UI tests

**Objective:**
Comply with the ML-Resilience 60-Second Timeout Rule and Max Retry parity across database modes.

**Changes:**
1. Increased `MAX_DB_RETRY_ATTEMPTS` from 2 to 3 in `src/server/db.rs`.
2. Updated assertions in `src/server/orchestration/state/parity_test.rs` to expect exactly 4 attempts (1 initial try + 3 retries).
3. Resolved unrelated timeout flakiness in `src/ui/next/src/app/plan/page.test.tsx` where tests were hanging due to the use of `await act(async () => render(...))` along with fetching mocks. Migrated tests to `render()` followed by `await screen.findByText(...)`.

**Verification:**
`bazelisk test //...` is 100% green. Both backend logic and frontend tests are now completely stable.

---
*PR created automatically by Jules for task [11736535841355962281](https://jules.google.com/task/11736535841355962281) started by @ql-owo-lp*