### PR TITLE
chore: optimize Postgres array batch queries in memory components

### DIFF
--- a/src/agents/builtin/memory_store.rs
+++ b/src/agents/builtin/memory_store.rs
@@ -593,24 +593,22 @@ impl VectorRepository {
         if source_types.is_empty() {
             return Ok(());
         }
-        let placeholders: Vec<String> = (1..=source_types.len()).map(|i| format!("${}", i + 3)).collect();
-        let in_clause = placeholders.join(", ");
-        let query_pg = format!("DELETE FROM consolidated_memory WHERE (last_referenced_at < $1 AND owner_override = FALSE AND reference_count < $2 AND source_type IN ({})) OR (reliability_score < $3 AND owner_override = FALSE AND last_referenced_at < $1)", in_clause);
-
         let placeholders_sqlite: Vec<String> = source_types.iter().map(|_| "?".to_string()).collect();
         let in_clause_sqlite = placeholders_sqlite.join(", ");
         let query_sqlite = format!("DELETE FROM consolidated_memory WHERE (last_referenced_at < ? AND owner_override = FALSE AND reference_count < ? AND source_type IN ({})) OR (reliability_score < ? AND owner_override = FALSE AND last_referenced_at < ?)", in_clause_sqlite);
 
         match &self.store {
             VectorMemoryStore::Postgres(pool) => {
-                let mut query = sqlx::query(&query_pg)
+                let query_pg = "DELETE FROM consolidated_memory WHERE (last_referenced_at < $1 AND owner_override = FALSE AND reference_count < $2 AND source_type = ANY($4)) OR (reliability_score < $3 AND owner_override = FALSE AND last_referenced_at < $1)";
+
+                let source_types_vec: Vec<String> = source_types.iter().map(|s| s.to_string()).collect();
+
+                sqlx::query(query_pg)
                     .bind(older_than)
                     .bind(max_reference_count)
-                    .bind(min_reliability);
-                for st in source_types {
-                    query = query.bind(st);
-                }
-                query.execute(pool).await.map_err(|e| e.to_string())?;
+                    .bind(min_reliability)
+                    .bind(&source_types_vec)
+                    .execute(pool).await.map_err(|e| e.to_string())?;
             }
             VectorMemoryStore::Sqlite(pool) => {
                 let mut query = sqlx::query(&query_sqlite)


### PR DESCRIPTION
chore: optimize Postgres array batch queries in memory components

Replaced dynamic iterative IN clauses with robust = ANY($x) bind logic
in agent_memory_pipeline.rs and memory_store.rs. This reduces parsing overhead
for the Postgres query planner and simplifies the Rust code by relying
on proper array binding.

Superpowers loaded: [verification-before-completion, subagent-driven-development]

---
*PR created automatically by Jules for task [710535226618709013](https://jules.google.com/task/710535226618709013) started by @ql-owo-lp*