### PR TITLE
🤖 Implementer: Harness Upgrade - Error Handling: LLM-Recoverable ToolMessages

### DIFF
--- a/src/agents/builtin/actor_model.rs
+++ b/src/agents/builtin/actor_model.rs
@@ -207,7 +207,7 @@ impl Actor for ToolActor {
                                 }
                                 Err(e) => {
                                     let error_str = match e {
-                                        ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg) => {
+                                        ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg) | ohc_builtin_agent_core::types::ToolError::LlmRecoverableWithContext { msg, .. } => {
                                             let count = *error_counts.entry(tc.name.clone()).or_insert(0) + 1;
                                             error_counts.insert(tc.name.clone(), count);
                                             if count > 2 {

--- a/src/agents/builtin/agent.rs
+++ b/src/agents/builtin/agent.rs
@@ -657,7 +657,7 @@ impl Agent {
                             error: String::new(),
                         };
                     }
-                    Err(crate::types::ToolError::LlmRecoverable(err_msg)) => {
+                    Err(crate::types::ToolError::LlmRecoverable(err_msg)) | Err(crate::types::ToolError::LlmRecoverableWithContext { msg: err_msg, .. }) => {
                         let self_correct_msg =
                             ohc_builtin_agent_core::types::ToolResult::new_llm_recoverable(
                                 tc.id.clone(),
@@ -761,7 +761,7 @@ impl Agent {
                             error: String::new(),
                         };
                     }
-                    Err(crate::types::ToolError::LlmRecoverable(err_msg)) => {
+                    Err(crate::types::ToolError::LlmRecoverable(err_msg)) | Err(crate::types::ToolError::LlmRecoverableWithContext { msg: err_msg, .. }) => {
                         let self_correct_msg =
                             ohc_builtin_agent_core::types::ToolResult::new_llm_recoverable(
                                 tc.id.clone(),
@@ -1390,7 +1390,7 @@ impl Agent {
                                     err_msg
                                 ))));
                             }
-                            Err(crate::types::ToolError::LlmRecoverable(err_msg)) => {
+                            Err(crate::types::ToolError::LlmRecoverable(err_msg)) | Err(crate::types::ToolError::LlmRecoverableWithContext { msg: err_msg, .. }) => {
                                 if let Some(checkpointer) = &self.checkpointer {
                                     if let Some(cp_id) = &current_checkpoint_id {
                                         let _ = checkpointer.restore_checkpoint(cp_id).await;
@@ -1526,7 +1526,7 @@ impl Agent {
                                         err_msg
                                     ))));
                                 }
-                                Err(crate::types::ToolError::LlmRecoverable(err_msg)) => {
+                                Err(crate::types::ToolError::LlmRecoverable(err_msg)) | Err(crate::types::ToolError::LlmRecoverableWithContext { msg: err_msg, .. }) => {
                                     if let Some(checkpointer) = &self.checkpointer {
                                         if let Some(cp_id) = &current_checkpoint_id {
                                             let _ = checkpointer.restore_checkpoint(cp_id).await;
@@ -1902,7 +1902,7 @@ impl Agent {
                                 error: "".to_string(),
                             };
                         }
-                        Err(crate::types::ToolError::LlmRecoverable(err_msg)) => {
+                        Err(crate::types::ToolError::LlmRecoverable(err_msg)) | Err(crate::types::ToolError::LlmRecoverableWithContext { msg: err_msg, .. }) => {
                             if let Some(checkpointer) = &checkpointer_node {
                                 if let Some(cp_id) = &current_checkpoint_id {
                                     let _ = checkpointer.restore_checkpoint(cp_id).await;
@@ -1957,7 +1957,7 @@ impl Agent {
                     let gating_err = crate::tools_gating::ToolGater::check_gating(&tc, false, &cfg_arc_node);
                     if let Err(e) = gating_err {
                         match e {
-                            crate::types::ToolError::LlmRecoverable(err_msg) => {
+                            crate::types::ToolError::LlmRecoverable(err_msg) | crate::types::ToolError::LlmRecoverableWithContext { msg: err_msg, .. } => {
                                 if let Some(checkpointer) = &checkpointer_node {
                                     if let Some(cp_id) = &current_checkpoint_id {
                                         let _ = checkpointer.restore_checkpoint(cp_id).await;
@@ -2031,7 +2031,7 @@ impl Agent {
                                     error: "".to_string(),
                                 };
                             }
-                            Err(crate::types::ToolError::LlmRecoverable(err_msg)) => {
+                            Err(crate::types::ToolError::LlmRecoverable(err_msg)) | Err(crate::types::ToolError::LlmRecoverableWithContext { msg: err_msg, .. }) => {
                                 if let Some(checkpointer) = &checkpointer_node {
                                     if let Some(cp_id) = &current_checkpoint_id {
                                         let _ = checkpointer.restore_checkpoint(cp_id).await;
@@ -2585,7 +2585,7 @@ impl Agent {
                                 break Err(crate::types::ToolError::Transient(format!("Error executing planned step: Transient error after retries: {}", msg)));
                             }
                         }
-                        Err(crate::types::ToolError::LlmRecoverable(err_msg)) => {
+                        Err(crate::types::ToolError::LlmRecoverable(err_msg)) | Err(crate::types::ToolError::LlmRecoverableWithContext { msg: err_msg, .. }) => {
                             if llm_recoverable_count >= 2 {
                                 break Err(crate::types::ToolError::Unexpected(format!("Error executing planned step: LLM-recoverable retries exhausted: {}", err_msg)));
                             }
@@ -2731,7 +2731,7 @@ impl Agent {
                             .into());
                         }
                     }
-                    Err(crate::types::ToolError::LlmRecoverable(err_msg)) => {
+                    Err(crate::types::ToolError::LlmRecoverable(err_msg)) | Err(crate::types::ToolError::LlmRecoverableWithContext { msg: err_msg, .. }) => {
                         if llm_recoverable_count >= 2 {
                             return Err(format!("Error executing planned step: LLM-recoverable retries exhausted: {}", err_msg).into());
                         }
@@ -4205,7 +4205,7 @@ impl Agent {
                         };
                     }
 
-                    Err(ToolError::LlmRecoverable(err_msg)) => {
+                    Err(ToolError::LlmRecoverable(err_msg)) | Err(ToolError::LlmRecoverableWithContext { msg: err_msg, .. }) => {
                         let count = tool_error_counts.entry(tc.name.clone()).or_insert(0);
                         *count += 1;
                         if *count > std::cmp::min(final_cfg.max_retries, 2) {
@@ -4468,7 +4468,7 @@ impl Agent {
                             content = r;
                             break;
                         }
-                        Err(ToolError::LlmRecoverable(err_msg)) => {
+                        Err(ToolError::LlmRecoverable(err_msg)) | Err(ToolError::LlmRecoverableWithContext { msg: err_msg, .. }) => {
                             let count = tool_error_counts.entry(tc.name.clone()).or_insert(0);
                             *count += 1;
                             if *count > std::cmp::min(final_cfg.max_retries, 2) {

--- a/src/agents/builtin/gather_act_verify.rs
+++ b/src/agents/builtin/gather_act_verify.rs
@@ -248,7 +248,7 @@ impl GatherActVerifyHarness {
                                             content: res.clone(),
                                             error: String::new(),
                                         }),
-                                        Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg)) => Ok(ohc_builtin_agent_core::types::ToolResult::new_llm_recoverable(tc.id.clone(), &tc_name, &msg)),
+                                        Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg)) | Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverableWithContext { msg, .. }) => Ok(ohc_builtin_agent_core::types::ToolResult::new_llm_recoverable(tc.id.clone(), &tc_name, &msg)),
                                         Err(e) => Err(e),
                                     }
                                 } else {
@@ -333,7 +333,7 @@ impl GatherActVerifyHarness {
                                         content: res.clone(),
                                         error: String::new(),
                                     }),
-                                    Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg)) => Ok(ohc_builtin_agent_core::types::ToolResult::new_llm_recoverable(tc.id.clone(), &tc.name, &msg)),
+                                    Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg)) | Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverableWithContext { msg, .. }) => Ok(ohc_builtin_agent_core::types::ToolResult::new_llm_recoverable(tc.id.clone(), &tc.name, &msg)),
                                     Err(e) => Err(e),
                                 }
                             } else {

--- a/src/agents/builtin/plan_and_execute.rs
+++ b/src/agents/builtin/plan_and_execute.rs
@@ -215,7 +215,7 @@ impl PlanAndExecuteOrchestrator {
 
                     match res {
                         Ok(r) => Ok::<_, String>((task.task_id, r)),
-                        Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg)) => {
+                        Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg)) | Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverableWithContext { msg, .. }) => {
                             Ok::<_, String>((
                                 task.task_id,
                                 ohc_builtin_agent_core::types::format_llm_recoverable_error(
@@ -262,7 +262,7 @@ impl PlanAndExecuteOrchestrator {
 
                 let final_res = match res {
                     Ok(r) => r,
-                    Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg)) => {
+                    Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg)) | Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverableWithContext { msg, .. }) => {
                         ohc_builtin_agent_core::types::format_llm_recoverable_error(
                             &task.tool_name,
                             &msg,

--- a/src/agents/builtin/tool_executor_engine.rs
+++ b/src/agents/builtin/tool_executor_engine.rs
@@ -39,6 +39,13 @@ impl ToolExecutionEngine {
                     info!("Tool execution successful");
                     return Ok(res);
                 }
+                Err(ToolError::LlmRecoverableWithContext { msg, .. }) => {
+                    warn!(
+                        "LLM-recoverable error encountered in tool '{}' (Pydantic-first schema failure or similar): {}",
+                        tool.name, msg
+                    );
+                    return Err(ToolError::LlmRecoverableWithContext { tool_name: tool.name.clone(), msg });
+                }
                 Err(ToolError::Transient(msg)) => {
                     // 1) Transient errors: orchestrator should retry with backoff.
                     if retry_count < max_retries {
@@ -65,15 +72,11 @@ impl ToolExecutionEngine {
                 }
                 Err(ToolError::LlmRecoverable(msg)) => {
                     // 2) LLM-recoverable: returned to the model so it can self-correct.
-                    // E.g., when the schema fails validation (Pydantic-first approach).
                     warn!(
                         "LLM-recoverable error encountered in tool '{}' (Pydantic-first schema failure or similar): {}",
                         tool.name, msg
                     );
-                    let formatted_msg = ohc_builtin_agent_core::types::format_llm_recoverable_error(
-                        &tool.name, &msg,
-                    );
-                    return Err(ToolError::LlmRecoverable(formatted_msg));
+                    return Err(ToolError::LlmRecoverableWithContext { tool_name: tool.name.clone(), msg });
                 }
                 Err(ToolError::UserFixable(msg)) => {
                     // 3) User-fixable: immediately bubble up to the orchestrator to request human-in-loop input.

--- a/src/agents/builtin/tool_executor_engine_tests.rs
+++ b/src/agents/builtin/tool_executor_engine_tests.rs
@@ -210,7 +210,7 @@ use ohc_builtin_agent::agent::AgentRunConfig;
 
         assert!(res.is_err());
         match res.expect_err("Expected error in test") {
-            ToolError::LlmRecoverable(msg) => {
+            ToolError::LlmRecoverableWithContext { msg, .. } => {
                 assert!(msg.contains("Validation Error (Pydantic-first tool schema)"));
                 assert!(msg.contains("missing field `required_int`"));
             },
@@ -241,7 +241,7 @@ use ohc_builtin_agent::agent::AgentRunConfig;
         assert!(res.is_err());
         assert!(res.as_ref().expect_err("Expected error in test").to_string().contains("Validation Error (Pydantic-first tool schema)"));
         match res.expect_err("Expected error in test") {
-            ToolError::LlmRecoverable(msg) => assert!(msg.contains("Validation Error (Pydantic-first tool schema)")),
+            ToolError::LlmRecoverableWithContext { msg, .. } => assert!(msg.contains("Validation Error (Pydantic-first tool schema)")),
             _ => panic!("Expected LlmRecoverable error"),
         }
     }
@@ -270,7 +270,7 @@ use ohc_builtin_agent::agent::AgentRunConfig;
         // Ensure the engine correctly bubbles up the exact recoverable error back to the orchestration loop
         assert!(res.is_err());
         match res.expect_err("Expected error in test") {
-            ToolError::LlmRecoverable(msg) => {
+            ToolError::LlmRecoverableWithContext { msg, .. } => {
                 assert!(msg.contains("Validation Error (Pydantic-first tool schema)"));
             },
             _ => panic!("Expected LlmRecoverable error"),
@@ -298,7 +298,7 @@ use ohc_builtin_agent::agent::AgentRunConfig;
         let res = ToolExecutionEngine::execute_tool_with_langgraph_mechanics(&tool, &tc, 2, &AgentRunConfig::default()).await;
         assert!(res.is_err());
         match res.expect_err("Expected error in test") {
-            ToolError::LlmRecoverable(msg) => assert!(msg.contains("parse error")),
+            ToolError::LlmRecoverableWithContext { msg, .. } => assert!(msg.contains("parse error")),
             _ => panic!("Expected LlmRecoverable error"),
         }
     }

--- a/src/agents/builtin/types.rs
+++ b/src/agents/builtin/types.rs
@@ -155,6 +155,8 @@ pub enum ToolError {
     /// Errors the LLM can fix if it sees them (e.g. invalid arguments, missing required param).
     /// Passed back to the LLM as a ToolMessage containing the raw error.
     LlmRecoverable(String),
+    /// Same as LlmRecoverable, but with explicitly attached tool name context to prevent loss of context.
+    LlmRecoverableWithContext { tool_name: String, msg: String },
     /// Errors requiring human intervention. Pauses execution and asks the user.
     UserFixable(String),
     /// Fatal errors. Bubbles up to debug/halt immediately.
@@ -170,6 +172,7 @@ impl std::fmt::Display for ToolError {
         match self {
             Self::Transient(msg) => write!(f, "Transient error: {}", msg),
             Self::LlmRecoverable(msg) => write!(f, "Recoverable error: {}", msg),
+            Self::LlmRecoverableWithContext { tool_name, msg } => write!(f, "Recoverable error in {}: {}", tool_name, msg),
             Self::UserFixable(msg) => write!(f, "User intervention required: {}", msg),
             Self::Fatal(msg) => write!(f, "Fatal error: {}", msg),
             Self::Unexpected(msg) => write!(f, "Unexpected error: {}", msg),

--- a/src/agents/builtin/visual_workflow.rs
+++ b/src/agents/builtin/visual_workflow.rs
@@ -326,7 +326,7 @@ impl WorkflowExecutor {
 
                         let result_str = match result {
                             Ok(res) => res,
-                            Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg)) => {
+                            Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverable(msg)) | Err(ohc_builtin_agent_core::types::ToolError::LlmRecoverableWithContext { msg, .. }) => {
                                 ohc_builtin_agent_core::types::format_llm_recoverable_error(
                                     &tool_name, &msg,
                                 )


### PR DESCRIPTION
**Product-use evidence:**
- **Persona:** N/A (Core framework/harness upgrade)
- **Workflow Attempted:** Orchestrator loops receiving recoverable errors from tools during agent planning or chat execution.
- **Observed Gap:** The `ToolExecutionEngine::execute_tool_with_langgraph_mechanics` was formatting the error message with the "SOTA Recovery Protocol" instructions string prematurely. Consequently, the error string was either "double-formatted" when it reached `ToolResult::new_llm_recoverable`, or orchestrators like `plan_and_execute.rs` and `visual_workflow.rs` were missing the standard formatting because they expected the engine to do it. The prior attempt to fix this stripped the `tool_name` from the error message.
- **Fix:** We implemented the "Error Handling: LLM-Recoverable ToolMessages" standard by adding a new `LlmRecoverableWithContext` variant to `ToolError` containing both `tool_name` and `msg`. The engine returns this context-rich typed error structure. Orchestrators safely match against it and format it *exactly once* right before it is pushed to the LLM, resolving the double-formatting bug without utilizing fragile string heuristics or dropping the critical tool name.
- **Post-Fix Workflow:** The `ToolExecutionEngine` successfully passes up raw errors wrapped in contextual structures. Orchestrators properly extract the error string and apply `format_llm_recoverable_error` directly, ensuring LLMs receive a well-formatted string containing the tool name so they can successfully self-correct validation failures.

**Superpowers used:**
- Rust compiler-driven development
- Heavy refactoring using algebraic data types
- 100% tests passing (`bazelisk test //...`) and Playwright E2E passing (`bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"`).

**Interaction Audit Table:**
| Element | Designed Purpose | Observed Result | Fix |
|---|---|---|---|
| `ToolError::LlmRecoverable` | Propagates LLM-recoverable validation errors | `execute_tool_with_langgraph_mechanics` prematurely formatted it with string prefixes. | Refactored type system to introduce `LlmRecoverableWithContext` to encapsulate the tool name alongside raw error, pushing formatting correctly to the edge. |

---
*PR created automatically by Jules for task [12690402432021306154](https://jules.google.com/task/12690402432021306154) started by @ql-owo-lp*