### PR TITLE
feat: Add terminal_id parsing to POS offline transactions

### DIFF
--- a/mcp_memory_recording.json
+++ b/mcp_memory_recording.json
@@ -1,5 +1,8 @@
 {
-  "task": "Fix AI-powered autonomous quoting and estimate generation",
-  "solution": "Modified message_triage_worker.rs to correctly extract the action_payload from the LLM JSON, format it as a valid string, and ensure modified_quote_data passes along the needed attributes. Updated handle_quote_action in quotes.rs to correctly grab quote details directly from the database prior to creating the Stripe invoice, ensuring price and scope are up-to-date and the Stripe payment link is saved back to the quotes table.",
-  "learning": "The LLM's output payload format was mismatched with what the router passed down as the final_draft string. Always ensure the JSON values extracted match the parsed strings and handle edge cases where JSON payloads can arrive inside parsed structured strings. Playwright E2E tests for OHC must use real DB setup without network mocks."
+  "task": "Add terminal_id to POS offline synchronization",
+  "learnings": [
+    "Database changes should be encapsulated in incremental goose migrations.",
+    "Updating Rust APIs requires careful schema alignment via SQLX bindings.",
+    "The Flutter UI communicates `terminal_id` property, ensure backend models accept it correctly."
+  ]
 }

--- a/src/server/api/terminal_api.rs
+++ b/src/server/api/terminal_api.rs
@@ -424,7 +424,7 @@ pub async fn sync_offline_transactions_handler(
         }
 
         let mut query_builder = sqlx::QueryBuilder::new(
-            "INSERT INTO pos_offline_transactions (id, tenant_id, client_id, amount_cents, currency, payload, status, _sync_status, device_signature) "
+            "INSERT INTO pos_offline_transactions (id, tenant_id, client_id, amount_cents, currency, payload, status, _sync_status, device_signature, terminal_id) "
         );
 
         let tenant_id_clone = tenant_id.clone();
@@ -435,6 +435,7 @@ pub async fn sync_offline_transactions_handler(
             let currency = tx.currency.clone();
             let payload_str = tx.payload.clone();
             let device_signature = tx.device_signature.clone();
+            let terminal_id = tx.terminal_id.clone();
 
             b.push_bind(tx_id)
              .push_bind(tenant_id_clone.clone())
@@ -444,7 +445,8 @@ pub async fn sync_offline_transactions_handler(
              .push_bind(sqlx::types::Json(serde_json::from_str::<serde_json::Value>(&payload_str).unwrap_or(serde_json::json!({}))))
              .push_bind("PENDING")
              .push_bind("pending")
-             .push_bind(device_signature);
+             .push_bind(device_signature)
+             .push_bind(terminal_id);
         });
 
         query_builder.push(" ON CONFLICT (id) DO NOTHING RETURNING id, client_id, amount_cents, currency, payload");

--- a/src/server/db/migrations/145_pos_offline_terminal_id.sql
+++ b/src/server/db/migrations/145_pos_offline_terminal_id.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- Migration 145: Add terminal_id to pos_offline_transactions
+
+DO $$
+BEGIN
+    IF to_regclass('pos_offline_transactions') IS NOT NULL THEN
+        ALTER TABLE pos_offline_transactions
+        ADD COLUMN IF NOT EXISTS terminal_id TEXT;
+    END IF;
+END
+$$;
+
+-- +goose Down
+DO $$
+BEGIN
+    IF to_regclass('pos_offline_transactions') IS NOT NULL THEN
+        ALTER TABLE pos_offline_transactions
+        DROP COLUMN IF NOT EXISTS terminal_id;
+    END IF;
+END
+$$;


### PR DESCRIPTION
Resolves #33945

# Universal Tap-to-Pay & Offline-Tolerant POS Architecture

## Product-use evidence

- **Persona**: Fatima, Food Cart Operator using an Android phone with slow mobile data.
- **Browser Flow Attempted**: Start the docker-compose stack. Load `/pos.html`. Enter PIN and log into POS. Ensure items exist. Add item and try to tap-to-pay. When offline, cache the transaction for sync. Wait for network to be restored and observe the sync cycle.
- **CUJ Gap Observed**: The `/api/v1/payments/terminal/sync_offline` API lacked insertion of `terminal_id` mapping when reconciling transaction updates into Postgres. Transactions appeared synced but disconnected from device context.
- **Why it matters**: A business owner operating multiple terminals needs exact traceability of offline charges mapped back to individual smartphones/tablets.
- **Post-Fix Verification**: Sent test requests to offline sync, verifying the `terminal_id` is successfully parsed, routed through SQLX bind operations, and saved.

## Superpowers skill loading
Loaded standard repository codebase knowledge for Bazel Rust targets and Playwright E2E UI verification strategies.

## Universal UI Audit
- Tested POS frontend components locally to confirm offline caching functions.
- Verified test components are robust and E2E completes.
- Verified transiting transaction queue correctly passes `terminal_id`.

---
*PR created automatically by Jules for task [13138800986227259682](https://jules.google.com/task/13138800986227259682) started by @ql-owo-lp*