### PR TITLE
⚡ Bolt: Eliminate mock data in code-native API route

### DIFF
--- a/src/ui/next/src/app/api/agents/code-native/route.test.ts
+++ b/src/ui/next/src/app/api/agents/code-native/route.test.ts
@@ -1,0 +1,72 @@
+import { POST } from "./route";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("POST /api/agents/code-native", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    vi.stubEnv("BACKEND_URL", "http://backend.internal");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should proxy the request to the backend and return the response", async () => {
+    const mockResponseData = { results: ["success 1", "success 2"] };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponseData,
+    });
+
+    const body = { test: true };
+    const req = new Request("http://localhost/api/agents/code-native", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(global.fetch).toHaveBeenCalledWith("http://backend.internal/api/agents/code-native", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(200);
+    expect(data).toEqual(mockResponseData);
+  });
+
+  it("should handle backend failure by returning 502", async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const req = new Request("http://localhost/api/agents/code-native", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(data).toEqual({ error: "Failed to execute code-native pipeline" });
+  });
+
+  it("should handle network failure by returning 502", async () => {
+    (global.fetch as any).mockRejectedValue(new Error("Network Error"));
+
+    const req = new Request("http://localhost/api/agents/code-native", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(data).toEqual({ error: "Failed to execute code-native pipeline" });
+  });
+});

--- a/src/ui/next/src/app/api/agents/code-native/route.ts
+++ b/src/ui/next/src/app/api/agents/code-native/route.ts
@@ -2,14 +2,21 @@ import { NextResponse } from 'next/server';
 
 export async function POST(req: Request) {
   try {
-    // Mocking the backend implementation of CodeNativePipeline for the UI
-    const results = [
-        "Generated rich data with ID: test_id",
-        "Processed data natively. New record count: 2"
-    ];
+    const body = await req.json().catch(() => ({}));
+    const backendUrl = process.env.BACKEND_URL || 'http://127.0.0.1:18789';
 
-    return NextResponse.json({ results });
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    const res = await fetch(`${backendUrl}/api/agents/code-native`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      return NextResponse.json(data);
+    }
+    return NextResponse.json({ error: 'Failed to execute code-native pipeline' }, { status: 502 });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to execute code-native pipeline' }, { status: 502 });
   }
 }


### PR DESCRIPTION
# ⚡ Bolt: Eliminate mock data in code-native API route

## Problem
The `src/ui/next/src/app/api/agents/code-native/route.ts` API route was returning hardcoded mock data for the `CodeNativePipeline`, violating the "Mock Elimination" specification.

## Solution
1. Replaced the mock data with a standard `fetch` proxy call to the backend.
2. Implemented "fail closed" error handling (returns a `502 Bad Gateway` status on fetch failures or network errors).
3. Added a new `route.test.ts` file to ensure the proxying and error handling logic is fully covered by tests.

## Verification
- Loaded superpowers: Mock elimination protocol.
- Executed `bazelisk test //...` and `bazelisk test //src/ui/next:next_vitest`. All 102 tests pass successfully.
- No direct UI layout modifications were made; this is a strict Next.js API layer proxy update.

---
*PR created automatically by Jules for task [11844916751729125693](https://jules.google.com/task/11844916751729125693) started by @ql-owo-lp*