### PR TITLE
feat(docs): support contextual tooltips on interactive walkthrough targets

### DIFF
--- a/src/ui/next/src/components/Walkthrough.tsx
+++ b/src/ui/next/src/components/Walkthrough.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, ReactNode } from 'react';
+import { WithTooltip } from './TooltipRegistry';
 
 export type Step = {
   targetId: string;
@@ -192,10 +193,14 @@ export function InteractiveWalkthrough({ steps, isOpen, onClose, onComplete }: W
  * It wraps its children in a relative container with the specified ID, which is then
  * targeted by the walkthrough overlay and speech bubble logic.
  */
-export function WalkthroughTarget({ id, children, className = "" }: { id: string, children?: ReactNode, className?: string }) {
-  return (
+export function WalkthroughTarget({ id, children, className = "", tooltipId }: { id: string, children?: ReactNode, className?: string, tooltipId?: string }) {
+  const inner = (
     <div id={id} className={`relative ${className}`}>
       {children || <div className="hidden" aria-hidden="true" />}
     </div>
   );
+  if (tooltipId) {
+    return <WithTooltip id={tooltipId}>{inner}</WithTooltip>;
+  }
+  return inner;
 }


### PR DESCRIPTION
This change modifies `WalkthroughTarget` in `src/ui/next/src/components/Walkthrough.tsx` to accept a `tooltipId` property. By conditionally wrapping the walkthrough target in the `WithTooltip` component from the `TooltipRegistry`, it satisfies the product requirement that every non-obvious UI element must have a contextual tooltip, allowing walkthrough targets to seamlessly benefit from registry-driven plain language tooltips without requiring disjoint UI definitions.

I've successfully verified this logic via the Vitest suite in `src/ui/next`. E2E suite (`bazelisk test //src/e2e:playwright...`) had isolated timeouts related to Playwright loading failures or Docker layer extraction blocking the backend, but the targeted frontend unit test for the interactive walkthrough components succeeded entirely.

---
*PR created automatically by Jules for task [363817393639749641](https://jules.google.com/task/363817393639749641) started by @ql-owo-lp*