### PR TITLE
test: Fix concurrency synchronization in chaos lock race conditions

### DIFF
--- a/src/server/orchestration/chaos_test.rs
+++ b/src/server/orchestration/chaos_test.rs
@@ -1014,11 +1014,17 @@ async fn test_redis_agent_lock_race_condition() {
     let l2 = mock_lock.clone();
 
     // Spawn two tasks racing to acquire the same lock, with simulated network lag
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+    let b1 = barrier.clone();
     let h1 = tokio::spawn(async move {
+        b1.wait().await;
         l1.acquire_with_chaos(".agent-lock/test", 10).await.unwrap()
     });
 
+    let b2 = barrier.clone();
     let h2 = tokio::spawn(async move {
+        b2.wait().await;
         l2.acquire_with_chaos(".agent-lock/test", 12).await.unwrap()
     });
 


### PR DESCRIPTION
This PR introduces synchronization to `test_redis_agent_lock_race_condition` within `src/server/orchestration/chaos_test.rs` to guarantee the chaos test actually runs as a concurrent race.

Previously, async tasks were spawned consecutively without forcing them to block and wait for one another. This could cause the first spawned task to execute its lock acquisition entirely before the scheduler even started the second task, rendering the "race condition" test moot.

By injecting a `tokio::sync::Barrier`, both tasks are now held precisely until both are spawned and ready, causing genuine simultaneous execution and accurately validating the underlying ML-Resilience lock protections under high contention.

---
*PR created automatically by Jules for task [16624329571693534400](https://jules.google.com/task/16624329571693534400) started by @ql-owo-lp*