### PR TITLE
🗺️ Guide: enforce 16px border-radius on glassmorphism in setup.html

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -44,7 +44,7 @@
       }
       /* OHC Premium Glassmorphism */
       .glassmorphism {
-        border-radius: 16px;
+        border-radius: 16px !important;
         background: rgba(255, 255, 255, 0.65);
         backdrop-filter: blur(30px) saturate(210%);
         -webkit-backdrop-filter: blur(30px) saturate(210%);
@@ -60,7 +60,7 @@
           backdrop-filter: blur(30px) saturate(210%);
           -webkit-backdrop-filter: blur(30px) saturate(210%);
           border: 1px solid rgba(255, 255, 255, 0.1);
-          border-radius: 16px;
+          border-radius: 16px !important;
         }
       }
 
@@ -1134,7 +1134,7 @@
       .glassmorphism.container,
       .glassmorphism.card,
       .glassmorphism.panel {
-        border-radius: 16px;
+        border-radius: 16px !important;
       }
           #instant-bio { min-height: 44px; box-sizing: border-box; border-radius: 8px; }
       .context-card { min-height: 44px; box-sizing: border-box; }
@@ -1153,7 +1153,7 @@
           backdrop-filter: blur(30px) saturate(210%) !important;
           -webkit-backdrop-filter: blur(30px) saturate(210%) !important;
           border: 1px solid rgba(255, 255, 255, 0.1) !important;
-          border-radius: 16px;
+          border-radius: 16px !important;
       }
         .context-card:hover {
           background: rgba(40, 40, 45, 0.7) !important;
@@ -4966,7 +4966,7 @@
     background: rgba(255, 255, 255, 0.65);
     backdrop-filter: blur(30px) saturate(210%);
     border-top: 1px solid rgba(255, 255, 255, 0.4);
-    border-radius: 16px;
+    border-radius: 16px !important;
     width: 100%;
     box-sizing: border-box;
   "


### PR DESCRIPTION
Updated the `.glassmorphism` CSS class in `src/ui/tauri/src/ui/setup.html` to ensure `border-radius: 16px !important;` is consistently applied. This aligns the onboarding flow with the OHC Premium Token library design standards for translucent glass styling, while avoiding breaking specific component overrides like chat bubble tails.

Verified with `bazelisk test //...` and `bazelisk test //src/e2e:playwright`.
Product-use evidence:
Persona: Nora - Agency Principal
Flow Attempted: Navigated through the onboarding flow. 
Gap Observed: The `.glassmorphism` class didn't strictly enforce a 16px border radius, leading to inconsistent styling across the app.
Fix: Added `!important` to `border-radius: 16px` for the `.glassmorphism` class blocks.

---
*PR created automatically by Jules for task [7275574814807451624](https://jules.google.com/task/7275574814807451624) started by @ql-owo-lp*