### PR TITLE
🗺️ Guide: [Fix Onboarding Wizard Navigation & UI Polish]

### DIFF
--- a/src/e2e/tests/onboarding_navigation.spec.ts
+++ b/src/e2e/tests/onboarding_navigation.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Onboarding Navigation and Aesthetics', () => {
+
+  test.beforeEach(async ({ page }) => {
+    // Navigate using the real stack URL
+    await page.goto('/setup.html');
+  });
+
+  test('Back button in domain step navigates to target audience step', async ({ page }) => {
+    await page.getByTestId('next-step-btn').first().click(); // to step-context
+    await page.getByTestId('context-storefront').click();
+    await page.getByTestId('next-step-btn').nth(1).click(); // to step-categories
+    await page.locator('#business-categories').selectOption('Other');
+    await page.getByTestId('next-step-btn').nth(2).click(); // to step-name
+    await page.locator('#business-name').fill('My Test Business');
+    await page.getByTestId('next-step-btn').nth(3).click(); // to step-assistant
+    await page.getByTestId('team-support').click();
+    await page.locator('#assistant-tone').selectOption('Professional');
+    await page.getByTestId('next-step-btn').nth(4).click(); // to step-admin
+    await page.locator('#admin-name').fill('Test User');
+    await page.locator('#admin-email').fill('test@test.com');
+    await page.locator('#admin-password').fill('pass123');
+    await page.getByTestId('next-step-btn').nth(5).click(); // to step-offer
+    await page.locator('#first-offer').fill('Awesome stuff');
+    await page.getByTestId('next-step-btn').nth(6).click(); // to step-location
+    await page.locator('#location-input').fill('Local');
+    await page.getByTestId('next-step-btn').nth(7).click(); // to step-target-audience
+
+    // Fill target audience and go to domain
+    await expect(page.locator('body')).toContainText('Who is your target audience?');
+    await page.locator('#target-audience').fill('Everyone');
+    await page.getByTestId('next-step-btn').nth(8).click();
+
+    // Domain step
+    await expect(page.locator('body')).toContainText('Where will your business live?');
+    const domainStep = page.locator('#step-domain');
+    await domainStep.getByTestId('prev-step-btn').click();
+
+    // Assert that we are back at Target Audience step, NOT offer step
+    await expect(page.locator('body')).toContainText('Who is your target audience?');
+    await expect(page.locator('#step-target-audience')).toBeVisible();
+    await expect(page.locator('#step-domain')).toBeHidden();
+    await expect(page.locator('#step-offer')).toBeHidden();
+  });
+
+  test('Setup UI should apply macOS translucent glass standards to offer input', async ({ page }) => {
+    // Navigate to step offer
+    await page.getByTestId('next-step-btn').first().click();
+    await page.getByTestId('context-storefront').click();
+    await page.getByTestId('next-step-btn').nth(1).click();
+    await page.locator('#business-categories').selectOption('Other');
+    await page.getByTestId('next-step-btn').nth(2).click();
+    await page.locator('#business-name').fill('My Test Business');
+    await page.getByTestId('next-step-btn').nth(3).click();
+    await page.getByTestId('team-support').click();
+    await page.locator('#assistant-tone').selectOption('Professional');
+    await page.getByTestId('next-step-btn').nth(4).click();
+    await page.locator('#admin-name').fill('Test User');
+    await page.locator('#admin-email').fill('test@test.com');
+    await page.locator('#admin-password').fill('pass123');
+    await page.getByTestId('next-step-btn').nth(5).click();
+
+    const offerInput = page.locator('#first-offer');
+    await expect(offerInput).toHaveClass(/glass-control/);
+    await expect(offerInput).toHaveClass(/glassmorphism/);
+  });
+
+  test('Setup UI should apply macOS translucent glass standards to location input', async ({ page }) => {
+    const locationInput = page.locator('#location-input');
+    await expect(locationInput).toHaveClass(/glass-control/);
+    await expect(locationInput).toHaveClass(/glassmorphism/);
+  });
+
+  test('Setup UI should apply macOS translucent glass standards to target audience input', async ({ page }) => {
+    const audienceInput = page.locator('#target-audience');
+    await expect(audienceInput).toHaveClass(/glass-control/);
+    await expect(audienceInput).toHaveClass(/glassmorphism/);
+  });
+
+  test('Setup UI navigation flows linearly from start to template selection without errors', async ({ page }) => {
+    await page.getByTestId('next-step-btn').first().click();
+    await page.getByTestId('context-storefront').click();
+    await page.getByTestId('next-step-btn').nth(1).click();
+    await page.locator('#business-categories').selectOption('Other');
+    await page.getByTestId('next-step-btn').nth(2).click();
+    await page.locator('#business-name').fill('My Test Business');
+    await page.getByTestId('next-step-btn').nth(3).click();
+    await page.getByTestId('team-support').click();
+    await page.locator('#assistant-tone').selectOption('Professional');
+    await page.getByTestId('next-step-btn').nth(4).click();
+    await page.locator('#admin-name').fill('Test User');
+    await page.locator('#admin-email').fill('test@test.com');
+    await page.locator('#admin-password').fill('pass123');
+    await page.getByTestId('next-step-btn').nth(5).click();
+    await page.locator('#first-offer').fill('Awesome stuff');
+    await page.getByTestId('next-step-btn').nth(6).click();
+    await page.locator('#location-input').fill('Local');
+    await page.getByTestId('next-step-btn').nth(7).click();
+    await page.locator('#target-audience').fill('Everyone');
+    await page.getByTestId('next-step-btn').nth(8).click();
+    await page.locator('#domain-name').fill('my-store');
+    await page.getByTestId('next-step-btn').nth(9).click();
+
+    await expect(page.locator('body')).toContainText('Template Selection');
+    await expect(page.locator('#step-template')).toBeVisible();
+  });
+});

--- a/src/ui/next/public/setup.html
+++ b/src/ui/next/public/setup.html
@@ -2391,7 +2391,7 @@
         <textarea
           id="first-offer"
           data-testid="first-offer"
-          class="glassmorphism"
+          class="glass-control glassmorphism"
           placeholder="e.g. I bake custom vegan cakes"
           inputmode="text"
           autocomplete="off"
@@ -2440,7 +2440,7 @@
           type="text"
           id="location-input"
           data-testid="location-input"
-          class="glassmorphism"
+          class="glass-control glassmorphism"
           placeholder="e.g. Portland, OR"
           inputmode="text"
           autocomplete="off"
@@ -2488,7 +2488,7 @@
           type="text"
           id="target-audience"
           data-testid="target-audience"
-          class="glassmorphism"
+          class="glass-control glassmorphism"
           placeholder="e.g. Local families, Tech startups"
           inputmode="text"
           autocomplete="off"
@@ -2595,7 +2595,7 @@
             aria-label="Previous Step"
             title="Previous Step"
             data-testid="prev-step-btn"
-            data-prev="step-offer"
+            data-prev="step-target-audience"
           >
             Back
           </button>


### PR DESCRIPTION
### Context
This pull request addresses a friction point in the initial "Day One" setup wizard for non-technical operators. 

### Changes
1. **Bug Fix:** Resolves a backward navigation logic bug in `setup.html` where hitting "Back" from the `step-domain` screen skipped intermediate screens and went straight to `step-offer`.
2. **Visual Polish:** Elevates the inputs for Offer, Location, and Target Audience to match the premium macOS translucent glass aesthetics by adding the `glass-control glassmorphism` classes.
3. **E2E Test Coverage:** Adds 5 new robust, unmocked Playwright E2E tests to `src/e2e/tests/onboarding_navigation.spec.ts` to verify the full linear flow, the corrected back button behavior, and the CSS classes.

### Product-Use Evidence
- Persona: Maya the Home Baker / Nora the Agency Principal
- Browser Flow Tried: Clicked "Step-by-Step Setup" -> Filled Context, Categories, Name, Assistant, Admin, Offer, Location, Target Audience -> Reached Domain step. Clicked "Back" to correct a typo in Target Audience. 
- Gap Observed: The wizard skipped backward over Target Audience and Location, returning directly to the Offer step. This forces the user to re-enter or click "Next" repeatedly through steps they've already completed.
- Post-fix UI flow used to verify: Clicking "Back" on the Domain step now correctly transitions to the Target Audience step.

---
*PR created automatically by Jules for task [11496265838317498432](https://jules.google.com/task/11496265838317498432) started by @ql-owo-lp*