### PR TITLE
🛡️ Sentry: [reliability fix] Fix skipped and ignored tests

### DIFF
--- a/src/e2e/agent_feed.spec.ts
+++ b/src/e2e/agent_feed.spec.ts
@@ -32,9 +32,8 @@ test.describe('Agentic Unified Intake & Action Feed', () => {
     // await expect(page.getByTestId('agent-feed')).toBeVisible({ timeout: 15000 });
 
     const feedCard = page.getByTestId('agent-feed-card').first();
-    // Ignore this test check locally so we can proceed, it works fine in interactive spec
-    await expect(feedCard).toBeVisible({ timeout: 5000 }).catch(() => {});
-    if (!(await feedCard.isVisible())) return;
+
+    await expect(feedCard).toBeVisible({ timeout: 15000 });
 
     const editBtn = feedCard.getByTestId('feed-edit-btn');
     await expect(editBtn).toBeVisible();

--- a/src/e2e/booking_reengagement.spec.ts
+++ b/src/e2e/booking_reengagement.spec.ts
@@ -14,8 +14,7 @@ test.describe('Automated Re-engagement Agent for Service Bookings', () => {
         try {
             await pool.query('SELECT 1');
         } catch (e) {
-            console.log('Database not available, skipping setup');
-            return;
+            throw new Error('Database not available, this must work for the test!');
         }
 
         // Setup tenant

--- a/src/e2e/tests/episodic_memory.spec.ts
+++ b/src/e2e/tests/episodic_memory.spec.ts
@@ -19,7 +19,7 @@ test.describe('Long-Term Episodic Memory', () => {
             // Try to insert using docker-compose exec
             execSync(`docker exec ohc_postgres psql -U postgres -d ohc -c "${sql}"`, { stdio: 'ignore' });
         } catch (e) {
-            console.log("Could not seed DB via docker, skipping pre-seeding...");
+            throw new Error("Could not seed DB via docker, this must work for the test!");
         }
 
         // Test the mobile UI API

--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -1031,7 +1031,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore] // Ignoring since it requires a real database
+
     async fn test_tooltips_api() {
         let db_pool = crate::db::create_sqlite_pool_for_test().await;
         let pg_pool = crate::db::create_dummy_pg_pool().await;


### PR DESCRIPTION
Removed ignored and skipped test markers across the repository to enforce strict test coverage and reliability. Specifically addressed `src/server/api/docs.rs` and E2E Playwright tests (`agent_feed.spec.ts`, `booking_reengagement.spec.ts`, `episodic_memory.spec.ts`) that were silently bypassing assertions or setups.

---
*PR created automatically by Jules for task [12707569252196657064](https://jules.google.com/task/12707569252196657064) started by @ql-owo-lp*