### PR TITLE
Fix flaky touch target tests in setup wizard and enforce min-height

### DIFF
--- a/src/e2e/setup.spec.ts
+++ b/src/e2e/setup.spec.ts
@@ -113,6 +113,7 @@ test.describe.serial('OHC Setup Wizard Flow', () => {
       });
     expect(hasHorizontalScroll).toBe(false);
     // Verify touch targets height
+    await page.locator('.next-step-btn').first().waitFor({ state: 'visible' });
     const btnBox = await page.locator('.next-step-btn').first().boundingBox();
     expect(btnBox?.height).toBeGreaterThanOrEqual(44);
   });
@@ -248,6 +249,7 @@ test.describe('OHC Setup Wizard Form Configuration', () => {
     await page.setViewportSize({ width: 375, height: 812   });
     await page.goto('http://mock/setup.html');
     // Verify touch targets height
+    await page.locator('.next-step-btn').first().waitFor({ state: 'visible' });
     const btnBox = await page.locator('.next-step-btn').first().boundingBox();
     expect(btnBox?.height).toBeGreaterThanOrEqual(44);
     });
@@ -255,7 +257,8 @@ test.describe('OHC Setup Wizard Form Configuration', () => {
     await page.setViewportSize({ width: 375, height: 812   });
     await page.goto('http://mock/setup.html');
     await page.locator('[data-testid="next-step-btn"][data-next="step-context"]').click();
-    const inputbox = await page.locator('label.context-card').first().boundingBox();
+    await page.locator("label.context-card").first().waitFor({ state: "visible" });
+    const inputbox = await page.locator("label.context-card").first().boundingBox();
     expect(inputbox?.height).toBeGreaterThanOrEqual(44);
     });
   });

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1620,7 +1620,7 @@
               class="glass-control glassmorphism"
               style="
                 width: 44px;
-                height: 44px;
+                min-height: 44px;
                 min-width: 44px;
                 padding: 0;
                 display: flex;
@@ -1674,7 +1674,7 @@
               class="glass-control glassmorphism"
               style="
                 width: 44px;
-                height: 44px;
+                min-height: 44px;
                 min-width: 44px;
                 border-radius: 8px;
                 padding: 0;


### PR DESCRIPTION
This commit fixes failing E2E tests in the `setup.spec.ts` suite.
The tests were failing because `boundingBox()` was returning `undefined` or a smaller height for elements that hadn't fully rendered or settled.

Changes:
- Added `waitFor({ state: 'visible' })` before calling `.boundingBox()` in Playwright tests.
- Replaced fixed `height: 44px;` with `min-height: 44px;` in `src/ui/tauri/src/ui/setup.html` to strictly enforce the 44px minimum touch target constraint while allowing for content scaling.
- Cleaned up any unintended modifications to lockfiles to keep the PR focused.

All tests in `src/e2e/setup.spec.ts` and `src/e2e/setup_wizard_comprehensive.spec.ts` now pass correctly.

---
*PR created automatically by Jules for task [2737567147596769926](https://jules.google.com/task/2737567147596769926) started by @ql-owo-lp*