### PR TITLE
⚙️ Consolidator: Configurable memory pruning thresholds

### DIFF
--- a/src/agents/builtin/consolidation_worker.rs
+++ b/src/agents/builtin/consolidation_worker.rs
@@ -9,6 +9,8 @@ pub struct ConsolidationWorker {
     pub repository: Arc<VectorRepository>,
     pub poll_interval: Duration,
     pub pruning_threshold_days: i64,
+    pub pruning_min_reliability: i32,
+    pub pruning_max_reference_count: i32,
     pub telemetry_error_callback: Option<Arc<dyn Fn(&str, &str) + Send + Sync>>,
 }
 
@@ -17,12 +19,16 @@ impl ConsolidationWorker {
         repository: Arc<VectorRepository>,
         poll_interval: Duration,
         pruning_threshold_days: i64,
+        pruning_min_reliability: i32,
+        pruning_max_reference_count: i32,
         telemetry_error_callback: Option<Arc<dyn Fn(&str, &str) + Send + Sync>>,
     ) -> Self {
         Self {
             repository,
             poll_interval,
             pruning_threshold_days,
+            pruning_min_reliability,
+            pruning_max_reference_count,
             telemetry_error_callback,
         }
     }
@@ -30,7 +36,7 @@ impl ConsolidationWorker {
     /// Run a single consolidation pass manually. Useful for testing.
     pub async fn run_once(&self) -> Result<(usize, bool), String> {
         let threshold_date = Utc::now() - chrono::Duration::days(self.pruning_threshold_days);
-        let pruning_success = match self.repository.prune_stale(threshold_date).await {
+        let pruning_success = match self.repository.prune_stale(threshold_date, self.pruning_min_reliability, self.pruning_max_reference_count).await {
             Ok(_) => true,
             Err(e) => {
                 tracing::error!("Consolidation Worker: Failed to prune stale context: {}", e);
@@ -113,7 +119,7 @@ mod tests {
     #[tokio::test]
     async fn test_consolidation_worker_run_once() {
         let repo = setup_sqlite_repo().await;
-        let worker = ConsolidationWorker::new(repo.clone(), Duration::from_secs(1), 180, None);
+        let worker = ConsolidationWorker::new(repo.clone(), Duration::from_secs(1), 180, 20, 2, None);
 
         // Insert a stale record that should be pruned
         let mut v1 = vec![0.0; 10];
@@ -158,6 +164,8 @@ mod tests {
             repo.clone(),
             Duration::from_millis(50),
             180,
+            20,
+            2,
             None,
         ));
 
@@ -230,6 +238,8 @@ mod tests {
             repo.clone(),
             std::time::Duration::from_millis(10),
             180,
+            20,
+            2,
             None,
         ));
         let handle = worker.spawn_background_task();

--- a/src/agents/builtin/memory_exhaustive_tests.rs
+++ b/src/agents/builtin/memory_exhaustive_tests.rs
@@ -3894,7 +3894,7 @@ mod tests_added_for_coverage {
         repo.upsert(&rec2).await.unwrap();
         repo.upsert(&rec3).await.unwrap();
 
-        repo.prune_stale(now - chrono::Duration::days(180))
+        repo.prune_stale(now - chrono::Duration::days(180), 20, 2)
             .await
             .unwrap();
 

--- a/src/agents/builtin/memory_store.rs
+++ b/src/agents/builtin/memory_store.rs
@@ -582,20 +582,28 @@ impl VectorRepository {
     }
 
     /// Prunes stale context to prevent unbounded memory growth.
-    /// It deletes records older than `older_than` where `owner_override = FALSE`
-    /// and `reference_count < 5`.
-    pub async fn prune_stale(&self, older_than: DateTime<Utc>) -> Result<(), String> {
+    /// It deletes records older than `older_than` where `owner_override = FALSE`.
+    pub async fn prune_stale(
+        &self,
+        older_than: DateTime<Utc>,
+        min_reliability: i32,
+        max_reference_count: i32,
+    ) -> Result<(), String> {
         match &self.store {
             VectorMemoryStore::Postgres(pool) => {
-                sqlx::query("DELETE FROM consolidated_memory WHERE (last_referenced_at < $1 AND owner_override = FALSE AND reference_count < 2 AND source_type = 'TASK_SUMMARY') OR (reliability_score < 20 AND owner_override = FALSE AND last_referenced_at < $1)")
+                sqlx::query("DELETE FROM consolidated_memory WHERE (last_referenced_at < $1 AND owner_override = FALSE AND reference_count < $2 AND source_type = 'TASK_SUMMARY') OR (reliability_score < $3 AND owner_override = FALSE AND last_referenced_at < $1)")
                     .bind(older_than)
+                    .bind(max_reference_count)
+                    .bind(min_reliability)
                     .execute(pool)
                     .await
                     .map_err(|e| e.to_string())?;
             }
             VectorMemoryStore::Sqlite(pool) => {
-                sqlx::query("DELETE FROM consolidated_memory WHERE (last_referenced_at < ? AND owner_override = FALSE AND reference_count < 2 AND source_type = 'TASK_SUMMARY') OR (reliability_score < 20 AND owner_override = FALSE AND last_referenced_at < ?)")
+                sqlx::query("DELETE FROM consolidated_memory WHERE (last_referenced_at < ? AND owner_override = FALSE AND reference_count < ? AND source_type = 'TASK_SUMMARY') OR (reliability_score < ? AND owner_override = FALSE AND last_referenced_at < ?)")
                     .bind(older_than)
+                    .bind(max_reference_count)
+                    .bind(min_reliability)
                     .bind(older_than)
                     .execute(pool)
                     .await
@@ -1174,6 +1182,89 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_prune_stale_configurable_thresholds() {
+        use std::str::FromStr;
+        let conn_opts = sqlx::sqlite::SqliteConnectOptions::from_str("sqlite::memory:").unwrap();
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .connect_with(conn_opts)
+            .await
+            .unwrap();
+
+        let _ = sqlx::query(
+            "CREATE TABLE IF NOT EXISTS consolidated_memory (
+                id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                agent_id TEXT,
+                content TEXT NOT NULL,
+                embedding TEXT,
+                source_type TEXT NOT NULL,
+                created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                last_referenced_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                reference_count INTEGER DEFAULT 0,
+                reliability_score INTEGER DEFAULT 50,
+                owner_override BOOLEAN DEFAULT FALSE,
+                metadata TEXT
+            );",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let repo = VectorRepository::new_sqlite(pool);
+
+        let now = Utc::now();
+        let old_time = now - chrono::Duration::days(181);
+        let threshold_time = now - chrono::Duration::days(180);
+
+        // Record with reliability 15 (less than configured 30, but higher than old hardcoded 20)
+        let prune_unreliable = EmbeddingRecord {
+            id: "prune_unreliable".to_string(),
+            tenant_id: "org1".to_string(),
+            agent_id: "agent1".to_string(),
+            content: "old unreliable stuff".to_string(),
+            embedding: vec![0.1; 10],
+            source_type: "NOTES".to_string(),
+            created_at: old_time,
+            last_referenced_at: old_time,
+            reference_count: 10,
+            reliability_score: 15,
+            owner_override: false,
+            metadata: None,
+        };
+
+        // Record with reference count 3 (less than configured 4, but higher than old hardcoded 2)
+        let prune_low_refs = EmbeddingRecord {
+            id: "prune_low_refs".to_string(),
+            tenant_id: "org1".to_string(),
+            agent_id: "agent1".to_string(),
+            content: "old low refs stuff".to_string(),
+            embedding: vec![0.1; 10],
+            source_type: "TASK_SUMMARY".to_string(),
+            created_at: old_time,
+            last_referenced_at: old_time,
+            reference_count: 3,
+            reliability_score: 50,
+            owner_override: false,
+            metadata: None,
+        };
+
+        repo.upsert(&prune_unreliable).await.unwrap();
+        repo.upsert(&prune_low_refs).await.unwrap();
+
+        // Pass 30 for min_reliability and 4 for max_reference_count
+        repo.prune_stale(threshold_time, 30, 4).await.unwrap();
+
+        assert!(
+            repo.get_by_id("prune_unreliable").await.unwrap().is_none(),
+            "Should have pruned record with reliability < 30"
+        );
+        assert!(
+            repo.get_by_id("prune_low_refs").await.unwrap().is_none(),
+            "Should have pruned record with refs < 4"
+        );
+    }
+
+    #[tokio::test]
     async fn test_prune_stale_conservative_logic() {
         use std::str::FromStr;
         let conn_opts = sqlx::sqlite::SqliteConnectOptions::from_str("sqlite::memory:").unwrap();
@@ -1275,7 +1366,7 @@ mod tests {
         repo.upsert(&rec3).await.unwrap();
         repo.upsert(&rec4).await.unwrap();
 
-        repo.prune_stale(threshold_date).await.unwrap();
+        repo.prune_stale(threshold_date, 20, 2).await.unwrap();
 
         assert!(repo.get_by_id("rec1").await.unwrap().is_none());
         assert!(repo.get_by_id("rec2").await.unwrap().is_some());
@@ -2188,7 +2279,7 @@ mod get_conflicts_tests {
         repo.upsert(&record4).await.unwrap();
 
         // Prune stale test
-        repo.prune_stale(now - chrono::Duration::days(180))
+        repo.prune_stale(now - chrono::Duration::days(180), 20, 2)
             .await
             .unwrap();
 
@@ -2436,7 +2527,7 @@ mod get_conflicts_tests {
         repo.upsert(&record2).await.unwrap();
 
         // Prune stale test
-        repo.prune_stale(now - chrono::Duration::days(180))
+        repo.prune_stale(now - chrono::Duration::days(180), 20, 2)
             .await
             .unwrap();
 
@@ -3115,7 +3206,7 @@ mod anthropic_memory_tests {
         repo.upsert(&old_record).await.unwrap();
         repo.upsert(&new_record).await.unwrap();
 
-        repo.prune_stale(threshold).await.unwrap();
+        repo.prune_stale(threshold, 20, 2).await.unwrap();
 
         use sqlx::Row;
         let query = "SELECT id FROM consolidated_memory";
@@ -3180,7 +3271,7 @@ mod anthropic_memory_tests {
         repo.upsert(&record1).await.unwrap();
 
         // Prune stale test
-        repo.prune_stale(now - chrono::Duration::days(180))
+        repo.prune_stale(now - chrono::Duration::days(180), 20, 2)
             .await
             .unwrap();
 
@@ -3688,7 +3779,7 @@ mod e2e_consolidation_tests {
         repo.upsert(&keep_new).await.unwrap();
 
         // Run pruning with threshold 180 days ago
-        repo.prune_stale(now - chrono::Duration::days(180))
+        repo.prune_stale(now - chrono::Duration::days(180), 20, 2)
             .await
             .unwrap();
 
@@ -3761,7 +3852,7 @@ mod e2e_consolidation_tests {
         repo.upsert(&stale_low_rel_but_override).await.unwrap();
 
         // Run pruning with threshold 180 days ago
-        repo.prune_stale(now - chrono::Duration::days(180))
+        repo.prune_stale(now - chrono::Duration::days(180), 20, 2)
             .await
             .unwrap();
 
@@ -4384,7 +4475,7 @@ mod get_and_delete_tests {
         repo.upsert(&keep_wrong_type).await.unwrap();
         repo.upsert(&prune_unreliable_old).await.unwrap();
 
-        repo.prune_stale(threshold_time).await.unwrap();
+        repo.prune_stale(threshold_time, 20, 2).await.unwrap();
 
         assert!(
             repo.get_by_id("prune_stale").await.unwrap().is_none(),

--- a/src/agents/builtin/service.rs
+++ b/src/agents/builtin/service.rs
@@ -202,6 +202,8 @@ impl AgentServiceImpl {
                                 repo.clone(),
                                 Duration::from_secs(3600),
                                 180,
+                                20,
+                                2,
                                 None,
                             ))
                             .spawn_background_task(),
@@ -221,6 +223,8 @@ impl AgentServiceImpl {
                                 repo.clone(),
                                 Duration::from_secs(3600),
                                 180,
+                                20,
+                                2,
                                 None,
                             ))
                             .spawn_background_task(),

--- a/src/server/autodream/mod.rs
+++ b/src/server/autodream/mod.rs
@@ -44,7 +44,7 @@ impl AutoDreamWorker {
                 };
 
                 let stale_threshold = chrono::Utc::now() - chrono::Duration::days(180);
-                if let Err(e) = repository.prune_stale(stale_threshold).await {
+                if let Err(e) = repository.prune_stale(stale_threshold, 20, 2).await {
                     debug!("AutoDream: pruning consolidated memory failed: {}", e);
                 }
 

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -2465,7 +2465,7 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
         crate::db::DbStore::Postgres => ohc_builtin_agent::memory_store::VectorRepository::new(db.pool.clone()),
         crate::db::DbStore::Sqlite(sqlite_pool) => ohc_builtin_agent::memory_store::VectorRepository::new_sqlite(sqlite_pool.clone()),
     });
-    let cb = std::sync::Arc::new(|msg: &str, _err: &str| { ::server_telemetry::record_error_signal(msg); }) as std::sync::Arc<dyn Fn(&str, &str) + Send + Sync>; let consolidation_worker = std::sync::Arc::new(crate::workers::memory::MemoryConsolidationWorker::new(vector_repo.clone(), std::time::Duration::from_secs(3600), 180, Some(cb)));
+    let cb = std::sync::Arc::new(|msg: &str, _err: &str| { ::server_telemetry::record_error_signal(msg); }) as std::sync::Arc<dyn Fn(&str, &str) + Send + Sync>; let consolidation_worker = std::sync::Arc::new(crate::workers::memory::MemoryConsolidationWorker::new(vector_repo.clone(), std::time::Duration::from_secs(3600), 180, 20, 2, Some(cb)));
     let _ = consolidation_worker.spawn_background_task();
 
     let retention_job = crate::workers::subscription_retention_job::SubscriptionRetentionJob::new(db.clone());

--- a/src/server/orchestration/departments/memory/e2e_journey_test.rs
+++ b/src/server/orchestration/departments/memory/e2e_journey_test.rs
@@ -116,7 +116,7 @@ async fn test_full_consolidated_memory_e2e_journey() {
     assert_eq!(resolved, 1, "Exactly 1 conflict should be resolved");
 
     // Run Pruning process (removes stale note older than 180 days)
-    repo.prune_stale(now - chrono::Duration::days(180)).await.expect("Failed to prune stale context");
+    repo.prune_stale(now - chrono::Duration::days(180), 20, 2).await.expect("Failed to prune stale context");
 
     // Cross-department retrieval: Operations fetches pricing context natively via vector repository
     // We explicitly use the application-level method provided by `VectorRepository` to satisfy the code review


### PR DESCRIPTION
This PR optimizes the memory consolidation layer by removing hardcoded limits (`20` for minimum reliability and `2` for maximum reference count) during the stale context pruning process. These parameters are now explicitly configurable in `VectorRepository` and passed in through `ConsolidationWorker`.

The implementation addresses the requirement to optimize existing systems when finding the initial request already implemented, utilizing `superpowers:test-driven-development` workflows to implement a new `test_prune_stale_configurable_thresholds` test covering this added flexibility. PostgreSQL and SQLite SQL commands are distinctively bound correctly for their respective drivers.

All callers in `src/agents/builtin` and `src/server` (e.g. `service.rs`, `agent_memory_pipeline.rs`, E2E tests) were updated safely to preserve their previous behavior by providing the initial values of 20 and 2.

---
*PR created automatically by Jules for task [4078735615460966497](https://jules.google.com/task/4078735615460966497) started by @ql-owo-lp*