### PR TITLE
✍️ Scribe: Fix missing tooltip texts in backend get_tooltips API

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.16)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0

--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -122,6 +122,11 @@ pub async fn get_tooltips(
         tooltips.insert("settings-delivery-tooltip".to_string(), "Turn this on to offer local delivery to your customers.".to_string());
         tooltips.insert("help-btn-tooltip".to_string(), "Need help? Click here to access our Help Center, Ask AI, Video Tutorials, and Release Notes.".to_string());
         tooltips.insert("help-search-tooltip".to_string(), "Search for help articles and videos...".to_string());
+        tooltips.insert("inventory-tooltip".to_string(), "Manage your inventory, prices, and stock levels.".to_string());
+        tooltips.insert("orders-tooltip".to_string(), "See what customers bought and track order fulfillment.".to_string());
+        tooltips.insert("total-sales-tooltip".to_string(), "Total revenue generated from your orders.".to_string());
+        tooltips.insert("recent-orders-tooltip".to_string(), "View the latest orders placed by your customers.".to_string());
+        tooltips.insert("inbox-activity-tooltip".to_string(), "Keep track of recent customer messages.".to_string());
     }
 
     Ok(Json(tooltips))


### PR DESCRIPTION
This PR fixes the failing E2E tests `src/e2e/docs.spec.ts` which expected certain tooltips to be present on the UI (dashboard and metrics panels). The missing tooltips have been added to the default fallback `HashMap` returned by the backend `get_tooltips` endpoint in `src/server/api/docs.rs`.

**Product-use evidence**
- Persona: Nora (Agency Principal) / General User
- Flow: Opening the `/dashboard` UI and hovering over metrics and data tables.
- Gap: The tooltips expected by the `Help Center E2E tests` (like `inventory-tooltip` and `orders-tooltip`) were missing, causing Playwright interaction timeouts. This leaves the user without necessary UI guidance.
- Fix: Add the tooltips into the backend. Verified by running E2E playwright tests `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"` which now fully pass.

Superpowers used: `playwright-testing` and `backend-rust-api`.

---
*PR created automatically by Jules for task [171317918283687541](https://jules.google.com/task/171317918283687541) started by @ql-owo-lp*