### PR TITLE
🚀 Nova: [Viral Loyalty Widget Mock Elimination]

### DIFF
--- a/src/e2e/viral-loyalty-widget.spec.ts
+++ b/src/e2e/viral-loyalty-widget.spec.ts
@@ -3,49 +3,40 @@ import { adminPage } from './fixtures';
 
 test.describe('Viral Loyalty Widget', () => {
   test('should load the widget and generate a loyalty program', async ({ page }) => {
-    // We mock the backend response here specifically because this is a static UI page
-    // in the tauri bundle that simulates growth mechanics.
-    await page.route('/api/v1/growth/referrals/generate', async route => {
-      await route.fulfill({ json: { referral_link: 'http://example.com/ref/12345' } });
+    // Use the adminPage fixture to run the CUJ properly (from dashboard)
+    await adminPage(page, async () => {
+      // Start from dashboard and click the widget link
+      await page.goto('/ui/dashboard.html');
+      await page.locator('#loyalty-link').click();
+
+      // Wait for main elements
+      await expect(page.locator('h1')).toHaveText('Viral Loyalty Widget Generator');
+      const generateBtn = page.locator('#generate-btn');
+      await expect(generateBtn).toBeVisible();
+
+      // Check initial stamps state
+      const emptyStamps = page.locator('.stamp.empty');
+      await expect(emptyStamps).toHaveCount(4);
+
+      // Click generate (this hits the real `/api/v1/growth/referrals/generate` endpoint)
+      await generateBtn.click();
+
+      // Verify animation starts
+      await expect(generateBtn).toBeDisabled();
+      await expect(generateBtn).toHaveText('Generating...');
+
+      // Wait for the animation to finish and result to show
+      const resultArea = page.locator('#result-area');
+      await expect(resultArea).toBeVisible({ timeout: 5000 });
+
+      // Verify filled stamps
+      const filledStamps = page.locator('.stamp.filled');
+      await expect(filledStamps).toHaveCount(4);
+
+      // Check share link generated correctly
+      const shareLink = page.locator('#share-link');
+      // Verify that the referral link uses the real format
+      await expect(shareLink).toHaveValue(/loyalty\/join\?ref=[0-9a-fA-F-]+/);
     });
-
-    const fs = require('fs');
-    const path = require('path');
-    const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
-
-    await page.route('/ui/viral-loyalty-widget.html', async route => {
-        const file = fs.readFileSync(path.join(tauriUiDir, 'viral-loyalty-widget.html'));
-        await route.fulfill({ body: file, contentType: 'text/html' });
-    });
-
-    await page.goto('/ui/viral-loyalty-widget.html');
-
-    // Wait for main elements
-    await expect(page.locator('h1')).toHaveText('Viral Loyalty Widget Generator');
-    const generateBtn = page.locator('#generate-btn');
-    await expect(generateBtn).toBeVisible();
-
-    // Check initial stamps state
-    const emptyStamps = page.locator('.stamp.empty');
-    await expect(emptyStamps).toHaveCount(4);
-
-    // Click generate
-    await generateBtn.click();
-
-    // Verify animation starts
-    await expect(generateBtn).toBeDisabled();
-    await expect(generateBtn).toHaveText('Generating...');
-
-    // Wait for the animation to finish and result to show
-    const resultArea = page.locator('#result-area');
-    await expect(resultArea).toBeVisible({ timeout: 5000 });
-
-    // Verify filled stamps
-    const filledStamps = page.locator('.stamp.filled');
-    await expect(filledStamps).toHaveCount(4);
-
-    // Check share link generated correctly
-    const shareLink = page.locator('#share-link');
-    await expect(shareLink).toHaveValue(/loyalty\/join\?ref=12345/);
   });
 });

--- a/src/ui/next/public/ui/viral-loyalty-widget.html
+++ b/src/ui/next/public/ui/viral-loyalty-widget.html
@@ -267,7 +267,7 @@
 
       try {
         const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'e2e-tenant';
-        let refId = tenantId;
+        let refId = null;
 
         try {
           // This simulates generating a program
@@ -286,6 +286,8 @@
           const data = await res.json();
           if (data.referral_link) {
               refId = data.referral_link.split('/').pop();
+          } else {
+              throw new Error("No referral link in response");
           }
         } catch (fetchErr) {
             console.error("Network unreachable or API error", fetchErr);

--- a/src/ui/tauri/src/ui/viral-loyalty-widget.html
+++ b/src/ui/tauri/src/ui/viral-loyalty-widget.html
@@ -340,7 +340,7 @@
 
       try {
         const tenantId = localStorage.getItem('tenant_id') || localStorage.getItem('tenant') || 'e2e-tenant';
-        let refId = tenantId;
+        let refId = null;
 
         try {
           // This simulates generating a program
@@ -359,6 +359,8 @@
           const data = await res.json();
           if (data.referral_link) {
               refId = data.referral_link.split('/').pop();
+          } else {
+              throw new Error("No referral link in response");
           }
         } catch (fetchErr) {
             console.error("Network unreachable or API error", fetchErr);


### PR DESCRIPTION
# 🚀 Nova: Viral Loyalty Widget Mock Elimination

## Owner/Operator Context
Maya runs a custom cake business and uses the "Viral Loyalty Widget" to generate a loyalty program share link for her customers. Previously, testing this widget relied entirely on mocked backend responses, meaning any regressions in the real backend (`/api/v1/growth/referrals/generate`) would go unnoticed. By eliminating these mocks, Maya can be confident that when she clicks "Generate Loyalty Program", the system will legitimately provision a trackable growth referral loop and present her with a fully functioning URL, failing transparently if the system encounters an error instead of pretending it worked. 

## Technical Details
* **UI E2E Test Hardening (`src/e2e/viral-loyalty-widget.spec.ts`):** Removed `page.route` file system mocks and API stubbing. The test now authenticates via the `adminPage` fixture, navigates to the dashboard, clicks the `loyalty-link`, and asserts that the generate button correctly triggers an animation before rendering a structurally sound referral UUID URL pattern (`/loyalty/join?ref=[0-9a-fA-F-]+/`).
* **Frontend Error Handling (`src/ui/tauri/src/ui/viral-loyalty-widget.html` & `src/ui/next/public/ui/viral-loyalty-widget.html`):** Removed the fallback `let refId = tenantId` which incorrectly simulated successful generation upon fetch failure. Now, if the API response omits a `referral_link`, the JS explicitly throws an error and fails closed, correctly triggering the error toast visualization.

## Verification
* Operated the UI manually to observe "failing closed" state when the `referral_link` is absent.
* Automated E2E test (`bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"`) ran and passed without stubs. 
* Total test suite `bazelisk test //...` is green.
* **Superpowers Loaded:** `mock-elimination-design` & `growth-viral-loyalty-widget-design` rules obeyed.

---
*PR created automatically by Jules for task [5948526606954343037](https://jules.google.com/task/5948526606954343037) started by @ql-owo-lp*