### PR TITLE
fix(sync): resolve local-first offline sync engine gaps for local SQLite mutations

### DIFF
--- a/src/ui/next/src/app/api/v1/sync/operation-intents/route.ts
+++ b/src/ui/next/src/app/api/v1/sync/operation-intents/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { backendHeaders } from "../../../../../ui/backendProxy";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const backendUrl = process.env.BACKEND_URL || 'http://127.0.0.1:18789';
+
+    const headers = backendHeaders(request, true);
+    if (!headers.has("x-spiffe-id") && request.headers.has("x-spiffe-id")) {
+       headers.set("x-spiffe-id", request.headers.get("x-spiffe-id") as string);
+    }
+
+    if (!headers.has("x-tenant-id") && request.headers.has("x-tenant-id")) {
+       headers.set("x-tenant-id", request.headers.get("x-tenant-id") as string);
+    }
+
+    const res = await fetch(`${backendUrl}/api/v1/sync/operation-intents`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body)
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      return NextResponse.json(data, { status: 200 });
+    } else {
+      const errorText = await res.text();
+      return NextResponse.json({ success: false, error: errorText }, { status: res.status });
+    }
+  } catch (err: any) {
+    console.error("Failed to forward operation intents:", err);
+    return NextResponse.json({ success: false, error: err.message }, { status: 500 });
+  }
+}

--- a/src/ui/next/src/app/kitchen/page.tsx
+++ b/src/ui/next/src/app/kitchen/page.tsx
@@ -63,8 +63,8 @@ export default function KitchenView() {
     // Add to sync queue for eventual consistency
     await SyncManager.getInstance().enqueue({
       id: `e2e-product-${itemId}`,
-      type: "inventory_toggle",
-      payload: { soldOut: !currentStatus },
+      type: "TOGGLE_SOLD_OUT",
+      payload: { item_id: itemId, is_sold_out: !currentStatus },
       timestamp: Date.now()
     });
   };
@@ -76,8 +76,10 @@ export default function KitchenView() {
     await SyncManager.getInstance().enqueue({
       id: `order-ready-${orderId}`,
       type: "UPDATE_ORDER_STATUS",
-      orderId: orderId,
-      status: "ready",
+      payload: {
+        order_id: orderId,
+        status: "ready"
+      },
       timestamp: Date.now()
     });
   };

--- a/src/ui/next/src/e2e/kitchen-offline.spec.ts
+++ b/src/ui/next/src/e2e/kitchen-offline.spec.ts
@@ -1,57 +1,56 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Kitchen Command Center Offline Sync', () => {
-  test.describe.configure({ mode: 'serial' });
+test.describe('Kitchen Command Center Offline-First Edge Client', () => {
+  test('optimistically updates UI and queues offline events then syncs when back online', async ({ page, context, request }) => {
+    await page.setViewportSize({ width: 375, height: 667 }); // Target Fatima's mobile context
 
-  test.beforeEach(async ({ page, context }) => {
-    // Clear cookies and state
-    await context.clearCookies();
+    // Create a product to ensure we have a menu item to click on
+    const loginRes = await request.post('/api/v1/auth/login', {
+        data: { email: 'admin@ohc.local', password: 'admin' }
+    });
+    expect(loginRes.ok()).toBeTruthy();
+    const { token, user } = await loginRes.json();
+
+    const productTitle = 'E2E Offline Kitchen ' + Date.now();
+    const createRes = await request.post('/api/v1/catalog/products', {
+        headers: { Authorization: `Bearer ${token}` },
+        data: {
+            title: productTitle,
+            price_cents: 800,
+            inventory_count: 5
+        }
+    });
+    expect(createRes.ok()).toBeTruthy();
+
     await page.goto('/kitchen');
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
+    await page.evaluate(() => localStorage.setItem('tenant_id', 'tenant-e2e-kitchen'));
 
-    // Wait for page to load
-    await expect(page.locator('text=Kitchen Command Center')).toBeVisible({ timeout: 10000 });
-  });
-
-  test('performs optimistic UI updates and syncs queue when offline', async ({ page, context }) => {
-    // Check initial state
-    await expect(page.locator('text=Active Orders')).toBeVisible();
-
-    // The backend might return empty orders or mock data based on our changes
-    // We want to test the toggle logic on Daily Menu items which should be present
-    await expect(page.locator('text=Daily Menu')).toBeVisible();
+    // Wait for the Kitchen UI to load completely
+    await expect(page.locator('text=Kitchen Command Center')).toBeVisible();
 
     const toggleButton = page.locator('button[id^="sold-out-toggle-"]').first();
+    await expect(toggleButton).toBeVisible({ timeout: 15000 });
 
-    // Check if there are menu items to toggle.
-    // If empty state, this test might need a seeded item, but let's assume we have items.
-    const hasMenuItems = await toggleButton.count() > 0;
-    if (!hasMenuItems) {
-        // If no menu items, test passes as vacuous true (nothing to toggle)
-        return;
-    }
-
-    const initialText = await toggleButton.textContent() || '';
-
-    // Set network to offline
+    // Go offline
     await context.setOffline(true);
     await page.evaluate(() => window.dispatchEvent(new Event('offline')));
 
-    // Perform optimistic action: Toggle sold out
+    const initialText = await toggleButton.textContent() || '';
+
+    // Real user click
     await toggleButton.click();
 
-    // Expect the text to change optimistically
+    // Verify optimistic UI
     await expect(toggleButton).not.toHaveText(initialText);
 
-    // Expect the Pending Sync indicator to show up
-    await expect(page.locator('text=Pending Sync')).toBeVisible();
+    // Pending Sync Banner Check
+    await expect(page.locator('id=queue-dashboard')).toBeVisible({ timeout: 10000 });
 
-    // Restore network
+    // Go back online
     await context.setOffline(false);
     await page.evaluate(() => window.dispatchEvent(new Event('online')));
 
-    // Expect offline badge to disappear (queue should process)
-    await expect(page.locator('text=Pending Sync')).toBeHidden({ timeout: 15000 });
+    // The SyncManager should trigger and clear the queue, hiding the banner
+    await expect(page.locator('id=queue-dashboard')).toBeHidden({ timeout: 15000 });
   });
 });

--- a/src/ui/next/src/lib/powersync/AppSchema.ts
+++ b/src/ui/next/src/lib/powersync/AppSchema.ts
@@ -25,8 +25,8 @@ const omniInboxMessages = new Table({
   updated_at: column.text
 });
 
-const pendingActions = new Table({
-  id: column.text, // added id column to make the insert work properly
+const localPendingActions = new Table({
+  id: column.text,
   type: column.text,
   payload: column.text,
   timestamp: column.integer
@@ -98,7 +98,7 @@ export const AppSchema = new Schema({
   service_routes: serviceRoutes,
   agent_feed_items: agentFeedItems,
   omni_inbox_messages: omniInboxMessages,
-  pending_actions: pendingActions,
+  local_pending_actions: localPendingActions,
   pos_offline_transactions: posOfflineTransactions,
   pos_terminal_sessions: posTerminalSessions
 });

--- a/src/ui/next/src/lib/sync/SyncManager.ts
+++ b/src/ui/next/src/lib/sync/SyncManager.ts
@@ -170,22 +170,27 @@ export class SyncManager {
         .filter(m => m.type === 'UPDATE_ORDER_STATUS' || m.type === 'TOGGLE_SOLD_OUT')
         .map(m => {
           if (m.type === 'UPDATE_ORDER_STATUS') {
+             // Extract payload correctly whether it's wrapped in payload or directly on the object
+             const payloadData = m.payload || m;
+             const orderId = payloadData.order_id || payloadData.orderId;
              return {
                 id: m.id,
                 entity_type: 'order',
-                entity_id: m.payload.order_id,
+                entity_id: orderId,
                 action_type: 'UpdateStatus',
-                payload: m.payload,
+                payload: payloadData,
                 base_version: 1,
                 timestamp: new Date(m.timestamp || Date.now()).toISOString()
              };
           } else {
+             const payloadData = m.payload || m;
+             const itemId = payloadData.item_id || payloadData.itemId;
              return {
                 id: m.id,
                 entity_type: 'product',
-                entity_id: m.payload.item_id,
+                entity_id: itemId,
                 action_type: 'ToggleSoldOut',
-                payload: m.payload,
+                payload: payloadData,
                 base_version: 1,
                 timestamp: new Date(m.timestamp || Date.now()).toISOString()
              };


### PR DESCRIPTION
This PR introduces robustness to the OHC Mobile Offline-First Sync Engine:
1. Ensure the `local_pending_actions` table name is consistent between the generic SQLite creation in `db.ts` and the PowerSync specific mapping in `AppSchema.ts`.
2. Fixes payload mapping for `UPDATE_ORDER_STATUS` and `TOGGLE_SOLD_OUT` offline mutations in `SyncManager.ts` by checking if the payload is directly embedded or mapped within a `.payload` wrapper.
3. Exposes the `/api/v1/sync/operation-intents` proxy correctly on the Next.js API layer.
4. Adds a functional Playwright E2E test `kitchen-offline.spec.ts` that specifically tests offline sync operations like queueing when the network disconnects and auto-syncing when restored.

---
*PR created automatically by Jules for task [4456191073164183645](https://jules.google.com/task/4456191073164183645) started by @ql-owo-lp*

Resolves #33778