### PR TITLE
🤖 Implementer: Harness Upgrade - Visual Workflow Block Connect UI Validation

### DIFF
--- a/src/agents/builtin/visual_workflow.rs
+++ b/src/agents/builtin/visual_workflow.rs
@@ -172,6 +172,9 @@ impl BlockConnectUI for WorkflowGraph {
         if matches!(target_node.node_type, NodeType::Input { .. }) {
             return Err("Input nodes cannot have incoming connections.".to_string());
         }
+        if matches!(source_node.node_type, NodeType::Input { .. }) && matches!(target_node.node_type, NodeType::Output) {
+            return Err("Direct connection from Input to Output is not allowed.".to_string());
+        }
         Ok(())
     }
 }
@@ -1604,6 +1607,6 @@ mod additional_tests {
         let res1 = graph.validate_connection(&out_node, &in_node);
         assert!(res1.is_err());
         let res2 = graph.validate_connection(&in_node, &out_node);
-        assert!(res2.is_ok());
+        assert!(res2.is_err());
     }
 }


### PR DESCRIPTION
This PR introduces an architectural upgrade from the Master Catalog targeting the **Visual/low-code orchestration** block-connect UI schema. 

Specifically, it enforces a constraint within the `WorkflowGraph::validate_connection` trait to reject direct connections originating from an `Input` node directly to an `Output` node without intermediary computation nodes, which prevents invalid "no-op" graph topologies that could result in unexpected run states. 

It updates unit tests to correctly assert this behavior, and `bazel test //...` verifies the change is hermetic.

---
*PR created automatically by Jules for task [497292568028553471](https://jules.google.com/task/497292568028553471) started by @ql-owo-lp*