### PR TITLE
fix(infra): use correct task UUIDs for department_dead_letters dead letter messages instead of generated UUIDs when cleaning up stuck items

### DIFF
--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -445,10 +445,10 @@ impl HybridSyncDaemon {
         const SQLITE_WHERE_CLAUSE: &str = "status IN ('IN_PROGRESS', 'RUNNING', 'STUCK', 'PENDING', 'CLOUD_ESCALATION', 'BURSTING') AND (last_synced_at < datetime('now', '-1 hours') OR (last_synced_at IS NULL AND updated_at < datetime('now', '-1 hours')))";
         const PG_WHERE_CLAUSE: &str = "status IN ('IN_PROGRESS', 'RUNNING', 'STUCK', 'PENDING', 'CLOUD_ESCALATION', 'BURSTING') AND (last_synced_at < NOW() - INTERVAL '1 hour' OR (last_synced_at IS NULL AND updated_at < NOW() - INTERVAL '1 hour'))";
 
-        let sqlite_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'mission_stuck', 'agent_missions', COALESCE(payload, '{{}}'), '[cleanup] Mission became stuck' FROM agent_missions WHERE {}", SQLITE_WHERE_CLAUSE);
+        let sqlite_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'mission_stuck', 'agent_missions', COALESCE(payload, '{{}}'), '[cleanup] Mission became stuck' FROM agent_missions WHERE {}", SQLITE_WHERE_CLAUSE);
         let sqlite_update = format!("UPDATE agent_missions SET status = 'FAILED' WHERE {}", SQLITE_WHERE_CLAUSE);
 
-        let pg_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'mission_stuck', 'agent_missions', COALESCE(payload::text, '{{}}'), '[cleanup] Mission became stuck' FROM agent_missions WHERE {}", PG_WHERE_CLAUSE);
+        let pg_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id::text, tenant_id, 'mission_stuck', 'agent_missions', COALESCE(payload::text, '{{}}'), '[cleanup] Mission became stuck' FROM agent_missions WHERE {}", PG_WHERE_CLAUSE);
         let pg_update = format!("UPDATE agent_missions SET status = 'FAILED' WHERE {}", PG_WHERE_CLAUSE);
 
         // SQLite
@@ -484,14 +484,14 @@ impl HybridSyncDaemon {
         const PG_RUNNING_WHERE: &str = "status = 'RUNNING' AND updated_at < NOW() - INTERVAL '1 hour'";
         const PG_QUEUED_WHERE: &str = "status = 'QUEUED' AND created_at < NOW() - INTERVAL '24 hours'";
 
-        let sqlite_running_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'job_stuck', 'ohc_job_queue', COALESCE(payload, '{{}}'), '[cleanup] Stagnant backlog item stuck in RUNNING for > 1 hour' FROM ohc_job_queue WHERE {}", SQLITE_RUNNING_WHERE);
+        let sqlite_running_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'job_stuck', 'ohc_job_queue', COALESCE(payload, '{{}}'), '[cleanup] Stagnant backlog item stuck in RUNNING for > 1 hour' FROM ohc_job_queue WHERE {}", SQLITE_RUNNING_WHERE);
         let sqlite_running_update = format!("UPDATE ohc_job_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE {}", SQLITE_RUNNING_WHERE);
-        let sqlite_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT lower(hex(randomblob(16))), tenant_id, 'job_failed', 'ohc_job_queue', COALESCE(payload, '{{}}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM ohc_job_queue WHERE {}", SQLITE_QUEUED_WHERE);
+        let sqlite_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id, tenant_id, 'job_failed', 'ohc_job_queue', COALESCE(payload, '{{}}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM ohc_job_queue WHERE {}", SQLITE_QUEUED_WHERE);
         let sqlite_queued_delete = format!("DELETE FROM ohc_job_queue WHERE {}", SQLITE_QUEUED_WHERE);
 
-        let pg_running_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'job_stuck', 'ohc_job_queue', COALESCE(payload::text, '{{}}'), '[cleanup] Stagnant backlog item stuck in RUNNING for > 1 hour' FROM ohc_job_queue WHERE {}", PG_RUNNING_WHERE);
+        let pg_running_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id::text, tenant_id, 'job_stuck', 'ohc_job_queue', COALESCE(payload::text, '{{}}'), '[cleanup] Stagnant backlog item stuck in RUNNING for > 1 hour' FROM ohc_job_queue WHERE {}", PG_RUNNING_WHERE);
         let pg_running_update = format!("UPDATE ohc_job_queue SET status = 'FAILED', updated_at = CURRENT_TIMESTAMP WHERE {}", PG_RUNNING_WHERE);
-        let pg_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT gen_random_uuid()::text, tenant_id, 'job_failed', 'ohc_job_queue', COALESCE(payload::text, '{{}}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM ohc_job_queue WHERE {}", PG_QUEUED_WHERE);
+        let pg_queued_insert = format!("INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message) SELECT id::text, tenant_id, 'job_failed', 'ohc_job_queue', COALESCE(payload::text, '{{}}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours' FROM ohc_job_queue WHERE {}", PG_QUEUED_WHERE);
         let pg_queued_delete = format!("DELETE FROM ohc_job_queue WHERE {}", PG_QUEUED_WHERE);
 
         // SQLite queue

--- a/src/server/orchestration/hybrid_sync/daemon_test.rs
+++ b/src/server/orchestration/hybrid_sync/daemon_test.rs
@@ -698,11 +698,11 @@ async fn test_hybrid_sync_pos_offline_transactions() {
         assert_eq!(row_running.get::<String, _>("status"), "FAILED");
 
         // Verify dead letters were created for running jobs
-        let dl_sqlite: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE payload LIKE '%stuck_running_sqlite%'")
+        let dl_sqlite: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE id = 'stuck_running_sqlite'")
             .fetch_one(&sqlite_pool).await.unwrap();
         assert_eq!(dl_sqlite.0, 1);
 
-        let dl_pg: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE payload LIKE '%stuck_running_pg%'")
+        let dl_pg: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE id = 'stuck_running_pg'")
             .fetch_one(&pg_pool).await.unwrap();
         assert_eq!(dl_pg.0, 1);
     }
@@ -768,12 +768,12 @@ async fn test_hybrid_sync_pos_offline_transactions() {
         daemon.prune_stuck_agent_missions().await.unwrap();
 
         // Verify SQLite mission failure category
-        let dl_sqlite: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE payload LIKE '%stuck_mission_sqlite_cat%'")
+        let dl_sqlite: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE id = 'stuck_mission_sqlite_cat'")
             .fetch_one(&sqlite_pool).await.unwrap();
         assert_eq!(dl_sqlite.0, 1);
 
         // Verify PG mission failure category
-        let dl_pg: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE payload LIKE '%stuck_mission_pg_cat%'")
+        let dl_pg: (i64,) = sqlx::query_as("SELECT count(*) FROM department_dead_letters WHERE id = 'stuck_mission_pg_cat'")
             .fetch_one(&pg_pool).await.unwrap();
         assert_eq!(dl_pg.0, 1);
     }

--- a/src/server/orchestration/queue/ohc_job_queue.rs
+++ b/src/server/orchestration/queue/ohc_job_queue.rs
@@ -140,12 +140,12 @@ impl OHCJobQueue {
         // Clean up stagnant backlog items: PENDING jobs stuck for > 24 hours
         let query_str = if is_standalone {
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
-             SELECT lower(hex(randomblob(16))), tenant_id, 'job_failed', 'job_queue', COALESCE(CAST(payload AS TEXT), '{}'), '[cleanup] Stagnant backlog item stuck in PENDING for > 24 hours'
+             SELECT id, tenant_id, 'job_failed', 'job_queue', COALESCE(CAST(payload AS TEXT), '{}'), '[cleanup] Stagnant backlog item stuck in PENDING for > 24 hours'
              FROM ohc_job_queue
              WHERE status = 'PENDING' AND created_at < datetime('now', '-24 hours')"
         } else {
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
-             SELECT gen_random_uuid()::text, tenant_id, 'job_failed', 'job_queue', COALESCE(payload::text, '{}'), '[cleanup] Stagnant backlog item stuck in PENDING for > 24 hours'
+             SELECT id::text, tenant_id, 'job_failed', 'job_queue', COALESCE(payload::text, '{}'), '[cleanup] Stagnant backlog item stuck in PENDING for > 24 hours'
              FROM ohc_job_queue
              WHERE status = 'PENDING' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
         };

--- a/src/server/queue.rs
+++ b/src/server/queue.rs
@@ -425,7 +425,7 @@ impl TaskQueue for PostgresTaskQueue {
         // Clean up stagnant backlog items: QUEUED jobs stuck for > 24 hours
         sqlx::query(
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
-             SELECT gen_random_uuid()::text, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload::text, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours'
+             SELECT id::text, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload::text, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours'
              FROM sub_agent_queue
              WHERE status = 'QUEUED' AND created_at < CURRENT_TIMESTAMP - INTERVAL '24 hours'"
         )
@@ -1149,7 +1149,7 @@ impl TaskQueue for SqliteTaskQueue {
         // Clean up stagnant backlog items: QUEUED jobs stuck for > 24 hours
         let _ = sqlx::query(
             "INSERT INTO department_dead_letters (id, tenant_id, event_type, department, payload, error_message)
-             SELECT lower(hex(randomblob(16))), tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours'
+             SELECT id, tenant_id, 'job_failed', 'sub_agent_queue', COALESCE(payload, '{}'), '[cleanup] Stagnant backlog item stuck in QUEUED for > 24 hours'
              FROM sub_agent_queue
              WHERE status = 'QUEUED' AND created_at < datetime('now', '-24 hour')"
         )


### PR DESCRIPTION
When jobs or tasks got stuck in the queue and were periodically collected by the stagnant/stuck item sweeper and inserted into the `department_dead_letters` table, the code was explicitly assigning brand new random UUIDs (via `gen_random_uuid()` or `lower(hex(randomblob(16)))`) as the primary key. This completely severed the linkage back to the original entity. 

This commit modifies the cleanup procedures across `daemon.rs`, `ohc_job_queue.rs`, and `queue.rs` to insert the actual `id` of the failing task into `department_dead_letters`. The associated tests in `daemon_test.rs` have also been updated to assert specific IDs explicitly rather than relying on payload fuzzy matching. 

A full test run via `bazelisk test //...` verified that 102/102 test suites successfully complete with these changes.

---
*PR created automatically by Jules for task [14284757610656893260](https://jules.google.com/task/14284757610656893260) started by @ql-owo-lp*