### PR TITLE
Fix: Update DashboardViralInviteWidget to use referrals link

### DIFF
--- a/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.test.tsx
+++ b/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.test.tsx
@@ -10,8 +10,11 @@ Object.assign(navigator, {
 });
 
 describe('DashboardViralInviteWidget', () => {
+  let originalFetch: typeof global.fetch;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    originalFetch = global.fetch;
     Object.defineProperty(window, 'localStorage', {
       value: {
         getItem: vi.fn((key) => {
@@ -21,6 +24,10 @@ describe('DashboardViralInviteWidget', () => {
       },
       writable: true,
     });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
   it('renders correctly', async () => {
@@ -34,6 +41,12 @@ describe('DashboardViralInviteWidget', () => {
   });
 
   it('generates link, copies to clipboard, and shares to X', async () => {
+    // Mock the fetch call for the generation
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: async () => ({ referral_link: 'https://ohc.app/ref/test-tenant-123' }),
+    });
+    global.fetch = mockFetch;
+
     render(<DashboardViralInviteWidget />);
 
     const generateBtn = screen.getByRole('button', { name: 'Get My Invite Link' });
@@ -48,7 +61,7 @@ describe('DashboardViralInviteWidget', () => {
     fireEvent.click(copyButton);
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      expect.stringContaining('test-tenant-123')
+      expect.stringContaining('https://ohc.app/ref/test-tenant-123')
     );
     expect(screen.getByText('Copied!')).toBeDefined();
 

--- a/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.tsx
+++ b/src/ui/next/src/app/dashboard/DashboardViralInviteWidget.tsx
@@ -22,21 +22,25 @@ export function DashboardViralInviteWidget() {
     try {
       const w = window as unknown as { __TAURI__?: { core?: { invoke: (cmd: string) => Promise<string> } } };
       if (w.__TAURI__ && w.__TAURI__.core) {
-        const link = await w.__TAURI__.core.invoke('generate_cloud_bridge_invite');
+        const link = await w.__TAURI__.core.invoke('generate_referral_link');
         setReferralLink(link);
       } else {
         const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'default';
-        const res = await fetch('/api/v1/growth/cloud-bridge/invite', {
+        const token = localStorage.getItem('token') || localStorage.getItem('ohc_token');
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (token) headers['authorization'] = `Bearer ${token}`;
+
+        const res = await fetch('/api/v1/growth/referrals/generate', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ team_id: tenantId, inviter_id: "owner", invitee_id: "pending" })
+          headers,
+          body: JSON.stringify({ tenant_id: tenantId, custom_message: "" })
         });
         const data = await res.json();
-        setReferralLink(data.invite_link || `https://ohc.app/invite/${tenantId}`);
+        setReferralLink(data.referral_link || `https://ohc.app/ref/${tenantId}`);
       }
     } catch (err) {
       console.error(err);
-      setReferralLink(`https://ohc.app/invite/${tenantId}`);
+      setReferralLink(`https://ohc.app/ref/${tenantId}`);
     }
     setLoading(false);
   };

--- a/src/ui/next/src/e2e/viral-loop-dashboard.spec.ts
+++ b/src/ui/next/src/e2e/viral-loop-dashboard.spec.ts
@@ -59,23 +59,24 @@ test.describe('Viral Loop Dashboard Widget', () => {
             });
         });
 
-        // Next, go to the Team page and generate an invite to trigger a change
-        await page.goto('/team');
-        const generateInviteBtn = page.locator('button:has-text("Invite to Cloud Team")');
+        // Next, go to the Referrals page and generate a link to trigger a change
+        await page.goto('/referrals');
 
-        await page.route('/api/v1/growth/cloud-bridge/invite', async route => {
-            await route.fulfill({ json: { invite_link: 'https://ohc.app/invite/test' } });
+        // Let's use the dashboard widget actually, or just simulate it directly on the dashboard
+        await page.goto('/dashboard');
+
+        const generateInviteBtn = page.locator('button:has-text("Get My Invite Link")');
+
+        await page.route('/api/v1/growth/referrals/generate', async route => {
+            await route.fulfill({ json: { referral_link: 'https://ohc.app/ref/test' } });
         });
 
         await expect(generateInviteBtn).toBeVisible();
         await generateInviteBtn.click();
 
         // The copy link input should become visible.
-        const copyInput = page.locator('#cloud-bridge-invite-link');
+        const copyInput = page.locator('#dashboard-invite-link');
         await expect(copyInput).toBeVisible({ timeout: 15000 });
-
-        // Go back to the dashboard and ensure the widget still renders
-        await page.goto('/dashboard');
         await expect(widgetHeader).toBeVisible();
 
         // Check if the number of invites sent has incremented


### PR DESCRIPTION
The DashboardViralInviteWidget was using the cloud-bridge endpoint (`/api/v1/growth/cloud-bridge/invite`) instead of the referral endpoints (`/api/v1/growth/referrals/generate`). This PR updates it to the correct referral endpoints and modifies tests to reflect those changes.

---
*PR created automatically by Jules for task [1874995866792274002](https://jules.google.com/task/1874995866792274002) started by @ql-owo-lp*