### PR TITLE
✍️ Scribe: [Refactor HelpChat, add missing tooltips, improve Walkthrough coverage]

### DIFF
--- a/src/server/api/docs.rs
+++ b/src/server/api/docs.rs
@@ -127,6 +127,9 @@ pub async fn get_tooltips(
         tooltips.insert("total-sales-tooltip".to_string(), "Total revenue generated from your orders.".to_string());
         tooltips.insert("recent-orders-tooltip".to_string(), "View the latest orders placed by your customers.".to_string());
         tooltips.insert("inbox-activity-tooltip".to_string(), "Keep track of recent customer messages.".to_string());
+        tooltips.insert("help-advanced-toggle-tooltip".to_string(), "Show advanced developer options.".to_string());
+        tooltips.insert("help-btn-tooltip-appshell".to_string(), "Need help? Click here to access our Help Center, Ask AI, Video Tutorials, and Release Notes.".to_string());
+        tooltips.insert("checkout-pay-tooltip".to_string(), "Click to process your payment.".to_string());
     }
 
     Ok(Json(tooltips))

--- a/src/ui/next/src/components/HelpChat.tsx
+++ b/src/ui/next/src/components/HelpChat.tsx
@@ -12,6 +12,57 @@ type Message = {
   link?: { url: string; title: string };
 };
 
+function SpinnerIcon() {
+  return (
+    <svg
+      className="w-5 h-5 animate-spin"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+      />
+    </svg>
+  );
+}
+
+function SendIcon() {
+  return (
+    <svg
+      className="w-5 h-5"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"
+      />
+    </svg>
+  );
+}
+
+function createMarkup(msgText: string) {
+  return {
+    __html: DOMPurify.sanitize(
+      msgText.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+             .replace(/\*(.*?)\*/g, '<em>$1</em>')
+             .replace(/\n\n/g, '</p><p>')
+             .replace(/^(.+)$/gm, '<p>$1</p>')
+             .replace(/<p><p>/g, '<p>')
+             .replace(/<\/p><\/p>/g, '</p>')
+             .replace(/\- (.*?)<\/p>/g, '<li>$1</li>')
+             .replace(/(<li>[\s\S]*?<\/li>)/, '<ul>$1</ul>')
+    )
+  };
+}
+
 function isSafeLink(url: unknown): url is string {
   return (
     typeof url === "string" &&
@@ -258,18 +309,7 @@ export function HelpChat() {
                       ? "bg-blue-600/90 backdrop-blur-[30px] saturate-[210%] text-white rounded-br-sm border border-white/20"
                       : "bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] border border-white/50 dark:border-white/20 text-gray-900 dark:text-gray-100 rounded-bl-sm prose prose-sm prose-blue dark:prose-invert max-w-none prose-p:my-1 prose-ul:my-1 prose-li:my-0.5"
                   }`}
-                  dangerouslySetInnerHTML={{
-                    __html: DOMPurify.sanitize(
-                      msg.text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-                             .replace(/\*(.*?)\*/g, '<em>$1</em>')
-                             .replace(/\n\n/g, '</p><p>')
-                             .replace(/^(.+)$/gm, '<p>$1</p>')
-                             .replace(/<p><p>/g, '<p>')
-                             .replace(/<\/p><\/p>/g, '</p>')
-                             .replace(/\- (.*?)<\/p>/g, '<li>$1</li>')
-                             .replace(/(<li>[\s\S]*?<\/li>)/, '<ul>$1</ul>')
-                    ),
-                  }}
+                  dangerouslySetInnerHTML={createMarkup(msg.text)}
                 />
                 {msg.link && (
                   <a
@@ -330,35 +370,7 @@ export function HelpChat() {
               className="bg-blue-600/95 backdrop-blur-md text-white p-2.5 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-2xl disabled:opacity-50 disabled:cursor-not-allowed hover:bg-blue-700/95 transition-all shadow-md active:scale-95"
               aria-label="Send message"
             >
-              {isLoading ? (
-                <svg
-                  className="w-5 h-5 animate-spin"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-                  />
-                </svg>
-              ) : (
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"
-                  />
-                </svg>
-              )}
+              {isLoading ? <SpinnerIcon /> : <SendIcon />}
             </button>
           </form>
         </div>

--- a/src/ui/next/src/components/TooltipRegistry.tsx
+++ b/src/ui/next/src/components/TooltipRegistry.tsx
@@ -25,7 +25,10 @@ export const DEFAULT_TOOLTIPS: Record<string, string> = {
   "help-nav-tooltip": "Open the Help Center to find guides, videos, and contact support.",
   "api-docs-tooltip": "Direct API access is for developers.",
   "changelog-nav-tooltip": "See what's new in the latest OneHumanCorp updates.",
-  "dashboard-walkthrough-btn": "Take a quick tour of the dashboard."
+  "dashboard-walkthrough-btn": "Take a quick tour of the dashboard.",
+  "help-advanced-toggle-tooltip": "Show advanced developer options.",
+  "help-btn-tooltip-appshell": "Need help? Click here to access our Help Center, Ask AI, Video Tutorials, and Release Notes.",
+  "checkout-pay-tooltip": "Click to process your payment."
 };
 
 export function TooltipProvider({ children }: { children: ReactNode }) {

--- a/src/ui/next/src/components/Walkthrough.test.tsx
+++ b/src/ui/next/src/components/Walkthrough.test.tsx
@@ -166,6 +166,23 @@ describe('Walkthrough Component', () => {
     expect(container.innerHTML).toContain('aria-hidden="true"');
   });
 
+  it('WalkthroughTarget wraps children with WithTooltip when tooltipId is provided', async () => {
+    const { WalkthroughTarget } = await import('./Walkthrough');
+    const { TooltipProvider } = await import('./TooltipRegistry');
+    const { container } = render(
+      <TooltipProvider>
+        <WalkthroughTarget id="some-id" tooltipId="test-tooltip">
+          <div>Test Content</div>
+        </WalkthroughTarget>
+      </TooltipProvider>
+    );
+
+    expect(container.innerHTML).toContain('id="some-id"');
+    expect(container.innerHTML).toContain('Test Content');
+    // Ensure WithTooltip wrapper renders its ID correctly
+    expect(container.innerHTML).toContain('id="test-tooltip"');
+  });
+
   it('recalculates bounds on window resize', async () => {
     const handleClose = vi.fn();
     render(


### PR DESCRIPTION
Refactored `HelpChat.tsx` to extract inline SVGs to top-level `SpinnerIcon` and `SendIcon` components. Extracted `DOMPurify.sanitize` and chained `replace` block into a reusable `createMarkup` helper function outside the component.
Added missing tooltips to the default list in `src/ui/next/src/components/TooltipRegistry.tsx` and the corresponding Rust API endpoint seed in `src/server/api/docs.rs` (`help-advanced-toggle-tooltip`, `help-btn-tooltip-appshell`, and `checkout-pay-tooltip`).
Increased test coverage for `Walkthrough.tsx` by adding a test case verifying `<WalkthroughTarget>` with a provided `tooltipId` parameter correctly wraps children with `WithTooltip` in `Walkthrough.test.tsx`.

---
*PR created automatically by Jules for task [4205889363319124978](https://jules.google.com/task/4205889363319124978) started by @ql-owo-lp*