### PR TITLE
🤖 Implementer: Harness Upgrade - Error Handling: LLM-Recoverable ToolMessages

### DIFF
--- a/src/agents/builtin/tool_executor_engine.rs
+++ b/src/agents/builtin/tool_executor_engine.rs
@@ -70,9 +70,7 @@ impl ToolExecutionEngine {
                         "LLM-recoverable error encountered in tool '{}' (Pydantic-first schema failure or similar): {}",
                         tool.name, msg
                     );
-                    let formatted_msg = ohc_builtin_agent_core::types::format_llm_recoverable_error(
-                        &tool.name, &msg,
-                    );
+                    let formatted_msg = msg; // Do not format twice. Let agent.rs call `new_llm_recoverable`.
                     return Err(ToolError::LlmRecoverable(formatted_msg));
                 }
                 Err(ToolError::UserFixable(msg)) => {
@@ -208,8 +206,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             ToolError::LlmRecoverable(msg) => {
-                assert!(msg.contains("LLM-Recoverable Tool Error"));
-                assert!(msg.contains("test_tool"));
+                // We no longer format inside execute_tool_with_langgraph_mechanics
                 assert!(msg.contains("bad schema"));
             }
             _ => panic!("Expected LlmRecoverable error"),


### PR DESCRIPTION
# 🤖 Implementer: Harness Upgrade - Error Handling: LLM-Recoverable ToolMessages

### Context & Implementation
This PR executes the "Roulette Protocol" and specifically addresses:
> **Error Handling (Compounding Error Prevention)**: Stripe limits retries to exactly 2. LangGraph Mechanic (4-types): 1) Transient (retry with backoff), 2) LLM-recoverable (return the raw error as a ToolMessage directly to the model so it can self-correct)

### Details
Previously, in `src/agents/builtin/tool_executor_engine.rs`, a `ToolError::LlmRecoverable` would pass its raw error message into `ohc_builtin_agent_core::types::format_llm_recoverable_error` directly, before passing the *already formatted* string up as the error string payload. However, the outer caller loop in `agent.rs` takes this string payload and re-calls `ToolResult::new_llm_recoverable`, which calls the format function *again*. 

This resulted in double-formatting the string. The fix implemented in this PR passes the raw `msg` out in `ToolError::LlmRecoverable(msg)` so that the caller can correctly format it precisely once. Accompanying unit tests have been updated.

### Testing
- `bazelisk test //...` passes 100%.
- Verified via direct unit tests under `tool_executor_engine_tests.rs`.

---
*PR created automatically by Jules for task [4310220862358997770](https://jules.google.com/task/4310220862358997770) started by @ql-owo-lp*