### PR TITLE
Fix Agentic Booking E2E Test Failures

### DIFF
--- a/bazel/rules/playwright/playwright_test.sh
+++ b/bazel/rules/playwright/playwright_test.sh
@@ -537,6 +537,11 @@ if [[ -n "$NEXT_APP_ROOT" ]]; then
   fi
 fi
 
+if [[ -z "${PLAYWRIGHT_BROWSERS_PATH:-}" ]]; then
+  # Fallback to local user cache in case hermetic browser isn't available
+  export PLAYWRIGHT_BROWSERS_PATH="$HOME/.cache/ms-playwright"
+fi
+
 if [[ -z "$NEXT_APP_ROOT" ]]; then
   echo "[playwright] Error: Next UI app not found in Bazel runfiles."
   exit 1

--- a/src/e2e/e2e-seed.sql
+++ b/src/e2e/e2e-seed.sql
@@ -824,3 +824,11 @@ INSERT INTO walkthrough_steps (tenant_id, page, step_order, selector, title, tex
 ('e2e-tenant', 'dashboard', 1, 'dashboard-title', 'Welcome', 'Welcome to your dashboard! This is your control center.'),
 ('e2e-tenant', 'dashboard', 2, 'wrapped-summary', 'AI Savings', 'Here you can see the time and effort your agents have saved you.')
 ON CONFLICT DO NOTHING;
+
+-- Add explicitly available blocks for the E2E test to find
+INSERT INTO availability_blocks (id, tenant_id, service_id, start_time, end_time, is_available)
+VALUES
+('block-1', 'tenant-1', '748888aa-3333-3333-3333-333333333333', CURRENT_DATE + TIME '09:00:00', CURRENT_DATE + TIME '10:00:00', true),
+('block-2', 'tenant-1', '748888aa-3333-3333-3333-333333333333', CURRENT_DATE + TIME '10:00:00', CURRENT_DATE + TIME '11:00:00', true),
+('block-3', 'tenant-1', '748888aa-3333-3333-3333-333333333333', CURRENT_DATE + TIME '11:00:00', CURRENT_DATE + TIME '12:00:00', true)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Resolves failures in the Playwright E2E suite `agentic-booking.spec.ts`
by seeding missing `availability_blocks` data into `e2e-seed.sql` so the
UI successfully loads time slots, allowing the booking test to complete.

Additionally adds a robust fallback for PLAYWRIGHT_BROWSERS_PATH in 
`playwright_test.sh` to ensure the browsers can be found gracefully in
varying local environments without breaking hermeticity in CI.

All Playwright and Rust backend tests are 100% passing.

---
*PR created automatically by Jules for task [2314629278438447099](https://jules.google.com/task/2314629278438447099) started by @ql-owo-lp*