### PR TITLE
Implement In-App Interactive Walkthroughs and Help Tooltips

### DIFF
--- a/src/e2e/walkthrough_tooltips.spec.ts
+++ b/src/e2e/walkthrough_tooltips.spec.ts
@@ -24,8 +24,27 @@ test.describe('Walkthrough and Tooltips features', () => {
     await expect(overlay).not.toBeVisible();
   });
 
+  test('Storefront walkthrough and help center elements are visible and work', async ({ page }) => {
+    await page.goto('/storefront-builder');
+
+    const walkBtn = page.locator('#storefront-walkthrough-btn');
+    await expect(walkBtn).toBeVisible();
+    await walkBtn.evaluate((btn) => btn.click()); await page.waitForTimeout(500);
+
+    const overlay = page.locator('.ohc-walkthrough-overlay');
+    await expect(overlay).toBeVisible();
+
+    const bubble = page.locator('.ohc-walkthrough-bubble');
+    await expect(bubble).toBeVisible();
+    await expect(bubble).toContainText('Storefront Builder');
+
+    const closeBtn = page.locator('.ohc-walkthrough-close');
+    await closeBtn.evaluate((btn) => btn.click()); await page.waitForTimeout(500);
+    await expect(overlay).not.toBeVisible();
+  });
+
   test('POS walkthrough and help center elements are visible and work', async ({ page }) => {
-    await page.goto('/api/ui/pos.html');
+    await page.goto('/payments');
 
     // Check Walkthrough button
     const walkBtn = page.locator('#pos-walkthrough-btn');
@@ -51,7 +70,7 @@ test.describe('Walkthrough and Tooltips features', () => {
   });
 
   test('Assistant walkthrough and help center elements are visible and work', async ({ page }) => {
-    await page.goto('/api/ui/assistant.html');
+    await page.goto('/agents');
 
     // Check Walkthrough button
     const walkBtn = page.locator('#assistant-walkthrough-btn');

--- a/src/ui/next/src/app/agents/page.test.tsx
+++ b/src/ui/next/src/app/agents/page.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
 import { expect, test, vi, beforeEach } from 'vitest';
 import AgentsPage from './page';
+import { TooltipProvider } from '../../components/TooltipRegistry';
 
 const mockFetch = vi.fn();
 const eventSources: MockWebSocket[] = [];
@@ -55,7 +56,7 @@ beforeEach(() => {
 });
 
 test('replaces /agents with a Workbuddy-style Expert Center catalog', async () => {
-  await act(async () => { render(<AgentsPage />); });
+  await act(async () => { render(<TooltipProvider><AgentsPage /></TooltipProvider>); });
 
   expect(await screen.findByRole('heading', { name: 'Expert Center' })).toBeDefined();
   expect(screen.getByRole('button', { name: 'Browse experts' })).toBeDefined();
@@ -73,7 +74,7 @@ test('replaces /agents with a Workbuddy-style Expert Center catalog', async () =
 });
 
 test('summons an expert into the task composer and starts a hire workflow', async () => {
-  await act(async () => { render(<AgentsPage />); });
+  await act(async () => { render(<TooltipProvider><AgentsPage /></TooltipProvider>); });
 
   const growthCard = await screen.findByTestId('expert-card-growth-strategist');
   fireEvent.click(within(growthCard).getByRole('button', { name: /Summon/i }));
@@ -102,7 +103,7 @@ test('summons an expert into the task composer and starts a hire workflow', asyn
 });
 
 test('shows result inspection and extension surfaces from Workbuddy', async () => {
-  await act(async () => { render(<AgentsPage />); });
+  await act(async () => { render(<TooltipProvider><AgentsPage /></TooltipProvider>); });
 
   expect(await screen.findAllByText('Artifacts')).toHaveLength(2);
   expect(screen.getAllByText('All files').length).toBeGreaterThan(0);
@@ -128,7 +129,7 @@ test('shows result inspection and extension surfaces from Workbuddy', async () =
 });
 
 test('covers every Workbuddy efficient-tip feature surface', async () => {
-  await act(async () => { render(<AgentsPage />); });
+  await act(async () => { render(<TooltipProvider><AgentsPage /></TooltipProvider>); });
 
   expect(await screen.findByLabelText('Context references')).toBeDefined();
   expect(screen.getByLabelText('Attachments')).toBeDefined();
@@ -188,7 +189,7 @@ test('covers every Workbuddy efficient-tip feature surface', async () => {
 });
 
 test('preserves approvals and activity feed operations', async () => {
-  await act(async () => { render(<AgentsPage />); });
+  await act(async () => { render(<TooltipProvider><AgentsPage /></TooltipProvider>); });
 
   await waitFor(() => {
     expect(eventSources[0]?.url).toBe('ws://127.0.0.1:18789/api/v1/feed/ws');
@@ -211,7 +212,7 @@ test('preserves approvals and activity feed operations', async () => {
 });
 
 test('sends Workbuddy context, attachment, model, and output controls in the hire payload', async () => {
-  await act(async () => { render(<AgentsPage />); });
+  await act(async () => { render(<TooltipProvider><AgentsPage /></TooltipProvider>); });
 
   fireEvent.change(await screen.findByLabelText('Context references'), {
     target: { value: '@orders @inventory @launch-plan' },
@@ -251,7 +252,7 @@ test('sends Workbuddy context, attachment, model, and output controls in the hir
 });
 
 test('supports interactive tab transitions and toggling grid extensions', async () => {
-  await act(async () => { render(<AgentsPage />); });
+  await act(async () => { render(<TooltipProvider><AgentsPage /></TooltipProvider>); });
 
   // Initial tab is Browse experts. Go to Skills.
   fireEvent.click(screen.getByRole('button', { name: 'Skills' }));
@@ -277,7 +278,7 @@ test('renders paywall dialog and handles simulated upgrade flow', async () => {
   const openSpy = vi.fn();
   vi.stubGlobal('open', openSpy);
 
-  await act(async () => { render(<AgentsPage />); });
+  await act(async () => { render(<TooltipProvider><AgentsPage /></TooltipProvider>); });
 
   // Click Toggle Pro Mode switch to trigger paywall
   fireEvent.click(screen.getByRole('button', { name: 'Toggle Pro Mode' }));

--- a/src/ui/next/src/app/agents/page.tsx
+++ b/src/ui/next/src/app/agents/page.tsx
@@ -2,6 +2,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { AgentWorkflowBuilder } from './components/AgentWorkflowBuilder';
+import { InteractiveWalkthrough, WalkthroughTarget } from '../../components/Walkthrough';
+import { WithTooltip } from '../../components/TooltipRegistry';
 import {
   automations,
   connectors,
@@ -94,6 +96,12 @@ export default function AgentsPage() {
   const [summonMessage, setSummonMessage] = useState('Growth Strategist is ready');
   const [runMessage, setRunMessage] = useState('');
   const [runError, setRunError] = useState('');
+  const [isWalkthroughOpen, setIsWalkthroughOpen] = useState(false);
+
+  const walkthroughSteps: import('../../components/Walkthrough').Step[] = [
+    { targetId: 'agents-composer-title', title: 'Task Composer', content: 'Assign tasks to your AI Agent here.' },
+    { targetId: 'activate-agent-btn', title: 'Activate your AI Support Agent', content: 'Click here to activate your AI Support Agent.' }
+  ];
   const [running, setRunning] = useState(false);
   const [workflows, setWorkflows] = useState<WorkflowRecord[]>([]);
   const [feed, setFeed] = useState<ApprovalItem[]>([]);
@@ -246,6 +254,7 @@ export default function AgentsPage() {
   }
   return (
     <div className="min-h-screen bg-stone-50 dark:bg-zinc-950 text-zinc-950 dark:text-zinc-50 transition-colors duration-200">
+      <InteractiveWalkthrough steps={walkthroughSteps} isOpen={isWalkthroughOpen} onClose={() => setIsWalkthroughOpen(false)} />
       <header className="border-b border-zinc-200 dark:border-zinc-850 bg-white/70 dark:bg-zinc-900/70 backdrop-blur-[30px] sticky top-0 z-30">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-5 sm:px-6 lg:px-8">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
@@ -253,7 +262,7 @@ export default function AgentsPage() {
               <Link href="/dashboard" className="text-sm font-bold text-teal-600 dark:text-teal-400 hover:underline">
                 ← Back to Dashboard
               </Link>
-              <h1 className="mt-2 text-3xl font-extrabold tracking-tight text-zinc-900 dark:text-white">AI Departments</h1>
+              <div className="flex items-center gap-4"><h1 className="mt-2 text-3xl font-extrabold tracking-tight text-zinc-900 dark:text-white">AI Departments</h1><button id="assistant-walkthrough-btn" onClick={() => setIsWalkthroughOpen(true)} className="px-3 py-1.5 text-sm bg-teal-50 text-teal-700 rounded-lg hover:bg-teal-100 font-semibold transition-colors mt-2">Start Tour</button></div>
               <h2 className="mt-1 text-sm font-bold text-zinc-500 dark:text-zinc-400">Expert Center</h2>
               <p className="mt-1 max-w-3xl text-sm text-zinc-600 dark:text-zinc-450">
                 Hire experts, summon expert teams, attach skills and connectors, schedule recurring work, and inspect generated results from one workspace.
@@ -705,7 +714,7 @@ function ComposerPanel({
     <section className="rounded-2xl border border-zinc-200/80 dark:border-zinc-800/80 bg-white/60 dark:bg-zinc-900/60 backdrop-blur-[30px] p-5 shadow-sm">
       <div className="flex items-center justify-between gap-3 mb-4">
         <div>
-          <h2 className="text-base font-bold text-zinc-900 dark:text-white">Task Composer</h2>
+          <WalkthroughTarget id="agents-composer-title"><h2 className="text-base font-bold text-zinc-900 dark:text-white">Task Composer</h2></WalkthroughTarget>
           <p className="text-xs font-semibold text-teal-600 dark:text-teal-400">{summonMessage}</p>
         </div>
         <span className="text-[10px] font-bold px-2 py-0.5 bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300 rounded-md">
@@ -904,6 +913,8 @@ function ComposerPanel({
       {runError && <p className="mt-3 text-xs font-bold text-red-650 dark:text-red-400">{runError}</p>}
       {runMessage && <p className="mt-3 text-xs font-bold text-emerald-600 dark:text-emerald-400">{runMessage}</p>}
       
+      <WalkthroughTarget id="activate-agent-btn">
+        <WithTooltip id="activate-agent-btn-tooltip" defaultText="Start task to activate your AI Support Agent">
       <button
         type="button"
         onClick={startTask}
@@ -912,6 +923,8 @@ function ComposerPanel({
       >
         {running ? 'Starting...' : 'Start task'}
       </button>
+      </WithTooltip>
+      </WalkthroughTarget>
     </section>
   );
 }

--- a/src/ui/next/src/app/payments/page.tsx
+++ b/src/ui/next/src/app/payments/page.tsx
@@ -1,11 +1,19 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { InteractiveWalkthrough, WalkthroughTarget } from "../../components/Walkthrough";
+import { WithTooltip } from "../../components/TooltipRegistry";
 
 export default function PaymentLedger() {
   const [revenue, setRevenue] = useState(0);
   const [amount, setAmount] = useState(50);
   const [status, setStatus] = useState("idle");
+  const [isWalkthroughOpen, setIsWalkthroughOpen] = useState(false);
+
+  const walkthroughSteps: import("../../components/Walkthrough").Step[] = [
+    { targetId: "payments-title", title: "Payments", content: "Track your revenue and manage transactions." },
+    { targetId: "request-payment-btn", title: "Accept Payment", content: "Click here to accept payments." }
+  ];
 
   useEffect(() => {
     fetchBalance();
@@ -57,7 +65,9 @@ export default function PaymentLedger() {
 
   return (
     <div className="max-w-[375px] mx-auto p-4 md:p-6 space-y-6">
-      <h2 className="text-2xl font-bold font-outfit text-gray-900 dark:text-gray-100">Dashboard</h2>
+      <InteractiveWalkthrough steps={walkthroughSteps} isOpen={isWalkthroughOpen} onClose={() => setIsWalkthroughOpen(false)} />
+      <WalkthroughTarget id="payments-title"><h2 className="text-2xl font-bold font-outfit text-gray-900 dark:text-gray-100">Dashboard</h2></WalkthroughTarget>
+      <button id="pos-walkthrough-btn" onClick={() => setIsWalkthroughOpen(true)} className="px-3 py-1.5 text-sm bg-blue-50 text-blue-600 rounded-lg hover:bg-blue-100 font-semibold transition-colors mt-2">Start Tour</button>
 
       <div className="glassmorphism p-6 flex flex-col space-y-2">
         <p className="m-0 text-gray-500 dark:text-gray-400 font-inter text-sm uppercase tracking-wide">Today's Revenue</p>
@@ -69,6 +79,7 @@ export default function PaymentLedger() {
       <div className="glassmorphism p-6 space-y-4">
         <h3 className="text-lg font-semibold font-outfit text-gray-900 dark:text-gray-100 mb-2">Request Payment</h3>
 
+        <WithTooltip id="payment-amount-input-tooltip" defaultText="Enter the exact amount to charge your customer">
         <input
           type="number"
           value={amount}
@@ -77,7 +88,10 @@ export default function PaymentLedger() {
           data-testid="payment-amount-input"
           aria-label="Payment Amount"
         />
+        </WithTooltip>
 
+        <WalkthroughTarget id="request-payment-btn">
+          <WithTooltip id="request-payment-btn-tooltip" defaultText="Click here to process a payment">
         <button
           onClick={handleRequestPayment}
           disabled={status === "Processing..."}
@@ -90,6 +104,8 @@ export default function PaymentLedger() {
         >
           {status === "Processing..." ? "Waiting for card..." : "Tap to Pay"}
         </button>
+        </WithTooltip>
+        </WalkthroughTarget>
 
         {status !== "idle" && status !== "Processing..." && (
           <p

--- a/src/ui/next/src/app/storefront-builder/page.test.tsx
+++ b/src/ui/next/src/app/storefront-builder/page.test.tsx
@@ -1,9 +1,15 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import StorefrontBuilderPage from './page';
+import { TooltipProvider } from '../../components/TooltipRegistry';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 // Mock TooltipRegistry and help components
+vi.mock('../../components/Walkthrough', () => ({
+  WalkthroughTarget: ({ children }: any) => <>{children}</>,
+  InteractiveWalkthrough: () => null
+}));
 vi.mock('../../components/TooltipRegistry', () => ({
+  TooltipProvider: ({ children }: any) => <>{children}</>,
   WithTooltip: ({ children }: any) => <div>{children}</div>
 }));
 vi.mock('../../components/help', () => ({
@@ -23,19 +29,19 @@ describe('StorefrontBuilderPage', () => {
   });
 
   it('renders initial setup state', () => {
-    render(<StorefrontBuilderPage />);
+    render(<TooltipProvider><StorefrontBuilderPage /></TooltipProvider>);
     expect(screen.getByText('Welcome to OHC Smart Builder')).toBeTruthy();
     expect(screen.getByText('Build My Storefront')).toBeTruthy();
   });
 
   it('handles empty input generation by keeping button disabled', () => {
-    render(<StorefrontBuilderPage />);
+    render(<TooltipProvider><StorefrontBuilderPage /></TooltipProvider>);
     const button = screen.getByText('Build My Storefront');
     expect(button.className).toContain('cursor-not-allowed');
   });
 
   it('enables button with valid input and calls generate', async () => {
-    render(<StorefrontBuilderPage />);
+    render(<TooltipProvider><StorefrontBuilderPage /></TooltipProvider>);
 
     const textarea = screen.getByPlaceholderText(/e.g. I run a mobile dog grooming service/i);
     fireEvent.change(textarea, { target: { value: 'Valid long business bio' } });
@@ -65,7 +71,7 @@ describe('StorefrontBuilderPage', () => {
   });
 
   it('handles publish workflow correctly', async () => {
-    render(<StorefrontBuilderPage />);
+    render(<TooltipProvider><StorefrontBuilderPage /></TooltipProvider>);
 
     // Setup state manually or go through flow
     const textarea = screen.getByPlaceholderText(/e.g. I run a mobile dog grooming service/i);
@@ -101,7 +107,7 @@ describe('StorefrontBuilderPage', () => {
   });
 
   it('handles chat with agent workflow', async () => {
-    render(<StorefrontBuilderPage />);
+    render(<TooltipProvider><StorefrontBuilderPage /></TooltipProvider>);
 
     const textarea = screen.getByPlaceholderText(/e.g. I run a mobile dog grooming service/i);
     fireEvent.change(textarea, { target: { value: 'Valid long business bio' } });

--- a/src/ui/next/src/app/storefront-builder/page.tsx
+++ b/src/ui/next/src/app/storefront-builder/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { SmartBlock, DraggableBlock, ActionSheet } from "../builder/components";
 import { useWalkthrough } from "../../components/help";
 import { WithTooltip } from "../../components/TooltipRegistry";
+import { InteractiveWalkthrough, WalkthroughTarget } from "../../components/Walkthrough";
 
 export default function StorefrontBuilderPage() {
   const [bio, setBio] = useState("");
@@ -17,6 +18,12 @@ export default function StorefrontBuilderPage() {
   const [isAddBlockOpen, setIsAddBlockOpen] = useState(false);
   const [editingBlockContent, setEditingBlockContent] = useState<any>(null);
   const [saveMessage, setSaveMessage] = useState("");
+  const [isWalkthroughOpen, setIsWalkthroughOpen] = useState(false);
+
+  const walkthroughSteps: import("../../components/Walkthrough").Step[] = [
+    { targetId: "storefront-title", title: "Storefront Builder", content: "This is where you can build and customize your storefront." },
+    { targetId: "bio-input-target", title: "Storefront Bio", content: "Tell your customers about your store." }
+  ];
   const [chatMessage, setChatMessage] = useState("");
   const { startWalkthrough } = useWalkthrough();
 
@@ -277,14 +284,16 @@ export default function StorefrontBuilderPage() {
             {saveMessage && <span className="text-[#34C759] text-sm font-semibold animate-fade-in">{saveMessage}</span>}
           </div>
           <div className="px-8 pb-8 pt-12 flex flex-col flex-1 justify-start overflow-y-auto">
+            <InteractiveWalkthrough steps={walkthroughSteps} isOpen={isWalkthroughOpen} onClose={() => setIsWalkthroughOpen(false)} />
+            <div className="flex justify-end mb-4"><button id="storefront-walkthrough-btn" onClick={() => setIsWalkthroughOpen(true)} className="px-3 py-1.5 text-sm bg-blue-50 text-blue-600 rounded-lg hover:bg-blue-100 font-semibold transition-colors">Start Tour</button></div>
             <div className="animate-fade-in" style={{ animation: 'fadeIn 250ms cubic-bezier(0.4, 0, 0.2, 1)' }}>
-              <h1 className="text-2xl font-bold font-outfit text-gray-900 dark:text-[#f5f5f7] mb-2">Welcome to OHC Smart Builder</h1>
+              <WalkthroughTarget id="storefront-title"><h1 className="text-2xl font-bold font-outfit text-gray-900 dark:text-[#f5f5f7] mb-2">Welcome to OHC Smart Builder</h1></WalkthroughTarget>
               <p className="text-gray-500 dark:text-[#a1a1a6] text-sm mb-8 leading-relaxed">
                 Review and add any extra details to help our AI generate the perfect store.
               </p>
 
               <label className="text-sm font-semibold text-gray-700 dark:text-[#a1a1a6] mb-2 block">Your Business Details</label>
-              <WithTooltip id="bio-input-tooltip" defaultText="Describe what you sell, your target audience, and the vibe of your brand.">
+              <WalkthroughTarget id="bio-input-target"><WithTooltip id="bio-input-tooltip" defaultText="Describe what you sell, your target audience, and the vibe of your brand.">
                 <textarea
                   id="bio-input"
                   enterKeyHint="done"
@@ -303,7 +312,7 @@ export default function StorefrontBuilderPage() {
                   placeholder="e.g. I run a mobile dog grooming service in Portland"
                   rows={6}
                 />
-              </WithTooltip>
+              </WithTooltip></WalkthroughTarget>
 
               <div className="flex gap-4">
                 <WithTooltip id="generate-btn-tooltip" defaultText="Our AI agents will analyze your description and build a ready-to-launch store for you.">


### PR DESCRIPTION
The objective was to implement documentation-critical features, specifically interactive walkthroughs and tooltips, without utilizing disruptive modals or popups.

Using the existing `InteractiveWalkthrough`, `WalkthroughTarget`, and `WithTooltip` components from `TooltipRegistry.tsx`, I have extended the help features seamlessly into these flows:
1. `storefront-builder` (Setting up the store)
2. `payments` (Requesting payment / Tapping to Pay)
3. `agents` (Task Composer / Activations)

E2E testing cases for the Walkthroughs (`src/e2e/walkthrough_tooltips.spec.ts`) were correctly mapped to their actual app router components instead of standalone `.html` mock files.

Unit tests via Vitest were successfully verified after context mocking (`TooltipProvider`).

---
*PR created automatically by Jules for task [16927263525063183426](https://jules.google.com/task/16927263525063183426) started by @ql-owo-lp*