### PR TITLE
fix(ui): apply global button disabled opacity 0.55 in setup

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -436,8 +436,11 @@
       .btn-instant-build:hover {
         background: #0052cc;
       }
-      .btn-instant-build:disabled {
-        opacity: 0.5;
+      .btn-instant-build:disabled,
+      button:disabled,
+      button[disabled],
+      .btn-primary:disabled {
+        opacity: 0.55;
         cursor: not-allowed;
       }
 
@@ -1451,7 +1454,7 @@
               display: flex;
               align-items: center;
               gap: 8px;
-              opacity: 0.5;
+              opacity: 0.55;
               transition: opacity 0.3s;
             "
           >
@@ -1472,7 +1475,7 @@
               display: flex;
               align-items: center;
               gap: 8px;
-              opacity: 0.5;
+              opacity: 0.55;
               transition: opacity 0.3s;
             "
           >
@@ -1493,7 +1496,7 @@
               display: flex;
               align-items: center;
               gap: 8px;
-              opacity: 0.5;
+              opacity: 0.55;
               transition: opacity 0.3s;
             "
           >


### PR DESCRIPTION
Updated `src/ui/tauri/src/ui/setup.html` to align disabled button styles with the design standards from `.glassmorphism` in `globals.css`. Added `.btn-instant-build:disabled, button:disabled, button[disabled], .btn-primary:disabled` to use `opacity: 0.55`. Tested locally with `npx playwright test src/e2e/playwright/onboarding.spec.ts` to ensure everything functions perfectly without regressions.

---
*PR created automatically by Jules for task [12022997606068770635](https://jules.google.com/task/12022997606068770635) started by @ql-owo-lp*