### PR TITLE
fix: correct KitchenView offline sync queue payload structures

### DIFF
--- a/src/ui/next/src/app/kitchen/page.tsx
+++ b/src/ui/next/src/app/kitchen/page.tsx
@@ -63,8 +63,8 @@ export default function KitchenView() {
     // Add to sync queue for eventual consistency
     await SyncManager.getInstance().enqueue({
       id: `e2e-product-${itemId}`,
-      type: "inventory_toggle",
-      payload: { soldOut: !currentStatus },
+      type: "TOGGLE_SOLD_OUT",
+      payload: { item_id: itemId, is_sold_out: !currentStatus },
       timestamp: Date.now()
     });
   };
@@ -76,8 +76,7 @@ export default function KitchenView() {
     await SyncManager.getInstance().enqueue({
       id: `order-ready-${orderId}`,
       type: "UPDATE_ORDER_STATUS",
-      orderId: orderId,
-      status: "ready",
+      payload: { order_id: orderId, status: "ready" },
       timestamp: Date.now()
     });
   };

--- a/src/ui/next/src/e2e/kitchen-offline.spec.ts
+++ b/src/ui/next/src/e2e/kitchen-offline.spec.ts
@@ -11,12 +11,12 @@ test.describe('Kitchen Command Center Offline Sync', () => {
     await page.reload();
 
     // Wait for page to load
-    await expect(page.locator('text=Kitchen Command Center')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=Kitchen Command Center').first()).toBeVisible({ timeout: 10000 });
   });
 
   test('performs optimistic UI updates and syncs queue when offline', async ({ page, context }) => {
     // Check initial state
-    await expect(page.locator('text=Active Orders')).toBeVisible();
+    await expect(page.locator('text=Active Orders').first()).toBeVisible();
 
     // The backend might return empty orders or mock data based on our changes
     // We want to test the toggle logic on Daily Menu items which should be present


### PR DESCRIPTION
Fixes optimistic UI update sync payload format in the offline event queue. SyncManager expects `item_id` and `order_id` in a `payload` field, but KitchenView was putting them flat on the action object. This PR updates `KitchenView` (at `src/ui/next/src/app/kitchen/page.tsx`) to pass `type: "TOGGLE_SOLD_OUT"` and `type: "UPDATE_ORDER_STATUS"` actions correctly. E2E test `kitchen-offline.spec.ts` was also updated to address ambiguity warnings.

Product-use evidence:
- Persona: Fatima (Food Cart Operator)
- Playwright E2E Flow Attempted: `src/ui/next/src/e2e/kitchen-offline.spec.ts`.
- CUJ Gap Observed: SyncManager was dropping necessary values (`order_id`, `item_id`) because they weren't wrapped under a `payload` key in the queued objects, leading to sync errors upon restoring connection.
- After fix: Playwright flow was repeated, resulting in tests passing and properly enqueueing the formatted actions.

Resolves #33778

---
*PR created automatically by Jules for task [13706930023017556612](https://jules.google.com/task/13706930023017556612) started by @ql-owo-lp*