### PR TITLE
Fix onboarding E2E test for draft restoration and remove unused mut warning

### DIFF
--- a/src/server/api/audio_command.rs
+++ b/src/server/api/audio_command.rs
@@ -98,7 +98,7 @@ pub async fn handle_voice_command(
 
     let api_key = std::env::var("MINIMAX_API_KEY").unwrap_or_else(|_| "fake-key".to_string());
 
-    let (mut dept, description, mut action_payload, final_transcription) = if api_key.is_empty() || api_key == "fake-key" {
+    let (dept, description, mut action_payload, final_transcription) = if api_key.is_empty() || api_key == "fake-key" {
         // Fallback for missing api key (tests)
         if transcription.contains("quote") {
             let total = 35000;

--- a/src/ui/next/src/e2e/onboarding.spec.ts
+++ b/src/ui/next/src/e2e/onboarding.spec.ts
@@ -167,7 +167,11 @@ test.describe('OnboardingWizard CUJ', () => {
     expect(lsStore).toContain('My Restored Business');
 
     // 2. Clear local storage to simulate device switch
+    const userId = await page.evaluate(() => window.localStorage.getItem('user_id'));
+    const tenantId = await page.evaluate(() => window.localStorage.getItem('tenant_id'));
     await page.evaluate(() => window.localStorage.clear());
+    if (userId) await page.evaluate((uid) => window.localStorage.setItem('user_id', uid), userId);
+    if (tenantId) await page.evaluate((tid) => window.localStorage.setItem('tenant_id', tid), tenantId);
 
     // 3. Reload page and check restoration
     await page.reload();


### PR DESCRIPTION
Fix onboarding E2E test for draft restoration and remove unused mut warning

---
*PR created automatically by Jules for task [9520091147409445465](https://jules.google.com/task/9520091147409445465) started by @ql-owo-lp*