### PR TITLE
Fix missing duration field in mobile optimized video tutorial API

### DIFF
--- a/src/e2e/help_videos.spec.ts
+++ b/src/e2e/help_videos.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Help Videos Page', () => {
+  test('displays video tutorials correctly and includes durations', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+
+    await page.goto('/help/videos');
+
+    await expect(page.locator('h1', { hasText: 'Video Guides' })).toBeVisible();
+
+    await expect(page.locator('.absolute.bottom-3.right-3').first()).toBeVisible({ timeout: 10000 });
+
+    const durationBadge = page.locator('.absolute.bottom-3.right-3').first();
+    await expect(durationBadge).toBeVisible();
+    await expect(durationBadge).not.toBeEmpty();
+
+    const text = await durationBadge.textContent();
+    expect(text?.trim()).toMatch(/^\d+:\d{2}$/);
+  });
+});

--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -303,6 +303,7 @@ pub async fn list_videos(Query(query): Query<DocsQuery>) -> Json<Vec<serde_json:
             serde_json::json!({
                 "id": v.id,
                 "title": v.title,
+                "duration": v.duration,
                 "video_url": v.video_url
             })
         }).collect();


### PR DESCRIPTION
Added the missing `duration` field to `VideoTutorial`'s serialization in `/api/videos` when fetched with `mobile_optimized=true`. Added an E2E test verifying duration renders.

---
*PR created automatically by Jules for task [3043087190202454595](https://jules.google.com/task/3043087190202454595) started by @ql-owo-lp*