### PR TITLE
style(ui): fix setup nav button border radius to match design system

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -856,7 +856,7 @@ button,
   min-width: 44px;
   padding: 6px 10px;
   border: 1px solid #d8e0ea;
-  border-radius: 999px;
+  border-radius: 8px;
   background: #f7f9fb !important;
   color: #526070;
   box-shadow: none;


### PR DESCRIPTION
Updates the .setup-nav-button class in the global CSS to use an 8px border radius, aligning with the OHC Premium Token library's mandate for controls and inputs to have 8px corners rather than pill shapes (999px).

---
*PR created automatically by Jules for task [15122370872622482257](https://jules.google.com/task/15122370872622482257) started by @ql-owo-lp*