### PR TITLE
✍️ Scribe: remove dummy data from help components

### DIFF
--- a/src/ui/next/src/app/kairos/page.tsx
+++ b/src/ui/next/src/app/kairos/page.tsx
@@ -68,11 +68,7 @@ function KairosContent() {
   const [isWalkthroughOpen, setIsWalkthroughOpen] = useState(false);
 
   useEffect(() => {
-    const forceWalkthrough = typeof window !== "undefined" && (
-      window.localStorage.getItem("TEST_WALKTHROUGH") === "true" ||
-      window.location.search.includes("test_walkthrough=true")
-    );
-    if ((searchParams.get("walkthrough") === "true" || forceWalkthrough) && !walkthroughStarted.current) {
+    if (searchParams.get("walkthrough") === "true" && !walkthroughStarted.current) {
       const timeoutId = window.setTimeout(() => {
         walkthroughStarted.current = true;
         setIsWalkthroughOpen(true);

--- a/src/ui/next/src/components/HelpChat.tsx
+++ b/src/ui/next/src/components/HelpChat.tsx
@@ -159,15 +159,6 @@ export function HelpChat() {
     return () => window.removeEventListener("open-help-chat", handleOpenHelpChat);
   }, []);
 
-  const isE2E = process.env.NEXT_PUBLIC_E2E === "true";
-  const forceChat =
-    typeof window !== "undefined" &&
-    window.location.search.includes("test_chat=true");
-  if (isE2E && !forceChat) {
-    // We shouldn't hide the HelpChat in E2E unless we specifically want it gone, but tests rely on it.
-    // Given the test failures, let's keep it mounted during E2E.
-  }
-
   return (
     <div className="help-chat-wrapper pointer-events-none">
       {/* Floating Button */}

--- a/src/ui/next/src/components/Walkthrough.tsx
+++ b/src/ui/next/src/components/Walkthrough.tsx
@@ -60,9 +60,6 @@ export function InteractiveWalkthrough({ steps, isOpen, onClose, onComplete }: W
   }, [isOpen, currentStepIndex, steps]);
 
   if (!isOpen || steps.length === 0) return null;
-  const isE2E = process.env.NEXT_PUBLIC_E2E === 'true';
-  const forceWalkthrough = typeof window !== 'undefined' && (window.localStorage.getItem('TEST_WALKTHROUGH') === 'true' || window.location.search.includes('test_walkthrough=true'));
-  if (isE2E && !forceWalkthrough) return null;
 
   const currentStep = steps[currentStepIndex];
   const isLastStep = currentStepIndex === steps.length - 1;

--- a/src/ui/next/src/e2e/help_components.spec.ts
+++ b/src/ui/next/src/e2e/help_components.spec.ts
@@ -28,7 +28,7 @@ test.describe('Help Components', () => {
   });
 
   test('Help Chat opens and sends a message', async ({ page }) => {
-    await page.goto('/help?test_chat=true');
+    await page.goto('/help');
 
     // Open chat
     const chatButton = page.locator('button[aria-label="Open help chat"]');
@@ -47,7 +47,7 @@ test.describe('Help Components', () => {
   });
 
   test('Help Chat clears messages', async ({ page }) => {
-    await page.goto('/help?test_chat=true');
+    await page.goto('/help');
 
     // Open chat
     const chatButton = page.locator('button[aria-label="Open help chat"]');
@@ -74,7 +74,7 @@ test.describe('Help Components', () => {
   });
 
   test('Interactive Walkthrough functions correctly on dashboard', async ({ page }) => {
-    await page.goto('/dashboard?test_walkthrough=true');
+    await page.goto('/dashboard');
 
     const startTourBtn = page.locator('button:has-text("Start Tour")');
     await expect(startTourBtn).toBeVisible();


### PR DESCRIPTION
Removed fallback data and test-only parameters (`test_chat=true`, `test_walkthrough=true`) from UI components and updated the corresponding Playwright tests to use real backend data. Ensures compliance with ZERO mock data directive.

---
*PR created automatically by Jules for task [2230458995144019263](https://jules.google.com/task/2230458995144019263) started by @ql-owo-lp*