### PR TITLE
fix(growth): fix cart recovery soft paywall and payload

### DIFF
--- a/src/server/cart_recovery.rs
+++ b/src/server/cart_recovery.rs
@@ -753,12 +753,15 @@ where
         .await
         .map_err(|err| CartRecoveryError::Store(err.to_string()))?;
 
-    if job_type == "cart_recovery_agent" {
-        let customer_name = payload.get("customer_name").and_then(|v| v.as_str()).unwrap_or("Customer").to_string();
-        let cart_value = payload.get("cart_value").and_then(|v| v.as_str()).unwrap_or("$0.00").to_string();
+    if job_type == CART_RECOVERY_JOB_TYPE || job_type == "cart_recovery_agent" {
+        let customer_name = payload.get("to").and_then(|v| v.as_str()).unwrap_or("Customer").to_string();
+        let amount_cents = payload.get("amount_cents").and_then(|v| v.as_i64()).unwrap_or(0);
+        let cart_value = format!("${:.2}", amount_cents as f64 / 100.0);
+        let body = payload.get("body").and_then(|v| v.as_str()).unwrap_or("").to_string();
         let id = uuid::Uuid::new_v4().to_string();
         let proposed_action = serde_json::json!({
-            "description": format!("The Assistant recovered 1 abandoned cart this week, securing {} in revenue. The Salesperson drafted a recovery message for {}.", cart_value, customer_name)
+            "description": format!("The Assistant recovered 1 abandoned cart this week, securing {} in revenue. The Salesperson drafted a recovery message for {}.", cart_value, customer_name),
+            "response": body
         });
 
         let mut completion_tx = pool

--- a/src/ui/next/src/app/cart-recovery/page.tsx
+++ b/src/ui/next/src/app/cart-recovery/page.tsx
@@ -57,10 +57,6 @@ export default function CartRecoveryPage() {
   };
 
   const handleGenerate = () => {
-    if (!hasPro) {
-      setShowSoftPaywall(true);
-      return;
-    }
     generateDraft();
   };
 
@@ -87,6 +83,10 @@ export default function CartRecoveryPage() {
   };
 
   const handleSend = async () => {
+    if (!hasPro) {
+      setShowSoftPaywall(true);
+      return;
+    }
 
     try {
       const res = await fetch('/api/v1/growth/campaign/send', {


### PR DESCRIPTION
Fix the cart recovery test failure for the "generates cart recovery campaign without mock paywall" task.

This PR does the following:
1. Shifts the soft paywall for Cart Recovery from blocking preview generation (`handleGenerate`) to blocking sending (`handleSend`). 
2. Correctly updates the backend processing loop in `src/server/cart_recovery.rs` to process regular `cart_recovery` jobs to be inserted as feed items instead of falling back to raw email processing immediately.
3. Maps `body`, `amount_cents` (converting into readable strings) into the `agent_feed_items.proposed_action` JSON payload so that it aligns with the frontend's UI.

* Tested with Bazel testing `src/e2e:playwright_shard_1_of_1`.
* Tested manually verifying UI rendering in local mode.

---
*PR created automatically by Jules for task [11654841665734830635](https://jules.google.com/task/11654841665734830635) started by @ql-owo-lp*