### PR TITLE
🗺️ Guide: enforce 44px minimum height touch targets on onboarding buttons

### DIFF
--- a/src/ui/next/src/app/onboarding/page.tsx
+++ b/src/ui/next/src/app/onboarding/page.tsx
@@ -2313,7 +2313,7 @@ export default function OnboardingWizard() {
                 <button
                   onClick={() => handleStartOnboarding()}
                   disabled={isLoading}
-                  className="w-full bg-[#0066FF] text-white p-4 font-bold shadow-[0_4px_14px_0_rgba(0,102,255,0.39)] hover:bg-[#0052cc] active:scale-[0.98] transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] disabled:opacity-50 disabled:cursor-not-allowed rounded-[8px]"
+                className="w-full bg-[#0066FF] text-white p-4 min-h-[44px] font-bold shadow-[0_4px_14px_0_rgba(0,102,255,0.39)] hover:bg-[#0052cc] active:scale-[0.98] transition-all duration-[250ms] ease-[cubic-bezier(0.4,0,0.2,1)] disabled:opacity-50 disabled:cursor-not-allowed rounded-[8px]"
                 >
                   {isLoading ? (
                     <span className="flex items-center justify-center gap-2">

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1384,7 +1384,7 @@
             aria-label="Generate Storefront"
             title="Generate Storefront"
             data-testid="generate-storefront-btn"
-            class="btn-primary" style="width: 100%;"
+            class="btn-primary" style="width: 100%; min-height: 44px;"
             disabled
           >
             Generate My Workspace
@@ -1734,7 +1734,7 @@
         ></div>
 
         <div class="btn-group">
-          <button id="approve-publish-btn" aria-label="Approve and Publish" title="Approve and Publish" data-testid="approve-publish-btn"  >
+          <button id="approve-publish-btn" aria-label="Approve and Publish" title="Approve and Publish" data-testid="approve-publish-btn" style="min-height: 44px;">
             Approve & Publish
           </button>
         </div>


### PR DESCRIPTION
- **Product-use evidence:**
  - **Persona:** Maya, Home Baker
  - **Browser UI Flow Attempted:** Navigate to setup/onboarding flow (`/setup.html` or `/onboarding`), review the main Call To Action elements to proceed (e.g., `#generate-storefront-btn`, `#approve-publish-btn`).
  - **CUJ Gap Observed:** Some crucial actionable elements, explicitly the "Generate My Workspace" (`#generate-storefront-btn`) and "Approve & Publish" (`#approve-publish-btn`) buttons on the initial setup flow, did not explicitly meet the `min-height: 44px` requirement despite having padding or standard button classes. This constraint is required as an OHC mobile-first non-negotiable standard.
  - **Why it matters:** On 375px mobile screens, touch targets under 44px create friction and user error, actively breaking the seamless onboarding promise for an owner operating on their phone.
  - **Post-fix UI Flow:** Verify that `#generate-storefront-btn`, `#approve-publish-btn` in `setup.html` and the Next.js `onboarding/page.tsx` publish button have explicit CSS inline or class logic (`min-h-[44px]`) guaranteeing they are easily tap-able.
  
- **Changes Made:**
  - Added `min-height: 44px;` style explicitly to `#generate-storefront-btn` and `#approve-publish-btn` within `src/ui/tauri/src/ui/setup.html`.
  - Added `min-h-[44px]` class to the final `handleStartOnboarding` button in `src/ui/next/src/app/onboarding/page.tsx` for cross-platform alignment.
  
- **Testing:**
  - Verified `//src/e2e:playwright_shard_1_of_1` and `//src/e2e:playwright` to ensure test coverage (specifically `test_heights.spec.ts`) passes.
  - E2E interactions with buttons remain unaffected functionality-wise.

- **Superpowers Used:**
  - `spiffe_identity_onboarding`, `day_one_onboarding` (implied awareness for maintaining clean flow).

---
*PR created automatically by Jules for task [211863646565306454](https://jules.google.com/task/211863646565306454) started by @ql-owo-lp*