### PR TITLE
fix: update offline network indicator to match required UX

### DIFF
--- a/src/e2e/degradation_validation.spec.ts
+++ b/src/e2e/degradation_validation.spec.ts
@@ -33,7 +33,7 @@ test.describe('Degradation Validation (Mobile/Thin Client)', () => {
     await context.setOffline(true);
     await memberPage.evaluate(() => window.dispatchEvent(new Event('offline')));
 
-    await expect(memberPage.getByText('Offline Mode')).toBeVisible({ timeout: 5000 });
+    await expect(memberPage.getByText('Offline - Changes saved locally')).toBeVisible({ timeout: 5000 });
 
     // Simulate write operation offline
     const quickChargeBtn = memberPage.getByText('Quick Charge $50');

--- a/src/e2e/mobile_pos_offline_sync.spec.ts
+++ b/src/e2e/mobile_pos_offline_sync.spec.ts
@@ -70,7 +70,7 @@ test.describe('Mobile POS - Offline Outbox Sync', () => {
     await page.evaluate(() => window.dispatchEvent(new Event('offline')));
 
     // Verify offline banner
-    await expect(page.locator('text=Offline Mode')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=Offline - Changes saved locally')).toBeVisible({ timeout: 10000 });
 
     // Process Cash Sale
     const recordCashSaleBtn = page.getByRole('button', { name: /Record Offline Cash Sale \$/ });

--- a/src/e2e/playwright/mobile_pos_offline_sync.spec.ts
+++ b/src/e2e/playwright/mobile_pos_offline_sync.spec.ts
@@ -55,7 +55,7 @@ test.describe('Mobile POS - Offline Outbox Sync', () => {
     await page.evaluate(() => window.dispatchEvent(new Event('offline')));
 
     // Verify offline banner
-    await expect(page.locator('text=Offline Mode')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=Offline - Changes saved locally')).toBeVisible({ timeout: 10000 });
 
     // Open Cash Sale Panel
     const cashMethodBtn = page.getByRole('button', { name: 'Cash' });

--- a/src/e2e/pos_offline_payment_failure_agent.spec.ts
+++ b/src/e2e/pos_offline_payment_failure_agent.spec.ts
@@ -26,7 +26,7 @@ test.describe('Offline-Tolerant POS Terminal Checkout - Payment Failure Agentic 
     });
 
     // Ensure the Offline Mode badge is visible
-    await expect(memberPage.locator('text=Offline Mode').first()).toBeVisible({ timeout: 5000 }).catch(() => {});
+    await expect(memberPage.locator('text=Offline - Changes saved locally').first()).toBeVisible({ timeout: 5000 }).catch(() => {});
 
     // Select the product we seeded that costs $40.02
     await memberPage.waitForSelector('text=Product Catalog', { timeout: 10000 });

--- a/src/e2e/terminal_pos.spec.ts
+++ b/src/e2e/terminal_pos.spec.ts
@@ -94,7 +94,7 @@ test.describe('Terminal POS - Mobile First & Inventory Sync', () => {
 
   test('Handles offline mode and sync queue', async ({ page }) => {
     await page.context().setOffline(true);
-    await expect(page.getByText('Offline Mode')).toBeVisible();
+    await expect(page.getByText('Offline - Changes saved locally')).toBeVisible();
     await page.getByRole('button', { name: 'Quick Charge $50' }).click();
     await page.context().setOffline(false);
     await expect(page.getByText('Online')).toBeVisible();

--- a/src/e2e/test_offline_first_mesh.spec.ts
+++ b/src/e2e/test_offline_first_mesh.spec.ts
@@ -16,7 +16,7 @@ test.describe('Offline-First AI Sync Mesh', () => {
     });
 
     // Check offline indicator
-    await expect(page.getByText('Offline Mode')).toBeVisible();
+    await expect(page.getByText('Offline - Changes saved locally')).toBeVisible();
 
     // Click "Quick Charge $50" which queues an offline transaction
     const quickChargeBtn = page.getByText('Quick Charge $50');

--- a/src/e2e/test_pos_offline_sync.spec.ts
+++ b/src/e2e/test_pos_offline_sync.spec.ts
@@ -26,7 +26,7 @@ test.describe('Offline-Tolerant POS Terminal Checkout', () => {
     });
 
     // Ensure the Offline Mode badge is visible
-    await expect(memberPage.locator('text=Offline Mode').first()).toBeVisible({ timeout: 5000 }).catch(() => {});
+    await expect(memberPage.locator('text=Offline - Changes saved locally').first()).toBeVisible({ timeout: 5000 }).catch(() => {});
 
     // Click "Quick Charge $50" while offline
     await memberPage.getByRole('button', { name: 'Quick Charge $50' }).click();
@@ -201,7 +201,7 @@ test.describe('Offline-Tolerant POS Terminal Checkout', () => {
     await memberPage.evaluate(() => {
       window.dispatchEvent(new Event('offline'));
     });
-    await expect(memberPage.locator('text=Offline Mode').first()).toBeVisible({ timeout: 5000 }).catch(() => {});
+    await expect(memberPage.locator('text=Offline - Changes saved locally').first()).toBeVisible({ timeout: 5000 }).catch(() => {});
 
     // Inject failed payment mock directly into IndexedDB Offline Queue
     await memberPage.evaluate(async () => {

--- a/src/ui/next/src/components/NetworkStatusIndicator.test.tsx
+++ b/src/ui/next/src/components/NetworkStatusIndicator.test.tsx
@@ -45,7 +45,7 @@ describe('NetworkStatusIndicator', () => {
     });
 
     // Check if the offline text is present
-    expect(screen.getByText('Offline Mode')).toBeInTheDocument();
+    expect(screen.getByText('Offline - Changes saved locally')).toBeInTheDocument();
   });
 
   it('applies the new Translucent Glass CSS classes', async () => {
@@ -59,7 +59,7 @@ describe('NetworkStatusIndicator', () => {
     });
 
     // Verify the div contains the specific Translucent Glass classes
-    const container = screen.getByText('Offline Mode').closest('div');
+    const container = screen.getByText('Offline - Changes saved locally').closest('div');
     expect(container).toHaveClass('bg-white/65');
     expect(container).toHaveClass('backdrop-blur-[30px]');
     expect(container).toHaveClass('saturate-[210%]');

--- a/src/ui/next/src/components/NetworkStatusIndicator.tsx
+++ b/src/ui/next/src/components/NetworkStatusIndicator.tsx
@@ -42,7 +42,7 @@ export function NetworkStatusIndicator() {
         <div className={`bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] px-4 py-1.5 rounded-full shadow border border-white/40 dark:border-white/10 flex items-center gap-2 pointer-events-auto animate-in slide-in-from-top duration-300`}>
           <div className={`w-2 h-2 rounded-full ${isOffline ? 'bg-amber-500' : 'bg-blue-500 animate-pulse'}`}></div>
           <span className="text-sm font-semibold text-gray-800">
-            {isOffline ? 'Offline Mode' : `Syncing ${syncQueueLength} action${syncQueueLength !== 1 ? 's' : ''}...`}
+            {isOffline ? 'Offline - Changes saved locally' : `Syncing ${syncQueueLength} action${syncQueueLength !== 1 ? 's' : ''}...`}
           </span>
         </div>
       </WithTooltip>

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -667,7 +667,7 @@
       <div id="network-status-indicator" class="hidden fixed top-2 left-1/2 transform -translate-x-1/2 z-50 flex items-center justify-center pointer-events-none" style="display: none;">
         <div class="bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] px-4 py-1.5 rounded-full shadow border border-white/40 dark:border-white/10 flex items-center gap-2 pointer-events-auto">
           <div id="network-status-dot" class="w-2 h-2 rounded-full bg-[#FF9500]"></div>
-          <span id="network-status-text" class="text-sm font-semibold text-gray-800">Working Offline</span>
+          <span id="network-status-text" class="text-sm font-semibold text-gray-800">Offline - Changes saved locally</span>
         </div>
       </div>
       <div id="queue-dashboard" class="hidden" style="display: none; background-color: #fef08a; color: #854d0e; padding: 12px; border-radius: 8px; margin-bottom: 16px; font-weight: bold; text-align: center;">0 Mutations Pending Sync</div>
@@ -3927,7 +3927,7 @@ document.addEventListener('DOMContentLoaded', () => {
             networkIndicator.style.display = "flex";
             networkIndicator.classList.remove("hidden");
             if (dot) dot.className = "w-2 h-2 rounded-full bg-[#FF9500]";
-            if (text) text.innerText = "Working Offline";
+            if (text) text.innerText = "Offline - Changes saved locally";
         } else if (queue.length > 0) {
             networkIndicator.style.display = "flex";
             networkIndicator.classList.remove("hidden");

--- a/src/ui/tauri/src/ui/pos.html
+++ b/src/ui/tauri/src/ui/pos.html
@@ -502,7 +502,7 @@
       <div id="network-status-indicator" class="hidden fixed top-2 left-1/2 transform -translate-x-1/2 z-50 flex items-center justify-center pointer-events-none" style="display: none;">
         <div class="bg-white/65 dark:bg-[#16161a]/70 backdrop-blur-[30px] saturate-[210%] px-4 py-1.5 rounded-full shadow border border-white/40 dark:border-white/10 flex items-center gap-2 pointer-events-auto">
           <div id="network-status-dot" class="w-2 h-2 rounded-full bg-yellow-400"></div>
-          <span id="network-status-text" class="text-sm font-semibold text-gray-800">Offline - Cash & Saved Cards Only</span>
+          <span id="network-status-text" class="text-sm font-semibold text-gray-800">Offline - Changes saved locally</span>
         </div>
       </div>
       <div id="queue-dashboard" class="hidden" style="display: none; background-color: #fef08a; color: #854d0e; padding: 12px; border-radius: 8px; margin-bottom: 16px; font-weight: bold; text-align: center;">0 Payments Pending Sync</div>
@@ -1945,7 +1945,7 @@ initWalkthrough();
             networkIndicator.style.display = "flex";
             networkIndicator.classList.remove("hidden");
             if (dot) dot.className = "w-2 h-2 rounded-full bg-yellow-400";
-            if (text) text.innerText = "Offline - Cash & Saved Cards Only";
+            if (text) text.innerText = "Offline - Changes saved locally";
         } else if (queue.length > 0) {
             networkIndicator.style.display = "flex";
             networkIndicator.classList.remove("hidden");


### PR DESCRIPTION
fix: update offline network indicator to match required UX

Resolves #33778

- Updated the network offline indicator text across all clients (`pos.html`, `dashboard.html`, and Next.js `NetworkStatusIndicator.tsx`) to match the "Offline - Changes saved locally" requirement from the issue.
- Updated the Playwright E2E tests (`degradation_validation.spec.ts`, `mobile_pos_offline_sync.spec.ts`, `pos_offline_payment_failure_agent.spec.ts`, `terminal_pos.spec.ts`, `test_offline_first_mesh.spec.ts`, `test_pos_offline_sync.spec.ts`) to assert the correct offline network status text and ensure CI passes.
- Confirmed that the remaining queue sync logic, SQLite/IndexedDB fallback (`@powersync/web`), exponential backoff, and idempotent backend event synchronization were already correctly implemented.

Product-use evidence:
- Persona: Fatima (Food Cart Operator) / Carlos (Field Service Owner).
- Journey: Navigating the OHC interface to `pos.html` or `dashboard.html` and setting the device to Airplane mode. 
- Gap observed: The status indicator read "Offline - Cash & Saved Cards Only" or "Working Offline" rather than assuring the owner that changes are safely queued.
- Post-fix: The top bar indicator now displays the required "Offline - Changes saved locally" message across the unified clients.

---
*PR created automatically by Jules for task [2191463144859180569](https://jules.google.com/task/2191463144859180569) started by @ql-owo-lp*