### PR TITLE
🔗 Link: [Add WhatsApp Cloud API audio message support]

### DIFF
--- a/src/e2e/whatsapp-cloud-api-flow.spec.ts
+++ b/src/e2e/whatsapp-cloud-api-flow.spec.ts
@@ -131,4 +131,43 @@ test.describe('WhatsApp Cloud API Flow CUJ', () => {
     await expect(page.getByText(/Look at this cake/i).first()).toBeVisible({ timeout: 15000 });
   });
 
+  test('Owner receives a WhatsApp Cloud API message with audio media', async ({ page, request }) => {
+    const apiBase = process.env.OHC_API_URL || process.env.BACKEND_URL || 'http://localhost:18789';
+
+    const payload = {
+        "entry": [
+            {
+                "changes": [
+                    {
+                        "value": {
+                            "metadata": {
+                                "display_phone_number": "tenant-whatsapp-id"
+                            },
+                            "messages": [
+                                {
+                                    "from": "0987654321",
+                                    "audio": {
+                                        "id": "audio123"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    };
+
+    const response = await request.post(`${apiBase}/api/v1/webhooks/meta`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: payload,
+    });
+    expect(response.ok()).toBeTruthy();
+
+    await page.goto('/inbox');
+    await expect(page.getByText(/\[Audio\]\(audio123\)/i).first()).toBeVisible({ timeout: 15000 });
+  });
+
 });

--- a/src/server/api/meta_webhook.rs
+++ b/src/server/api/meta_webhook.rs
@@ -128,6 +128,9 @@ pub async fn meta_webhook_post_handler(
                                       let id = img.get("id").and_then(|i| i.as_str()).unwrap_or("unknown");
                                       let caption = img.get("caption").and_then(|c| c.as_str()).unwrap_or("");
                                       format!("![Image]({}) {}", id, caption).trim().to_string()
+                                  } else if let Some(audio) = message.get("audio") {
+                                      let id = audio.get("id").and_then(|i| i.as_str()).unwrap_or("unknown");
+                                      format!("[Audio]({})", id)
                                   } else {
                                       "".to_string()
                                   };


### PR DESCRIPTION
Added support for inbound WhatsApp Cloud API audio messages, resolving #33535.
The changes correctly extract the `audio.id` from incoming Meta webhooks, allowing owners to manage audio conversations in the inbox view.
The Playwright E2E test `whatsapp-cloud-api-flow.spec.ts` was moved from an ignored directory to `src/e2e/` to correctly run on Bazel, and was augmented to cover the new audio support.

---
*PR created automatically by Jules for task [15345816934836468020](https://jules.google.com/task/15345816934836468020) started by @ql-owo-lp*

Resolves #33535