### PR TITLE
✍️ Scribe: Implement documentation features and style updates

### DIFF
--- a/src/ui/next/src/app/api-docs/page.tsx
+++ b/src/ui/next/src/app/api-docs/page.tsx
@@ -45,7 +45,7 @@ export default function ApiDocsPage() {
         .swagger-ui table { display: block; overflow-x: auto; max-width: 100%; box-sizing: border-box; }
         .swagger-ui .markdown p { word-break: break-word; box-sizing: border-box; }
         .swagger-ui .info { margin: 20px 0; box-sizing: border-box; }
-        .swagger-ui .scheme-container { background: transparent; padding: 10px 0; margin-bottom: 20px; border-radius: 12px; box-shadow: none; border: 1px solid rgba(0,0,0,0.1); box-sizing: border-box; width: 100%; }
+        .swagger-ui .scheme-container { background: transparent; padding: 10px 0; margin-bottom: 20px; border-radius: 12px; box-shadow: none; background: rgba(255, 255, 255, 0.4); backdrop-filter: blur(20px); box-shadow: 0 4px 12px rgba(0,0,0,0.05); border: 1px solid rgba(255,255,255,0.3); box-sizing: border-box; width: 100%; }
         .swagger-ui .responses-inner { overflow-x: auto; max-width: 100%; box-sizing: border-box; }
         .swagger-ui .model-box { overflow-x: auto; max-width: 100%; box-sizing: border-box; }
         .swagger-ui .opblock-tag { font-size: 20px; padding: 10px; box-sizing: border-box; }

--- a/src/ui/next/src/components/Walkthrough.tsx
+++ b/src/ui/next/src/components/Walkthrough.tsx
@@ -144,7 +144,7 @@ export function InteractiveWalkthrough({ steps, isOpen, onClose, onComplete }: W
         role="dialog"
         aria-label={`${currentStep.title} walkthrough step`}
         id="walkthrough-bubble"
-        className="ohc-walkthrough-bubble fixed z-[10000] backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.15)] p-6 w-[300px] max-w-[calc(100vw-32px)] font-inter animate-pop-in"
+        className="ohc-walkthrough-bubble fixed z-[10000] backdrop-blur-[30px] saturate-[210%] bg-white/65 dark:bg-[#16161a]/70 border border-white/40 dark:border-white/10 shadow-[0_12px_40px_rgba(0,0,0,0.2)] p-6 w-[300px] max-w-[calc(100vw-32px)] font-inter animate-pop-in"
         style={bubbleStyle}
       >
         {targetRect && (
@@ -153,7 +153,7 @@ export function InteractiveWalkthrough({ steps, isOpen, onClose, onComplete }: W
 
         <div className="flex justify-between items-start mb-3">
           <h4 className="font-bold font-outfit text-gray-900 dark:text-gray-100 text-lg leading-tight pr-4">{currentStep.title}</h4>
-          <button onClick={handleSkip} id="wt-close" className="wt-close text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 bg-black/5 hover:bg-black/10 dark:bg-white/5 dark:hover:bg-white/10 backdrop-blur-[30px] saturate-[210%] rounded-full p-1.5 transition-all flex-shrink-0">
+          <button onClick={handleSkip} id="wt-close" className="wt-close text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 bg-black/10 hover:bg-black/20 dark:bg-white/10 dark:hover:bg-white/20 backdrop-blur-[30px] saturate-[210%] rounded-full p-1.5 transition-all flex-shrink-0">
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
           </button>
         </div>

--- a/src/ui/next/src/components/help.tsx
+++ b/src/ui/next/src/components/help.tsx
@@ -218,7 +218,7 @@ export function HelpWidget() {
           <button
             id="ohc-floating-help-btn"
             onClick={() => setOpen(!open)}
-            className="w-14 h-14 bg-blue-600/90 backdrop-blur-[20px] saturate-200 text-white rounded-full shadow-[0_8px_32px_rgba(37,99,235,0.3)] flex items-center justify-center hover:bg-blue-700/90 active:scale-95 transition-all min-h-[44px] min-w-[44px]"
+            className="w-14 h-14 bg-blue-600/90 backdrop-blur-[30px] saturate-200 text-white rounded-full shadow-[0_12px_40px_rgba(37,99,235,0.4)] flex items-center justify-center hover:bg-blue-700/90 active:scale-95 transition-all min-h-[44px] min-w-[44px]"
             aria-label="Open help chat"
           >
             <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -310,7 +310,7 @@ export function HelpWidget() {
                       setOpen(false);
                       router.push("/kairos?walkthrough=true");
                     }}
-                    className="w-full text-left bg-indigo-50/80 backdrop-blur-[20px] saturate-200 p-4 rounded-2xl shadow-sm border border-indigo-100 hover:bg-indigo-100/90 hover:shadow-md transition-all min-h-[44px]"
+                    className="w-full text-left bg-indigo-50/80 backdrop-blur-[30px] saturate-200 p-4 rounded-2xl shadow-sm border border-indigo-100 hover:bg-indigo-100/90 hover:shadow-md transition-all min-h-[44px]"
                   >
                     <span className="font-bold font-outfit text-indigo-800 text-base block">Tour: KAIROS AI OS Orchestration</span>
                   </button>


### PR DESCRIPTION
Enhanced UI documentation components to better align with the OHC Premium tokens (macOS Translucent Glass styles).

Changes:
1. `src/ui/next/src/app/api-docs/page.tsx`: Replaced standard `.swagger-ui .scheme-container` styling with translucent glass styling.
2. `src/ui/next/src/components/Walkthrough.tsx`: Updated the Walkthrough bubble shadow depth and close button contrast for a premium look.
3. `src/ui/next/src/components/help.tsx`: Enhanced the floating help widget button with deeper shadow and stronger `backdrop-blur` class.

---
*PR created automatically by Jules for task [1463454846452120601](https://jules.google.com/task/1463454846452120601) started by @ql-owo-lp*