### PR TITLE
🛡️ Sentinel: Strictly enforce tenant isolation in auth stores

### DIFF
--- a/src/server/auth/postgres_store.rs
+++ b/src/server/auth/postgres_store.rs
@@ -82,23 +82,12 @@ impl UserRepository for PgUserRepository {
     async fn get_by_id(&self, id: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
 
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-
-        let query = if should_bypass {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1"
-        } else {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1 AND tenant_id = current_setting('app.current_tenant')::text"
-        };
+        let query = "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1 AND tenant_id = current_setting('app.current_tenant')::text";
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
 
-        let row_opt = if should_bypass {
-            sqlx::query(query).bind(id).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query).bind(id).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
-        };
+        let row_opt = sqlx::query(query).bind(id).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?;
 
         let row = match row_opt {
             Some(r) => r,
@@ -128,23 +117,12 @@ impl UserRepository for PgUserRepository {
     async fn get_by_username(&self, username: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
 
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-
-        let query = if should_bypass {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE username = $1"
-        } else {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE username = $1 AND tenant_id = current_setting('app.current_tenant')::text"
-        };
+        let query = "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE username = $1 AND tenant_id = current_setting('app.current_tenant')::text";
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
 
-        let row_opt = if should_bypass {
-            sqlx::query(query).bind(username).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query).bind(username).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
-        };
+        let row_opt = sqlx::query(query).bind(username).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?;
 
         let row = match row_opt {
             Some(r) => r,
@@ -173,23 +151,12 @@ impl UserRepository for PgUserRepository {
     async fn get_by_email(&self, email: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
 
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-
-        let query = if should_bypass {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1"
-        } else {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1 AND tenant_id = current_setting('app.current_tenant')::text"
-        };
+        let query = "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1 AND tenant_id = current_setting('app.current_tenant')::text";
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
 
-        let row_opt = if should_bypass {
-            sqlx::query(query).bind(email).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query).bind(email).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
-        };
+        let row_opt = sqlx::query(query).bind(email).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?;
 
         let row = match row_opt {
             Some(r) => r,
@@ -218,23 +185,12 @@ impl UserRepository for PgUserRepository {
     async fn get_by_oidc_subject(&self, sub: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
 
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-
-        let query = if should_bypass {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1"
-        } else {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1 AND tenant_id = current_setting('app.current_tenant')::text"
-        };
+        let query = "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1 AND tenant_id = current_setting('app.current_tenant')::text";
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
 
-        let row_opt = if should_bypass {
-            sqlx::query(query).bind(sub).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query).bind(sub).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
-        };
+        let row_opt = sqlx::query(query).bind(sub).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?;
 
         let row = match row_opt {
             Some(r) => r,
@@ -262,22 +218,12 @@ impl UserRepository for PgUserRepository {
 
     async fn list_users(&self, org_id: &str) -> Result<Vec<User>, String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-        let query = if should_bypass {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users ORDER BY created_at"
-        } else {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE tenant_id = current_setting('app.current_tenant')::text ORDER BY created_at"
-        };
+        let query = "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE tenant_id = current_setting('app.current_tenant')::text ORDER BY created_at";
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
 
-        let rows = if should_bypass {
-            sqlx::query(query).fetch_all(&mut *tx).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query).bind(org_id).fetch_all(&mut *tx).await.map_err(|e| e.to_string())?
-        };
+        let rows = sqlx::query(query).fetch_all(&mut *tx).await.map_err(|e| e.to_string())?;
 
         let mut users = Vec::new();
         for row in rows {
@@ -306,53 +252,28 @@ impl UserRepository for PgUserRepository {
     async fn update_user(&self, user: User, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
         let roles_json = serde_json::to_string(&user.roles).unwrap_or_default();
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
 
-        let query = if should_bypass {
-            r#"
-            UPDATE users SET username=$2, email=$3, password_hash=$4, roles=$5::jsonb, active=$6,
-            oidc_subject=$7, updated_at=$8
-            WHERE id=$1 RETURNING id
-            "#
-        } else {
-            r#"
+        let query = r#"
             UPDATE users SET username=$2, email=$3, password_hash=$4, roles=$5::jsonb, active=$6,
             oidc_subject=$7, updated_at=$8
             WHERE id=$1 AND tenant_id = current_setting('app.current_tenant')::text RETURNING id
-            "#
-        };
+            "#;
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
 
-        let res = if should_bypass {
-            sqlx::query(query)
-                .bind(&user.id)
-                .bind(&user.username)
-                .bind(&user.email)
-                .bind(&user.password_hash)
-                .bind(roles_json)
-                .bind(user.active)
-                .bind(&user.oidc_subject)
-                .bind(user.updated_at)
-                .fetch_optional(&mut *tx)
-                .await
-                .map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query)
-                .bind(&user.id)
-                .bind(&user.username)
-                .bind(&user.email)
-                .bind(&user.password_hash)
-                .bind(roles_json)
-                .bind(user.active)
-                .bind(&user.oidc_subject)
-                .bind(user.updated_at)
-                .fetch_optional(&mut *tx)
-                .await
-                .map_err(|e| e.to_string())?
-        };
+        let res = sqlx::query(query)
+            .bind(&user.id)
+            .bind(&user.username)
+            .bind(&user.email)
+            .bind(&user.password_hash)
+            .bind(roles_json)
+            .bind(user.active)
+            .bind(&user.oidc_subject)
+            .bind(user.updated_at)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| e.to_string())?;
 
         if res.is_none() {
             return Err("user not found or unauthorized".to_string());
@@ -365,22 +286,12 @@ impl UserRepository for PgUserRepository {
 
     async fn delete_user(&self, id: &str, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-        let query = if should_bypass {
-            "DELETE FROM users WHERE id = $1 RETURNING id"
-        } else {
-            "DELETE FROM users WHERE id = $1 AND tenant_id = current_setting('app.current_tenant')::text RETURNING id"
-        };
+        let query = "DELETE FROM users WHERE id = $1 AND tenant_id = current_setting('app.current_tenant')::text RETURNING id";
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
 
-        let res = if should_bypass {
-            sqlx::query(query).bind(id).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query).bind(id).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?
-        };
+        let res = sqlx::query(query).bind(id).fetch_optional(&mut *tx).await.map_err(|e| e.to_string())?;
 
         if res.is_none() {
             return Err("user not found or unauthorized".to_string());
@@ -421,27 +332,16 @@ impl UserRepository for PgUserRepository {
 
     async fn is_revoked(&self, jti: &str, org_id: &str) -> Result<bool, String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
 
         let mut tx = self.pool.begin().await.map_err(|e| e.to_string())?;
         set_org_context(&mut *tx, org_id).await.map_err(|e| e.to_string())?;
 
-        let row = if should_bypass {
-            sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $2")
-                .bind(jti)
-                .bind(chrono::Utc::now())
-                .fetch_one(&mut *tx)
-                .await
-                .map_err(|e| e.to_string())?
-        } else {
-            sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $2 AND tenant_id = current_setting('app.current_tenant')::text")
-                .bind(jti)
-                .bind(chrono::Utc::now())
-                .fetch_one(&mut *tx)
-                .await
-                .map_err(|e| e.to_string())?
-        };
+        let row = sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $2 AND tenant_id = current_setting('app.current_tenant')::text")
+            .bind(jti)
+            .bind(chrono::Utc::now())
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| e.to_string())?;
 
         let count: i64 = row.get(0);
         tx.rollback().await.map_err(|e| e.to_string())?;

--- a/src/server/auth/sqlite_store.rs
+++ b/src/server/auth/sqlite_store.rs
@@ -73,18 +73,8 @@ impl UserRepository for SqliteUserRepository {
 
     async fn get_by_id(&self, id: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-        let query = if should_bypass {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1"
-        } else {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1 AND tenant_id = $2"
-        };
-        let row_opt = if should_bypass {
-            sqlx::query(query).bind(id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query).bind(id).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
-        };
+        let query = "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE id = $1 AND tenant_id = $2";
+        let row_opt = sqlx::query(query).bind(id).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?;
 
         let row = match row_opt {
             Some(r) => r,
@@ -110,18 +100,8 @@ impl UserRepository for SqliteUserRepository {
 
     async fn get_by_username(&self, username: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-        let query = if should_bypass {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE username = $1"
-        } else {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE username = $1 AND tenant_id = $2"
-        };
-        let row_opt = if should_bypass {
-            sqlx::query(query).bind(username).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query).bind(username).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
-        };
+        let query = "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE username = $1 AND tenant_id = $2";
+        let row_opt = sqlx::query(query).bind(username).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?;
 
         let row = match row_opt {
             Some(r) => r,
@@ -147,18 +127,8 @@ impl UserRepository for SqliteUserRepository {
 
     async fn get_by_email(&self, email: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-        let query = if should_bypass {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1"
-        } else {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1 AND tenant_id = $2"
-        };
-        let row_opt = if should_bypass {
-            sqlx::query(query).bind(email).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query).bind(email).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
-        };
+        let query = "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE email = $1 AND tenant_id = $2";
+        let row_opt = sqlx::query(query).bind(email).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?;
 
         let row = match row_opt {
             Some(r) => r,
@@ -184,18 +154,8 @@ impl UserRepository for SqliteUserRepository {
 
     async fn get_by_oidc_subject(&self, sub: &str, org_id: &str) -> Result<User, String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-        let query = if should_bypass {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1"
-        } else {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1 AND tenant_id = $2"
-        };
-        let row_opt = if should_bypass {
-            sqlx::query(query).bind(sub).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query).bind(sub).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?
-        };
+        let query = "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE oidc_subject = $1 AND tenant_id = $2";
+        let row_opt = sqlx::query(query).bind(sub).bind(org_id).fetch_optional(&self.pool).await.map_err(|e| e.to_string())?;
 
         let row = match row_opt {
             Some(r) => r,
@@ -221,18 +181,8 @@ impl UserRepository for SqliteUserRepository {
 
     async fn list_users(&self, org_id: &str) -> Result<Vec<User>, String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-        let query = if should_bypass {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users ORDER BY created_at"
-        } else {
-            "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE tenant_id = $1 ORDER BY created_at"
-        };
-        let rows = if should_bypass {
-            sqlx::query(query).fetch_all(&self.pool).await.map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query).bind(org_id).fetch_all(&self.pool).await.map_err(|e| e.to_string())?
-        };
+        let query = "SELECT id, username, email, password_hash, roles, active, tenant_id, oidc_subject, created_at, updated_at FROM users WHERE tenant_id = $1 ORDER BY created_at";
+        let rows = sqlx::query(query).bind(org_id).fetch_all(&self.pool).await.map_err(|e| e.to_string())?;
 
         let mut users = Vec::new();
         for row in rows {
@@ -258,51 +208,26 @@ impl UserRepository for SqliteUserRepository {
     async fn update_user(&self, user: User, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
         let roles_json = serde_json::to_string(&user.roles).unwrap_or_default();
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
 
-        let query = if should_bypass {
-            r#"
-            UPDATE users SET username=$2, email=$3, password_hash=$4, roles=json($5), active=$6,
-            oidc_subject=$7, updated_at=$8
-            WHERE id=$1 RETURNING id
-            "#
-        } else {
-            r#"
+        let query = r#"
             UPDATE users SET username=$2, email=$3, password_hash=$4, roles=json($5), active=$6,
             oidc_subject=$7, updated_at=$8
             WHERE id=$1 AND tenant_id = $9 RETURNING id
-            "#
-        };
+            "#;
 
-        let res = if should_bypass {
-            sqlx::query(query)
-                .bind(&user.id)
-                .bind(&user.username)
-                .bind(&user.email)
-                .bind(&user.password_hash)
-                .bind(roles_json)
-                .bind(user.active)
-                .bind(&user.oidc_subject)
-                .bind(user.updated_at)
-                .fetch_optional(&self.pool)
-                .await
-                .map_err(|e| e.to_string())?
-        } else {
-            sqlx::query(query)
-                .bind(&user.id)
-                .bind(&user.username)
-                .bind(&user.email)
-                .bind(&user.password_hash)
-                .bind(roles_json)
-                .bind(user.active)
-                .bind(&user.oidc_subject)
-                .bind(user.updated_at)
-                .bind(org_id)
-                .fetch_optional(&self.pool)
-                .await
-                .map_err(|e| e.to_string())?
-        };
+        let res = sqlx::query(query)
+            .bind(&user.id)
+            .bind(&user.username)
+            .bind(&user.email)
+            .bind(&user.password_hash)
+            .bind(roles_json)
+            .bind(user.active)
+            .bind(&user.oidc_subject)
+            .bind(user.updated_at)
+            .bind(org_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| e.to_string())?;
 
         if res.is_none() {
             return Err("user not found or unauthorized".to_string());
@@ -312,18 +237,8 @@ impl UserRepository for SqliteUserRepository {
 
     async fn delete_user(&self, id: &str, org_id: &str) -> Result<(), String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
-        let query = if should_bypass {
-            "DELETE FROM users WHERE id = $1 RETURNING id"
-        } else {
-            "DELETE FROM users WHERE id = $1 AND tenant_id = $2 RETURNING id"
-        };
-        let res = if should_bypass {
-            sqlx::query(query).bind(id).fetch_optional(&self.pool).await.map_err(|e: sqlx::Error| e.to_string())?
-        } else {
-            sqlx::query(query).bind(id).bind(org_id).fetch_optional(&self.pool).await.map_err(|e: sqlx::Error| e.to_string())?
-        };
+        let query = "DELETE FROM users WHERE id = $1 AND tenant_id = $2 RETURNING id";
+        let res = sqlx::query(query).bind(id).bind(org_id).fetch_optional(&self.pool).await.map_err(|e: sqlx::Error| e.to_string())?;
 
         if res.is_none() {
             return Err("user not found or unauthorized".to_string());
@@ -360,25 +275,14 @@ impl UserRepository for SqliteUserRepository {
 
     async fn is_revoked(&self, jti: &str, org_id: &str) -> Result<bool, String> {
         validate_org_id!(org_id);
-        let is_multitenant = is_multitenant_mode();
-        let should_bypass = !is_multitenant;
 
-        let row = if should_bypass {
-            sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $2")
-                .bind(jti)
-                .bind(chrono::Utc::now())
-                .fetch_one(&self.pool)
-                .await
-                .map_err(|e: sqlx::Error| e.to_string())?
-        } else {
-            sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $3 AND tenant_id = $2")
-                .bind(jti)
-                .bind(org_id)
-                .bind(chrono::Utc::now())
-                .fetch_one(&self.pool)
-                .await
-                .map_err(|e: sqlx::Error| e.to_string())?
-        };
+        let row = sqlx::query("SELECT COUNT(*) FROM revoked_tokens WHERE jti = $1 AND expires_at >= $3 AND tenant_id = $2")
+            .bind(jti)
+            .bind(org_id)
+            .bind(chrono::Utc::now())
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e: sqlx::Error| e.to_string())?;
 
         let count: i32 = row.get(0);
         Ok(count > 0)


### PR DESCRIPTION
- Removed `should_bypass` flag and hardcoded multitenant bypasses in `postgres_store.rs` and `sqlite_store.rs`.
- Enforced strict tenant isolation in all database access methods (`update_user`, `get_by_id`, `delete_user`, `list_users`, `get_by_email`, `get_by_oidc_subject`, `is_revoked`, `get_by_username`).
- Tested with bazel test //src/server/auth/... to ensure correctness.

---
*PR created automatically by Jules for task [17753531872333452170](https://jules.google.com/task/17753531872333452170) started by @ql-owo-lp*