### PR TITLE
Fix UI glitches properly

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -1206,7 +1206,7 @@ html.dark .glass-panel {
   }
 }
 /* Global border radius to fix UI regression */
-.glassmorphism, .glass-card {
+.app-card, .glassmorphism, .glass-card {
   border-radius: 16px !important;
 }
 .glass-control {

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1046,11 +1046,11 @@
           min-height: 44px;
         }
         .persona-row {
-          flex-direction: column;
+          flex-direction: column !important;
         }
-        .work-context-cards {
+        .work-context-cards, #context-group {
           display: flex;
-          flex-direction: column;
+          flex-direction: column !important;
         }
       }
 
@@ -4348,13 +4348,11 @@
         if (el) {
           el.addEventListener('input', () => {
             // Remove error styling instantly
-            if (el.value.trim().length > 0) {
-              if (errEl) errEl.style.display = 'none';
-              el.classList.remove('invalid-input');
-            }
+            if (errEl) errEl.style.display = 'none';
+            el.classList.remove('invalid-input');
 
             // Sync to state and localStorage for cross-device resume
-            state[field.stateKey] = el.value.trim();
+            state[field.stateKey] = el.value;
             localStorage.setItem("onboardingState", JSON.stringify(state));
           });
         }


### PR DESCRIPTION
Fix UI glitches properly in globals.css and setup wizard

* Add `.app-card` to the list of elements using `.glassmorphism, .glass-card` for `16px !important` border radius.
* Add `#context-group` and `!important` to `flex-direction: column` at mobile media breakpoints to ensure the wizard displays single-column nicely on 375px rendering.
* Update real-time setup validation logic to use `el.value` instead of `.trim()` when storing the typing state so typing space works smoothly and instantly clears error states without `length > 0` condition on `.trim()`.

---
*PR created automatically by Jules for task [3282042869758184573](https://jules.google.com/task/3282042869758184573) started by @ql-owo-lp*