### PR TITLE
Fix frontend test failures and timeouts

### DIFF
--- a/src/ui/next/src/app/dashboard/page.test.tsx
+++ b/src/ui/next/src/app/dashboard/page.test.tsx
@@ -91,7 +91,7 @@ test('renders dashboard with actionable feed', async () => {
   });
 
   await waitFor(() => {
-    expect(screen.getAllByText("Business Analytics").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Business Analytics").length).toBeGreaterThan(0);
   });
 
   expect(screen.getByText("Operations Map")).toBeDefined();

--- a/src/ui/next/src/app/onboarding/page.test.tsx
+++ b/src/ui/next/src/app/onboarding/page.test.tsx
@@ -1318,7 +1318,7 @@ describe("OnboardingWizard", () => {
     await user.click(continueButton);
 
     await waitFor(() => {
-      expect(screen.queryByText(/Please tell us what you sell/i)).toBeInTheDocument();
+      expect(screen.queryByText("Please tell us what you sell.")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
This commit addresses tests that were timing out or failing due to React Testing Library queries throwing errors prematurely inside \`waitFor\` blocks or matching inexactly.

Specifically:
- In \`src/ui/next/src/app/dashboard/page.test.tsx\`, \`getAllByText\` throws if no elements are found immediately, failing the \`waitFor\` block loop before it gets a chance to poll. Changing this to \`queryAllByText\` allows the length assertion to evaluate and retry correctly.
- In \`src/ui/next/src/app/onboarding/page.test.tsx\`, matching the exact string "Please tell us what you sell." directly catches the error state robustly without regex fuzziness.

---
*PR created automatically by Jules for task [4845527600518781274](https://jules.google.com/task/4845527600518781274) started by @ql-owo-lp*