### PR TITLE
Fix flaky chaos test by yielding tokio executor

### DIFF
--- a/src/server/benchmarks/chaos_bench.rs
+++ b/src/server/benchmarks/chaos_bench.rs
@@ -32,6 +32,8 @@ mod tests {
         // We use tokio::time::advance to instantly bypass the 2s lock duration
         // without sleeping in real-time, removing flakiness in CI.
         tokio::time::advance(Duration::from_secs(3)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
 
         let acquired2_retry = transport.acquire_lock(&resource, "agent_2", 2).await.unwrap_or(false);
         assert!(acquired2_retry, "Agent 2 failed to acquire lock after wait");


### PR DESCRIPTION
This change addresses the flakiness in the `test_simulate_sql_sync_lag` chaos benchmark test. When using `tokio::time::advance`, the test was not consistently allowing the lock retry background task to execute before evaluating the assertions. By adding `tokio::task::yield_now().await`, we ensure the executor yields control, allowing pending background timers and retries to process deterministically. This resolves intermittent CI failures without resorting to real-time sleeps.

---
*PR created automatically by Jules for task [8193635448240827146](https://jules.google.com/task/8193635448240827146) started by @ql-owo-lp*