### PR TITLE
Add inline edit functionality to AmbassadorReplyCard in unified agent feed

### DIFF
--- a/src/ui/next/src/app/dashboard/AmbassadorReplyCard.tsx
+++ b/src/ui/next/src/app/dashboard/AmbassadorReplyCard.tsx
@@ -4,9 +4,25 @@ type AmbassadorReplyCardProps = {
   approval: any;
   onApprove?: () => void;
   onDismiss?: () => void;
+  isEditing?: boolean;
+  editContent?: string;
+  onEdit?: () => void;
+  onCancelEdit?: () => void;
+  onSaveEdit?: () => void;
+  setEditContent?: (content: string) => void;
 };
 
-export const AmbassadorReplyCard: React.FC<AmbassadorReplyCardProps> = ({ approval, onApprove, onDismiss }) => {
+export const AmbassadorReplyCard: React.FC<AmbassadorReplyCardProps> = ({
+  approval,
+  onApprove,
+  onDismiss,
+  isEditing = false,
+  editContent = "",
+  onEdit,
+  onCancelEdit,
+  onSaveEdit,
+  setEditContent
+}) => {
   const payloadSource = approval.payload?.original_payload || approval.payload || approval.proposed_action || approval.context_payload || {};
   const pastOrders = payloadSource.past_orders;
   const contextUsed = payloadSource.context_used;
@@ -63,36 +79,88 @@ export const AmbassadorReplyCard: React.FC<AmbassadorReplyCardProps> = ({ approv
         </svg>
         Draft Reply
       </div>
-      <div className="bg-[#0066FF] p-3 rounded-[8px] text-xs text-white shadow-inner">
-        {approval.payload?.generated_response || (approval.proposed_action || approval.context_payload)?.generated_response || (approval.proposed_action || approval.context_payload)?.original_payload?.generated_response || approval.payload?.original_payload?.generated_response || "Ready to send."}
-      </div>
-      <div className="flex flex-col sm:flex-row gap-3 w-full mt-2">
-        {onApprove && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onApprove();
-            }}
-            className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all duration-200 shadow-md flex items-center justify-center"
-            aria-label="✨ Approve & Send Draft" data-testid="feed-approve-btn"
-          >
-            ✨ Approve & Send Draft
-          </button>
-        )}
-        {onDismiss && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onDismiss();
-            }}
-            className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
-            aria-label="Dismiss"
-            data-testid="feed-dismiss-btn"
-          >
-            Dismiss
-          </button>
-        )}
-      </div>
+      {isEditing ? (
+        <div className="flex flex-col gap-3 w-full mt-2">
+          <textarea
+            className="w-full min-h-[44px] p-3 rounded-[8px] border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-[#1D1D1F] dark:text-[#F5F5F7] text-sm focus:ring-2 focus:ring-[#0066FF] outline-none transition-all resize-none"
+            rows={4}
+            value={editContent}
+            onChange={(e) => setEditContent && setEditContent(e.target.value)}
+            data-testid="feed-edit-input"
+            autoFocus
+          />
+          <div className="flex flex-col sm:flex-row gap-3 w-full">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onSaveEdit && onSaveEdit();
+              }}
+              className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all duration-200 shadow-md flex items-center justify-center"
+              aria-label="Save & Send Draft"
+              data-testid="feed-save-edit-btn"
+            >
+              Save & Send
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onCancelEdit && onCancelEdit();
+              }}
+              className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
+              aria-label="Cancel Edit"
+              data-testid="feed-cancel-edit-btn"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="bg-[#0066FF] p-3 rounded-[8px] text-xs text-white shadow-inner">
+            {approval.payload?.generated_response || (approval.proposed_action || approval.context_payload)?.generated_response || (approval.proposed_action || approval.context_payload)?.original_payload?.generated_response || approval.payload?.original_payload?.generated_response || "Ready to send."}
+          </div>
+          <div className="flex flex-col sm:flex-row gap-3 w-full mt-2">
+            {onApprove && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onApprove();
+                }}
+                className="flex-[2] min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all duration-200 shadow-md flex items-center justify-center"
+                aria-label="✨ Approve & Send Draft" data-testid="feed-approve-btn"
+              >
+                ✨ Approve & Send Draft
+              </button>
+            )}
+            {onEdit && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit();
+                }}
+                className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
+                aria-label="Edit"
+                data-testid="feed-edit-btn"
+              >
+                Edit
+              </button>
+            )}
+            {onDismiss && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDismiss();
+                }}
+                className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
+                aria-label="Dismiss"
+                data-testid="feed-dismiss-btn"
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/ui/next/src/components/feed/AgentActionCard.tsx
+++ b/src/ui/next/src/components/feed/AgentActionCard.tsx
@@ -304,6 +304,19 @@ export const AgentActionCard: React.FC<AgentActionCardProps> = ({
               ?.feature_type === "ambassador_reply" && (
               <AmbassadorReplyCard
                 approval={approval}
+                isEditing={editingId === approval.id}
+                editContent={editContent}
+                setEditContent={setEditContent}
+                onEdit={() => {
+                  setEditingId(approval.id);
+                  const textToEdit = approval.payload?.generated_response || (approval.proposed_action || approval.context_payload)?.generated_response || (approval.proposed_action || approval.context_payload)?.original_payload?.generated_response || approval.payload?.original_payload?.generated_response || "";
+                  setEditContent(textToEdit);
+                }}
+                onCancelEdit={() => setEditingId(null)}
+                onSaveEdit={() => {
+                  handleDecision(approval.id, true, editContent, approval.event_source);
+                  setEditingId(null);
+                }}
                 onApprove={() =>
                   wrapDecision(
                     approval.id,


### PR DESCRIPTION
This PR adds the missing edit capability to `AmbassadorReplyCard` which handles `The Ambassador Agent` draft replies in the agent feed. 

It introduces the standard inline editing UX with textarea, Save, and Cancel buttons within the mobile-first UX feed card, utilizing `data-testid`s consistent with other action cards (`feed-edit-btn`, `feed-edit-input`, etc).

The edit properties and state (`isEditing`, `editContent`) are properly hooked up to the enclosing `AgentActionCard`, ensuring smooth transition and saving when the owner chooses to modify the agent's drafted message with 1-tap.

Resolves #33517

---
*PR created automatically by Jules for task [18078493085572857887](https://jules.google.com/task/18078493085572857887) started by @ql-owo-lp*