### PR TITLE
🎨 Canvas: Omni-Channel POS Inventory Sync

### DIFF
--- a/src/server/services/inventory/service.rs
+++ b/src/server/services/inventory/service.rs
@@ -534,6 +534,28 @@ impl InventoryService {
             .await
             .unwrap_or(None);
 
+        if update_result.is_some() {
+            let inventory_level_res = sqlx::query("SELECT id FROM inventory_levels WHERE variant_id = $1 AND tenant_id = $2")
+                .bind(product_id)
+                .bind(tenant_id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| e.to_string())?;
+
+            if let Some(row) = inventory_level_res {
+                let level_id: String = sqlx::Row::get(&row, "id");
+                let tx_id = uuid::Uuid::new_v4().to_string();
+                sqlx::query("INSERT INTO inventory_transactions (id, tenant_id, inventory_level_id, type, quantity_change) VALUES ($1, $2, $3, 'SALE', -$4)")
+                    .bind(&tx_id)
+                    .bind(tenant_id)
+                    .bind(level_id)
+                    .bind(quantity)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+
         if update_result.is_none() {
             // Enforce row-level locking for final commit on legacy
             let _ = sqlx::query("SELECT inventory_count FROM products WHERE id = $1 AND tenant_id = $2 FOR UPDATE")

--- a/src/server/workers/pos_sync_worker.rs
+++ b/src/server/workers/pos_sync_worker.rs
@@ -235,6 +235,27 @@ impl crate::queue::TaskJobHandler for PosSyncWorker {
                     .execute(&mut *tx)
                     .await;
 
+                let inventory_level_res = sqlx::query("UPDATE inventory_levels SET available_count = GREATEST(0, available_count - $1) WHERE variant_id = $2 AND tenant_id = $3 RETURNING id")
+                    .bind(quantity_deducted)
+                    .bind(product_id)
+                    .bind(&job.tenant_id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| e.to_string())?;
+
+                if let Some(row) = inventory_level_res {
+                    let level_id: String = sqlx::Row::get(&row, "id");
+                    let tx_id = uuid::Uuid::new_v4().to_string();
+                    sqlx::query("INSERT INTO inventory_transactions (id, tenant_id, inventory_level_id, type, quantity_change) VALUES ($1, $2, $3, 'OFFLINE_POS_SYNC', -$4)")
+                        .bind(&tx_id)
+                        .bind(&job.tenant_id)
+                        .bind(level_id)
+                        .bind(quantity_deducted)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                }
+
                 // Record order for offline sync
                 let order_id = uuid::Uuid::new_v4().to_string();
                 let total_amount = (amount_cents as f64) / 100.0;
@@ -457,6 +478,27 @@ impl crate::queue::TaskJobHandler for PosSyncWorker {
                                 .bind(&job.tenant_id)
                                 .execute(&mut *tx)
                                 .await;
+
+                            let inventory_level_res = sqlx::query("UPDATE inventory_levels SET available_count = GREATEST(0, available_count - $1) WHERE variant_id = $2 AND tenant_id = $3 RETURNING id")
+                                .bind(qty)
+                                .bind(product_id)
+                                .bind(&job.tenant_id)
+                                .fetch_optional(&mut *tx)
+                                .await
+                                .map_err(|e| e.to_string())?;
+
+                            if let Some(row) = inventory_level_res {
+                                let level_id: String = sqlx::Row::get(&row, "id");
+                                let tx_id = uuid::Uuid::new_v4().to_string();
+                                sqlx::query("INSERT INTO inventory_transactions (id, tenant_id, inventory_level_id, type, quantity_change) VALUES ($1, $2, $3, 'OFFLINE_POS_SYNC', -$4)")
+                                    .bind(&tx_id)
+                                    .bind(&job.tenant_id)
+                                    .bind(level_id)
+                                    .bind(qty)
+                                    .execute(&mut *tx)
+                                    .await
+                                    .map_err(|e| e.to_string())?;
+                            }
 
                             let new_stock = std::cmp::max(0, stock - qty as i32);
 


### PR DESCRIPTION
Resolves #33877

This implements the logic to record multi-channel inventory updates properly to `inventory_levels` directly through the backend worker parsing mutations from POS Terminal operations.
Errors are mapped correctly to ensure that the process fails cleanly without swallowing any issues with database connections.

---
*PR created automatically by Jules for task [17570418594848377549](https://jules.google.com/task/17570418594848377549) started by @ql-owo-lp*