### PR TITLE
Fix: Resolve unused function compiler warning

### DIFF
--- a/src/server/services/onboarding/onboarding_agent.rs
+++ b/src/server/services/onboarding/onboarding_agent.rs
@@ -60,6 +60,7 @@ pub struct OnboardingAgent {
 }
 
 
+#[allow(dead_code)]
 fn repair_truncated_json(input: &str) -> Result<IntakeData, String> {
     serde_json::from_str(input).or_else(|_| {
         let mut clean = String::with_capacity(input.len() + 10);


### PR DESCRIPTION
- Suppressed `repair_truncated_json` unused function warning to resolve compiler warning output in `src/server/services/onboarding/onboarding_agent.rs`.

---
*PR created automatically by Jules for task [1426111809823961390](https://jules.google.com/task/1426111809823961390) started by @ql-owo-lp*