### PR TITLE
🎨 Canvas: [fix] Ensure optimistic sync E2E tests pass after login UI change

### DIFF
--- a/src/ui/next/src/e2e/pos-inventory-sync-optimistic.spec.ts
+++ b/src/ui/next/src/e2e/pos-inventory-sync-optimistic.spec.ts
@@ -4,9 +4,9 @@ test.describe('POS Inventory Sync - Optimistic UI', () => {
   test('POS terminal immediately updates stock UI on charge before API returns', async ({ page }) => {
     // 1. Log in to get token
     await page.goto('/login');
-    await page.getByPlaceholder('Email address').fill('admin@ohc.local');
+    await page.getByPlaceholder('Email or Username').fill('admin@ohc.local');
     await page.getByPlaceholder('Password').fill('admin');
-    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.getByRole('button', { name: 'Log In' }).click();
     await expect(page.locator('text=Dashboard').first()).toBeVisible({ timeout: 15000 });
 
     const response = await page.request.post('/api/v1/auth/login', {
@@ -74,9 +74,9 @@ test.describe('POS Inventory Sync - Optimistic UI', () => {
   test('Offline sync conflict generates Operations Agent Triage Task', async ({ page }) => {
     // 1. Log in to get token
     await page.goto('/login');
-    await page.getByPlaceholder('Email address').fill('admin@ohc.local');
+    await page.getByPlaceholder('Email or Username').fill('admin@ohc.local');
     await page.getByPlaceholder('Password').fill('admin');
-    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.getByRole('button', { name: 'Log In' }).click();
     await expect(page.locator('text=Dashboard').first()).toBeVisible({ timeout: 15000 });
 
     const response = await page.request.post('/api/v1/auth/login', {
@@ -179,9 +179,9 @@ test.describe('POS Inventory Sync - Optimistic UI', () => {
   test('POS terminal immediately updates stock UI on cash sale before API returns', async ({ page }) => {
     // 1. Log in to get token
     await page.goto('/login');
-    await page.getByPlaceholder('Email address').fill('admin@ohc.local');
+    await page.getByPlaceholder('Email or Username').fill('admin@ohc.local');
     await page.getByPlaceholder('Password').fill('admin');
-    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.getByRole('button', { name: 'Log In' }).click();
     await expect(page.locator('text=Dashboard').first()).toBeVisible({ timeout: 15000 });
 
     const response = await page.request.post('/api/v1/auth/login', {


### PR DESCRIPTION
This pull request fixes a regression in the `pos-inventory-sync-optimistic.spec.ts` End-to-End tests where they timed out during the login sequence. 

The application's login UI was updated at some point, changing the placeholder text from `"Email address"` to `"Email or Username"` and the button text from `"Sign In"` to `"Log In"`. This caused the Playwright locators to fail, preventing the core feature tests (Tap-to-Pay Offline Resilience / Optimistic Inventory Sync) from being validated in CI.

**Resolves #33877**

### Superpowers Skills Loaded:
- mcp_github tools to check code context
- playwright test execution locally to debug failure details
- grep / sed for refactoring

### UI Interaction Verification:
- `Log In` button on the POS optimistic sync spec now correctly authenticates user.
- `Email or Username` login input placeholder now correctly routes E2E playwright inputs.

### Product-use evidence:
- **Persona:** Priya (The Boutique Owner, 35) trying to verify that offline Point-of-Sale works robustly when synced later.
- **Test Flow:** Playwright tries to log in, navigate to POS, perform a sale transaction while offline, and assert inventory sync offline conflict task is handled gracefully.
- **The UI gap:** The login button string was modified from `Sign In` to `Log In` and `Email address` to `Email or Username`. 
- **Fix applied:** Changed the E2E strings to route the e2e test properly. Verified all tests passed successfully using `bazelisk test //...` and `bazelisk test //src/e2e:playwright_shard_1_of_1`.

---
*PR created automatically by Jules for task [968510771918257738](https://jules.google.com/task/968510771918257738) started by @ql-owo-lp*