### PR TITLE
Fix dashboard drift across canonical and mirrored paths

### DIFF
--- a/deploy/docker/grafana/provisioning/dashboards/cost_dashboard.json
+++ b/deploy/docker/grafana/provisioning/dashboards/cost_dashboard.json
@@ -107,8 +107,7 @@
         }
       ],
       "title": "LLM Cost by Agent (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -183,8 +182,7 @@
         }
       ],
       "title": "API Cost by Integration (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -259,8 +257,7 @@
         }
       ],
       "title": "Storage Cost (Bytes/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -335,8 +332,7 @@
         }
       ],
       "title": "Email Send Cost (Count/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     }
   ],
   "refresh": false,

--- a/deploy/grafana/dashboards/cost_dashboard.json
+++ b/deploy/grafana/dashboards/cost_dashboard.json
@@ -107,8 +107,7 @@
         }
       ],
       "title": "LLM Cost by Agent (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -183,8 +182,7 @@
         }
       ],
       "title": "API Cost by Integration (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -259,8 +257,7 @@
         }
       ],
       "title": "Storage Cost (Bytes/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -335,8 +332,7 @@
         }
       ],
       "title": "Email Send Cost (Count/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     }
   ],
   "refresh": false,

--- a/deploy/helm/ohc/dashboards/cost_dashboard.json
+++ b/deploy/helm/ohc/dashboards/cost_dashboard.json
@@ -107,8 +107,7 @@
         }
       ],
       "title": "LLM Cost by Agent (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -183,8 +182,7 @@
         }
       ],
       "title": "API Cost by Integration (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -259,8 +257,7 @@
         }
       ],
       "title": "Storage Cost (Bytes/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -335,8 +332,7 @@
         }
       ],
       "title": "Email Send Cost (Count/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     }
   ],
   "refresh": false,


### PR DESCRIPTION
Fix dashboard drift across canonical and mirrored paths.

Synchronized the `cost_dashboard.json` file from the canonical source (`src/server/monitoring/dashboards/`) to its mirrored locations in `deploy/docker/grafana/provisioning/dashboards/`, `deploy/grafana/dashboards/`, and `deploy/helm/ohc/dashboards/`. This resolves the `test_hybrid_telemetry_drift` test failure.

---
*PR created automatically by Jules for task [12769911481955749446](https://jules.google.com/task/12769911481955749446) started by @ql-owo-lp*