### PR TITLE
feat: AI Unified Inbox & Omnichannel Customer Memory

### DIFF
--- a/src/server/api/unified_inbox_webhook.rs
+++ b/src/server/api/unified_inbox_webhook.rs
@@ -26,6 +26,7 @@ pub struct UnifiedWebhookPayload {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DraftedResponse {
+    pub feature_type: String,
     pub customer_id: String,
     pub context_summary: String,
     pub draft_reply: String,
@@ -319,6 +320,7 @@ pub async fn handle_unified_webhook(
                 &state.db,
             ).await;
             let action_payload = serde_json::to_string(&DraftedResponse {
+                feature_type: "ambassador_reply".to_string(),
                 customer_id: customer_id.clone(),
                 context_summary,
                 draft_reply,
@@ -376,6 +378,7 @@ pub async fn handle_unified_webhook(
                 &state.db,
             ).await;
             let action_payload = serde_json::to_string(&DraftedResponse {
+                feature_type: "ambassador_reply".to_string(),
                 customer_id: customer_id.clone(),
                 context_summary,
                 draft_reply,

--- a/src/ui/next/src/app/dashboard/AmbassadorReplyCard.tsx
+++ b/src/ui/next/src/app/dashboard/AmbassadorReplyCard.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 type AmbassadorReplyCardProps = {
   approval: any;
-  onApprove?: () => void;
+  onApprove?: (editedResponse?: string) => void;
   onDismiss?: () => void;
 };
 
@@ -10,6 +10,11 @@ export const AmbassadorReplyCard: React.FC<AmbassadorReplyCardProps> = ({ approv
   const payloadSource = approval.payload?.original_payload || approval.payload || approval.proposed_action || approval.context_payload || {};
   const pastOrders = payloadSource.past_orders;
   const contextUsed = payloadSource.context_used;
+
+  const initialResponse = approval.payload?.generated_response || (approval.proposed_action || approval.context_payload)?.generated_response || (approval.proposed_action || approval.context_payload)?.original_payload?.generated_response || approval.payload?.original_payload?.generated_response || "Ready to send.";
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedResponse, setEditedResponse] = useState(initialResponse);
 
   return (
     <div className="app-list-item mb-4 p-4 bg-white/65 dark:bg-[#16161A]/70 backdrop-blur-[30px] saturate-[210%] border border-white/40 dark:border-white/10 flex flex-col gap-3" data-testid="ambassador-reply-card">
@@ -63,36 +68,82 @@ export const AmbassadorReplyCard: React.FC<AmbassadorReplyCardProps> = ({ approv
         </svg>
         Draft Reply
       </div>
-      <div className="bg-[#0066FF] p-3 rounded-[8px] text-xs text-white shadow-inner">
-        {approval.payload?.generated_response || (approval.proposed_action || approval.context_payload)?.generated_response || (approval.proposed_action || approval.context_payload)?.original_payload?.generated_response || approval.payload?.original_payload?.generated_response || "Ready to send."}
-      </div>
-      <div className="flex flex-col sm:flex-row gap-3 w-full mt-2">
-        {onApprove && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onApprove();
-            }}
-            className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all duration-200 shadow-md flex items-center justify-center"
-            aria-label="✨ Approve & Send Draft" data-testid="feed-approve-btn"
-          >
-            ✨ Approve & Send Draft
-          </button>
-        )}
-        {onDismiss && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onDismiss();
-            }}
-            className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
-            aria-label="Dismiss"
-            data-testid="feed-dismiss-btn"
-          >
-            Dismiss
-          </button>
-        )}
-      </div>
+      {isEditing ? (
+        <div className="flex flex-col gap-2">
+          <textarea
+            className="w-full min-h-[80px] p-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm focus:ring-1 focus:ring-[#0066FF] outline-none"
+            value={editedResponse}
+            onChange={(e) => setEditedResponse(e.target.value)}
+            data-testid="feed-edit-input"
+          />
+          <div className="flex flex-col sm:flex-row gap-3 w-full mt-2">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsEditing(false);
+              }}
+              className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all duration-200 shadow-md flex items-center justify-center"
+              aria-label="Save" data-testid="feed-save-edit-btn"
+            >
+              Save
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setEditedResponse(initialResponse);
+                setIsEditing(false);
+              }}
+              className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
+              aria-label="Cancel" data-testid="feed-cancel-edit-btn"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="bg-[#0066FF] p-3 rounded-[8px] text-xs text-white shadow-inner">
+            {editedResponse}
+          </div>
+          <div className="flex flex-col sm:flex-row gap-3 w-full mt-2">
+            {onApprove && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onApprove(editedResponse !== initialResponse ? editedResponse : undefined);
+                }}
+                className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] bg-[#0066FF] text-white font-medium hover:bg-[#0052CC] transition-all duration-200 shadow-md flex items-center justify-center"
+                aria-label="✨ Approve & Send Draft" data-testid="feed-approve-btn"
+              >
+                ✨ Approve & Send Draft
+              </button>
+            )}
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsEditing(true);
+              }}
+              className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
+              aria-label="Edit" data-testid="feed-edit-btn"
+            >
+              Edit
+            </button>
+            {onDismiss && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDismiss();
+                }}
+                className="flex-1 min-h-[44px] min-w-[44px] px-4 rounded-[8px] border border-gray-300 dark:border-gray-600 text-[#1D1D1F] dark:text-[#F5F5F7] font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 flex items-center justify-center"
+                aria-label="Dismiss"
+                data-testid="feed-dismiss-btn"
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/ui/next/src/app/feed/page.tsx
+++ b/src/ui/next/src/app/feed/page.tsx
@@ -132,12 +132,14 @@ export default function FeedPage() {
         ...item.proposed_action,
         description: isAmbassador ? item.proposed_action?.description : editValue,
         generated_response: isAmbassador ? editValue : item.proposed_action?.generated_response,
+        draft_reply: isAmbassador ? editValue : item.proposed_action?.draft_reply,
     };
 
     const updatedContext = {
         ...item.context_payload,
         summary: isAmbassador ? item.context_payload?.summary : editValue,
         generated_response: isAmbassador ? editValue : item.context_payload?.generated_response,
+        draft_reply: isAmbassador ? editValue : item.context_payload?.draft_reply,
     };
 
     setItems((prev) => prev.map((i) => {

--- a/src/ui/next/src/components/feed/AgentActionCard.tsx
+++ b/src/ui/next/src/components/feed/AgentActionCard.tsx
@@ -304,11 +304,11 @@ export const AgentActionCard: React.FC<AgentActionCardProps> = ({
               ?.feature_type === "ambassador_reply" && (
               <AmbassadorReplyCard
                 approval={approval}
-                onApprove={() =>
+                onApprove={(editedResponse?: string) =>
                   wrapDecision(
                     approval.id,
                     true,
-                    undefined,
+                    editedResponse,
                     approval.event_source,
                   )
                 }


### PR DESCRIPTION
Implements the "AI Unified Inbox & Omnichannel Customer Memory" feature requested by the user.

* Updated `DraftedResponse` and its instantiations in `src/server/api/unified_inbox_webhook.rs` to include `feature_type: "ambassador_reply".to_string()`.
* Updated `src/ui/next/src/app/dashboard/AmbassadorReplyCard.tsx` to include an edit state with a textarea (`data-testid='feed-edit-input'`) and a save button (`data-testid='feed-save-edit-btn'`), matching the requirements in the tests. It tracks local changes to the string and correctly invokes the upstream callback `onApprove`.
* Updated `src/ui/next/src/app/feed/page.tsx` and `src/ui/next/src/components/feed/AgentActionCard.tsx` to use the modified AmbassadorReplyCard component and appropriately route the edit changes down so it persists to the server correctly.

All local and automated tests (including `bazel test //...` and `bazelisk test //src/e2e:playwright`) have passed successfully.

---
*PR created automatically by Jules for task [11351416595769584211](https://jules.google.com/task/11351416595769584211) started by @ql-owo-lp*

Resolves #33517