### PR TITLE
fix(memory): adjust pgvector lateral join syntax

### DIFF
--- a/src/agents/builtin/memory_store.rs
+++ b/src/agents/builtin/memory_store.rs
@@ -899,9 +899,10 @@ impl VectorRepository {
                         FROM consolidated_memory b_inner
                         WHERE b_inner.tenant_id = a.tenant_id
                           AND b_inner.id > a.id
+                          AND b_inner.embedding <=> a.embedding < 0.05
                         ORDER BY b_inner.embedding <=> a.embedding
                         LIMIT 1
-                    ) b ON a.embedding <=> b.embedding < 0.05
+                    ) b ON true
                     LIMIT 100
                 ";
                 let rows = sqlx::query(query)


### PR DESCRIPTION
Fixed a bug where the conflict resolution system failed to appropriately pick conflicting pairs of semantic memory records inside PostgreSQL by applying the `< 0.05` constraint as part of the `WHERE` clauses for the lateral subquery instead of the external `ON` condition, allowing the `ORDER BY ... LIMIT 1` inner query to effectively evaluate similarity metrics.

---
*PR created automatically by Jules for task [17393962048299915062](https://jules.google.com/task/17393962048299915062) started by @ql-owo-lp*