### PR TITLE
fix: correct retry limits in db execute_with_retry tests

### DIFF
--- a/src/server/orchestration/state/parity_test.rs
+++ b/src/server/orchestration/state/parity_test.rs
@@ -889,7 +889,7 @@ mod parity_tests {
         assert!(res.is_err());
         assert!(res.unwrap_err().contains("Database retry exhausted"));
         // execute_with_retry makes 1 initial attempt + 2 retries (max_attempts = 2)
-        assert_eq!(*attempts.lock().unwrap(), 4);
+        assert_eq!(*attempts.lock().unwrap(), crate::db::MAX_DB_RETRY_ATTEMPTS + 1);
 
         let pg_db = setup_postgres_db().await;
         if let Some(db) = pg_db {
@@ -907,7 +907,7 @@ mod parity_tests {
 
             assert!(res.is_err());
             assert!(res.unwrap_err().contains("Database retry exhausted"));
-            assert_eq!(*attempts.lock().unwrap(), 4);
+            assert_eq!(*attempts.lock().unwrap(), crate::db::MAX_DB_RETRY_ATTEMPTS + 1);
         }
     }
 
@@ -965,7 +965,7 @@ mod parity_tests {
             async move {
                 let mut a = attempts_clone.lock().unwrap();
                 *a += 1;
-                if *a < 4 {
+                if *a < crate::db::MAX_DB_RETRY_ATTEMPTS + 1 {
                     Err("database is locked".to_string())
                 } else {
                     Ok("success".to_string())
@@ -975,7 +975,7 @@ mod parity_tests {
 
         assert!(res.is_ok());
         assert_eq!(res.unwrap(), "success");
-        assert_eq!(*attempts.lock().unwrap(), 4);
+        assert_eq!(*attempts.lock().unwrap(), crate::db::MAX_DB_RETRY_ATTEMPTS + 1);
 
         let pg_db = setup_postgres_db().await;
         if let Some(db) = pg_db {
@@ -987,7 +987,7 @@ mod parity_tests {
                 async move {
                     let mut a = attempts_clone.lock().unwrap();
                     *a += 1;
-                    if *a < 4 {
+                    if *a < crate::db::MAX_DB_RETRY_ATTEMPTS + 1 {
                         Err("serialization failure".to_string())
                     } else {
                         Ok("success".to_string())
@@ -997,7 +997,7 @@ mod parity_tests {
 
             assert!(res.is_ok());
             assert_eq!(res.unwrap(), "success");
-            assert_eq!(*attempts.lock().unwrap(), 4);
+            assert_eq!(*attempts.lock().unwrap(), crate::db::MAX_DB_RETRY_ATTEMPTS + 1);
         }
     }
 }


### PR DESCRIPTION
This change ensures that `execute_with_retry` and related chaos testing assertions dynamically adhere to `crate::db::MAX_DB_RETRY_ATTEMPTS`, resolving brittle states in orchestration parity tests where the retry attempts were hardcoded to `4` (1 initial + 3 retries). This aligns test conditions directly with configured retry limits, ensuring stability during future config changes.

---
*PR created automatically by Jules for task [12199566461082988041](https://jules.google.com/task/12199566461082988041) started by @ql-owo-lp*