### PR TITLE
Fix AI-powered autonomous quoting and estimate generation

### DIFF
--- a/mcp_memory_recording.json
+++ b/mcp_memory_recording.json
@@ -1,0 +1,5 @@
+{
+  "task": "Fix AI-powered autonomous quoting and estimate generation",
+  "solution": "Modified message_triage_worker.rs to correctly extract the action_payload from the LLM JSON, format it as a valid string, and ensure modified_quote_data passes along the needed attributes. Updated handle_quote_action in quotes.rs to correctly grab quote details directly from the database prior to creating the Stripe invoice, ensuring price and scope are up-to-date and the Stripe payment link is saved back to the quotes table.",
+  "learning": "The LLM's output payload format was mismatched with what the router passed down as the final_draft string. Always ensure the JSON values extracted match the parsed strings and handle edge cases where JSON payloads can arrive inside parsed structured strings. Playwright E2E tests for OHC must use real DB setup without network mocks."
+}

--- a/src/server/domain/quotes.rs
+++ b/src/server/domain/quotes.rs
@@ -7,22 +7,69 @@ use crate::integrations::stripe::client::StripeClient;
 use server_integrations_stripe::client::StripeClient;
 
 pub async fn handle_quote_action(tenant_id: &str, payload: &Value, pool: &PgPool) -> Result<(), sqlx::Error> {
+    let mut db_price = 0.0;
+    let mut db_scope = String::new();
+    let mut db_client_id = String::new();
+
     if let Some(quote_id) = payload.get("quote_id").and_then(|v| v.as_str()) {
         tracing::info!("Approved quote draft: {}", quote_id);
+        let quote_uuid = uuid::Uuid::parse_str(quote_id).unwrap_or_default();
         sqlx::query("UPDATE quotes SET status = 'SENT', updated_at = NOW() WHERE id = $1 AND tenant_id = $2")
-            .bind(uuid::Uuid::parse_str(quote_id).unwrap_or_default())
+            .bind(quote_uuid)
             .bind(tenant_id)
             .execute(pool)
             .await?;
+
+        // Fetch quote details to ensure we use correct values
+        let row = sqlx::query("SELECT customer_id, total_amount_cents FROM quotes WHERE id = $1 AND tenant_id = $2")
+            .bind(quote_uuid)
+            .bind(tenant_id)
+            .fetch_optional(pool)
+            .await?;
+
+        if let Some(r) = row {
+            use sqlx::Row;
+            let total_cents: i64 = r.try_get("total_amount_cents").unwrap_or(0);
+            db_price = (total_cents as f64) / 100.0;
+            let cust_uuid: uuid::Uuid = r.try_get("customer_id").unwrap_or_default();
+            db_client_id = cust_uuid.to_string();
+        }
+
+        let lines = sqlx::query("SELECT description FROM quote_line_items WHERE quote_id = $1 AND tenant_id = $2")
+            .bind(quote_uuid)
+            .bind(tenant_id)
+            .fetch_all(pool)
+            .await?;
+
+        for row in lines {
+            use sqlx::Row;
+            let desc: String = row.try_get("description").unwrap_or_default();
+            if !db_scope.is_empty() {
+                db_scope.push_str(", ");
+            }
+            db_scope.push_str(&desc);
+        }
     }
 
     // Generate an invoice automatically upon proposal/quote approval
     let invoice_id = uuid::Uuid::new_v4().to_string();
 
     let client_name = payload.get("client_name").and_then(|v| v.as_str()).unwrap_or("Client");
-    let client_id = payload.get("customer_id").and_then(|v| v.as_str()).unwrap_or("unknown");
-    let price = payload.get("price").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let scope = payload.get("scope").and_then(|v| v.as_str()).unwrap_or("Service");
+
+    let mut client_id = payload.get("customer_id").and_then(|v| v.as_str()).unwrap_or("unknown");
+    if !db_client_id.is_empty() {
+        client_id = &db_client_id;
+    }
+
+    let mut price = payload.get("price").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    if db_price > 0.0 {
+        price = db_price;
+    }
+
+    let mut scope = payload.get("scope").and_then(|v| v.as_str()).unwrap_or("Service");
+    if !db_scope.is_empty() {
+        scope = &db_scope;
+    }
 
     // If it's not just a quote_id update, but an actual approval containing price info, create invoice
     if price > 0.0 {
@@ -74,6 +121,17 @@ pub async fn handle_quote_action(tenant_id: &str, payload: &Value, pool: &PgPool
             .await?;
 
         tracing::info!("Invoice line items added for invoice {}", invoice_id);
+
+        // Also update the quote with the stripe link
+        if let Some(quote_id) = payload.get("quote_id").and_then(|v| v.as_str()) {
+            let quote_uuid = uuid::Uuid::parse_str(quote_id).unwrap_or_default();
+            sqlx::query("UPDATE quotes SET stripe_payment_link = $1 WHERE id = $2 AND tenant_id = $3")
+                .bind(&stripe_payment_link)
+                .bind(quote_uuid)
+                .bind(tenant_id)
+                .execute(pool)
+                .await?;
+        }
     }
 
     Ok(())

--- a/src/server/workers/message_triage_worker.rs
+++ b/src/server/workers/message_triage_worker.rs
@@ -299,8 +299,18 @@ Output JSON format:
             let omni_result = omni_result_res.unwrap();
 
             let action_type = extracted.get("action_type").and_then(|v| v.as_str()).unwrap_or("Draft Reply");
-            let action_payload_str = omni_result.final_draft;
-            let action_payload = action_payload_str.as_str();
+
+            let mut action_payload_str = omni_result.final_draft;
+            if action_type == "Draft Quote" || action_type == "Draft Booking" {
+                if let Some(payload) = extracted.get("action_payload") {
+                    if payload.is_object() || payload.is_array() {
+                        action_payload_str = serde_json::to_string(payload).unwrap_or(action_payload_str);
+                    } else if let Some(s) = payload.as_str() {
+                        action_payload_str = s.to_string();
+                    }
+                }
+            }
+            let mut action_payload = action_payload_str.clone();
 
             let agent_feed_item_id = Uuid::new_v4().to_string();
             let mut event_source = source.to_string();
@@ -384,6 +394,7 @@ Output JSON format:
                 }
             } else if action_type == "Draft Quote" {
                 if let Ok(quote_data) = serde_json::from_str::<serde_json::Value>(&action_payload) {
+                    let mut modified_quote_data = quote_data.clone();
                     let draft_quote_id = Uuid::new_v4();
                     quote_id_opt = Some(draft_quote_id.to_string());
                     let total_amount_cents = quote_data.get("total_amount_cents").and_then(|v| v.as_i64()).unwrap_or(0);
@@ -404,7 +415,13 @@ Output JSON format:
                                 .execute(&mut *tx).await;
 
                                 if let Some(items) = quote_data.get("line_items").and_then(|v| v.as_array()) {
+                                    let mut scope = String::new();
                                     for item in items {
+                                        let desc = item.get("description").and_then(|v| v.as_str()).unwrap_or("");
+                                        if !scope.is_empty() {
+                                            scope.push_str(", ");
+                                        }
+                                        scope.push_str(desc);
                                         let item_id = Uuid::new_v4();
                                         let desc = item.get("description").and_then(|v| v.as_str()).unwrap_or("");
                                         let price = item.get("unit_price_cents").and_then(|v| v.as_i64()).unwrap_or(0);
@@ -424,6 +441,22 @@ Output JSON format:
                                     }
                                 }
                                 let _ = tx.commit().await;
+
+                                modified_quote_data["price"] = serde_json::json!((total_amount_cents as f64) / 100.0);
+                                if let Some(items) = quote_data.get("line_items").and_then(|v| v.as_array()) {
+                                    let mut scope = String::new();
+                                    for item in items {
+                                        let desc = item.get("description").and_then(|v| v.as_str()).unwrap_or("");
+                                        if !scope.is_empty() {
+                                            scope.push_str(", ");
+                                        }
+                                        scope.push_str(desc);
+                                    }
+                                    modified_quote_data["scope"] = serde_json::json!(scope);
+                                }
+                                modified_quote_data["client_name"] = serde_json::json!("Client");
+                                action_payload_str = serde_json::to_string(&modified_quote_data).unwrap_or(action_payload_str);
+                                action_payload = action_payload_str.clone();
                             }
                         },
                         crate::db::DbStore::Sqlite(sqlite_pool) => {
@@ -457,6 +490,22 @@ Output JSON format:
                                     .execute(&*sqlite_pool).await;
                                 }
                             }
+
+                            modified_quote_data["price"] = serde_json::json!((total_amount_cents as f64) / 100.0);
+                            if let Some(items) = quote_data.get("line_items").and_then(|v| v.as_array()) {
+                                let mut scope = String::new();
+                                for item in items {
+                                    let desc = item.get("description").and_then(|v| v.as_str()).unwrap_or("");
+                                    if !scope.is_empty() {
+                                        scope.push_str(", ");
+                                    }
+                                    scope.push_str(desc);
+                                }
+                                modified_quote_data["scope"] = serde_json::json!(scope);
+                            }
+                            modified_quote_data["client_name"] = serde_json::json!("Client");
+                            action_payload_str = serde_json::to_string(&modified_quote_data).unwrap_or(action_payload_str);
+                            action_payload = action_payload_str.clone();
                         }
                     }
                 }
@@ -553,7 +602,8 @@ Output JSON format:
                         "inbox_message_id": message_id,
                         "quote_id": quote_id_opt,
                         "booking_id": booking_id_opt,
-                        "feature_type": if action_type == "Draft Booking" { "booking_draft" } else if event_source == "instagram_dm" || action_type == "Draft Reply" { "ambassador_reply" } else { "quote_draft" }
+                        "feature_type": if action_type == "Draft Booking" { "booking_draft" } else if event_source == "instagram_dm" || action_type == "Draft Reply" { "ambassador_reply" } else { "quote_draft" },
+                        "action_payload": action_payload
                     }))
                     .execute(&self.db.pool).await {
                         tracing::error!("Failed to insert agent feed item: {}", e);
@@ -681,7 +731,8 @@ Output JSON format:
                         "inbox_message_id": message_id,
                         "quote_id": quote_id_opt,
                         "booking_id": booking_id_opt,
-                        "feature_type": if action_type == "Draft Booking" { "booking_draft" } else if event_source == "instagram_dm" || action_type == "Draft Reply" { "ambassador_reply" } else { "quote_draft" }
+                        "feature_type": if action_type == "Draft Booking" { "booking_draft" } else if event_source == "instagram_dm" || action_type == "Draft Reply" { "ambassador_reply" } else { "quote_draft" },
+                        "action_payload": action_payload
                     }).to_string())
                     .execute(&*sqlite_pool).await {
                         tracing::error!("Failed to insert agent feed item (SQLite): {}", e);


### PR DESCRIPTION
Modified `message_triage_worker.rs` to correctly parse `action_payload` for `Draft Quote` actions and include the necessary JSON data for downstream processing.
Updated `quotes.rs` `handle_quote_action` to fetch quote details from the database when an action is executed, ensuring accurate amounts are used to generate the Stripe payment link. The Stripe payment link is now properly saved back into the `quotes` table.
Loaded Superpowers skills to aid in solving issue.

Product-use evidence:
**Persona**: Nora - Agency Principal
**Flow**: Web webhook sends a new customer inquiry regarding custom project -> Wait for Operations Agent to draft quote -> Triage item appears on Dashboard -> View quote -> Approve & Send -> Stripe link generated -> Customer clicks the Stripe link and accepts.
**Gap**: The "Estimator Agent" was unable to parse the LLM JSON because it attempted to parse the full string. In addition, the generated Stripe link and details weren't properly being saved because the agent feed item lost context about the price.
**Fix**: Updated the `message_triage_worker.rs` parser to properly parse `action_payload` and inject `price`/`scope`. `quotes.rs` now properly pulls quotes from the DB if `quote_id` is supplied to generate the correct Stripe payload.
**Post-fix**: UI flow passes and the `quote_deposit_pipeline.spec.ts` E2E test runs successfully.

Resolves #33747

---
*PR created automatically by Jules for task [10123522640341854515](https://jules.google.com/task/10123522640341854515) started by @ql-owo-lp*