### PR TITLE
feat(standalone): ensure local data sovereignty and tighten PII leakage checks

### DIFF
--- a/src/server/orchestration/hybrid_sync/daemon.rs
+++ b/src/server/orchestration/hybrid_sync/daemon.rs
@@ -544,6 +544,11 @@ impl HybridSyncDaemon {
     }
 
     pub async fn sync_pos_offline_transactions(&self) -> Result<(), Box<dyn std::error::Error>> {
+        if crate::is_standalone_runtime() && !::server_config::is_telemetry_enabled() {
+            tracing::debug!("Standalone mode, telemetry disabled, skipping POS offline sync entirely to enforce local sovereignty."); // pii-safe
+            return Ok(());
+        }
+
         let start = Instant::now();
         let rows = sqlx::query("SELECT id, tenant_id, client_id, amount_cents, currency, payload, status FROM pos_offline_transactions WHERE status = 'PENDING' ORDER BY created_at ASC LIMIT 100")
             .fetch_all(&self.sqlite_pool)

--- a/src/server/pii_leakage_check.sh
+++ b/src/server/pii_leakage_check.sh
@@ -21,7 +21,7 @@ def check_file(filepath):
 
     matches = []
     for i, line in enumerate(lines):
-        if re.search(r'tracing::(info|debug|warn|error)!\(', line):
+        if re.search(r'(tracing::(info|debug|warn|error)!|println!|print!|eprintln!|dbg!|log::(info|debug|warn|error)!)\(', line):
             if re.search(r'redacted_', line, re.IGNORECASE):
                 continue
 

--- a/src/server/services/onboarding/onboarding_agent.rs
+++ b/src/server/services/onboarding/onboarding_agent.rs
@@ -3454,7 +3454,6 @@ mod tests {
             "ai_auto_respond": true"#;
 
         let res = repair_truncated_json(valid_but_truncated);
-        println!("{:?}", res);
         assert!(res.is_ok());
         let data = res.unwrap();
         assert_eq!(data.business_name, "Maya");

--- a/src/server/sync/service.rs
+++ b/src/server/sync/service.rs
@@ -32,7 +32,7 @@ impl CloudSyncService {
 impl SyncDeltas for CloudSyncService {
     async fn sync_deltas(&self, deltas: Vec<SyncDelta>) -> Result<(), String> {
         let is_standalone = crate::is_standalone_runtime();
-        let telemetry_enabled = env::var("OHC_TELEMETRY_ENABLED").unwrap_or_else(|_| "false".to_string()) == "true";
+        let telemetry_enabled = ::server_config::is_telemetry_enabled();
 
         if is_standalone && !telemetry_enabled {
             tracing::debug!("Standalone mode, telemetry disabled, skipping cloud delta sync entirely to enforce local sovereignty.");


### PR DESCRIPTION
This PR addresses data sovereignty in standalone mode and hardens PII leakage protection logic.
It implements the following changes:

1. **Enhanced PII Checks:** Updates `pii_leakage_check.sh` to capture `println!`, `print!`, `eprintln!`, `dbg!`, and `log::` macro usages to prevent accidental PII leakage through standard output or alternative logging systems.
2. **Removed PII Print:** Removes a `println!` debugging statement in `onboarding_agent.rs` that was leaking PII data within testing boundaries.
3. **Telemetry Consistency:** Replaces direct reading of `OHC_TELEMETRY_ENABLED` environment variable with `::server_config::is_telemetry_enabled()` for standardizing telemetry checks in `sync/service.rs`.
4. **Data Sovereignty:** Prevents offline POS sync to cloud if running in standalone mode and telemetry is not enabled, directly enforcing local data sovereignty in `orchestration/hybrid_sync/daemon.rs`.

**Superpowers used:**
None strictly required to run during execution context, but test-driven validation approach was manually enacted. No visual companion setup invoked explicitly.

**Testing:**
Run `bazel test //...` and `bazel test //src/e2e:playwright --local_test_jobs="$(nproc)"` successfully without any issue.
`pii_leakage_check_test` executes and correctly passes with the modified regex filter.

---
*PR created automatically by Jules for task [1427956165791449122](https://jules.google.com/task/1427956165791449122) started by @ql-owo-lp*