### PR TITLE
🗺️ Guide: Optimize duplicated CSS in mobile onboarding HTML

### DIFF
--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -1148,7 +1148,7 @@
       .glassmorphism.card,
       .glassmorphism.panel {
       }
-          #instant-bio { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; border-radius: 8px; }
+      #instant-bio { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; border-radius: 8px; }
       .context-card { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; }
 
       /* --- OHC Premium Dark Mode & Animations --- */
@@ -1333,8 +1333,6 @@
           box-shadow: 0 0 0 1px #0066FF;
         }
       }
-          #instant-bio { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; border-radius: 8px; }
-      .context-card { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; }
     </style>
 
 
@@ -4809,8 +4807,6 @@
       .ohc-tooltip.visible {
         opacity: 1;
       }
-          #instant-bio { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; border-radius: 8px; }
-      .context-card { min-height: 44px !important; padding: 12px; margin: 4px; box-sizing: border-box; }
     </style>
     <script>
       document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
This PR cleans up the CSS within `src/ui/tauri/src/ui/setup.html` by removing redundant CSS declarations that redefined properties for `#instant-bio` and `.context-card`. The duplicate rules added unnecessary bloat without changing the cascade or specificity properties since they were identical in values (e.g. `min-height: 44px !important`). All mobile dimension targets remain verified and unbroken per the Playwright UI automation suite.

### Product-use evidence
- **Persona:** Maya (Home Baker) / Non-technical Owner
- **Attempted Flow:** Start the OHC backend via `docker compose`, launch the Tauri Web UI locally, navigate to the onboarding flow `/setup.html`, resize the browser window specifically down to `375px`, interact with the text inputs on the start page.
- **Observed behavior before fix:** UI correctly adheres to standard 375px rules and 44px targets, but development audit found the source HTML bloated with identical redundant CSS rules redefining identical properties across multiple media queries.
- **After fix:** Verified that removing the redundant CSS bloat did not negatively impact the actual visual styling or touch-target validations when emulating mobile devices in the Chromium engine (as proven by automated interaction test passing).

### Loaded Superpowers Skills
No specific superpowers were necessary for this purely HTML refactor.

### Interaction Audit Table
Tested interactive elements natively inside the `setup.html` onboarding context.

| Tested Element | Designed Purpose | Observed Result | Fix |
|---|---|---|---|
| `#generate-storefront-btn` | Starts the Instant Build generator flow. | Button is visually large enough (>=44px), fires expected API requests upon submission with payload, gets disabled during loading. | No action required. |
| `.context-card` buttons | Proceeds to next wizard setup view. | Accurately accepts taps and changes visibility of step views. Passes >44px height checks. | Redundant identical styling definitions cleaned out. |

---
*PR created automatically by Jules for task [12776340726157623495](https://jules.google.com/task/12776340726157623495) started by @ql-owo-lp*