### PR TITLE
✍️ Scribe: Implement Delete Tooltip Functionality in Tooltip Registry

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -175,6 +175,47 @@ pub async fn update_tooltip(
     }
 }
 
+pub async fn delete_tooltip(
+    axum::extract::Extension(db): axum::extract::Extension<std::sync::Arc<crate::db::DB>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap
+) -> Result<Json<SuccessResponse>, axum::http::StatusCode> {
+    let tenant_id = headers
+        .get("x-tenant-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("default");
+    match &db.store {
+        crate::db::DbStore::Postgres => {
+            match sqlx::query("DELETE FROM tooltips WHERE id = $1 AND tenant_id = $2")
+                .bind(id.clone())
+                .bind(tenant_id)
+                .execute(&db.pool)
+                .await
+            {
+                Ok(_) => Ok(Json(SuccessResponse { success: true })),
+                Err(e) => {
+                    tracing::error!("Failed to delete tooltip: {}", e);
+                    Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+                }
+            }
+        },
+        crate::db::DbStore::Sqlite(pool) => {
+            match sqlx::query("DELETE FROM tooltips WHERE id = ? AND tenant_id = ?")
+                .bind(id.clone())
+                .bind(tenant_id)
+                .execute(pool)
+                .await
+            {
+                Ok(_) => Ok(Json(SuccessResponse { success: true })),
+                Err(e) => {
+                    tracing::error!("Failed to delete tooltip: {}", e);
+                    Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+                }
+            }
+        }
+    }
+}
+
 
 
 pub fn get_articles() -> Vec<HelpArticle> {
@@ -584,6 +625,39 @@ pub async fn get_api_docs_spec() -> Json<serde_json::Value> {
                                     "schema": {
                                         "type": "object",
                                         "additionalProperties": { "type": "string" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+
+            "/api/tooltips/{id}": {
+                "delete": {
+                    "summary": "Delete a Tooltip",
+                    "description": "Deletes a tooltip by its element ID.",
+                    "tags": ["Documentation"],
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "success": { "type": "boolean" }
+                                        }
                                     }
                                 }
                             }
@@ -1058,5 +1132,38 @@ mod tests {
             tooltips.get("test-tooltip-id").map(|s| s.as_str()),
             Some("This is a test tooltip")
         );
+    }
+
+    #[tokio::test]
+    async fn test_delete_tooltip_api() {
+        let db_pool = crate::db::create_sqlite_pool_for_test().await;
+        let pg_pool = crate::db::create_dummy_pg_pool().await;
+        sqlx::query("CREATE TABLE IF NOT EXISTS tooltips (id TEXT, tenant_id TEXT, text TEXT, PRIMARY KEY (tenant_id, id))").execute(&db_pool).await.unwrap();
+        let db = std::sync::Arc::new(crate::db::DB { pool: pg_pool, store: crate::db::DbStore::Sqlite(db_pool) });
+
+        // Insert a tooltip manually
+        sqlx::query("INSERT INTO tooltips (id, tenant_id, text) VALUES ('delete-test-id', 'test-tenant', 'Tooltip to delete')")
+            .execute(match &db.store { crate::db::DbStore::Sqlite(p) => p, _ => unreachable!() })
+            .await
+            .unwrap();
+
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-tenant-id", axum::http::HeaderValue::from_static("test-tenant"));
+
+        // Verify it exists
+        let tooltips_res = get_tooltips(axum::extract::Extension(db.clone()), headers.clone()).await.unwrap();
+        assert_eq!(tooltips_res.0.get("delete-test-id").map(|s| s.as_str()), Some("Tooltip to delete"));
+
+        // Delete the tooltip
+        let res = delete_tooltip(
+            axum::extract::Extension(db.clone()),
+            axum::extract::Path("delete-test-id".to_string()),
+            headers.clone(),
+        ).await.unwrap();
+        assert!(res.0.success);
+
+        // Fetch tooltips and verify the deletion
+        let tooltips_res_after = get_tooltips(axum::extract::Extension(db.clone()), headers).await.unwrap();
+        assert!(!tooltips_res_after.0.contains_key("delete-test-id"));
     }
 }

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -6854,6 +6854,7 @@ async fn create_ui_bom_item_handler(
         .route("/api/help/{article_id}", axum::routing::get(crate::api::docs::get_article_handler))
         .route("/api/tooltips", axum::routing::get(crate::api::docs::get_tooltips).layer(axum::extract::Extension(std::sync::Arc::new(db.clone()))))
         .route("/api/tooltips", axum::routing::post(crate::api::docs::update_tooltip).layer(axum::extract::Extension(std::sync::Arc::new(db.clone()))))
+        .route("/api/tooltips/{id}", axum::routing::delete(crate::api::docs::delete_tooltip).layer(axum::extract::Extension(std::sync::Arc::new(db.clone()))))
         .route("/api/walkthrough/{page}", axum::routing::get(crate::api::docs::get_walkthrough))
         .route("/api/videos", axum::routing::get(crate::api::docs::list_videos))
         .route("/api/changelog", axum::routing::get(crate::api::docs::get_changelog))

--- a/src/ui/tauri/src/ui/tooltip-registry.html
+++ b/src/ui/tauri/src/ui/tooltip-registry.html
@@ -125,7 +125,12 @@
                     tbody.innerHTML += `<tr>
                         <td>${id}</td>
                         <td><input type="text" id="input-${id}" value="${text.replace(/"/g, '&quot;')}" /></td>
-                        <td><button onclick="update('${id}', event)">Save</button></td>
+                        <td>
+                            <div style="display: flex; gap: 8px;">
+                                <button onclick="update('${id}', event)">Save</button>
+                                <button onclick="deleteTooltip('${id}', event)" style="background-color: #EF4444; box-shadow: 0 4px 6px rgba(239, 68, 68, 0.2);">Delete</button>
+                            </div>
+                        </td>
                     </tr>`;
                 }
             } catch (e) {
@@ -133,6 +138,30 @@
                 showToast("Failed to load tooltips", true);
             }
         }
+        window.deleteTooltip = async function(id, event) {
+            if (!confirm('Are you sure you want to delete this tooltip?')) return;
+            const btn = event ? event.target : null;
+            let originalText = '';
+            if (btn) {
+                originalText = btn.innerText;
+                btn.innerText = 'Deleting...';
+                btn.disabled = true;
+            }
+            try {
+                const res = await fetch('/api/tooltips/' + id, { method: 'DELETE' });
+                if (!res.ok) throw new Error('Failed to delete');
+                showToast("Tooltip deleted successfully");
+                await loadTooltips();
+            } catch (e) {
+                console.error('Failed to delete tooltip', e);
+                showToast("Failed to delete tooltip", true);
+            } finally {
+                if (btn) {
+                    btn.innerText = originalText;
+                    btn.disabled = false;
+                }
+            }
+        };
         window.update = async function(id, event) {
             const text = document.getElementById('input-' + id).value;
             const btn = event ? event.target : null;


### PR DESCRIPTION
- Implemented `delete_tooltip` handler in `src/server/api/docs.rs` for `DELETE /api/tooltips/{id}`.
- Added a `.delete` route in `src/server/lib.rs` for `/api/tooltips/{id}`.
- Added tests `test_delete_tooltip_api` in `src/server/api/docs.rs` to verify deletion logic.
- Documented `DELETE /api/tooltips/{id}` in the OpenAPI specification for `api-docs.html`.
- Updated `src/ui/tauri/src/ui/tooltip-registry.html` to add a UI Delete button with a corresponding Javascript `deleteTooltip(id)` function.
- Verified functionality and robustness via Playwright E2E and Rust unit tests.

---
*PR created automatically by Jules for task [9340464435461432634](https://jules.google.com/task/9340464435461432634) started by @ql-owo-lp*