### PR TITLE
Fix UI drift, script inclusion errors, and API panics for dashboard

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -73,7 +73,7 @@ pub async fn get_tooltips(
     let mut tooltips = std::collections::HashMap::new();
     match &db.store {
         crate::db::DbStore::Postgres => {
-            match sqlx::query("SELECT id, text FROM tooltips WHERE tenant_id = $1").bind(tenant_id)
+            match sqlx::query("SELECT id, text FROM tooltips WHERE tenant_id = $1").bind(tenant_id.to_string())
                 .fetch_all(&db.pool)
                 .await
             {
@@ -92,7 +92,7 @@ pub async fn get_tooltips(
             }
         },
         crate::db::DbStore::Sqlite(pool) => {
-            match sqlx::query("SELECT id, text FROM tooltips WHERE tenant_id = ?").bind(tenant_id)
+            match sqlx::query("SELECT id, text FROM tooltips WHERE tenant_id = ?").bind(tenant_id.to_string())
                 .fetch_all(pool)
                 .await
             {

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6908,6 +6908,19 @@ async fn create_ui_bom_item_handler(
         .route("/pos.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/pos.html"))
         }))
+
+        .route("/api/ui/help-widget.mjs", axum::routing::get(|| async {
+            axum::response::Response::builder()
+                .header("content-type", "application/javascript")
+                .body(axum::body::Body::from(include_str!("../ui/tauri/src/ui/help-widget.mjs")))
+                .unwrap()
+        }))
+        .route("/api/ui/voice-assistant.mjs", axum::routing::get(|| async {
+            axum::response::Response::builder()
+                .header("content-type", "application/javascript")
+                .body(axum::body::Body::from(include_str!("../ui/tauri/src/ui/voice-assistant.mjs")))
+                .unwrap()
+        }))
         .route("/api/ui/assistant.html", axum::routing::get(|| async {
             axum::response::Html(include_str!("../ui/tauri/src/ui/assistant.html"))
         }))

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -1789,7 +1789,7 @@
       const copyBtn = document.getElementById('copy-btn');
       const referralLink = document.getElementById('referral-link');
 
-      generateBtn.addEventListener('click', async () => {
+      if (generateBtn) { generateBtn.addEventListener('click', async () => {
         generateBtn.innerText = "Generating...";
         // Call the real Tauri backend
         if (window.__TAURI__ && window.__TAURI__.core) {
@@ -1824,7 +1824,8 @@
         }
       });
 
-      copyBtn.addEventListener('click', () => {
+      }
+      if (copyBtn) { copyBtn.addEventListener('click', () => {
         const link = referralLink.value;
         const text = `Join my team on OHC! Here is your invite link:\n\n${link}\n\n⚡ Powered by OHC`;
 
@@ -1852,15 +1853,17 @@
         });
       });
 
+      }
       const shareWhatsAppBtn = document.getElementById('share-whatsapp-btn');
-      shareWhatsAppBtn.addEventListener('click', () => {
+      if (shareWhatsAppBtn) { shareWhatsAppBtn.addEventListener('click', () => {
         const link = referralLink.value;
         const text = `Join my team on OHC! Here is your invite link:\n\n${link}\n\n⚡ Powered by OHC`;
         window.open(`https://wa.me/?text=${encodeURIComponent(text)}`, '_blank');
       });
 
+      }
       const shareXBtn = document.getElementById('share-x-btn');
-      shareXBtn.addEventListener('click', () => {
+      if (shareXBtn) { shareXBtn.addEventListener('click', () => {
         const link = referralLink.value;
         const text = `Join my team on OHC! Here is your invite link:\n\n${link}\n\n⚡ Powered by OHC`;
         window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`, '_blank');
@@ -1870,6 +1873,7 @@
 
 
 
+      }
       const triageSection = document.getElementById('triage-section');
       const triageQueue = document.getElementById('triage-queue');
       let currentTriageTab = 'proposals';


### PR DESCRIPTION
I found console and API errors when crawling the UI using Playwright:
1. Some UI files in the dashboard tried adding event listeners to missing buttons, crashing JavaScript execution.
2. The UI attempted to load missing `.mjs` scripts which caused 404s.
3. The `/api/tooltips` endpoint crashed due to improper SQL binding.

Fixed by wrapping Javascript execution, including the missing UI routes in the Axum Rust server, and converting the SQL parameter to string.
These fixes allow all test cases and E2E to pass successfully.

---
*PR created automatically by Jules for task [1601369633841387204](https://jules.google.com/task/1601369633841387204) started by @ql-owo-lp*