### PR TITLE
🎨 Canvas: Agentic Offline-First Field Service Route & Job Management

### DIFF
--- a/src/server/api/field_ops.rs
+++ b/src/server/api/field_ops.rs
@@ -180,6 +180,32 @@ pub async fn update_appointment(
         )
     })?;
 
+    if payload.status == "Completed" {
+        let tenant_id_row: Result<(String,), _> = sqlx::query_as("SELECT tenant_id FROM appointments WHERE id = $1")
+            .bind(&payload.id)
+            .fetch_one(&state.pool)
+            .await;
+
+        if let Ok((tenant_id,)) = tenant_id_row {
+            if let Err(e) = sqlx::query(
+                "INSERT INTO department_tasks (id, tenant_id, department, event_type, payload, status)
+                 VALUES ($1, $2, 'operations', 'job.completed.offline_sync', $3::jsonb, 'PENDING')"
+            )
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(&tenant_id)
+            .bind(serde_json::json!({
+                "job_id": payload.id,
+                "status": payload.status,
+                "notes": payload.notes,
+                "trigger_workflows": ["eta_sms", "invoice_generation"]
+            }).to_string())
+            .execute(&state.pool)
+            .await {
+                tracing::error!("Failed to enqueue department_tasks for completed appointment {}: {}", payload.id, e);
+            }
+        }
+    }
+
     let event = ::server_ohc::orchestration::TeammateMeshEvent {
         agent_id: "system".into(),
         action: "job:status_changed".into(),

--- a/src/ui/next/src/e2e/field-ops-offline.spec.ts
+++ b/src/ui/next/src/e2e/field-ops-offline.spec.ts
@@ -52,7 +52,7 @@ test.describe('Offline-Tolerant Field Ops CUJ', () => {
     await expect(page.getByText('IN-PROGRESS')).toBeVisible();
 
     // Mark as complete
-    const doneBtn = page.getByText('Job Done');
+    const doneBtn = page.getByText('Complete & Pay');
     await doneBtn.click();
 
     // Verify optimistic UI update

--- a/src/ui/next/src/e2e/field-ops.spec.ts
+++ b/src/ui/next/src/e2e/field-ops.spec.ts
@@ -52,8 +52,8 @@ test.describe("Field Service Routing & Dispatch Engine UI updates", () => {
     await expect(startWorkBtn).toBeVisible({ timeout: 5000 });
     await startWorkBtn.click();
 
-    // Check that we moved to 'Job Done'
-    const jobDoneBtn = page.locator("button", { hasText: "Job Done" }).first();
+    // Check that we moved to 'Complete & Pay'
+    const jobDoneBtn = page.locator("button", { hasText: "Complete & Pay" }).first();
     await expect(jobDoneBtn).toBeVisible({ timeout: 5000 });
     await jobDoneBtn.click();
 


### PR DESCRIPTION
Addresses #33656 by ensuring that `update_appointment` intercepts offline syncs representing "Completed" statuses. It will trigger downstream workflows like ETA SMS and invoice generation by enqueuing a `department_tasks` job for the operations agent. Test references have been modified to map to the correct "Complete & Pay" button.

Resolves #33656

---
*PR created automatically by Jules for task [12370996444157283076](https://jules.google.com/task/12370996444157283076) started by @ql-owo-lp*