### PR TITLE
chore: Eliminate API mock fallbacks and fix telemetry drift

### DIFF
--- a/deploy/docker/grafana/provisioning/dashboards/cost_dashboard.json
+++ b/deploy/docker/grafana/provisioning/dashboards/cost_dashboard.json
@@ -107,8 +107,7 @@
         }
       ],
       "title": "LLM Cost by Agent (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -183,8 +182,7 @@
         }
       ],
       "title": "API Cost by Integration (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -259,8 +257,7 @@
         }
       ],
       "title": "Storage Cost (Bytes/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -335,8 +332,7 @@
         }
       ],
       "title": "Email Send Cost (Count/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     }
   ],
   "refresh": false,

--- a/deploy/grafana/dashboards/cost_dashboard.json
+++ b/deploy/grafana/dashboards/cost_dashboard.json
@@ -107,8 +107,7 @@
         }
       ],
       "title": "LLM Cost by Agent (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -183,8 +182,7 @@
         }
       ],
       "title": "API Cost by Integration (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -259,8 +257,7 @@
         }
       ],
       "title": "Storage Cost (Bytes/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -335,8 +332,7 @@
         }
       ],
       "title": "Email Send Cost (Count/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     }
   ],
   "refresh": false,

--- a/deploy/helm/ohc/dashboards/cost_dashboard.json
+++ b/deploy/helm/ohc/dashboards/cost_dashboard.json
@@ -107,8 +107,7 @@
         }
       ],
       "title": "LLM Cost by Agent (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -183,8 +182,7 @@
         }
       ],
       "title": "API Cost by Integration (USD/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -259,8 +257,7 @@
         }
       ],
       "title": "Storage Cost (Bytes/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
@@ -335,8 +332,7 @@
         }
       ],
       "title": "Email Send Cost (Count/sec)",
-      "type": "timeseries",
-      "transparent": true
+      "type": "timeseries"
     }
   ],
   "refresh": false,

--- a/src/ui/next/src/app/api/assistant/connectors/route.ts
+++ b/src/ui/next/src/app/api/assistant/connectors/route.ts
@@ -13,10 +13,10 @@ function backendHeaders(request?: Request) {
   return headers;
 }
 
-async function upstreamJson(response: Response, fallbackMessage: string) {
+async function upstreamJson(response: Response, errorMessage: string) {
   const data = await response.json().catch(() => ({}));
   if (!response.ok) {
-    return NextResponse.json({ error: data.error || fallbackMessage }, { status: response.status === 404 ? 404 : 502 });
+    return NextResponse.json({ error: data.error || errorMessage }, { status: response.status === 404 ? 404 : 502 });
   }
   return NextResponse.json(data);
 }

--- a/src/ui/next/src/app/api/assistant/memory/route.ts
+++ b/src/ui/next/src/app/api/assistant/memory/route.ts
@@ -13,10 +13,10 @@ function backendHeaders(request?: Request) {
   return headers;
 }
 
-async function upstreamJson(response: Response, fallbackMessage: string) {
+async function upstreamJson(response: Response, errorMessage: string) {
   const data = await response.json().catch(() => ({}));
   if (!response.ok) {
-    return NextResponse.json({ error: data.error || fallbackMessage }, { status: response.status === 404 ? 404 : 502 });
+    return NextResponse.json({ error: data.error || errorMessage }, { status: response.status === 404 ? 404 : 502 });
   }
   return NextResponse.json(data);
 }

--- a/src/ui/next/src/app/api/assistant/skills/route.ts
+++ b/src/ui/next/src/app/api/assistant/skills/route.ts
@@ -13,10 +13,10 @@ function backendHeaders(request?: Request) {
   return headers;
 }
 
-async function upstreamJson(response: Response, fallbackMessage: string) {
+async function upstreamJson(response: Response, errorMessage: string) {
   const data = await response.json().catch(() => ({}));
   if (!response.ok) {
-    return NextResponse.json({ error: data.error || fallbackMessage }, { status: response.status === 404 ? 404 : 502 });
+    return NextResponse.json({ error: data.error || errorMessage }, { status: response.status === 404 ? 404 : 502 });
   }
   return NextResponse.json(data);
 }

--- a/src/ui/next/src/app/api/assistant/tasks/route.ts
+++ b/src/ui/next/src/app/api/assistant/tasks/route.ts
@@ -13,10 +13,10 @@ function backendHeaders(request?: Request) {
   return headers;
 }
 
-async function upstreamJson(response: Response, fallbackMessage: string) {
+async function upstreamJson(response: Response, errorMessage: string) {
   const data = await response.json().catch(() => ({}));
   if (!response.ok) {
-    return NextResponse.json({ error: data.error || fallbackMessage }, { status: response.status === 404 ? 404 : 502 });
+    return NextResponse.json({ error: data.error || errorMessage }, { status: response.status === 404 ? 404 : 502 });
   }
   return NextResponse.json(data);
 }

--- a/src/ui/next/src/app/api/v1/growth/cloud-bridge/invite/route.ts
+++ b/src/ui/next/src/app/api/v1/growth/cloud-bridge/invite/route.ts
@@ -30,42 +30,16 @@ export async function POST(request: Request) {
       headers.set('cookie', cookie);
     }
 
-    let backendRes;
-    try {
-      backendRes = await fetch(`${backendUrl}/api/v1/growth/team-invites`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(payload)
-      });
-    } catch (e) {
-       if (process.env.PLAYWRIGHT_TEST === "1" || process.env.CI) {
-         // Fallback for playwright testing when backend doesn't exist
-         return NextResponse.json({
-             id: "test-invite-123",
-             team_id: payload.team_id,
-             inviter_id: payload.inviter_id,
-             invitee_id: payload.invitee_id,
-             invite_link: `https://ohc.app/invite/test-invite-123`,
-             status: "PENDING"
-         });
-       }
-       throw e;
-    }
+    const backendRes = await fetch(`${backendUrl}/api/v1/growth/team-invites`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload)
+    });
 
     if (backendRes.ok) {
         const data = await backendRes.json();
         return NextResponse.json(data);
     } else {
-        if (process.env.PLAYWRIGHT_TEST === "1" || process.env.CI) {
-           return NextResponse.json({
-               id: "test-invite-123",
-               team_id: payload.team_id,
-               inviter_id: payload.inviter_id,
-               invitee_id: payload.invitee_id,
-               invite_link: `https://ohc.app/invite/test-invite-123`,
-               status: "PENDING"
-           });
-        }
         return NextResponse.json(
             { error: 'Failed to generate cloud bridge invite link' },
             { status: backendRes.status }

--- a/src/ui/next/src/app/api/v1/growth/loyalty/route.test.ts
+++ b/src/ui/next/src/app/api/v1/growth/loyalty/route.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GET } from './route';
+
+vi.mock('pg', () => {
+  return {
+    Pool: vi.fn().mockImplementation(function() {
+      return {
+        query: vi.fn().mockRejectedValue(new Error('Connection failed')),
+        end: vi.fn(),
+      };
+    }),
+  };
+});
+
+describe('/api/v1/growth/loyalty', () => {
+  it('should fail with 502 and not return fake data when DB fails', async () => {
+    const req = new Request('http://localhost:3000/api/v1/growth/loyalty?tenant_id=t1&customer_id=c1');
+    const res = await GET(req);
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.error).toBe('Failed to fetch loyalty data');
+    expect(json.points_balance).toBeUndefined(); // Proves no mock/fallback 0
+  });
+});

--- a/src/ui/next/src/app/api/v1/growth/loyalty/route.ts
+++ b/src/ui/next/src/app/api/v1/growth/loyalty/route.ts
@@ -29,8 +29,7 @@ export async function GET(request: Request) {
     }
   } catch (error) {
     console.error('Error fetching loyalty points:', error);
-    // As a fallback (if table missing or offline), return 0 so it doesn't crash
-    return NextResponse.json({ points_balance: 0 });
+    return NextResponse.json({ error: 'Failed to fetch loyalty data' }, { status: 502 });
   } finally {
     await pool.end();
   }


### PR DESCRIPTION
I have fully investigated and implemented the mock elimination mandate across the API routes.

Highlights of changes:
- Removed `PLAYWRIGHT_TEST` fallback in the `/api/v1/growth/cloud-bridge/invite` route.
- Modified the `/api/v1/growth/loyalty` route to return a 502 error status instead of falling back to 0 points when the database is unavailable. Added a unit test to verify this failure mode using a proper `pg` mock.
- Renamed `fallbackMessage` to `errorMessage` across assistant API route tests to match the "fail closed" semantics.
- Fixed a test failure in `//src/server/telemetry:server_telemetry_unit_test` (`dashboard_test::test_hybrid_telemetry_drift`) by correctly syncing the `cost_dashboard.json` files between the `src` definitions and their deployment targets.

All bazel tests, including `bazel test //...`, have been completed and are 100% passing. The code review confirmed the patch is correct and safe.

---
*PR created automatically by Jules for task [1789084842102269927](https://jules.google.com/task/1789084842102269927) started by @ql-owo-lp*