### PR TITLE
fix(wizard): resolve domain error validation dynamic hiding

### DIFF
--- a/src/ui/next/public/setup.html
+++ b/src/ui/next/public/setup.html
@@ -2928,6 +2928,19 @@
         }
       });
 
+
+      if (inputs.domain_name) {
+        inputs.domain_name.addEventListener("input", () => {
+          const domainRegex = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+          const val = inputs.domain_name.value.trim();
+          if (val.length >= 3 && domainRegex.test(val)) {
+            const errEl = document.getElementById("domain-error");
+            if (errEl) errEl.style.display = "none";
+            inputs.domain_name.classList.remove("invalid-input");
+          }
+        });
+      }
+
       inputs.admin_email.addEventListener("input", () => {
         if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(inputs.admin_email.value.trim())) {
           errors.admin_email.style.display = "none";
@@ -3312,7 +3325,8 @@
             inputs.domain_name.classList.add("invalid-input");
             isValid = false;
           } else {
-            errors.domain_name.style.display = "none";
+            const errEl = document.getElementById("domain-error");
+            if (errEl) errEl.style.display = "none";
             inputs.domain_name.classList.remove("invalid-input");
             state.domain = inputs.domain_name.value.trim();
           }

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2995,7 +2995,8 @@
             inputs.domain_name.value.trim().length >= 3 &&
             domainRegex.test(inputs.domain_name.value.trim())
           ) {
-            errors.domain_name.style.display = "none";
+            const errEl = document.getElementById("domain-error");
+            if (errEl) errEl.style.display = "none";
             inputs.domain_name.classList.remove("invalid-input");
           }
         });
@@ -3340,7 +3341,8 @@
             inputs.domain_name.classList.add("invalid-input");
             isValid = false;
           } else {
-            errors.domain_name.style.display = "none";
+            const errEl = document.getElementById("domain-error");
+            if (errEl) errEl.style.display = "none";
             inputs.domain_name.classList.remove("invalid-input");
             state.domain = inputs.domain_name.value.trim();
           }


### PR DESCRIPTION
The goal was to fix the issue where the validation for the domain error did not go away dynamically. This issue could be observed in the setup wizards where typing a valid domain name after an invalid one did not dismiss the error message automatically.

Changes:
- Added dynamic error removal logic for `inputs.domain_name` by looking up `#domain-error` and setting `style.display = "none"` when valid in `src/ui/next/public/setup.html`.
- Updated existing `inputs.domain_name` listener logic in `src/ui/tauri/src/ui/setup.html` to reliably select `#domain-error` and safely hide it.

Tested using playwright and running the full bazel test suite. No regressions found.

---
*PR created automatically by Jules for task [10149734039729601299](https://jules.google.com/task/10149734039729601299) started by @ql-owo-lp*