### PR TITLE
💰 Miser: Refactor agent cost calculation & coverage

### DIFF
--- a/src/server/integrations/stripe/routing.rs
+++ b/src/server/integrations/stripe/routing.rs
@@ -207,6 +207,29 @@ mod mercadopago_tests {
 }
 
 #[cfg(test)]
+mod alipay_tests {
+    use super::*;
+
+    #[test]
+    fn test_optimize_payment_method_alipay() {
+        assert_eq!(PaymentRouter::optimize_payment_method_with_currency(100.0, "CNY"), PaymentMethod::Alipay);
+        assert_eq!(PaymentRouter::optimize_payment_method_with_currency(1000.0, "cny"), PaymentMethod::Alipay);
+    }
+}
+
+#[cfg(test)]
+mod batch_payout_tests {
+    use super::*;
+
+    #[test]
+    fn test_should_batch_payout() {
+        assert!(PaymentRouter::should_batch_payout(5000));
+        assert!(!PaymentRouter::should_batch_payout(10000));
+        assert!(!PaymentRouter::should_batch_payout(15000));
+    }
+}
+
+#[cfg(test)]
 mod cost_analysis_tests {
     use super::*;
 

--- a/src/server/pricing/cost_aggregator.rs
+++ b/src/server/pricing/cost_aggregator.rs
@@ -212,12 +212,54 @@ mod tests {
             assert_eq!(item.total_cost, 0);
         }
     }
+
+    #[test]
+    fn test_process_agent_cost_rows() {
+        let rows = vec![
+            AgentCostRawRow {
+                agent_id: Some("agent1".to_string()),
+                total: Some(100.0),
+            },
+            AgentCostRawRow {
+                agent_id: None,
+                total: Some(200.0),
+            },
+            AgentCostRawRow {
+                agent_id: Some("agent3".to_string()),
+                total: Some(0.0), // Should be filtered out
+            },
+            AgentCostRawRow {
+                agent_id: Some("agent4".to_string()),
+                total: None, // Should be filtered out
+            },
+        ];
+        let res = process_agent_cost_rows(rows);
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0].agent_id, "agent1");
+        assert_eq!(res[0].cost_cents, 100);
+        assert_eq!(res[1].agent_id, "unknown");
+        assert_eq!(res[1].cost_cents, 200);
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub struct AgentCostRow {
     pub agent_id: String,
     pub cost_cents: i64,
+}
+
+pub struct AgentCostRawRow {
+    pub agent_id: Option<String>,
+    pub total: Option<f64>,
+}
+
+pub fn process_agent_cost_rows(rows: Vec<AgentCostRawRow>) -> Vec<AgentCostRow> {
+    rows.into_iter().map(|r| AgentCostRow {
+        agent_id: r.agent_id.unwrap_or_else(|| "unknown".to_string()),
+        cost_cents: r.total.unwrap_or(0.0) as i64,
+    })
+    .filter(|r| r.cost_cents > 0)
+    .collect()
 }
 
 pub async fn aggregate_agent_costs(pool: &PgPool, tenant_id: &str) -> Vec<AgentCostRow> {
@@ -247,14 +289,10 @@ pub async fn aggregate_agent_costs(pool: &PgPool, tenant_id: &str) -> Vec<AgentC
         }
     };
 
-    raw_rows.into_iter().map(|r| AgentCostRow {
-        agent_id: r.try_get::<Option<String>, _>("agent_id")
-            .unwrap_or(None)
-            .unwrap_or_else(|| "unknown".to_string()),
-        cost_cents: r.try_get::<Option<f64>, _>("total")
-            .unwrap_or(None)
-            .unwrap_or(0.0) as i64,
-    })
-    .filter(|r| r.cost_cents > 0)
-    .collect()
+    let processed_rows = raw_rows.into_iter().map(|r| AgentCostRawRow {
+        agent_id: r.try_get::<Option<String>, _>("agent_id").unwrap_or(None),
+        total: r.try_get::<Option<f64>, _>("total").unwrap_or(None),
+    }).collect();
+
+    process_agent_cost_rows(processed_rows)
 }


### PR DESCRIPTION
- Refactored `aggregate_agent_costs` to use `process_agent_cost_rows` for better testability.
- Added comprehensive unit tests for `process_agent_cost_rows` in `cost_aggregator.rs`.
- Added unit tests for Alipay routing and `should_batch_payout` logic in `stripe/routing.rs` to boost coverage.

---
*PR created automatically by Jules for task [17662043637084823266](https://jules.google.com/task/17662043637084823266) started by @ql-owo-lp*