### PR TITLE
miser: enforce mock elimination and cache cost dashboard queries

### DIFF
--- a/src/server/api/billing_api.rs
+++ b/src/server/api/billing_api.rs
@@ -331,9 +331,7 @@ pub async fn create_checkout_session_handler(
             },
         }
     } else {
-        // Fallback for tests / missing Stripe config
-        let fallback_tier = req.tier.clone().unwrap_or_else(|| "product".to_string());
-        Ok(Json(CreateCheckoutSessionResponse { checkout_url: format!("/checkout?tier={}", fallback_tier) }))
+        Err(axum::http::StatusCode::SERVICE_UNAVAILABLE)
     }
 }
 

--- a/src/server/pricing/cost_aggregator.rs
+++ b/src/server/pricing/cost_aggregator.rs
@@ -67,7 +67,25 @@ pub fn process_telemetry_rows(rows: Vec<TelemetryRow>) -> Vec<DailyCost> {
     sorted
 }
 
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+use std::collections::HashMap;
+
+static DAILY_COST_CACHE: OnceLock<Mutex<HashMap<String, (Instant, Vec<DailyCost>)>>> = OnceLock::new();
+static AGENT_COST_CACHE: OnceLock<Mutex<HashMap<String, (Instant, Vec<AgentCostRow>)>>> = OnceLock::new();
+
+const CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
+
 pub async fn aggregate_daily_costs(pool: &PgPool, tenant_id: &str) -> Vec<DailyCost> {
+    let cache = DAILY_COST_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(map) = cache.lock() {
+        if let Some((ts, data)) = map.get(tenant_id) {
+            if ts.elapsed() < CACHE_TTL {
+                return data.clone();
+            }
+        }
+    }
+
     // Optimized Query: Cast labels_json to jsonb explicitly if it isn't already,
     // and use the ->> operator for faster execution than json_extract_path_text.
     // Ensure we handle potential errors robustly instead of silently failing.
@@ -112,7 +130,14 @@ pub async fn aggregate_daily_costs(pool: &PgPool, tenant_id: &str) -> Vec<DailyC
         }),
     }).collect();
 
-    process_telemetry_rows(rows)
+    let result = process_telemetry_rows(rows);
+
+    let cache = DAILY_COST_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(mut map) = cache.lock() {
+        map.insert(tenant_id.to_string(), (Instant::now(), result.clone()));
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -263,6 +288,15 @@ pub fn process_agent_cost_rows(rows: Vec<AgentCostRawRow>) -> Vec<AgentCostRow> 
 }
 
 pub async fn aggregate_agent_costs(pool: &PgPool, tenant_id: &str) -> Vec<AgentCostRow> {
+    let cache = AGENT_COST_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(map) = cache.lock() {
+        if let Some((ts, data)) = map.get(tenant_id) {
+            if ts.elapsed() < CACHE_TTL {
+                return data.clone();
+            }
+        }
+    }
+
     let raw_rows_result = sqlx::query(
         r#"
         SELECT
@@ -294,5 +328,12 @@ pub async fn aggregate_agent_costs(pool: &PgPool, tenant_id: &str) -> Vec<AgentC
         total: r.try_get::<Option<f64>, _>("total").unwrap_or(None),
     }).collect();
 
-    process_agent_cost_rows(processed_rows)
+    let result = process_agent_cost_rows(processed_rows);
+
+    let cache = AGENT_COST_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(mut map) = cache.lock() {
+        map.insert(tenant_id.to_string(), (Instant::now(), result.clone()));
+    }
+
+    result
 }


### PR DESCRIPTION
I have successfully resolved the problem by adhering to the `docs/superpowers/specs/2026-07-01-mock-elimination-design.md` instructions and implementing caching optimizations as required by the Continuous Codebase Optimization Protocol.

1. **Mock Elimination**: I modified `src/server/api/billing_api.rs` to ensure `create_checkout_session_handler` accurately fails closed with `axum::http::StatusCode::SERVICE_UNAVAILABLE` rather than defaulting to a local mock test link (`/checkout?tier=...`) when the real external service config is missing.
2. **PostgreSQL Read Operations Optimized**: For continuous codebase optimization (`aggregate_daily_costs` and `aggregate_agent_costs`), I added in-memory `OnceLock` caches that provide up to a 5-minute TTL memory layer for these expensive aggregation queries executed under the `src/server/pricing/cost_aggregator.rs` paths, dramatically minimizing Postgres load during tenant traffic spikes for My Plan widgets and billing dashboards.
3. All `bazel build //...`, `bazel test //...` unit tests, and Playwright UI tests passed seamlessly across the codebase, confirming no regressions.

---
*PR created automatically by Jules for task [15245780846473353689](https://jules.google.com/task/15245780846473353689) started by @ql-owo-lp*