### PR TITLE
feat(pos): implement offline-first create_order flow with optimistic ui

### DIFF
--- a/src/server/api/terminal_api.rs
+++ b/src/server/api/terminal_api.rs
@@ -454,7 +454,12 @@ pub async fn sync_offline_transactions_handler(
                 // Evaluate conflicts for pending reconciliation synchronously
                 for tx in &req_data.transactions {
                     if let Ok(payload_val) = serde_json::from_str::<serde_json::Value>(&tx.payload) {
-                        if let Some(items) = payload_val.as_array() {
+                        let items = if let Some(arr) = payload_val.as_array() {
+                            Some(arr.clone())
+                        } else {
+                            payload_val.get("cart").and_then(|v| v.as_array()).cloned()
+                        };
+                        if let Some(items) = items {
                             for item in items {
                                 if let (Some(product_id), Some(quantity)) = (
                                     item.get("product_id").and_then(|v| v.as_str()),

--- a/src/server/workers/pos_sync_worker.rs
+++ b/src/server/workers/pos_sync_worker.rs
@@ -113,7 +113,76 @@ impl crate::queue::TaskJobHandler for PosSyncWorker {
 
         // Handle tap_to_pay offline processing via Stripe
         let mutation_type = payload.get("mutation_type").and_then(|v| v.as_str()).unwrap_or("");
-        if mutation_type == "tap_to_pay" {
+        if mutation_type == "create_order" {
+            // It's already recorded optimistically on frontend, but we need to commit it logically
+            // Deduct inventory for all items in the cart
+            let cart = payload.get("cart").and_then(|v| v.as_array());
+            if let Some(items) = cart {
+                for item in items {
+                    if let (Some(product_id), Some(quantity_val)) = (item.get("product_id").and_then(|v| v.as_str()), item.get("quantity")) {
+                        let quantity_deducted = quantity_val.as_i64().unwrap_or(1);
+
+                        let current_stock_res = sqlx::query("SELECT available_quantity FROM products WHERE id = $1 AND tenant_id = $2 FOR UPDATE")
+                            .bind(product_id)
+                            .bind(&job.tenant_id)
+                            .fetch_optional(&mut *tx)
+                            .await;
+
+                        if let Ok(Some(row)) = current_stock_res {
+                            let stock: i32 = sqlx::Row::get(&row, "available_quantity");
+                            let is_conflict = stock < quantity_deducted as i32;
+
+                            let _ = sqlx::query("UPDATE products SET pn_counter_n = pn_counter_n + $1, inventory_count = GREATEST(0, pn_counter_p - (pn_counter_n + $1)), available_quantity = GREATEST(0, available_quantity - $1) WHERE id = $2 AND tenant_id = $3")
+                                .bind(quantity_deducted)
+                                .bind(product_id)
+                                .bind(&job.tenant_id)
+                                .execute(&mut *tx)
+                                .await;
+
+                            if is_conflict {
+                                let feed_id = uuid::Uuid::new_v4().to_string();
+                                let feed_payload = serde_json::json!({
+                                    "transaction_id": transaction_id,
+                                    "product_id": product_id,
+                                    "shortage": (quantity_deducted as i32) - stock,
+                                });
+                                let proposed_action = serde_json::json!({
+                                    "action": "Resolve POS offline conflict"
+                                });
+                                let _ = sqlx::query(
+                                    "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state) VALUES ($1, $2, 'operations', $3::jsonb, $4::jsonb, 'PENDING_APPROVAL')"
+                                )
+                                .bind(&feed_id)
+                                .bind(&job.tenant_id)
+                                .bind(feed_payload)
+                                .bind(proposed_action)
+                                .execute(&mut *tx)
+                                .await;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Create the order
+            let order_id = uuid::Uuid::new_v4().to_string();
+            let amount_cents = payload.get("amount_cents").and_then(|v| v.as_i64()).unwrap_or(0);
+            let total_amount = (amount_cents as f64) / 100.0;
+
+            let _ = sqlx::query("INSERT INTO orders (id, tenant_id, total_amount, status) VALUES ($1, $2, $3, 'completed') ON CONFLICT DO NOTHING")
+                .bind(&order_id).bind(&job.tenant_id).bind(total_amount).execute(&mut *tx).await;
+
+            if let Some(items) = cart {
+                for item in items {
+                    if let (Some(product_id), Some(quantity_val)) = (item.get("product_id").and_then(|v| v.as_str()), item.get("quantity")) {
+                        let quantity_deducted = quantity_val.as_i64().unwrap_or(1);
+                        let item_id = uuid::Uuid::new_v4().to_string();
+                        let _ = sqlx::query("INSERT INTO order_items (id, tenant_id, order_id, product_id, quantity, price) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT DO NOTHING")
+                            .bind(&item_id).bind(&job.tenant_id).bind(&order_id).bind(product_id).bind(quantity_deducted).bind(total_amount).execute(&mut *tx).await;
+                    }
+                }
+            }
+        } else if mutation_type == "tap_to_pay" {
             // Securely create and capture Stripe intent since it's an offline tap-to-pay
             let stripe_key = std::env::var("STRIPE_API_KEY").unwrap_or_default();
             let client = crate::integrations::stripe::client::StripeClient::new(stripe_key);

--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -96,15 +96,18 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
        const syncManager = SyncManager.getInstance();
        if (onOptimisticReserve) onOptimisticReserve();
 
-       cart?.forEach(item => {
-           SyncManager.getInstance().enqueue({
-             type: 'tap_to_pay',
-             product_id: item.product.id,
-             quantity: item.quantity,
-             amount: item.product.price_cents * item.quantity,
-             currency: 'usd',
-             payload: { amount_cents: item.product.price_cents * item.quantity, product_id: item.product.id, quantity: item.quantity }
-          });
+       const txId = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : Date.now().toString() + Math.random().toString().substring(2);
+       SyncManager.getInstance().enqueue({
+         id: txId,
+         type: 'create_order',
+         payload: {
+           type: 'tap_to_pay',
+           amount_cents: amount,
+           currency: 'usd',
+           mutation_type: 'tap_to_pay',
+           cart: cart?.map(item => ({ product_id: item.product.id, quantity: item.quantity, price_cents: item.product.price_cents })) || [],
+           status: 'completed'
+         }
        });
 
        setTimeout(() => {
@@ -173,13 +176,18 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
   const processCashSale = async () => {
      if (typeof window !== 'undefined' && !navigator.onLine) {
          if (onOptimisticReserve) onOptimisticReserve();
-         cart?.forEach(item => {
-               SyncManager.getInstance().enqueue({
-               type: 'cash_sale',
-               product_id: item.product.id,
-               quantity: item.quantity,
-               payload: { amount_cents: item.product.price_cents * item.quantity }
-            });
+         const txId = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : Date.now().toString() + Math.random().toString().substring(2);
+         SyncManager.getInstance().enqueue({
+           id: txId,
+           type: 'create_order',
+           payload: {
+             type: 'cash_sale',
+             amount_cents: amount,
+             currency: 'usd',
+             mutation_type: 'cash_sale',
+             cart: cart?.map(item => ({ product_id: item.product.id, quantity: item.quantity, price_cents: item.product.price_cents })) || [],
+             status: 'completed'
+           }
          });
          setTimeout(() => {
            setStatus('Saved Offline - Will sync when connected');

--- a/src/ui/next/src/e2e/pos_offline_order.spec.ts
+++ b/src/ui/next/src/e2e/pos_offline_order.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, devices } from '@playwright/test';
+
+test.use({
+  ...devices['iPhone 13'],
+});
+
+test.describe('POS Terminal - Offline Create Order Flow', () => {
+  test('should allow creating an order offline and optimistically saving it', async ({ page }) => {
+    await page.goto('http://localhost:3000/dashboard');
+
+    const sellInPersonBtn = page.locator('#sell-in-person-btn');
+    await expect(sellInPersonBtn).toBeVisible();
+    await sellInPersonBtn.click();
+    await expect(page).toHaveURL(/.*\/pos\/terminal/);
+
+    // Turn off network to simulate dead zone
+    await page.context().setOffline(true);
+
+    try {
+      const pinInput = page.locator('input[type="password"]');
+      await pinInput.waitFor({ state: 'visible', timeout: 5000 });
+      await pinInput.fill('1234');
+      await page.click('button:has-text("Unlock")');
+      await page.waitForTimeout(1000);
+    } catch (e) {
+      // Pin screen might be skipped if already authenticated
+    }
+
+    // Verify offline indicator
+    await expect(page.getByText('Offline Mode Active').or(page.getByText('Offline Mode'))).toBeVisible({ timeout: 15000 });
+
+    const isCatalogVisible = await page.locator('h3:has-text("Product Catalog")').isVisible();
+    expect(isCatalogVisible).toBeTruthy();
+
+    const productButton = page.locator('.grid.grid-cols-1.gap-3.mb-8 button').first();
+    const count = await productButton.count();
+    expect(count).toBeGreaterThan(0);
+
+    await productButton.click();
+
+    const bottomBarChargeBtn = page.locator('button', { hasText: 'Charge' }).last();
+    await expect(bottomBarChargeBtn).toBeVisible();
+    await bottomBarChargeBtn.click();
+
+    // Verify Cart Drawer is open
+    await expect(page.locator('h2:has-text("Current Order")')).toBeVisible();
+
+    const cashBtn = page.locator('button', { hasText: /Record Cash Sale/ });
+    await expect(cashBtn).toBeVisible();
+    await cashBtn.click();
+
+    // Optimistic UI updates
+    await expect(page.getByText('Cash sale recorded offline. Will sync later.').or(page.getByText('Saved Offline - Will sync when connected'))).toBeVisible({ timeout: 15000 });
+
+    // Reconnect to verify sync mechanism is triggered (optional here, but we check if KDS handles it ideally)
+    await page.context().setOffline(false);
+  });
+});

--- a/src/ui/next/src/lib/powersync/AppSchema.ts
+++ b/src/ui/next/src/lib/powersync/AppSchema.ts
@@ -93,6 +93,27 @@ const posTerminalSessions = new Table({
   pending_reconciliation: column.text
 });
 
+const orders = new Table({
+  id: column.text,
+  tenant_id: column.text,
+  customer_id: column.text,
+  total_amount: column.real,
+  status: column.text,
+  notes: column.text,
+  translated_notes: column.text,
+  created_at: column.text,
+  updated_at: column.text
+});
+
+const orderItems = new Table({
+  id: column.text,
+  tenant_id: column.text,
+  order_id: column.text,
+  product_id: column.text,
+  quantity: column.integer,
+  price: column.real
+});
+
 export const AppSchema = new Schema({
   appointments: appointments,
   service_routes: serviceRoutes,
@@ -100,5 +121,7 @@ export const AppSchema = new Schema({
   omni_inbox_messages: omniInboxMessages,
   pending_actions: pendingActions,
   pos_offline_transactions: posOfflineTransactions,
-  pos_terminal_sessions: posTerminalSessions
+  pos_terminal_sessions: posTerminalSessions,
+  orders: orders,
+  order_items: orderItems
 });

--- a/src/ui/next/src/lib/sync/SyncManager.ts
+++ b/src/ui/next/src/lib/sync/SyncManager.ts
@@ -144,7 +144,7 @@ export class SyncManager {
 
     try {
       // Separate POS transactions from general offline sync
-      const posTransactions = queue.filter(m => m.type === 'tap_to_pay' || m.type === 'cash_sale').map(m => {
+      const posTransactions = queue.filter(m => m.type === 'tap_to_pay' || m.type === 'cash_sale' || m.type === 'create_order').map(m => {
         let storedDeviceId = 'terminal_client';
         if (typeof window !== 'undefined') {
             storedDeviceId = localStorage.getItem('ohc_pos_device_id') || 'terminal_client';
@@ -158,12 +158,12 @@ export class SyncManager {
           payload: typeof m.payload === 'string' ? m.payload : JSON.stringify(m.payload || [{ product_id: m.product_id, quantity: m.quantity || 1 }]),
           timestamp: new Date(m.timestamp || Date.now()).toISOString(),
           device_signature: m.device_signature || `sig_offline_${storedDeviceId}_${m.id}`,
-          mutation_type: m.type,
+          mutation_type: m.type === 'create_order' ? 'create_order' : m.type,
           terminal_id: storedDeviceId
         };
       });
 
-      const generalMutations = queue.filter(m => m.type !== 'tap_to_pay' && m.type !== 'cash_sale').map(m => this.mapGeneralMutation(m));
+      const generalMutations = queue.filter(m => m.type !== 'tap_to_pay' && m.type !== 'cash_sale' && m.type !== 'create_order').map(m => this.mapGeneralMutation(m));
 
       // Route POS offline mutations through SyncEvents standard sync_gateway
       const posSyncEvents = queue
@@ -281,7 +281,7 @@ export class SyncManager {
       }
 
       // Sync operation intents (from MutationService)
-      const operationIntents = queue.filter(m => m.type !== 'tap_to_pay' && m.type !== 'cash_sale' && m.type !== 'UPDATE_ORDER_STATUS' && m.type !== 'TOGGLE_SOLD_OUT' && m.type !== 'update_quote' && m.type !== 'approve_quote' && m.type !== 'CRDT_MUTATION' && m.type !== 'triage_action' && m.type !== 'advisory_action' && m.type !== 'field_ops_status' && m.type !== 'generate_invoice');
+      const operationIntents = queue.filter(m => m.type !== 'tap_to_pay' && m.type !== 'cash_sale' && m.type !== 'create_order' && m.type !== 'UPDATE_ORDER_STATUS' && m.type !== 'TOGGLE_SOLD_OUT' && m.type !== 'update_quote' && m.type !== 'approve_quote' && m.type !== 'CRDT_MUTATION' && m.type !== 'triage_action' && m.type !== 'advisory_action' && m.type !== 'field_ops_status' && m.type !== 'generate_invoice');
 
       if (operationIntents.length > 0) {
         const mappedIntents = operationIntents.map(m => ({


### PR DESCRIPTION
**Product-use evidence:**
Persona: Fatima (Food Cart Operator)
Action: Tried to process an order while in a network dead zone.
Observed Result: The checkout process enqueued disjointed mutations (`cash_sale` or `tap_to_pay`) but didn't optimistically generate a local order, leaving the KDS out-of-sync or causing backend conflicts that weren't routed to the Triage feed correctly.
Expected Result: A `create_order` action encapsulates the transaction, optimistically displays in the KDS, and robustly handles online sync/inventory deduction.

**Implementation:**
- Added `orders` and `order_items` tables to the local `AppSchema.ts` (PowerSync).
- Updated POS checkout to fire a grouped `create_order` mutation instead of disparate payment mutations.
- Updated `SyncManager.ts` to dispatch `create_order` alongside pos transactions via the offline sync endpoint.
- Handled `create_order` in `pos_sync_worker.rs`, enforcing logical stock deductions and firing conflict resolution tickets to the Ops Agent when inventory falls below 0.
- Implemented `pos_offline_order.spec.ts` to assert offline order capability.

Resolves #33571

---
*PR created automatically by Jules for task [12955991572108061334](https://jules.google.com/task/12955991572108061334) started by @ql-owo-lp*