### PR TITLE
test: fix `test_sipdb_chaos_parity` strict assertion check and verify chaos tests

### DIFF
--- a/src/server/chaos.rs
+++ b/src/server/chaos.rs
@@ -93,6 +93,7 @@ mod tests {
 
             assert_eq!(pg_row.0, "1");
             assert_eq!(pg_row.1, None, "NULL handling parity must be maintained between SQLite and Postgres");
+            assert_eq!(pg_row.1, row.1, "NULL handling parity must be exactly maintained between SQLite and Postgres schema types");
             assert!(pg_row.2.timestamp() > 0);
             let _ = sqlx::query(&format!("DROP TABLE IF EXISTS {}", table_name)).execute(&pg_pool).await;
         }


### PR DESCRIPTION
- Added `assert_eq!(pg_row.1, row.1)` to `test_sipdb_chaos_parity` to ensure that `NULL` handling parity between Postgres and SQLite schema types is strictly asserted on `mission_log`.
- Confirmed running `bazel test //...` that the requested team mesh pubsub/redis/agent lock chaos tests and the stress test experiments perform gracefully.

---
*PR created automatically by Jules for task [4219846631686994252](https://jules.google.com/task/4219846631686994252) started by @ql-owo-lp*