### PR TITLE
Fix pii leakage log checks

### DIFF
--- a/src/server/billing.rs
+++ b/src/server/billing.rs
@@ -240,14 +240,14 @@ impl Tracker {
     }
 
     pub fn track_outbound_api_call(&self, tenant_id: &str, endpoint: &str) {
-        tracing::info!("💰 Miser telemetry: Recording outbound API call for tenant: {}, endpoint: {}", tenant_id, endpoint); // pii-safe // pii-safe
+        tracing::info!("💰 Miser telemetry: Recording outbound API call for tenant: {}, endpoint: {}", tenant_id, endpoint); // pii-safe
         if let Some(ref auditor) = self.auditor {
             auditor.record_api_call(tenant_id, endpoint);
         }
     }
 
     pub fn track_email_send(&self, tenant_id: &str) {
-        tracing::info!("💰 Miser telemetry: Recording communication metric for tenant: {}", tenant_id); // pii-safe // pii-safe
+        tracing::info!("💰 Miser telemetry: Recording communication metric for tenant: {}", tenant_id); // pii-safe
         if let Some(ref auditor) = self.auditor {
             auditor.record_email_send(tenant_id);
         }

--- a/src/server/domain/action_router.rs
+++ b/src/server/domain/action_router.rs
@@ -71,7 +71,7 @@ pub async fn dispatch_action(
             }
         }
         "loyalty_reward_notification" => {
-            tracing::info!("Approved loyalty reward notification for tenant: {}", tenant_id);
+            tracing::info!("Approved loyalty reward notification for tenant: {}", tenant_id); // pii-safe
             if let Some(customer_id) = payload.get("customer_id").and_then(|v| v.as_str()) {
                 let id = uuid::Uuid::new_v4().to_string();
                 let discount_code = format!("LOYALTY-{}", uuid::Uuid::new_v4().to_string().chars().take(8).collect::<String>().to_uppercase());

--- a/src/server/interop/protocol.rs
+++ b/src/server/interop/protocol.rs
@@ -219,7 +219,7 @@ impl InteropProtocol {
         use prost::Message as ProstMessage;
         use std::sync::atomic::Ordering;
 
-        tracing::info!(job_id = %job_id, tenant_id = %tenant_id, action_name = %action_name, "Dispatching background job"); // pii-safe // pii-safe
+        tracing::info!(job_id = %job_id, tenant_id = %tenant_id, action_name = %action_name, "Dispatching background job"); // pii-safe
 
         let received = Arc::new(AtomicBool::new(false));
         let rx = received.clone();

--- a/src/server/pricing/rate_limit.rs
+++ b/src/server/pricing/rate_limit.rs
@@ -244,7 +244,7 @@ impl RedisRateLimiter {
         let now = chrono::Utc::now();
         let month_key = now.format("%Y-%m").to_string();
 
-        tracing::info!("💰 Miser telemetry: Recording {} tokens for tenant: {} model: {}", tokens, tenant_id, model); // pii-safe // pii-safe
+        tracing::info!("💰 Miser telemetry: Recording {} tokens for tenant: {} model: {}", tokens, tenant_id, model); // pii-safe
 
         let tenant_key = format!("tenant:{}:tokens_used:{}", tenant_id, month_key);
         let model_key = format!("tenant:{}:tokens_used:{}:{}", tenant_id, model, month_key);


### PR DESCRIPTION
Fix pii leakage log checks by removing double `// pii-safe` comments and adding missing ones.

---
*PR created automatically by Jules for task [8877704227268670078](https://jules.google.com/task/8877704227268670078) started by @ql-owo-lp*