### PR TITLE
fix(ui): enforce 44px mobile touch targets and stabilize Playwright onboarding E2E tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,8 +305,8 @@ importers:
         specifier: ^5.32.6
         version: 5.32.6(@types/react@19.2.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       uuid:
-        specifier: ^14.0.0
-        version: 14.0.0
+        specifier: ^14.0.1
+        version: 14.0.1
       vite:
         specifier: ^6.0.0
         version: 6.4.3(@types/node@20.19.42)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)
@@ -3906,6 +3906,10 @@ packages:
 
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -8032,6 +8036,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@14.0.0: {}
+
+  uuid@14.0.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/src/e2e/onboarding.spec.ts
+++ b/src/e2e/onboarding.spec.ts
@@ -357,6 +357,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
     const startMyBusinessButton = page.locator('[data-next="step-context"]');
     await startMyBusinessButton.click();
 
+    await expect(page.locator('.context-card').first()).toBeVisible({ timeout: 5000 });
     // Check .context-card
     const contextCard = page.locator(".context-card").first();
     const cardBox = await contextCard.boundingBox();
@@ -379,6 +380,7 @@ test.describe('Onboarding Wizard E2E Flow - Instant Build Extensions', () => {
 
     // Instant Build is now the initial screen
 
+    await expect(page.locator('#instant-bio')).toBeVisible({ timeout: 5000 });
     const bioInput = page.locator('#instant-bio');
     const box = await bioInput.boundingBox();
     expect(Math.round(box?.height || 0)).toBeGreaterThanOrEqual(44);

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1139,8 +1139,8 @@
       .glassmorphism.panel {
         border-radius: 16px !important;
       }
-          #instant-bio { min-height: 44px; box-sizing: border-box; border-radius: 8px; }
-      .context-card { min-height: 44px; box-sizing: border-box; }
+          #instant-bio { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; border-radius: 8px; }
+      .context-card { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; }
 
       /* --- OHC Premium Dark Mode & Animations --- */
       @media (prefers-color-scheme: dark) {
@@ -1324,8 +1324,8 @@
           box-shadow: 0 0 0 1px #0066FF;
         }
       }
-          #instant-bio { min-height: 44px; box-sizing: border-box; border-radius: 8px; }
-      .context-card { min-height: 44px; box-sizing: border-box; }
+          #instant-bio { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; border-radius: 8px; }
+      .context-card { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; }
     </style>
 
 
@@ -1401,7 +1401,7 @@
             aria-label="Generate Storefront"
             title="Generate Storefront"
             data-testid="generate-storefront-btn"
-            class="btn-primary" style="width: 100%; min-height: 44px;"
+            class="btn-primary" style="width: 100%; min-height: 44px !important; padding: 12px; margin: 4px;"
             disabled
           >
             Generate My Workspace
@@ -4798,8 +4798,8 @@
       .ohc-tooltip.visible {
         opacity: 1;
       }
-          #instant-bio { min-height: 44px; box-sizing: border-box; border-radius: 8px; }
-      .context-card { min-height: 44px; box-sizing: border-box; }
+          #instant-bio { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; border-radius: 8px; }
+      .context-card { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; }
     </style>
     <script>
       document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
The `src/e2e/onboarding.spec.ts` Playwright test was failing because:

1. The test elements `.context-card` and `#instant-bio` inside `setup.html` fell short of the 44px height needed for touch targets without proper spacing/sizing elements applied when rendering in the Playwright environment under constrained 375px mobile viewports.
2. The boundingBox calculations executed immediately without ensuring elements were actually fully rendered and visible.

**Fix Details:**
- Modified `setup.html` CSS rules for `.context-card` and `#instant-bio` classes to include `padding: 12px`, `margin: 4px` and set `min-height: 44px !important;` explicitly forcing the sizing to match touch target limits correctly. The same styling was given inline to `#generate-storefront-btn`.
- Fixed race conditions in tests by explicitly inserting `await expect(...).toBeVisible()` before measuring sizes on these targets to guarantee the elements are correctly rendered prior to `boundingBox()` computations.

---
*PR created automatically by Jules for task [9439254643778101771](https://jules.google.com/task/9439254643778101771) started by @ql-owo-lp*