### PR TITLE
test(orchestration): verify dead letter creation for stuck queues and missions

### DIFF
--- a/src/server/orchestration/hybrid_sync/daemon_test.rs
+++ b/src/server/orchestration/hybrid_sync/daemon_test.rs
@@ -586,6 +586,24 @@ async fn test_hybrid_sync_pos_offline_transactions() {
         let row_queue = sqlx::query("SELECT status FROM ohc_job_queue WHERE id = 'stuck_queue_pg'")
             .fetch_one(&pg_pool).await.unwrap();
         assert_eq!(row_queue.get::<String, _>("status"), "FAILED");
+
+        // Verify dead letters were created for missions
+        let dl_sqlite_mission: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE event_type = 'mission_stuck'")
+            .fetch_one(&sqlite_pool).await.unwrap();
+        assert_eq!(dl_sqlite_mission.0, 1);
+
+        let dl_pg_mission: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE event_type = 'mission_stuck'")
+            .fetch_one(&pg_pool).await.unwrap();
+        assert_eq!(dl_pg_mission.0, 1);
+
+        // Verify dead letters were created for running jobs
+        let dl_sqlite_job: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE event_type = 'job_stuck'")
+            .fetch_one(&sqlite_pool).await.unwrap();
+        assert_eq!(dl_sqlite_job.0, 1);
+
+        let dl_pg_job: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE event_type = 'job_stuck'")
+            .fetch_one(&pg_pool).await.unwrap();
+        assert_eq!(dl_pg_job.0, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
test(orchestration): verify dead letter creation for stuck queues and missions

This commit adds the missing assertions in `src/server/orchestration/hybrid_sync/daemon_test.rs` to verify that `department_dead_letters` rows are correctly created for both stuck agent missions and stuck `ohc_job_queue` items across both SQLite and PostgreSQL.

Loaded and adhered to the `superpowers` test-driven development workflow to ensure regressions are captured effectively. Tested against all `bazel test //...` and `e2e` Playwright UI tasks.

Product-use evidence:
- Persona: Principal SRE, Triage & Infrastructure Lead
- Flow Attempted: Monitored the background job queue pruning and found incomplete assertions in `test_prune_stuck_missions_and_queue`.
- Resolution: Augmented the unit test to verify that `job_stuck` and `mission_stuck` events correctly generate dead letters.

---
*PR created automatically by Jules for task [9044009808109464279](https://jules.google.com/task/9044009808109464279) started by @ql-owo-lp*