### PR TITLE
fix(setup): Fix deposit percentage UI string fallback

### DIFF
--- a/src/e2e/playwright/zero_click_onboarding.spec.ts
+++ b/src/e2e/playwright/zero_click_onboarding.spec.ts
@@ -36,7 +36,7 @@ test.describe('Zero-Click Onboarding Flow', () => {
     await expect(page.locator('h1', { hasText: 'Ready to Launch' })).toBeVisible({ timeout: 15000 });
     await expect(page.locator('#approval-details')).toBeVisible();
     await expect(page.locator('#approval-details')).toContainText('Suggested Deposit Policy');
-    await expect(page.locator('#approval-details')).toContainText(/Requires a \d+% upfront deposit/);
+    await expect(page.locator('#approval-details')).toContainText(/Requires a \\d+% upfront deposit/);
 
     // Click Approve & Publish
     const approveBtn = page.locator('#approve-publish-btn');

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -4069,7 +4069,7 @@
             if (approvalDetails) {
                 approvalDetails.innerHTML = `
                     <div style="display: flex; flex-direction: column; align-items: center; gap: 16px;">
-                        <p style="font-size: 14px; text-align: center; color: #1D1D1F;" class="dark:text-[#F5F5F7]"><strong>Suggested Deposit Policy:</strong> Requires a ${startReq.deposit_percentage || 50}% upfront deposit on custom orders.</p>
+                        <p style="font-size: 14px; text-align: center; color: #1D1D1F;" class="dark:text-[#F5F5F7]"><strong>Suggested Deposit Policy:</strong> Requires a ${startReq.deposit_percentage !== undefined ? startReq.deposit_percentage : 50}% upfront deposit on custom orders.</p>
                         <div style="width: 375px; max-width: 100%; aspect-ratio: 9/16; border: 1px solid rgba(255, 255, 255, 0.4); border-radius: 16px; overflow: hidden; background: white; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
                             <div style="background: #0066FF; color: white; padding: 12px; text-align: center; font-weight: bold;">
                                 ${startReq.company_name}


### PR DESCRIPTION
This PR fixes the zero-click setup page by updating the deposit template UI string correctly. Instead of using `||` logical OR which considers `0` falsy and falls back to `50`, we use `!== undefined` checking. Also updates test mocking of `setup.html` navigation and `/dashboard.html`.

---
*PR created automatically by Jules for task [6184742831301164616](https://jules.google.com/task/6184742831301164616) started by @ql-owo-lp*