### PR TITLE
feat: implement Universal Tap-to-Pay & Offline-Tolerant POS Architecture

### DIFF
--- a/src/e2e/playwright/mobile_pos_offline_sync.spec.ts
+++ b/src/e2e/playwright/mobile_pos_offline_sync.spec.ts
@@ -3,6 +3,86 @@ import { test, expect } from '@playwright/test';
 test.describe('Mobile POS - Offline Outbox Sync', () => {
   test.use({ viewport: { width: 375, height: 812 } });
 
+  test('Persona: Field Service Owner uses Quick Charge offline Tap-to-Pay', async ({ page, context }) => {
+    const tenantId = `tenant-quick-charge-${Date.now()}`;
+
+    await page.goto('http://127.0.0.1:3000/').catch(() => {});
+    await page.evaluate((tenant) => {
+        localStorage.setItem('tenant_id', tenant);
+        localStorage.setItem('ohc_offline_staff', JSON.stringify([{ id: 'staff_1', name: 'Carlos', role: 'Owner', pin_hash: '1234', tenant_id: tenant }]));
+        localStorage.setItem('ohc_offline_events', JSON.stringify([]));
+        localStorage.setItem('ohc_pos_device_id', 'test_device_123');
+        localStorage.setItem('ohc_catalog_default', JSON.stringify([]));
+    }, tenantId);
+
+    // 1. Navigate to Feed and click New Sale
+    await page.goto('/feed');
+    const newSaleBtn = page.getByRole('link', { name: 'New Sale' });
+    await expect(newSaleBtn).toBeVisible({ timeout: 15000 });
+    await newSaleBtn.click();
+
+    // 2. Unlock Terminal
+    await expect(page.getByText('Terminal Locked')).toBeVisible({ timeout: 15000 });
+    const pins = ['1', '2', '3', '4'];
+    for (const p of pins) {
+      await page.getByRole('button', { name: p, exact: true }).click();
+    }
+    await page.locator('button:has-text("Clock In")').click({ force: true, timeout: 5000 }).catch(() => {});
+
+    // 3. Switch to Quick Charge mode
+    const quickChargeTab = page.getByRole('button', { name: 'Quick Charge' });
+    await expect(quickChargeTab).toBeVisible({ timeout: 15000 });
+    await quickChargeTab.click();
+
+    // 4. Enter $15.00
+    await page.getByRole('button', { name: '1', exact: true }).click();
+    await page.getByRole('button', { name: '5', exact: true }).click();
+    await page.getByRole('button', { name: '0', exact: true }).first().click();
+    await page.getByRole('button', { name: '0', exact: true }).first().click();
+    await expect(page.getByText('$15.00')).toBeVisible();
+
+    // 5. Hit Charge
+    const chargeBtn = page.getByRole('button', { name: 'Charge $15.00' });
+    await expect(chargeBtn).toBeVisible();
+    await chargeBtn.click();
+
+    // 6. Go offline
+    await context.setOffline(true);
+    await page.evaluate(() => window.dispatchEvent(new Event('offline')));
+    await expect(page.locator('text=Offline - Changes saved locally')).toBeVisible({ timeout: 10000 });
+
+    // 7. Select Tap to Pay
+    const tapToPayBtn = page.getByRole('button', { name: 'Tap to Pay' });
+    await expect(tapToPayBtn).toBeVisible();
+    await tapToPayBtn.click();
+
+    // Wait for the Offline Tap-to-Pay confirmation
+    await expect(page.getByText('Saved Offline - Will sync when connected')).toBeVisible({ timeout: 10000 });
+
+    // Check Success Screen
+    await expect(page.getByText('Payment Successful!')).toBeVisible({ timeout: 10000 });
+
+    // Verify it's in the IndexedDB offline queue
+    const queueData = await page.evaluate(async () => {
+        return new Promise<string>((resolve) => {
+            const req = window.indexedDB.open('OHC_Offline_Queue', 1);
+            req.onsuccess = (e) => {
+                const db = (e.target as IDBOpenDBRequest).result;
+                if (!db.objectStoreNames.contains('actions')) return resolve('[]');
+                const tx = db.transaction('actions', 'readonly');
+                const reqAll = tx.objectStore('actions').getAll();
+                reqAll.onsuccess = () => resolve(JSON.stringify(reqAll.result));
+            };
+            req.onerror = () => resolve('[]');
+        });
+    });
+    expect(queueData).toContain('tap_to_pay');
+
+    // Restore Network
+    await context.setOffline(false);
+    await page.evaluate(() => window.dispatchEvent(new Event('online')));
+  });
+
   test('Persona: Boutique Operator records offline cash sale and syncs it', async ({ page, context }) => {
     const tenantId = `tenant-offline-sync-${Date.now()}`;
 

--- a/src/server/api/terminal_api.rs
+++ b/src/server/api/terminal_api.rs
@@ -1122,6 +1122,26 @@ pub async fn capture_payment_intent_handler(
                                         .execute(&mut *agent_tx).await;
                                     let _ = agent_tx.commit().await;
                                 }
+
+                                // Draft success card in agent feed
+                                if let Ok(mut feed_tx) = crate::db::get_pool().begin().await {
+                                    let _ = sqlx::query(
+                                        "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state, created_at, updated_at) VALUES ($1, $2, 'terminal', $3, $4, 'PENDING_APPROVAL', NOW(), NOW())"
+                                    )
+                                    .bind(uuid::Uuid::new_v4().to_string())
+                                    .bind(&tenant_id)
+                                    .bind(serde_json::json!({
+                                        "feature_type": "receipt_draft",
+                                        "transaction_successful": true,
+                                        "payment_intent_id": req_data.payment_intent_id,
+                                    }))
+                                    .bind(serde_json::json!({
+                                        "description": "Transaction successful. Send receipt?"
+                                    }))
+                                    .execute(&mut *feed_tx)
+                                    .await;
+                                    let _ = feed_tx.commit().await;
+                                }
                             },
                             Err(e) => {
                                 tracing::error!("Failed to commit inventory after successful capture: {}", e);

--- a/src/server/workers/pos_sync_worker.rs
+++ b/src/server/workers/pos_sync_worker.rs
@@ -542,6 +542,23 @@ impl crate::queue::TaskJobHandler for PosSyncWorker {
                             .execute(&mut *tx)
                             .await;
 
+                            // Draft success card in agent feed
+                            let _ = sqlx::query(
+                                "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state, created_at, updated_at) VALUES ($1, $2, 'terminal', $3, $4, 'PENDING_APPROVAL', NOW(), NOW())"
+                            )
+                            .bind(uuid::Uuid::new_v4().to_string())
+                            .bind(&job.tenant_id)
+                            .bind(serde_json::json!({
+                                "feature_type": "receipt_draft",
+                                "transaction_successful": true,
+                                "transaction_id": transaction_id,
+                            }))
+                            .bind(serde_json::json!({
+                                "description": "Transaction successful. Send receipt?"
+                            }))
+                            .execute(&mut *tx)
+                            .await;
+
                             if new_stock <= 5 && !is_conflict {
                                 let action_request_id = uuid::Uuid::new_v4().to_string();
                                 let payload = serde_json::json!({

--- a/src/ui/next/src/app/feed/page.tsx
+++ b/src/ui/next/src/app/feed/page.tsx
@@ -289,7 +289,7 @@ export default function FeedPage() {
   };
 
   return (
-    <AppShell title="Daily Work" subtitle="Your daily priorities, coordinated by your team.">
+    <AppShell title="Daily Work" subtitle="Your daily priorities, coordinated by your team." actions={[{ label: "New Sale", href: "/pos/terminal", primary: true }]}>
       <div className="w-full max-w-full overflow-hidden px-4 mx-auto space-y-4" data-testid="agent-feed">
 
         {loading && (

--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -108,13 +108,31 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
        // Offline Mode Payment Enqueue
        setStatus('Offline Tap-to-Pay. Authorizing locally...');
 
-       cart?.forEach(item => {
+       if (cart && cart.length > 0) {
+           cart.forEach(item => {
+               MutationService.getInstance().executeMutation(
+                   'tap_to_pay',
+                   {
+                       amount_cents: item.product.price_cents * item.quantity,
+                       product_id: item.product.id,
+                       quantity: item.quantity,
+                   },
+                   () => {
+                       if (onOptimisticReserve) onOptimisticReserve();
+                   },
+                   () => {
+                       if (onOptimisticRollback) onOptimisticRollback();
+                       setStatus('Failed to save offline payment.');
+                   }
+               );
+           });
+       } else {
            MutationService.getInstance().executeMutation(
                'tap_to_pay',
                {
-                   amount_cents: item.product.price_cents * item.quantity,
-                   product_id: item.product.id,
-                   quantity: item.quantity,
+                   amount_cents: amount,
+                   product_id: productId || 'custom-charge',
+                   quantity: 1,
                },
                () => {
                    if (onOptimisticReserve) onOptimisticReserve();
@@ -124,7 +142,7 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
                    setStatus('Failed to save offline payment.');
                }
            );
-       });
+       }
 
        setTimeout(() => {
          setStatus('Saved Offline - Will sync when connected');
@@ -191,23 +209,41 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
 
   const processCashSale = async () => {
      if (typeof window !== 'undefined' && !navigator.onLine) {
-         cart?.forEach(item => {
-            MutationService.getInstance().executeMutation(
-                'cash_sale',
-                {
-                    amount_cents: item.product.price_cents * item.quantity,
-                    product_id: item.product.id,
-                    quantity: item.quantity
-                },
-                () => {
-                    if (onOptimisticReserve) onOptimisticReserve();
-                },
-                () => {
-                    if (onOptimisticRollback) onOptimisticRollback();
-                    setStatus('Failed to save offline cash sale.');
-                }
-            );
-         });
+         if (cart && cart.length > 0) {
+             cart.forEach(item => {
+                MutationService.getInstance().executeMutation(
+                    'cash_sale',
+                    {
+                        amount_cents: item.product.price_cents * item.quantity,
+                        product_id: item.product.id,
+                        quantity: item.quantity
+                    },
+                    () => {
+                        if (onOptimisticReserve) onOptimisticReserve();
+                    },
+                    () => {
+                        if (onOptimisticRollback) onOptimisticRollback();
+                        setStatus('Failed to save offline cash sale.');
+                    }
+                );
+             });
+         } else {
+             MutationService.getInstance().executeMutation(
+                 'cash_sale',
+                 {
+                     amount_cents: amount,
+                     product_id: productId || 'custom-charge',
+                     quantity: 1
+                 },
+                 () => {
+                     if (onOptimisticReserve) onOptimisticReserve();
+                 },
+                 () => {
+                     if (onOptimisticRollback) onOptimisticRollback();
+                     setStatus('Failed to save offline cash sale.');
+                 }
+             );
+         }
          setTimeout(() => {
            setStatus('Saved Offline - Will sync when connected');
            if (onSuccess) onSuccess();

--- a/src/ui/next/src/app/pos/terminal/page.tsx
+++ b/src/ui/next/src/app/pos/terminal/page.tsx
@@ -40,6 +40,9 @@ export default function POSTerminal() {
   const [offlineConversion, setOfflineConversion] = useState(false);
   const [pendingSyncCount, setPendingSyncCount] = useState(0);
   const [syncSuccess, setSyncSuccess] = useState(false);
+  const [chargeAmount, setChargeAmount] = useState('0');
+  const [showPaymentSheet, setShowPaymentSheet] = useState(false);
+  const [posMode, setPosMode] = useState<'catalog' | 'quick_charge'>('catalog');
 
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [deviceId, setDeviceId] = useState<string>('');
@@ -212,9 +215,23 @@ export default function POSTerminal() {
   const cartTotal = cart.reduce((sum: number, item: any) => sum + (item.product.price_cents * item.quantity), 0);
   const cartItemCount = cart.reduce((sum: number, item: any) => sum + item.quantity, 0);
 
+  const handleKeypadPress = (val: string) => {
+    setChargeAmount(prev => {
+      if (val === 'backspace') {
+        return prev.length > 1 ? prev.slice(0, -1) : '0';
+      }
+      if (prev === '0' && val !== '0') return val;
+      if (prev === '0' && val === '0') return prev;
+      if (prev.length < 8) return prev + val;
+      return prev;
+    });
+  };
+
   const handleCheckoutComplete = () => {
     setCheckoutComplete(true);
     setIsCartOpen(false);
+    setShowPaymentSheet(false);
+    setChargeAmount('0');
   };
 
   const handleSendReceipt = () => {
@@ -430,29 +447,93 @@ export default function POSTerminal() {
              </button>
            </div>
 
-           {/* Catalog Selection */}
-           <h3 className="text-sm font-bold text-gray-400 uppercase tracking-wider mb-4 px-2 mt-8">{t('Product Catalog')}</h3>
-           <div className="grid grid-cols-1 gap-3 mb-8">
-              {inventory.length === 0 ? (
-                <p className="text-center text-gray-500 py-4 italic">{t('No products found in catalog')}</p>
-              ) : inventory.map(product => (
-                <button
-                  key={product.id}
-                  onClick={() => handleAddToCart(product)} disabled={reserving || isCartOpen}
-                  className={`p-4 rounded-[8px] text-left transition-all active:scale-[0.98] min-h-[64px] min-w-[44px] shadow-lg backdrop-blur-[30px] saturate-[210%] ${selectedProduct?.id === product.id ? 'bg-white/80 ring-1 ring-[#0066FF] border border-[#0066FF]' : 'bg-white/65 border border-white/50'}`}
-                >
-                  <div className="flex justify-between items-center">
-                    <div>
-                      <div className="font-bold text-gray-900">{product.name}</div>
-                      <div className="text-xs text-gray-500 line-clamp-1">{product.description} &bull; Stock: {product.stock}</div>
-                    </div>
-                    <div className="text-[#0071E3] font-bold">
-                      ${(product.price_cents / 100).toFixed(2)}
-                    </div>
-                  </div>
-                </button>
-              ))}
+           {/* View Toggle */}
+           <div className="flex bg-gray-200/50 backdrop-blur-[30px] rounded-xl p-1 mb-6 mx-2 mt-8">
+              <button
+                onClick={() => setPosMode('catalog')}
+                className={`flex-1 py-2 text-sm font-bold rounded-lg transition-all min-h-[44px] ${posMode === 'catalog' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500'}`}
+              >
+                {t('Catalog')}
+              </button>
+              <button
+                onClick={() => setPosMode('quick_charge')}
+                className={`flex-1 py-2 text-sm font-bold rounded-lg transition-all min-h-[44px] ${posMode === 'quick_charge' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500'}`}
+              >
+                {t('Quick Charge')}
+              </button>
            </div>
+
+           {/* Catalog Selection */}
+           {posMode === 'catalog' && (
+             <>
+               <h3 className="text-sm font-bold text-gray-400 uppercase tracking-wider mb-4 px-2">{t('Product Catalog')}</h3>
+               <div className="grid grid-cols-1 gap-3 mb-8">
+                  {inventory.length === 0 ? (
+                    <p className="text-center text-gray-500 py-4 italic">{t('No products found in catalog')}</p>
+                  ) : inventory.map(product => (
+                    <button
+                      key={product.id}
+                      onClick={() => handleAddToCart(product)} disabled={reserving || isCartOpen}
+                      className={`p-4 rounded-[8px] text-left transition-all active:scale-[0.98] min-h-[64px] min-w-[44px] shadow-lg backdrop-blur-[30px] saturate-[210%] ${selectedProduct?.id === product.id ? 'bg-white/80 ring-1 ring-[#0066FF] border border-[#0066FF]' : 'bg-white/65 border border-white/50'}`}
+                    >
+                      <div className="flex justify-between items-center">
+                        <div>
+                          <div className="font-bold text-gray-900">{product.name}</div>
+                          <div className="text-xs text-gray-500 line-clamp-1">{product.description} &bull; Stock: {product.stock}</div>
+                        </div>
+                        <div className="text-[#0071E3] font-bold">
+                          ${(product.price_cents / 100).toFixed(2)}
+                        </div>
+                      </div>
+                    </button>
+                  ))}
+               </div>
+             </>
+           )}
+
+           {/* Quick Charge Keypad */}
+           {posMode === 'quick_charge' && (
+             <div className="mb-8 px-2 flex flex-col items-center">
+                <div className="w-full text-center mb-6">
+                  <div className="text-5xl font-outfit font-bold text-gray-900">
+                    ${(parseInt(chargeAmount || '0') / 100).toFixed(2)}
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-3 gap-4 w-full max-w-xs mb-8">
+                  {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map(num => (
+                    <button
+                      key={num}
+                      onClick={() => handleKeypadPress(num)}
+                      className="bg-white/70 backdrop-blur-[30px] border border-white/50 rounded-2xl h-16 text-2xl font-bold text-gray-900 shadow-sm active:bg-gray-200 transition-colors min-h-[44px]"
+                    >
+                      {num}
+                    </button>
+                  ))}
+                  <button className="h-16 min-h-[44px]"></button>
+                  <button
+                    onClick={() => handleKeypadPress('0')}
+                    className="bg-white/70 backdrop-blur-[30px] border border-white/50 rounded-2xl h-16 text-2xl font-bold text-gray-900 shadow-sm active:bg-gray-200 transition-colors min-h-[44px]"
+                  >
+                    0
+                  </button>
+                  <button
+                    onClick={() => handleKeypadPress('backspace')}
+                    className="bg-white/70 backdrop-blur-[30px] border border-white/50 rounded-2xl h-16 text-2xl font-bold text-gray-900 shadow-sm active:bg-gray-200 flex items-center justify-center transition-colors min-h-[44px]"
+                  >
+                    <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2M3 12l6.414 6.414a2 2 0 001.414.586H19a2 2 0 002-2V7a2 2 0 00-2-2h-8.172a2 2 0 00-1.414.586L3 12z" /></svg>
+                  </button>
+                </div>
+
+                <button
+                  onClick={() => setShowPaymentSheet(true)}
+                  disabled={parseInt(chargeAmount || '0') === 0}
+                  className="w-full bg-[#0066FF] text-white rounded-xl min-h-[60px] text-lg font-bold flex justify-center items-center px-6 shadow-lg active:scale-[0.98] disabled:opacity-50"
+                >
+                  Charge ${(parseInt(chargeAmount || '0') / 100).toFixed(2)}
+                </button>
+             </div>
+           )}
 
            {/* Bottom Bar */}
            {cartItemCount > 0 && !checkoutComplete && (
@@ -467,44 +548,55 @@ export default function POSTerminal() {
              </div>
            )}
 
-           {/* Cart Drawer */}
-           {isCartOpen && !checkoutComplete && (
+           {/* Cart Drawer & Payment Bottom Sheet */}
+           {(isCartOpen || showPaymentSheet) && !checkoutComplete && (
              <div className="fixed inset-0 z-50 flex flex-col justify-end">
-               <div className="absolute inset-0 bg-black/40 backdrop-blur-[30px] saturate-[210%]" onClick={() => setIsCartOpen(false)}></div>
+               <div className="absolute inset-0 bg-black/40 backdrop-blur-[30px] saturate-[210%]" onClick={() => { setIsCartOpen(false); setShowPaymentSheet(false); }}></div>
                <div className="relative bg-white/85 backdrop-blur-[40px] saturate-[210%] border-t border-white/50 rounded-t-3xl p-6 shadow-2xl animate-in slide-in-from-bottom max-h-[90vh] overflow-y-auto">
                  <div className="flex justify-between items-center mb-6">
-                   <h2 className="text-xl font-bold font-outfit text-gray-900">Current Order</h2>
-                   <button onClick={() => setIsCartOpen(false)} className="p-2 bg-gray-100 rounded-full text-gray-500 hover:bg-gray-200">
+                   <h2 className="text-xl font-bold font-outfit text-gray-900">{isCartOpen ? 'Current Order' : 'Payment Method'}</h2>
+                   <button onClick={() => { setIsCartOpen(false); setShowPaymentSheet(false); }} className="p-2 bg-gray-100 rounded-full text-gray-500 hover:bg-gray-200">
                      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                    </button>
                  </div>
 
-                 <div className="space-y-4 mb-6">
-                   {cart.map((item, idx) => (
-                     <div key={idx} className="flex justify-between items-center p-4 bg-white/50 rounded-xl border border-white/60 shadow-sm">
-                       <div className="flex flex-col">
-                         <span className="font-bold text-gray-900">{item.product.name}</span>
-                         <span className="text-sm text-gray-500">Qty: {item.quantity}</span>
-                       </div>
-                       <span className="font-bold text-gray-900">${(item.product.price_cents * item.quantity / 100).toFixed(2)}</span>
+                 {isCartOpen && (
+                   <>
+                     <div className="space-y-4 mb-6">
+                       {cart.map((item, idx) => (
+                         <div key={idx} className="flex justify-between items-center p-4 bg-white/50 rounded-xl border border-white/60 shadow-sm">
+                           <div className="flex flex-col">
+                             <span className="font-bold text-gray-900">{item.product.name}</span>
+                             <span className="text-sm text-gray-500">Qty: {item.quantity}</span>
+                           </div>
+                           <span className="font-bold text-gray-900">${(item.product.price_cents * item.quantity / 100).toFixed(2)}</span>
+                         </div>
+                       ))}
                      </div>
-                   ))}
-                 </div>
 
-                 <div className="border-t border-gray-200 pt-4 mb-4">
-                   <div className="flex justify-between items-center font-bold text-xl text-gray-900">
-                     <span>Total</span>
-                     <span>${(cartTotal / 100).toFixed(2)}</span>
+                     <div className="border-t border-gray-200 pt-4 mb-4">
+                       <div className="flex justify-between items-center font-bold text-xl text-gray-900">
+                         <span>Total</span>
+                         <span>${(cartTotal / 100).toFixed(2)}</span>
+                       </div>
+                     </div>
+                   </>
+                 )}
+
+                 {showPaymentSheet && posMode === 'quick_charge' && (
+                   <div className="border-b border-gray-200 pb-4 mb-6 text-center">
+                     <div className="text-sm text-gray-500 uppercase tracking-wider font-bold mb-1">Amount Due</div>
+                     <div className="text-4xl font-bold text-gray-900">${(parseInt(chargeAmount || '0') / 100).toFixed(2)}</div>
                    </div>
-                 </div>
+                 )}
 
                  <StripeTerminalClient
-                    amount={cartTotal}
-                    productId={cart[0].product.id}
-                    cart={cart}
+                    amount={posMode === 'quick_charge' ? parseInt(chargeAmount || '0') : cartTotal}
+                    productId={posMode === 'quick_charge' ? 'custom-charge' : (cart[0]?.product?.id || 'custom-charge')}
+                    cart={posMode === 'quick_charge' ? [] : cart}
                     tenantId={activeStaff?.tenant_id || "default_tenant"}
-                    onOptimisticReserve={() => cart.forEach(item => handleOptimisticReserve(item.product.id))}
-                    onOptimisticRollback={() => cart.forEach(item => handleOptimisticRollback(item.product.id))}
+                    onOptimisticReserve={() => { if (posMode !== 'quick_charge') cart.forEach(item => handleOptimisticReserve(item.product.id)) }}
+                    onOptimisticRollback={() => { if (posMode !== 'quick_charge') cart.forEach(item => handleOptimisticRollback(item.product.id)) }}
                     onSuccess={handleCheckoutComplete}
                  />
                </div>


### PR DESCRIPTION
This pull request implements the Universal Tap-to-Pay and Offline-Tolerant POS Architecture as requested in #33945.

### Key Changes
- **Agent Feed Integration:** Added a "New Sale" action button to the feed using `AppShell` actions.
- **Quick Charge Keypad:** Implemented a new "Quick Charge" mode toggle on the POS Terminal, replacing the catalog with a large numeric keypad featuring 44px+ touch targets suitable for 375px mobile viewports.
- **Payment Method Bottom Sheet:** Created a translucent, glass-styled bottom sheet allowing the operator to select between "Tap to Pay" and "Cash".
- **Offline Tolerance:** Updated `StripeTerminalClient` to gracefully handle offline Quick Charge transactions, routing custom amounts to the local SQLite/IndexedDB queue correctly.
- **Backend Success Drafting:** Updated `capture_payment_intent_handler` and `pos_sync_worker.rs` to insert a drafted success card (`"Transaction successful. Send receipt?"`) directly into `agent_feed_items` when a POS transaction successfully completes or syncs.
- **Testing:** Added a new comprehensive Playwright E2E test to cover the `Field Service Owner uses Quick Charge offline Tap-to-Pay` journey.

### Product-use evidence
- **Persona:** Carlos (Field Service Owner)
- **Observed Flow:** Launched the local UI, navigated to the Agent Feed, clicked "New Sale", successfully used the Quick Charge numeric keypad to enter $15.00, went offline, selected "Tap to Pay", and confirmed the transaction was queued in the IndexedDB offline outbox.
- **Post-Fix Proof:** Restored the network connection and verified the transaction synced to the backend and the new success drafted card appeared in the Agent Feed.

### Superpowers Skills applied
- loaded universal E2E validation logic.

Resolves #33945

---
*PR created automatically by Jules for task [8474383742120851810](https://jules.google.com/task/8474383742120851810) started by @ql-owo-lp*