### PR TITLE
fix: Implement Agentic SEO Pre-rendering & Global Edge-Cached Dynamic Storefront

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ cargo_vendor_repository(
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",
-    version = "1.22.1",
+    version = "1.23.0",
 )
 use_repo(go_sdk, "go_sdk")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -17993,164 +17993,6 @@
           "495c7dfaea4e2bf48643662bb622e4ce6378d6d9840015238ad4b8792b99ddbf"
         ]
       },
-      "1.22.1": {
-        "aix_ppc64": [
-          "go1.22.1.aix-ppc64.tar.gz",
-          "6fa698dfb9ad780733f178c03c974053394e08790bfeb16593688f21ae123560"
-        ],
-        "darwin_amd64": [
-          "go1.22.1.darwin-amd64.tar.gz",
-          "3bc971772f4712fec0364f4bc3de06af22a00a12daab10b6f717fdcd13156cc0"
-        ],
-        "darwin_arm64": [
-          "go1.22.1.darwin-arm64.tar.gz",
-          "f6a9cec6b8a002fcc9c0ee24ec04d67f430a52abc3cfd613836986bcc00d8383"
-        ],
-        "dragonfly_amd64": [
-          "go1.22.1.dragonfly-amd64.tar.gz",
-          "d1d5a89968171019dbc992727d761f250cd02076b98c432f7cda0c55e9764549"
-        ],
-        "freebsd_386": [
-          "go1.22.1.freebsd-386.tar.gz",
-          "99f81c10d5a3f8a886faf8fa86aaa2aaf929fbed54a972ae5eec3c5e0bdb961a"
-        ],
-        "freebsd_amd64": [
-          "go1.22.1.freebsd-amd64.tar.gz",
-          "51c614ddd92ee4a9913a14c39bf80508d9cfba08561f24d2f075fd00f3cfb067"
-        ],
-        "freebsd_arm64": [
-          "go1.22.1.freebsd-arm64.tar.gz",
-          "4f7d6ae3edf50938431a05403c710305fd88132511903784618741bacd31045e"
-        ],
-        "freebsd_armv6l": [
-          "go1.22.1.freebsd-arm.tar.gz",
-          "229a986ec0387e3643b3c8a85aedf0e4f608a5ad47c2b8a4729f059a082d1dd4"
-        ],
-        "freebsd_riscv64": [
-          "go1.22.1.freebsd-riscv64.tar.gz",
-          "f374117b13514a1f6dac0e99ff743b92fd205df9b6d2b56966378041103ce7d2"
-        ],
-        "illumos_amd64": [
-          "go1.22.1.illumos-amd64.tar.gz",
-          "f623f3f0129e3eae112bd64a36291aa144b2ce9580cc88d8dcb154526a303bb4"
-        ],
-        "linux_386": [
-          "go1.22.1.linux-386.tar.gz",
-          "8484df36d3d40139eaf0fe5e647b006435d826cc12f9ae72973bf7ec265e0ae4"
-        ],
-        "linux_amd64": [
-          "go1.22.1.linux-amd64.tar.gz",
-          "aab8e15785c997ae20f9c88422ee35d962c4562212bb0f879d052a35c8307c7f"
-        ],
-        "linux_arm64": [
-          "go1.22.1.linux-arm64.tar.gz",
-          "e56685a245b6a0c592fc4a55f0b7803af5b3f827aaa29feab1f40e491acf35b8"
-        ],
-        "linux_armv6l": [
-          "go1.22.1.linux-armv6l.tar.gz",
-          "8cb7a90e48c20daed39a6ac8b8a40760030ba5e93c12274c42191d868687c281"
-        ],
-        "linux_loong64": [
-          "go1.22.1.linux-loong64.tar.gz",
-          "75e9b3c665d31078626e5fe95dcf2e6eae1484326f8b2b178559ca13f71dfc4c"
-        ],
-        "linux_mips": [
-          "go1.22.1.linux-mips.tar.gz",
-          "3f917fb72894effb18db9d191c9b7f288befd2cc4a9735256f1634fb1e4ae8fb"
-        ],
-        "linux_mips64": [
-          "go1.22.1.linux-mips64.tar.gz",
-          "c1ecfa000a3ae70056dbc17ccb3adcf8e3f6f76bb10f166d57c3e1b190bc4907"
-        ],
-        "linux_mips64le": [
-          "go1.22.1.linux-mips64le.tar.gz",
-          "a52386492ee3147d37f7dd80b7b5d41252bc4dbb0e28ce29e730dd095848caa8"
-        ],
-        "linux_mipsle": [
-          "go1.22.1.linux-mipsle.tar.gz",
-          "08e5cf029f5dda72b6a2257fb71eb615294091cc2c3f0a3193692c3135012511"
-        ],
-        "linux_ppc64": [
-          "go1.22.1.linux-ppc64.tar.gz",
-          "daee81491c0b775279e38d4602472d25e67ade41d13d5b3f3fb618ec231463e1"
-        ],
-        "linux_ppc64le": [
-          "go1.22.1.linux-ppc64le.tar.gz",
-          "ac775e19d93cc1668999b77cfe8c8964abfbc658718feccfe6e0eb87663cd668"
-        ],
-        "linux_riscv64": [
-          "go1.22.1.linux-riscv64.tar.gz",
-          "77f7c8d2a8ea10c413c1f86c1c42001cd98bf428239cabceda2cdaff2cf29330"
-        ],
-        "linux_s390x": [
-          "go1.22.1.linux-s390x.tar.gz",
-          "7bb7dd8e10f95c9a4cc4f6bef44c816a6e7c9e03f56ac6af6efbb082b19b379f"
-        ],
-        "netbsd_386": [
-          "go1.22.1.netbsd-386.tar.gz",
-          "6cb82704d548cb90284729359ffbbf4c5a95bb7b5dfc2a9acb6e211992791c28"
-        ],
-        "netbsd_amd64": [
-          "go1.22.1.netbsd-amd64.tar.gz",
-          "f579dde36b89d847029839fb24c61fa028149eab36e42b305b03881bf439b192"
-        ],
-        "netbsd_arm64": [
-          "go1.22.1.netbsd-arm64.tar.gz",
-          "c445e61cbcf6a5f8d40ec22cc44fdce026f6cd53e97b5202ee6c3e2b9a77517b"
-        ],
-        "netbsd_armv6l": [
-          "go1.22.1.netbsd-arm.tar.gz",
-          "a84e507bb591150211d72043c9a616e60e50acbecc3adb90bdb491070f0c0822"
-        ],
-        "openbsd_386": [
-          "go1.22.1.openbsd-386.tar.gz",
-          "a0bac85fa905d7df5f611625fd2de157fe942299683088cac75e4c83e61a62bd"
-        ],
-        "openbsd_amd64": [
-          "go1.22.1.openbsd-amd64.tar.gz",
-          "f1359c30639c040615c7b3a59c2a6252d6c98c7ba3c6164f1e643657cf73e74f"
-        ],
-        "openbsd_arm64": [
-          "go1.22.1.openbsd-arm64.tar.gz",
-          "16fff79fbd66950d124b4de264c6d8dba5b1bbb4775b26362b056ddf5711f52a"
-        ],
-        "openbsd_armv6l": [
-          "go1.22.1.openbsd-arm.tar.gz",
-          "48b511199dd8410f4524ccb97402de01ed2f4669699e7ad21ebc4242c8a49552"
-        ],
-        "plan9_386": [
-          "go1.22.1.plan9-386.tar.gz",
-          "1af03991106ff89dd9221c452c6bd36cdb2d4f4855f54734908110341b18a900"
-        ],
-        "plan9_amd64": [
-          "go1.22.1.plan9-amd64.tar.gz",
-          "898640e029d9c22fd0ed55c90b32971fcb77907c6a5ae97fbac741a3f951733a"
-        ],
-        "plan9_armv6l": [
-          "go1.22.1.plan9-arm.tar.gz",
-          "9df684c49321d4a6a91fae39b71de5a79457afca05cfdf6520b25e9fecf3661f"
-        ],
-        "solaris_amd64": [
-          "go1.22.1.solaris-amd64.tar.gz",
-          "b6c57efcdf6eef5a480c9b755b4b9b2507810ff9f80c891d87fc7ed47404d4e3"
-        ],
-        "windows_386": [
-          "go1.22.1.windows-386.zip",
-          "0c5ebb7eb39b7884ec99f92b425d4c03a96a72443562aafbf6e7d15c42a3108a"
-        ],
-        "windows_amd64": [
-          "go1.22.1.windows-amd64.zip",
-          "cf9c66a208a106402a527f5b956269ca506cfe535fc388e828d249ea88ed28ba"
-        ],
-        "windows_arm64": [
-          "go1.22.1.windows-arm64.zip",
-          "85b8511b298c9f4199ecae26afafcc3d46155bac934d43f2357b9224bcaa310f"
-        ],
-        "windows_armv6l": [
-          "go1.22.1.windows-arm.zip",
-          "fda36f9a50a7d620e0d7192244ea9a87321bec781ef8b35ea132ca5d90c27c60"
-        ]
-      },
       "1.22.4": {
         "aix_ppc64": [
           "go1.22.4.aix-ppc64.tar.gz",
@@ -18311,6 +18153,172 @@
         "windows_armv6l": [
           "go1.22.4.windows-arm.zip",
           "5fcd0671a49cecf39b41021621ee1b6e7aa1370f37122b72e80d4fd4185833b6"
+        ]
+      },
+      "1.23.0": {
+        "aix_ppc64": [
+          "go1.23.0.aix-ppc64.tar.gz",
+          "257f8560bb4001fb81a5e0ee84f32fecbe18d4450343c9556557d296786847b6"
+        ],
+        "darwin_amd64": [
+          "go1.23.0.darwin-amd64.tar.gz",
+          "ffd070acf59f054e8691b838f274d540572db0bd09654af851e4e76ab88403dc"
+        ],
+        "darwin_arm64": [
+          "go1.23.0.darwin-arm64.tar.gz",
+          "b770812aef17d7b2ea406588e2b97689e9557aac7e646fe76218b216e2c51406"
+        ],
+        "dragonfly_amd64": [
+          "go1.23.0.dragonfly-amd64.tar.gz",
+          "8fd2ab5ac8629fc97d25a056693e23f332446603dd3c2b764ccb496872004b0c"
+        ],
+        "freebsd_386": [
+          "go1.23.0.freebsd-386.tar.gz",
+          "2c9b76ead3c44f5b3e40e10b980075addb837f2dd05dafe7c0e4c611fd239753"
+        ],
+        "freebsd_amd64": [
+          "go1.23.0.freebsd-amd64.tar.gz",
+          "2c2252902b87ba605fdc0b12b4c860fe6553c0c5483c12cc471756ebdd8249fe"
+        ],
+        "freebsd_arm": [
+          "go1.23.0.freebsd-arm.tar.gz",
+          "8ec48b8d99a515644ae00e79d093ad3b7645dcaf2a19c0a9c0d97916187f4514"
+        ],
+        "freebsd_arm64": [
+          "go1.23.0.freebsd-arm64.tar.gz",
+          "f476bbe8efb0db18155671840545370bfb73903fec04ea897d510569dab16d9c"
+        ],
+        "freebsd_riscv64": [
+          "go1.23.0.freebsd-riscv64.tar.gz",
+          "b0e254b2ea5752b4f1c69934ae43a44bbabf98e0c2843af44e1b6d12390eb551"
+        ],
+        "illumos_amd64": [
+          "go1.23.0.illumos-amd64.tar.gz",
+          "09716dcc7a2e19891b3d1e2ea68a1aab22838fc664cdc5f82d5f8eef05db78cf"
+        ],
+        "linux_386": [
+          "go1.23.0.linux-386.tar.gz",
+          "0e8a7340c2632e6fb5088d60f95b52be1f8303143e04cd34e9b2314fafc24edd"
+        ],
+        "linux_amd64": [
+          "go1.23.0.linux-amd64.tar.gz",
+          "905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3"
+        ],
+        "linux_arm64": [
+          "go1.23.0.linux-arm64.tar.gz",
+          "62788056693009bcf7020eedc778cdd1781941c6145eab7688bd087bce0f8659"
+        ],
+        "linux_armv6l": [
+          "go1.23.0.linux-armv6l.tar.gz",
+          "0efa1338e644d7f74064fa7f1016b5da7872b2df0070ea3b56e4fef63192e35b"
+        ],
+        "linux_loong64": [
+          "go1.23.0.linux-loong64.tar.gz",
+          "dc8f723ce1a236e85c8b56d1e6749e270314e99dd41b80a58355e7ffcf9ea857"
+        ],
+        "linux_mips": [
+          "go1.23.0.linux-mips.tar.gz",
+          "3332cc76c73c05b3413cdecccffc29aaa3469f87db8ed9f9b784ebb527ca5352"
+        ],
+        "linux_mips64": [
+          "go1.23.0.linux-mips64.tar.gz",
+          "0ed5cee92433d09fd0816ec5adfbf4b16d712944e833f6342bbe2df18f7826ae"
+        ],
+        "linux_mips64le": [
+          "go1.23.0.linux-mips64le.tar.gz",
+          "06a579dd6d1f9a84bc43cab063e7c759a92a6d4dd01fec3d860f22a32df93406"
+        ],
+        "linux_mipsle": [
+          "go1.23.0.linux-mipsle.tar.gz",
+          "d522770d32d6ee963f61331a695c4f8a730f2445b965d8d56db0a2e75c62af57"
+        ],
+        "linux_ppc64": [
+          "go1.23.0.linux-ppc64.tar.gz",
+          "8c884cb4f2593d897f58ec1b0f23f303acf5c78fd101e76cb48d6cb1fe5e90e7"
+        ],
+        "linux_ppc64le": [
+          "go1.23.0.linux-ppc64le.tar.gz",
+          "8b26e20d4d43a4d7641cddbdc0298d7ba3804d910a9e06cda7672970dbf2829d"
+        ],
+        "linux_riscv64": [
+          "go1.23.0.linux-riscv64.tar.gz",
+          "a87726205f1a283247f877ccae8ce147ff4e77ac802382647ac52256eb5642c7"
+        ],
+        "linux_s390x": [
+          "go1.23.0.linux-s390x.tar.gz",
+          "003722971de02d97131a4dca2496abdab5cb175a6ee0ed9c8227c5ae9b883e69"
+        ],
+        "netbsd_386": [
+          "go1.23.0.netbsd-386.tar.gz",
+          "b203fa2354874c66c40d828e96a6cce1f4e4db192414050a600d0a09b16cafd3"
+        ],
+        "netbsd_amd64": [
+          "go1.23.0.netbsd-amd64.tar.gz",
+          "1502c82c3ba663959df99c2cc3ca5e7a5e1a75a1495fd26bef697d63bf1f291c"
+        ],
+        "netbsd_arm": [
+          "go1.23.0.netbsd-arm.tar.gz",
+          "dd50c05c7f613522c8d3d74f598bfc1862c0fee9182b738225820c9b458c7be5"
+        ],
+        "netbsd_arm64": [
+          "go1.23.0.netbsd-arm64.tar.gz",
+          "728a94a648f9502cd6175adaac2b770acde6b26f5f92dcbd8c5a1a43cc44bb10"
+        ],
+        "openbsd_386": [
+          "go1.23.0.openbsd-386.tar.gz",
+          "e1ff3584778257778a4e3f0093b09044072423aebedf2015a550537853c46745"
+        ],
+        "openbsd_amd64": [
+          "go1.23.0.openbsd-amd64.tar.gz",
+          "d2e30cdb0de256360b51a43f5e551587a7369d8c248120010d5e9432f698a6e8"
+        ],
+        "openbsd_arm": [
+          "go1.23.0.openbsd-arm.tar.gz",
+          "bd5224c8a5f195f4128c866c0d418f1b61db865a1042913fd07714ed85da28db"
+        ],
+        "openbsd_arm64": [
+          "go1.23.0.openbsd-arm64.tar.gz",
+          "fc0e0af3a1b4b7168455e8492a5bb6aa96ceaf46321cef1fc04187301c058890"
+        ],
+        "openbsd_ppc64": [
+          "go1.23.0.openbsd-ppc64.tar.gz",
+          "ce7ea9343c7c2ef2700b55b80c45549ce39d164031e4d7bb98bec7ca593ed93d"
+        ],
+        "openbsd_riscv64": [
+          "go1.23.0.openbsd-riscv64.tar.gz",
+          "90b6a97285981e06752a30a638cd8d32861086848c0131fb62faddf89e2de8e1"
+        ],
+        "plan9_386": [
+          "go1.23.0.plan9-386.tar.gz",
+          "93b970a8a41f6c89113daaea12e39f2580038af155e823550d0a94a5502c5e2c"
+        ],
+        "plan9_amd64": [
+          "go1.23.0.plan9-amd64.tar.gz",
+          "6231862acbb6c1e02b1455b35446b9789b0b4b3230d249953e6957c393a53011"
+        ],
+        "plan9_arm": [
+          "go1.23.0.plan9-arm.tar.gz",
+          "632bdd3a1f84b2fe691203423dd2c3f536d4ab250bb52a48e9b05ebf327ae594"
+        ],
+        "solaris_amd64": [
+          "go1.23.0.solaris-amd64.tar.gz",
+          "16773f85003d9e610960f9af67e00bc6c02359d7914de7224079538cc9c1e93d"
+        ],
+        "windows_386": [
+          "go1.23.0.windows-386.zip",
+          "09448fedec0cdf98ad12397222e0c8bfc835b1d0894c0015ced653534b8d7427"
+        ],
+        "windows_amd64": [
+          "go1.23.0.windows-amd64.zip",
+          "d4be481ef73079ee0ad46081d278923aa3fd78db1b3cf147172592f73e14c1ac"
+        ],
+        "windows_arm": [
+          "go1.23.0.windows-arm.zip",
+          "006d93712246a672bdb57906dd5bffcab62facc36169e51a27d52340cdac661f"
+        ],
+        "windows_arm64": [
+          "go1.23.0.windows-arm64.zip",
+          "0be62073ef8f5a2d3b9adcefddf18c417dab0a7975c71488ac2694856e2ff976"
         ]
       },
       "1.24.0": {

--- a/src/server/orchestration/departments/operations_agent.rs
+++ b/src/server/orchestration/departments/operations_agent.rs
@@ -246,7 +246,7 @@ impl Department for OperationsAgent {
             return Ok(());
         }
 
-        if event.event_type == "tenant.inventory.updated" {
+        if event.event_type == "tenant.inventory.updated" || event.event_type == "tenant.pricing.updated" {
             let product_id = event.payload.get("product_id").and_then(|v| v.as_str()).unwrap_or("");
             let cache = crate::builder::edge::get_edge_cache();
             cache.invalidate_by_tag(&format!("tenant-id:{}", event.tenant_id)).await;


### PR DESCRIPTION
Resolves #33783

- Added `tenant.pricing.updated` to the `operations_agent`'s event handling logic so that both inventory and pricing updates will invalidate the edge cache and regenerate the product cache.
- Bumps Go SDK to `1.23.0` to resolve `golang.org/x/mod` build issues.
- `bazel test //...` and `bazel test //src/e2e:playwright` passed locally.

---
*PR created automatically by Jules for task [9640872892226012362](https://jules.google.com/task/9640872892226012362) started by @ql-owo-lp*