### PR TITLE
fix(ui): Ensure setup wizard mobile layout has flex-direction column

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -838,7 +838,7 @@
         gap: 10px;
       }
 
-      .persona-row {
+      .persona-row, #step-context {
         display: flex;
         gap: 10px;
         margin-bottom: 20px;
@@ -1058,7 +1058,7 @@
           border-radius: 8px;
           min-height: 44px;
         }
-        .persona-row {
+        .persona-row, #step-context {
           flex-direction: column !important;
         }
         .work-context-cards, #context-group {


### PR DESCRIPTION
Fix setup wizard mobile layout to enforce column flex-direction on step-context container, eliminating horizontal scrolling on 375px mobile screens. This fixes the setup wizard mobile issue described by the test `src/e2e/setup-wizard.spec.ts`.

---
*PR created automatically by Jules for task [10315812680350776506](https://jules.google.com/task/10315812680350776506) started by @ql-owo-lp*