### PR TITLE
fix(ui): correct data-prev attributes for setup wizard back navigation

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2378,7 +2378,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-admin"
+            data-prev="step-assistant"
           >
             Back
           </button>
@@ -2426,7 +2426,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-offer"
+            data-prev="step-admin"
           >
             Back
           </button>
@@ -2473,7 +2473,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-location"
+            data-prev="step-offer"
           >
             Back
           </button>
@@ -2520,7 +2520,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-target-audience"
+            data-prev="step-location"
           >
             Back
           </button>
@@ -2579,7 +2579,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-domain"
+            data-prev="step-target-audience"
           >
             Back
           </button>


### PR DESCRIPTION
The "Back" buttons in the onboarding wizard were incorrectly pointing to the wrong step IDs due to copy-paste errors or outdated flow sequence mapping. This caused the backward navigation to skip steps or behave unpredictably.

This commit updates the `data-prev` attributes in `src/ui/tauri/src/ui/setup.html` to correctly map to the preceding step in the flow.

Test coverage confirmed this fixes the e2e test failures in `onboarding_wizard.spec.ts`.

---
*PR created automatically by Jules for task [7044621979982320829](https://jules.google.com/task/7044621979982320829) started by @ql-owo-lp*