### PR TITLE
fix: ensure telemetry categories are not emitted unconditionally in hybrid sync daemons and job queues

### DIFF
--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -454,20 +454,24 @@ impl HybridSyncDaemon {
         // SQLite
         if let Err(e) = sqlx::query(&sqlite_insert).execute(&self.sqlite_pool).await {
             warn!("Failed to insert dead letter for SQLite agent missions: {}", e);
+            ::server_telemetry::record_error_signal("[bug] Failed to insert dead letter for SQLite agent missions");
         }
         if let Ok(res) = sqlx::query(&sqlite_update).execute(&self.sqlite_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck agent missions from SQLite", res.rows_affected());
+                ::server_telemetry::record_error_signal("[cleanup] Pruned stuck agent missions from SQLite");
             }
         }
 
         // PG
         if let Err(e) = sqlx::query(&pg_insert).execute(&self.pg_pool).await {
             warn!("Failed to insert dead letter for PostgreSQL agent missions: {}", e);
+            ::server_telemetry::record_error_signal("[bug] Failed to insert dead letter for PostgreSQL agent missions");
         }
         if let Ok(res) = sqlx::query(&pg_update).execute(&self.pg_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck agent missions from PostgreSQL", res.rows_affected());
+                ::server_telemetry::record_error_signal("[cleanup] Pruned stuck agent missions from PostgreSQL");
             }
         }
 
@@ -493,38 +497,46 @@ impl HybridSyncDaemon {
         // SQLite queue
         if let Err(e) = sqlx::query(&sqlite_running_insert).execute(&self.sqlite_pool).await {
             warn!("Failed to insert dead letter for SQLite RUNNING jobs: {}", e);
+            ::server_telemetry::record_error_signal("[bug] Failed to insert dead letter for SQLite RUNNING jobs");
         }
         if let Ok(res) = sqlx::query(&sqlite_running_update).execute(&self.sqlite_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck RUNNING jobs from SQLite ohc_job_queue", res.rows_affected());
+                ::server_telemetry::record_error_signal("[cleanup] Pruned stuck RUNNING jobs from SQLite ohc_job_queue");
             }
         }
 
         if let Err(e) = sqlx::query(&sqlite_queued_insert).execute(&self.sqlite_pool).await {
             warn!("Failed to insert dead letter for SQLite QUEUED jobs: {}", e);
+            ::server_telemetry::record_error_signal("[bug] Failed to insert dead letter for SQLite QUEUED jobs");
         }
         if let Ok(res) = sqlx::query(&sqlite_queued_delete).execute(&self.sqlite_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck QUEUED jobs from SQLite ohc_job_queue", res.rows_affected());
+                ::server_telemetry::record_error_signal("[cleanup] Pruned stuck QUEUED jobs from SQLite ohc_job_queue");
             }
         }
 
         // PG queue
         if let Err(e) = sqlx::query(&pg_running_insert).execute(&self.pg_pool).await {
             warn!("Failed to insert dead letter for PostgreSQL RUNNING jobs: {}", e);
+            ::server_telemetry::record_error_signal("[bug] Failed to insert dead letter for PostgreSQL RUNNING jobs");
         }
         if let Ok(res) = sqlx::query(&pg_running_update).execute(&self.pg_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck RUNNING jobs from PostgreSQL ohc_job_queue", res.rows_affected());
+                ::server_telemetry::record_error_signal("[cleanup] Pruned stuck RUNNING jobs from PostgreSQL ohc_job_queue");
             }
         }
 
         if let Err(e) = sqlx::query(&pg_queued_insert).execute(&self.pg_pool).await {
             warn!("Failed to insert dead letter for PostgreSQL QUEUED jobs: {}", e);
+            ::server_telemetry::record_error_signal("[bug] Failed to insert dead letter for PostgreSQL QUEUED jobs");
         }
         if let Ok(res) = sqlx::query(&pg_queued_delete).execute(&self.pg_pool).await {
             if res.rows_affected() > 0 {
                 info!("Pruned {} stuck QUEUED jobs from PostgreSQL ohc_job_queue", res.rows_affected());
+                ::server_telemetry::record_error_signal("[cleanup] Pruned stuck QUEUED jobs from PostgreSQL ohc_job_queue");
             }
         }
 

--- a/src/server/orchestration/queue/ohc_job_queue.rs
+++ b/src/server/orchestration/queue/ohc_job_queue.rs
@@ -150,10 +150,10 @@ impl OHCJobQueue {
              WHERE status = 'PENDING' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
         };
 
-        sqlx::query(query_str)
-        .execute(&mut *tx)
-        .await
-        .map_err(|e| e.to_string())?;
+        if let Err(e) = sqlx::query(query_str).execute(&mut *tx).await {
+            ::server_telemetry::record_error_signal("[bug] Failed to insert dead letter for stagnant backlog items");
+            return Err(e.to_string());
+        }
 
         let query_str = if is_standalone {
             "DELETE FROM ohc_job_queue
@@ -167,6 +167,10 @@ impl OHCJobQueue {
         .execute(&mut *tx)
         .await
         .map_err(|e| e.to_string())?;
+
+        if stagnant_result.rows_affected() > 0 {
+            ::server_telemetry::record_error_signal("[cleanup] Stagnant backlog item stuck in PENDING for > 24 hours");
+        }
 
         tx.commit().await.map_err(|e| e.to_string())?;
         Ok(result.rows_affected() + stagnant_result.rows_affected())


### PR DESCRIPTION
fix: ensure telemetry categories are not emitted unconditionally in hybrid sync daemons and job queues

---
*PR created automatically by Jules for task [10673640012976628071](https://jules.google.com/task/10673640012976628071) started by @ql-owo-lp*