### PR TITLE
💰 Miser: Fix budget health alert threshold logic for dashboard

### DIFF
--- a/src/server/pricing/budget.rs
+++ b/src/server/pricing/budget.rs
@@ -92,10 +92,10 @@ impl BudgetManager {
 
     pub fn is_projected_cost_over_threshold(&self, projected_cost_cents: i64) -> bool {
         if self.total_limit_cents <= 0 {
-            return projected_cost_cents > 0;
+            return projected_cost_cents > 0 || self.current.load(Ordering::SeqCst) > 0;
         }
         let limit_threshold_cents = ((self.total_limit_cents as f64) * (self.alert_threshold_percent / 100.0)).round() as i64;
-        projected_cost_cents >= limit_threshold_cents
+        projected_cost_cents >= limit_threshold_cents || self.current.load(Ordering::SeqCst) >= limit_threshold_cents
     }
 
     pub fn check_alert_threshold_cents(&self, total_limit_cents: i64) -> bool {


### PR DESCRIPTION
Fixes the budget health alert condition to prevent users from missing soft limit alerts if they reach the threshold. Modifies `is_projected_cost_over_threshold` to include `self.current.load(Ordering::SeqCst)` in the threshold checks.

**Product-use evidence:**
- Persona: Nora (Agency Principal) using the dashboard to review AI spend limits.
- Flow attempted: Playwright UI E2E suite (`src/e2e/test_billing_limits.spec.ts`) simulated reaching soft limit thresholds (e.g. $2000 on the Starter Plan).
- CUJ gap observed: The "Cost Soft Limit friendly prompt shows" E2E test failed. The dashboard failed to conditionally render the "Soft Limit Approaching" alert component (`#budget-health-alert-text`). The `is_projected_cost_over_threshold` in `src/server/pricing/budget.rs` was not verifying the actual current cost, meaning if projection tracking lagged, the alert didn't show even if `self.current` tracked the accurate high usage.
- Fix: Corrected `is_projected_cost_over_threshold` to fall back to validating `self.current.load(Ordering::SeqCst) >= limit_threshold_cents` so it doesn't solely rely on the single passed projection parameter.
- Verification: E2E and Unit test suites (`bazelisk test //...` and `bazelisk test //src/e2e:playwright`) pass.

---
*PR created automatically by Jules for task [841302372596068345](https://jules.google.com/task/841302372596068345) started by @ql-owo-lp*