### PR TITLE
💰 Miser: fix pricing page subscription upgrade checkout session

### DIFF
--- a/src/ui/next/src/app/pricing/page.test.tsx
+++ b/src/ui/next/src/app/pricing/page.test.tsx
@@ -326,7 +326,7 @@ describe('PricingPage', () => {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ tier: 'Business', subscription_interval: 'month' }),
+        body: JSON.stringify({ tier: 'Business', is_subscription: true, subscription_interval: 'month' }),
       });
       expect(window.location.href).toBe(mockCheckoutUrl);
     });
@@ -371,7 +371,7 @@ describe('PricingPage', () => {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ tier: 'Pro', subscription_interval: 'month' }),
+        body: JSON.stringify({ tier: 'Pro', is_subscription: true, subscription_interval: 'month' }),
       });
       expect(window.location.href).toBe(mockCheckoutUrl);
     });

--- a/src/ui/next/src/app/pricing/page.test.tsx
+++ b/src/ui/next/src/app/pricing/page.test.tsx
@@ -100,7 +100,7 @@ describe('PricingPage', () => {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ tier: 'Starter', subscription_interval: 'month' }),
+        body: JSON.stringify({ tier: 'Starter', is_subscription: true, subscription_interval: 'month' }),
       });
       expect(window.location.href).toBe(mockCheckoutUrl);
     });

--- a/src/ui/next/src/app/pricing/page.tsx
+++ b/src/ui/next/src/app/pricing/page.tsx
@@ -74,7 +74,7 @@ export default function PricingPage() {
           'Content-Type': 'application/json',
           ...(token ? { 'Authorization': `Bearer ${token}` } : {})
         },
-        body: JSON.stringify({ tier, subscription_interval: isAnnualSelected ? 'year' : 'month' }),
+        body: JSON.stringify({ tier, is_subscription: true, subscription_interval: isAnnualSelected ? 'year' : 'month' }),
       });
 
       if (!response.ok) {


### PR DESCRIPTION
This PR addresses an issue where clicking "Upgrade" on the pricing page was missing the `is_subscription` parameter in the payload sent to `/api/billing/create-checkout-session`. This ensures that when a user upgrades their plan, they are enrolled in a recurring subscription on Stripe rather than being charged for a one-off payment.

**Product-use evidence:**
*   **Persona:** Non-technical owner looking to upgrade their Starter plan to Pro to remove limits on AI actions.
*   **UI Flow:** Click "Upgrade to Pro via Stripe".
*   **CUJ Gap:** Previously sent missing subscription metadata resulting in a backend mismatch/default behavior, missing subscription logic if not passed.
*   **Post-fix UI Flow:** "Upgrade to Pro via Stripe" successfully passes `{ is_subscription: true }` and sets up the recurring Stripe session correctly.

**Superpowers skills loaded:** none.

---
*PR created automatically by Jules for task [6171905878958521704](https://jules.google.com/task/6171905878958521704) started by @ql-owo-lp*