### PR TITLE
feat: implement Ambassador agent draft reply editing capability

### DIFF
--- a/src/e2e/e2e_ambassador_rag.spec.ts
+++ b/src/e2e/e2e_ambassador_rag.spec.ts
@@ -56,8 +56,30 @@ test.describe('Ambassador RAG Pipeline', () => {
     await expect(approvalCard.getByText('Do you have vegan cakes today?')).toBeVisible({ timeout: 15000 });
     await expect(approvalCard.getByText('AI Draft')).toBeVisible();
 
-    // Approve the response
-    const approveButton = approvalCard.getByRole('button', { name: /Send Draft/ }).first();
+    // Now test editing functionality through the Team Approval Inbox
+    await page.goto('/team');
+
+    // 1. Enter The Ambassador department
+    const ambassadorDept = page.locator('button', { hasText: 'The Ambassador' });
+    await expect(ambassadorDept).toBeVisible({ timeout: 15000 });
+    await ambassadorDept.click();
+
+    // 2. Find the card
+    const teamApprovalCard = page.locator('.glassmorphism').filter({ hasText: 'Do you have vegan cakes today?' }).first();
+    await expect(teamApprovalCard).toBeVisible({ timeout: 15000 });
+
+    // 3. Click Edit
+    const editButton = teamApprovalCard.getByRole('button', { name: 'Edit' }).first();
+    await expect(editButton).toBeVisible();
+    await editButton.click();
+
+    // 4. Update the draft
+    const draftTextarea = page.getByTestId('edit-ambassador-draft');
+    await expect(draftTextarea).toBeVisible();
+    await draftTextarea.fill('Yes we do! We have fresh vegan chocolate cakes available right now.');
+
+    // 5. Approve & Send
+    const approveButton = page.getByTestId('modal-approve-btn');
     await expect(approveButton).toBeVisible();
 
     // Ensure the button has a min 44x44 bounding box
@@ -71,6 +93,6 @@ test.describe('Ambassador RAG Pipeline', () => {
     await approveButton.click();
 
     // Verify it disappears
-    await expect(approvalCard).not.toBeVisible({ timeout: 10000 });
+    await expect(teamApprovalCard).not.toBeVisible({ timeout: 10000 });
   });
 });

--- a/src/server/domain/booking.rs
+++ b/src/server/domain/booking.rs
@@ -107,17 +107,14 @@ pub async fn handle_autonomous_quote_action(tenant_id: &str, payload: &Value, po
         let link_res = stripe_client.create_payment_link(service, deposit_amount_cents).await;
         if let Ok(link) = link_res {
             stripe_payment_link = link;
-            drafted_message = format!("{}
-
-To secure your booking, please pay the deposit here: {}", drafted_message, stripe_payment_link);
         } else if let Err(e) = link_res {
              tracing::error!("Failed to generate Stripe payment link for deposit: {}", e);
              // Fallback to dummy link for testing/e2e if API fails
              stripe_payment_link = format!("https://buy.stripe.com/test_{}", uuid::Uuid::new_v4().simple().to_string().chars().take(16).collect::<String>());
-             drafted_message = format!("{}
+        }
+        drafted_message = format!("{}
 
 To secure your booking, please pay the deposit here: {}", drafted_message, stripe_payment_link);
-        }
     }
 
     // Insert into quotes

--- a/src/ui/next/src/app/team/components/ApprovalInbox.tsx
+++ b/src/ui/next/src/app/team/components/ApprovalInbox.tsx
@@ -25,6 +25,7 @@ export default function ApprovalInbox({
     null,
   );
   const [editedQuote, setEditedQuote] = useState<{ suggested_price: string, scope: string } | null>(null);
+  const [editedDraft, setEditedDraft] = useState<string | null>(null);
 
   const handleToggle = async () => {
     const newValue = !reviewAll;
@@ -677,6 +678,8 @@ export default function ApprovalInbox({
                               suggested_price: String(payload.suggested_price || ''),
                               scope: payload.scope || ''
                             });
+                          } else if (payload.feature_type === "ambassador_reply") {
+                            setEditedDraft(payload.generated_response || payload.draft_reply || payload.reply || '');
                           }
                         } else {
                           onReject(req.id);
@@ -765,6 +768,19 @@ export default function ApprovalInbox({
                     />
                   </div>
                 </div>
+              ) : extractPayload(selectedReview.description).payload?.feature_type === "ambassador_reply" ? (
+                <div className="mb-6">
+                  <p className="text-xs text-gray-500 font-medium uppercase tracking-wider mb-1">
+                    Edit Draft Reply
+                  </p>
+                  <textarea
+                    value={editedDraft || ''}
+                    onChange={(e) => setEditedDraft(e.target.value)}
+                    rows={4}
+                    className="w-full px-4 py-3 rounded-xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-[#0066FF]/50 bg-white resize-none"
+                    data-testid="edit-ambassador-draft"
+                  />
+                </div>
               ) : (
                 <div className="mb-6">
                   <p className="text-xs text-gray-500 font-medium uppercase tracking-wider mb-1">
@@ -783,6 +799,7 @@ export default function ApprovalInbox({
                     onReject(selectedReview.id);
                     setSelectedReview(null);
                     setEditedQuote(null);
+                    setEditedDraft(null);
                   }}
                   className="flex-1 py-3 px-4 rounded-xl font-semibold text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 min-h-[44px] min-w-[44px]"
                 >
@@ -792,6 +809,7 @@ export default function ApprovalInbox({
                   onClick={() => {
                     setSelectedReview(null);
                     setEditedQuote(null);
+                    setEditedDraft(null);
                   }}
                   className="flex-1 py-3 px-4 rounded-xl font-semibold text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 min-h-[44px] min-w-[44px]"
                 >
@@ -805,11 +823,19 @@ export default function ApprovalInbox({
                          suggested_price: parseFloat(editedQuote.suggested_price) || 0,
                          scope: editedQuote.scope
                       });
+                    } else if (extractPayload(selectedReview.description).payload?.feature_type === "ambassador_reply" && editedDraft !== null) {
+                      onApprove(selectedReview.id, {
+                         ...extractPayload(selectedReview.description).payload,
+                         generated_response: editedDraft,
+                         draft_reply: editedDraft,
+                         reply: editedDraft
+                      });
                     } else {
                       onApprove(selectedReview.id);
                     }
                     setSelectedReview(null);
                     setEditedQuote(null);
+                    setEditedDraft(null);
                   }}
                   className="flex-1 py-3 px-4 rounded-xl font-bold text-sm bg-[#0066FF] text-white hover:bg-[#0052CC] shadow-md shadow-[#0066FF]/20 active:scale-[0.98] transition-all min-h-[44px] min-w-[44px]"
                   data-testid="modal-approve-btn"


### PR DESCRIPTION
Resolves #33517

## Description
This PR implements the missing edit capability for Ambassador drafted replies in the unified Agent Feed inbox, aligning it with the existing workflow for quote drafts. 

Previously, users were unable to modify the generated response from `ambassador_reply` features via the ApprovalInbox UI. This PR adds a `setEditedDraft` state and exposes a textarea inside the review modal for `ambassador_reply` events. Upon approval, it merges the edited draft string back into `generated_response`, `draft_reply`, and `reply` keys to ensure compatibility with downstream webhook delivery tasks.

It also resolves an unused variable warning that arose during the test compilation related to `drafted_message` in `booking.rs`.

**Superpowers used:**
* Loaded general context. Used the Playwright tool effectively to pinpoint and simulate E2E runs.

**Product-use evidence:**
* **Persona:** Maya (Home Baker) / Carlos (Handyman)
* **Flow:** Incoming Message -> Action Required (ApprovalInbox UI) -> Review -> Edit Text -> Approve & Send
* **Gap Observed:** The `ApprovalInbox` Review Modal component only offered `Edit` behavior if the `feature_type` was `quote_draft`. When clicking Edit on a `Customer Inquiry` / `ambassador_reply` card, no editor was rendered.
* **Why this matters:** Owners need the ability to lightly tweak AI drafted responses before sending them off to customers. Without the edit button working for replies, the owner would have to reject the action entirely or send a potentially flawed text.
* **Verification:** Re-ran `bazelisk test //...` (101/101 targets passing) and successfully invoked `e2e_ambassador_rag.spec.ts` test that directly edits an Ambassador draft from the Team ApprovalInbox component.

## Interaction Audit Table
| Element | Designed Purpose | Observed Result | Fix |
|---|---|---|---|
| `Edit` Button (Ambassador Card) | Opens the Review Modal with editable state | Triggered state change but rendered no textarea | Handled `ambassador_reply` in the boolean switch rendering the `<textarea data-testid="edit-ambassador-draft">` component. |
| `Approve & Send` Button (Modal) | Approves the feed item with the updated payload | Functioned only for quotes | Merged `editedDraft` state into the response payload explicitly for `ambassador_reply`. |

---
*PR created automatically by Jules for task [5908963185617495350](https://jules.google.com/task/5908963185617495350) started by @ql-owo-lp*