### PR TITLE
fix: Update empty state text in unified triage feed

### DIFF
--- a/src/e2e/playwright/triage-feed-agent.spec.ts
+++ b/src/e2e/playwright/triage-feed-agent.spec.ts
@@ -60,7 +60,7 @@ test.describe('Agentic Work Triage Feed', () => {
 
     // It should either show the empty state or an empty feed, but given we might have real data,
     // let's just ensure it loads without crashing and either shows items or caught up state.
-    const emptyState = page.locator('text=No items need your attention right now');
+    const emptyState = page.locator('text=All caught up! Your business is running smoothly.');
     const feed = page.locator('[data-testid^="triage-card-"]').first();
 
     // Wait for either to be visible

--- a/src/ui/next/public/api/ui/dashboard.html
+++ b/src/ui/next/public/api/ui/dashboard.html
@@ -1044,7 +1044,7 @@
           let items = data.triage || data.agent_feed || (Array.isArray(data) ? data : (data.items || []));
 
           if (!Array.isArray(items) || items.length === 0) {
-            triageQueue.innerHTML = '<div class="triage-card empty">No items need your attention right now. Great job!</div>';
+            triageQueue.innerHTML = '<div class="triage-card empty">All caught up! Your business is running smoothly.</div>';
             return;
           }
 

--- a/src/ui/next/public/api/ui/triage.html
+++ b/src/ui/next/public/api/ui/triage.html
@@ -407,7 +407,7 @@
         // List
         const listEl = document.getElementById("triage-list");
         if (items.length === 0) {
-          listEl.innerHTML = `<div class="app-empty">No items need your attention right now. Great job!</div>`;
+          listEl.innerHTML = `<div class="app-empty">All caught up! Your business is running smoothly.</div>`;
         } else {
           listEl.innerHTML = items.map(item => `
             <button


### PR DESCRIPTION
This PR updates the empty state text in the unified triage feed (dashboard and standalone triage page) from "No items need your attention right now. Great job!" to "All caught up! Your business is running smoothly." to provide a better, more natural user experience, aligning with the "Assistant-First" product vision. Playwright E2E tests have also been updated to reflect this change.

Resolves #33704

---
*PR created automatically by Jules for task [4102154518155012371](https://jules.google.com/task/4102154518155012371) started by @ql-owo-lp*