### PR TITLE
chore: Proactive test coverage and drift fixes

### DIFF
--- a/deploy/docker/grafana/provisioning/dashboards/cost_dashboard.json
+++ b/deploy/docker/grafana/provisioning/dashboards/cost_dashboard.json
@@ -107,8 +107,7 @@
         }
       ],
       "title": "LLM Cost by Agent (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -183,8 +182,7 @@
         }
       ],
       "title": "API Cost by Integration (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -259,8 +257,7 @@
         }
       ],
       "title": "Storage Cost (Bytes/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -335,8 +332,7 @@
         }
       ],
       "title": "Email Send Cost (Count/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     }
   ],
   "refresh": false,

--- a/deploy/grafana/dashboards/cost_dashboard.json
+++ b/deploy/grafana/dashboards/cost_dashboard.json
@@ -107,8 +107,7 @@
         }
       ],
       "title": "LLM Cost by Agent (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -183,8 +182,7 @@
         }
       ],
       "title": "API Cost by Integration (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -259,8 +257,7 @@
         }
       ],
       "title": "Storage Cost (Bytes/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -335,8 +332,7 @@
         }
       ],
       "title": "Email Send Cost (Count/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     }
   ],
   "refresh": false,

--- a/deploy/helm/ohc/dashboards/cost_dashboard.json
+++ b/deploy/helm/ohc/dashboards/cost_dashboard.json
@@ -107,8 +107,7 @@
         }
       ],
       "title": "LLM Cost by Agent (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -183,8 +182,7 @@
         }
       ],
       "title": "API Cost by Integration (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -259,8 +257,7 @@
         }
       ],
       "title": "Storage Cost (Bytes/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -335,8 +332,7 @@
         }
       ],
       "title": "Email Send Cost (Count/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     }
   ],
   "refresh": false,

--- a/src/e2e/test_mobile_payload_optimization.spec.ts
+++ b/src/e2e/test_mobile_payload_optimization.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from './fixtures';
+
+test.describe("Mobile Payload Optimization", () => {
+  test.use({ viewport: { width: 375, height: 667 } });
+
+  test('supply returns mobile_optimized payload', async ({ page, loginAs, unlimitedAdminUser, request }) => {
+    await loginAs(page, unlimitedAdminUser);
+
+    // Call the endpoint directly with mobile_optimized=true
+    const response = await request.get('/api/ui/supply?mobile_optimized=true', {
+      headers: {
+        "x-tenant-id": unlimitedAdminUser.tenantId || "e2e-tenant",
+        "Authorization": `Bearer ${unlimitedAdminUser.token || "e2e-token"}`
+      }
+    });
+
+    expect(response.status()).toBe(200);
+    const data = await response.json();
+
+    expect(data.vendors).toBeDefined();
+    if (data.vendors && data.vendors.length > 0) {
+        expect(data.vendors[0].contact_info).toBeUndefined();
+    }
+
+    expect(data.raw_materials).toBeDefined();
+    if (data.raw_materials && data.raw_materials.length > 0) {
+        expect(data.raw_materials[0].reorder_threshold).toBeUndefined();
+    }
+  });
+
+  test('list_jobs returns mobile_optimized payload', async ({ page, loginAs, unlimitedAdminUser, request }) => {
+    await loginAs(page, unlimitedAdminUser);
+    // Call the endpoint directly with mobile_optimized=true
+    const response = await request.get('/api/ohc-job-queue/?mobile_optimized=true', {
+      headers: {
+        "x-tenant-id": unlimitedAdminUser.tenantId || "e2e-tenant",
+        "Authorization": `Bearer ${unlimitedAdminUser.token || "e2e-token"}`
+      }
+    });
+
+    expect(response.status()).toBe(200);
+    const data = await response.json();
+
+    expect(data.jobs).toBeDefined();
+    if (data.jobs && data.jobs.length > 0) {
+        expect(data.jobs[0].retry_count).toBeUndefined();
+    }
+  });
+
+});


### PR DESCRIPTION
This commit does two things:
1. Fixes the broken `dashboard_test::test_hybrid_telemetry_drift` benchmark/test by copying the `cost_dashboard.json` into the proper canonical folders (`deploy/grafana/dashboards/`, `deploy/docker/grafana/provisioning/dashboards/`, `deploy/helm/ohc/dashboards/`).
2. Adds `src/e2e/test_mobile_payload_optimization.spec.ts` which uses the `unlimitedAdminUser` context to explicitly check that Mobile Payload Optimization returns trimmed JSON structures via `mobile_optimized=true` (testing `/api/ui/supply` and `/api/ohc-job-queue`).

---
*PR created automatically by Jules for task [11940930048190516024](https://jules.google.com/task/11940930048190516024) started by @ql-owo-lp*