### PR TITLE
🔨 Forge: Implement agentic product creation workflow

### DIFF
--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -129,6 +129,7 @@ SERVER_RS_SRCS = [
     "//src/server/domain:compute.rs",
     "//src/server/domain:federation.rs",
     "//src/server/domain:action_router.rs",
+    "//src/server/domain:catalog.rs",
     "//src/server/domain:agent_approvals.rs",
     "//src/server/domain:inbox.rs",
     "//src/server/domain:incidents.rs",

--- a/src/server/domain/BUILD.bazel
+++ b/src/server/domain/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 exports_files(
     [
         "action_router.rs",
+        "catalog.rs",
         "agent_approvals.rs",
         "b2b.rs",
         "blueprint.rs",
@@ -31,6 +32,7 @@ rust_library(
     srcs = [
         "bazel_lib.rs",
         "action_router.rs",
+        "catalog.rs",
         "agent_approvals.rs",
         "b2b.rs",
         "blueprint.rs",

--- a/src/server/domain/action_router.rs
+++ b/src/server/domain/action_router.rs
@@ -29,6 +29,12 @@ pub async fn dispatch_action(
             // Real implementation would buffer post here to AYRSHARE.
             tracing::info!("Approved and scheduled SocialPostDraft for tenant: {}", tenant_id); // pii-safe
         }
+
+        "create_product" => {
+            crate::domain::catalog::handle_create_product(tenant_id, payload, pool)
+                .await
+                .map_err(|e| e.to_string())?;
+        }
         "booking_draft" => {
             crate::domain::booking::handle_booking_action(tenant_id, payload, pool)
                 .await

--- a/src/server/domain/catalog.rs
+++ b/src/server/domain/catalog.rs
@@ -1,0 +1,41 @@
+use sqlx::PgPool;
+use serde_json::Value;
+
+pub async fn handle_create_product(tenant_id: &str, payload: &Value, pool: &PgPool) -> Result<(), sqlx::Error> {
+    let title = payload.get("title").or_else(|| payload.get("name")).and_then(|v| v.as_str()).unwrap_or("New Product");
+    let description = payload.get("description").and_then(|v| v.as_str()).unwrap_or("");
+
+    let price_str = payload.get("price").and_then(|v| {
+        if v.is_string() { v.as_str() }
+        else if v.is_number() { None } // Will handle in a moment if it's a number
+        else { None }
+    });
+
+    let price_f64 = if let Some(s) = price_str {
+        s.parse::<f64>().unwrap_or(0.0)
+    } else if let Some(n) = payload.get("price").and_then(|v| v.as_f64()) {
+        n
+    } else {
+        0.0
+    };
+
+    let price_cents = (price_f64 * 100.0).round() as i64;
+    let item_type = payload.get("item_type").and_then(|v| v.as_str()).unwrap_or("Product");
+    let product_id = uuid::Uuid::new_v4().to_string();
+
+    tracing::info!("Creating product via action_router for tenant: {}, title: {}", tenant_id, title);
+
+    sqlx::query(
+        "INSERT INTO products (id, tenant_id, title, description, type, price_cents, inventory_count, is_subscribable, subscription_frequency, subscription_discount_percent) VALUES ($1, $2, $3, $4, $5, $6, 100, false, null, 0)"
+    )
+    .bind(&product_id)
+    .bind(tenant_id)
+    .bind(title)
+    .bind(description)
+    .bind(item_type)
+    .bind(price_cents)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}

--- a/src/server/domain/mod.rs
+++ b/src/server/domain/mod.rs
@@ -21,3 +21,5 @@ pub mod agent_approvals;
 pub mod booking;
 pub mod money;
 pub use money::Money;
+
+pub mod catalog;

--- a/src/server/services/agent_feed/service.rs
+++ b/src/server/services/agent_feed/service.rs
@@ -21,7 +21,7 @@ impl AgentFeedService {
     pub async fn process_event(&self, tenant_id: &str, event_source: &str, payload: &Value) -> Result<AgentFeedItem, String> {
         // Build context via LLM/Minimax
         let prompt = format!(
-            "Analyze the following event and provide a concise JSON object with a 'draft_action' containing a suggested response or action, and 'intent' summarizing the reason. Tenant: {}. Source: {}. Payload: {}",
+            "Analyze the following event and provide a concise JSON object. If the user's intent is to create a product or service, include 'feature_type': 'create_product', along with a 'payload' object containing 'title', 'description', 'price', and 'item_type' (Product or Service). Otherwise, provide a 'draft_action' containing a suggested response or action, and 'intent' summarizing the reason. Tenant: {}. Source: {}. Payload: {}",
             tenant_id, event_source, payload
         );
         let prompt = crate::pricing::compression::reduce_tokens(&prompt);

--- a/src/ui/tauri/src/ui/triage.html
+++ b/src/ui/tauri/src/ui/triage.html
@@ -586,6 +586,11 @@
         }
       }
 
+
+      async function updateActionStatus(id, approved) {
+        return handleDecision(id, approved);
+      }
+
       async function handleDecision(id, approved, editValue = null) {
         try {
           // If approved is false, status should be DISMISSED
@@ -730,7 +735,29 @@
           let actionHtml = '';
 
           let buttonsHtml = '';
-          if (editingId === item.id) {
+          const featureType = item.proposed_action?.feature_type || item.action_type || '';
+
+          if (featureType === 'create_product' || featureType === 'product_creation') {
+             const payload = item.proposed_action?.payload || {};
+             const title = payload.title || payload.name || 'New Product';
+             const price = payload.price || '0.00';
+             const description = payload.description || 'No description provided.';
+             const itemType = payload.item_type || 'Product';
+
+             actionHtml = `
+                 <div class="proposed-action glassmorphism" style="padding: 16px; margin-top: 12px; border: 1px solid rgba(255, 255, 255, 0.4);">
+                   <div style="display: flex; justify-content: space-between; align-items: start; margin-bottom: 12px;">
+                       <div style="font-weight: 600; font-size: 16px; color: var(--text-primary, #1D1D1F);">Proposed ${itemType}: ${title}</div>
+                   </div>
+                   <div style="font-size: 14px; color: var(--text-primary, #1D1D1F); margin-bottom: 8px;"><strong>Price:</strong> $${price}</div>
+                   <div style="font-size: 14px; color: var(--text-secondary, #555);">${description}</div>
+                   <div style="margin-top: 16px;">
+                       <button class="triage-btn primary" onclick="updateActionStatus('${item.id}', true)" style="width: 100%; min-height: 44px; margin-bottom: 8px;">Approve & Create</button>
+                       <button class="triage-btn secondary" onclick="updateActionStatus('${item.id}', false)" style="width: 100%; min-height: 44px;">Dismiss</button>
+                   </div>
+                 </div>
+             `;
+          } else if (editingId === item.id) {
              buttonsHtml = `
                 <div class="triage-buttons" style="flex-direction: column;">
                    <div style="font-weight: 600; font-size: 14px; margin-bottom: 8px;">Edit Draft:</div>
@@ -741,7 +768,7 @@
                    </div>
                 </div>
              `;
-          } else if (reviewingId === item.id) {
+          } else if (featureType !== 'create_product' && featureType !== 'product_creation' && reviewingId === item.id) {
              buttonsHtml = `
                  <div class="proposed-action glassmorphism" style="padding: 16px; margin-top: 12px; border: 1px solid rgba(255, 255, 255, 0.4);">
                    <div style="display: flex; justify-content: space-between; align-items: start; margin-bottom: 12px;">
@@ -757,7 +784,7 @@
                    </div>
                  </div>
              `;
-          } else {
+          } else if (featureType !== 'create_product' && featureType !== 'product_creation') {
               if (draftReply) {
                   buttonsHtml = `
                     <div class="triage-buttons">


### PR DESCRIPTION
Resolves #33630

**Product-use evidence:**
- **Persona:** Maya, Home Baker.
- **Workflow Attempted:** Use the Assistant chat to ask to add a new 'Chocolate Dream Cake' to the store.
- **Observed Gap:** The Assistant did not understand the intent to create a product and instead just gave textual advice.
- **Fix:** Enhanced the `AgentFeedService` to detect the `create_product` intent and generate a structured payload. Implemented a backend action router (`src/server/domain/catalog.rs`) to handle the database insertion of the new product when approved. Updated the Triage interface (`src/ui/tauri/src/ui/triage.html`) to render a "Proposed Product" card and an "Approve & Create" button to trigger the backend execution.
- **Post-Fix Workflow:** The Assistant correctly parses the intent, routes a proposed action to the Triage interface, which renders the product card and executes the creation successfully when approved.

**Interaction Audit Table:**
| Element | Designed Purpose | Observed Result | Fix |
|---|---|---|---|
| Assistant Chat Input | Enter intents | Interpreted creation as general text | Updated LLM prompt to detect `create_product` |
| Triage UI Feed | Display proposed actions | Standard message rendering | Added specific "Proposed Product" card |
| Approve & Create Button | Approve product creation | N/A | Wired to `updateActionStatus` to approve and dispatch the `create_product` action in the queue. |

**Superpowers used:**
- Proactive testing using Playwright
- Codebase Optimization

All tests passing: `bazelisk test //...` and `bazelisk test //src/e2e:playwright --local_test_jobs="$(nproc)"` completed successfully.

---
*PR created automatically by Jules for task [9758145096270075665](https://jules.google.com/task/9758145096270075665) started by @ql-owo-lp*