### PR TITLE
Fix setup-nav-button border radius to 8px

### DIFF
--- a/src/ui/next/src/app/globals.css
+++ b/src/ui/next/src/app/globals.css
@@ -856,7 +856,7 @@ button,
   min-width: 44px;
   padding: 6px 10px;
   border: 1px solid #d8e0ea;
-  border-radius: 8px;
+  border-radius: 8px !important;
   background: #f7f9fb !important;
   color: #526070;
   box-shadow: none;


### PR DESCRIPTION
The `onboarding_glassmorphism.spec.ts` test was failing because the `.setup-nav-button` button on the onboarding wizard setup screen had an incorrect border radius of `999px`. This has been corrected to use the expected `8px` styling. 

It was fixed by targeting the `.setup-nav-button` selector explicitly in `globals.css` avoiding global modifications.

---
*PR created automatically by Jules for task [14387537032736188180](https://jules.google.com/task/14387537032736188180) started by @ql-owo-lp*