### PR TITLE
Fix WhatsApp Cloud API Integration E2E tests and registry state

### DIFF
--- a/src/e2e/whatsapp-integration.spec.ts
+++ b/src/e2e/whatsapp-integration.spec.ts
@@ -64,7 +64,7 @@ test.describe('WhatsApp Integration UI', () => {
     await page.getByRole('button', { name: 'Save & Connect' }).click();
 
     // Check for success status updates
-    await expect(page.locator('.app-status-item', { hasText: 'Twilio for WhatsApp connected.' })).toBeVisible();
+    await expect(page.locator('[role="status"]', { hasText: 'Twilio for WhatsApp connected.' })).toBeVisible();
   });
 
   test('can open WhatsApp Cloud API modal', async ({ page }) => {
@@ -85,6 +85,6 @@ test.describe('WhatsApp Integration UI', () => {
     await page.getByRole('button', { name: 'Continue with Meta' }).click();
 
     // Check for success status updates
-    await expect(page.locator('.app-status-item', { hasText: 'WhatsApp Cloud API connected.' })).toBeVisible();
+    await expect(page.locator('[role="status"]', { hasText: 'WhatsApp Cloud API connected.' })).toBeVisible();
   });
 });

--- a/src/server/integrations/registry.rs
+++ b/src/server/integrations/registry.rs
@@ -18,7 +18,6 @@ pub struct IntegrationsRegistry {
     twilio_clients: std::sync::RwLock<std::collections::HashMap<String, std::sync::Arc<crate::integrations::twilio::provider::TwilioProvider>>>,
     nats_clients: std::sync::Arc<std::sync::RwLock<std::collections::HashMap<String, std::sync::Arc<crate::integrations::nats::provider::NatsProvider>>>>,
     meta_clients: std::sync::RwLock<std::collections::HashMap<String, std::sync::Arc<crate::integrations::meta::provider::MetaProvider>>>,
-    whatsapp_clients: std::sync::RwLock<std::collections::HashMap<String, std::sync::Arc<crate::integrations::meta::provider::MetaProvider>>>,
     calendly_clients: std::sync::RwLock<std::collections::HashMap<String, std::sync::Arc<crate::integrations::calendly::provider::CalendlyProvider>>>,
     cal_com_clients: std::sync::RwLock<std::collections::HashMap<String, std::sync::Arc<crate::integrations::cal_com::provider::CalComProvider>>>,
     google_calendar_clients: std::sync::RwLock<std::collections::HashMap<String, std::sync::Arc<crate::integrations::google_calendar::provider::GoogleCalendarProvider>>>,
@@ -63,7 +62,6 @@ impl IntegrationsRegistry {
             twilio_clients: std::sync::RwLock::new(std::collections::HashMap::new()),
             nats_clients: std::sync::Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
             meta_clients: std::sync::RwLock::new(std::collections::HashMap::new()),
-            whatsapp_clients: std::sync::RwLock::new(std::collections::HashMap::new()),
             calendly_clients: std::sync::RwLock::new(std::collections::HashMap::new()),
             cal_com_clients: std::sync::RwLock::new(std::collections::HashMap::new()),
             google_calendar_clients: std::sync::RwLock::new(std::collections::HashMap::new()),
@@ -156,13 +154,8 @@ impl IntegrationsRegistry {
                          let text = content.to_string();
 
                          let client = {
-                             if integration_id == "whatsapp" || integration_id == "whatsapp_cloud_api" {
-                                 let clients = self.whatsapp_clients.read().unwrap();
-                                 clients.get(integration_id).cloned()
-                             } else {
-                                 let clients = self.meta_clients.read().unwrap();
-                                 clients.get(integration_id).cloned()
-                             }
+                             let clients = self.meta_clients.read().unwrap();
+                             clients.get(integration_id).cloned()
                          };
                          if let Some(client) = client {
                              let client = client.clone();
@@ -238,7 +231,7 @@ impl IntegrationsRegistry {
             )));
         }
         if integration_id == "whatsapp" || integration_id == "whatsapp_cloud_api" {
-            let mut clients = self.whatsapp_clients.write().unwrap();
+            let mut clients = self.meta_clients.write().unwrap();
             clients.insert(integration_id.to_string(), std::sync::Arc::new(crate::integrations::meta::provider::MetaProvider::new(
                 creds.api_token.clone()
             )));
@@ -477,13 +470,8 @@ impl IntegrationsRegistry {
             }
         } else if integration_id == "meta" || integration_id == "whatsapp" || integration_id == "whatsapp_cloud_api" {
             let client = {
-                if integration_id == "whatsapp" || integration_id == "whatsapp_cloud_api" {
-                    let clients = self.whatsapp_clients.read().unwrap();
-                    clients.get(integration_id).cloned()
-                } else {
-                    let clients = self.meta_clients.read().unwrap();
-                    clients.get(integration_id).cloned()
-                }
+                let clients = self.meta_clients.read().unwrap();
+                clients.get(integration_id).cloned()
             };
             if let Some(c) = client {
                 return c.send_message("whatsapp", to, body).await;
@@ -585,11 +573,8 @@ impl IntegrationsRegistry {
 
     pub async fn send_message(&self, integration_id: &str, platform: &str, to: &str, body: &str) -> Result<(), String> {
         let client = {
-            if integration_id == "meta" {
+            if integration_id == "meta" || integration_id == "whatsapp" || integration_id == "whatsapp_cloud_api" {
                 let clients = self.meta_clients.read().unwrap();
-                clients.get(integration_id).cloned()
-            } else if integration_id == "whatsapp" || integration_id == "whatsapp_cloud_api" {
-                let clients = self.whatsapp_clients.read().unwrap();
                 clients.get(integration_id).cloned()
             } else {
                 None


### PR DESCRIPTION
Fix WhatsApp Cloud API Integration E2E tests and registry state

- Fixes the UI E2E test `whatsapp-integration.spec.ts` assertions to locate the status messages by `[role="status"]` instead of `.app-status-item`.
- Refactors `IntegrationsRegistry` in `src/server/integrations/registry.rs` to correctly utilize `meta_clients` for storing the `whatsapp_cloud_api` and `whatsapp` integration states as `MetaProvider` instances, effectively removing redundant `whatsapp_clients` map.
- Resolves #33535

---
*PR created automatically by Jules for task [2681347179720401397](https://jules.google.com/task/2681347179720401397) started by @ql-owo-lp*