### PR TITLE
🎥 Lens Audit: Remove mock data and fix E2E imports

### DIFF
--- a/src/ui/next/src/app/inbox/page.tsx
+++ b/src/ui/next/src/app/inbox/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import DOMPurify from 'isomorphic-dompurify';
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { AppShell } from "../components/AppShell";
 import { useQuery } from "@powersync/react";
@@ -219,10 +219,27 @@ function InboxWorkspace({
     }
   }
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   function handleAttachPhoto() {
-    // Mock attaching a photo by appending an image markdown URL
-    const mockImageUrl = "https://example.com/mock-upload.jpg";
-    setManualReply(prev => prev + (prev.endsWith(" ") || prev === "" ? "" : " ") + `![Image](${mockImageUrl})`);
+    fileInputRef.current?.click();
+  }
+
+  async function handleFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = async (event) => {
+      const base64String = event.target?.result as string;
+      setManualReply(prev => prev + (prev.endsWith(" ") || prev === "" ? "" : " ") + `![Image](${base64String})`);
+    };
+    reader.readAsDataURL(file);
+
+    // reset input
+    if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+    }
   }
 
   async function handleApproveAndSend(inboxMessageId: string) {
@@ -328,6 +345,7 @@ function InboxWorkspace({
                         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
                         Attach Photo
                       </button>
+                      <input type="file" accept="image/*" className="hidden" ref={fileInputRef} onChange={handleFileSelected} />
                     </div>
                   </div>
                 )}

--- a/src/ui/next/src/e2e/agent-marketplace.spec.ts
+++ b/src/ui/next/src/e2e/agent-marketplace.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Agent Marketplace', () => {
   test('should load the agent marketplace and allow searching, verifying basic data presence', async ({ page }) => {

--- a/src/ui/next/src/e2e/agentic-booking.spec.ts
+++ b/src/ui/next/src/e2e/agentic-booking.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Agentic Service Booking & Quoting CUJ', () => {
   test('Customer requests a service and Owner approves AI quote draft', async ({ page }) => {

--- a/src/ui/next/src/e2e/agentic_subscription_retention.spec.ts
+++ b/src/ui/next/src/e2e/agentic_subscription_retention.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 import { setupAuthAndDatabase } from './test_setup';
 
 test.describe('Agentic Subscription Retention CUJ', () => {

--- a/src/ui/next/src/e2e/ai-usage-limit-widget.spec.ts
+++ b/src/ui/next/src/e2e/ai-usage-limit-widget.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('AI Usage Limit Widget', () => {
   test('displays usage data, upgrade CTA, and viral Share button', async ({ page }) => {

--- a/src/ui/next/src/e2e/ai-usage-paywall.spec.ts
+++ b/src/ui/next/src/e2e/ai-usage-paywall.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('AI Usage Paywall Growth Loop', () => {
   test('displays usage data, upgrade CTA, and Powered by OHC viral branding', async ({ page }) => {

--- a/src/ui/next/src/e2e/ambassador-auto-reply.spec.ts
+++ b/src/ui/next/src/e2e/ambassador-auto-reply.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Ambassador Auto-Responder CUJ', () => {
   test('Owner sees AI Handled auto-replied message in inbox', async ({ page, request }) => {

--- a/src/ui/next/src/e2e/ambassador-reply.spec.ts
+++ b/src/ui/next/src/e2e/ambassador-reply.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Ambassador Auto-Responder CUJ', () => {
   test('Owner connects Meta Graph API and approves Ambassador drafted reply', async ({ page, request }) => {

--- a/src/ui/next/src/e2e/anthropic-guardrails.spec.ts
+++ b/src/ui/next/src/e2e/anthropic-guardrails.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Anthropic 3-Stage Tool Gating - Marketplace Simulation', () => {
   test('should load the agent marketplace and allow searching, verifying basic data presence', async ({ page }) => {

--- a/src/ui/next/src/e2e/api-docs.spec.ts
+++ b/src/ui/next/src/e2e/api-docs.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('API Documentation', () => {
   test('should load the Swagger UI on the api-docs page', async ({ page }) => {

--- a/src/ui/next/src/e2e/assistant.spec.ts
+++ b/src/ui/next/src/e2e/assistant.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 
 test.describe('Assistant Page', () => {

--- a/src/ui/next/src/e2e/branding-loop.spec.ts
+++ b/src/ui/next/src/e2e/branding-loop.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Branding Growth Loop', () => {
     test('Powered by OHC footer is present and links correctly', async ({ page }) => {

--- a/src/ui/next/src/e2e/business-analytics.spec.ts
+++ b/src/ui/next/src/e2e/business-analytics.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Business Analytics Flow', () => {
   test('Dashboard contains link to Business Analytics', async ({ page }) => {

--- a/src/ui/next/src/e2e/calendar.spec.ts
+++ b/src/ui/next/src/e2e/calendar.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Calendar & Bookings', () => {
   test('should display upcoming appointments and operations agent activity', async ({ page }) => {

--- a/src/ui/next/src/e2e/cart-recovery-auth.spec.ts
+++ b/src/ui/next/src/e2e/cart-recovery-auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Cart Recovery Auth and Metrics', () => {
   test('Dashboard loads abandoned carts without mock data', async ({ page }) => {

--- a/src/ui/next/src/e2e/cart-recovery.spec.ts
+++ b/src/ui/next/src/e2e/cart-recovery.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Cart Recovery E2E', () => {
   test('should display Powered by OHC component when generating draft', async ({ page }) => {

--- a/src/ui/next/src/e2e/changelog.spec.ts
+++ b/src/ui/next/src/e2e/changelog.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Release Notes & Changelog', () => {
     test('renders Changelog page with screenshots and can be accessed from AppShell', async ({ page }) => {

--- a/src/ui/next/src/e2e/client-intake-quoting.spec.ts
+++ b/src/ui/next/src/e2e/client-intake-quoting.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Autonomous Client Intake & Dynamic Quoting', () => {
   test('creates quote from intake and allows approval', async ({ request, page }) => {

--- a/src/ui/next/src/e2e/client-side-image-optimization.spec.ts
+++ b/src/ui/next/src/e2e/client-side-image-optimization.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';

--- a/src/ui/next/src/e2e/code-native.spec.ts
+++ b/src/ui/next/src/e2e/code-native.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test('Code-Native Execution E2E CUJ', async ({ page }) => {
   await page.goto('/code-native-execution');

--- a/src/ui/next/src/e2e/cost-dashboard.spec.ts
+++ b/src/ui/next/src/e2e/cost-dashboard.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Cost Dashboard Loop', () => {
   test('Cost dashboard loads and displays main metrics correctly', async ({ page }) => {

--- a/src/ui/next/src/e2e/dashboard_unified_feed.spec.ts
+++ b/src/ui/next/src/e2e/dashboard_unified_feed.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Real-Time Multi-Tenant Edge Notifications & Sync via WebSocket', () => {
   test('Dashboard Unified Feed receives real-time approval_request event', async ({ page }) => {

--- a/src/ui/next/src/e2e/dashboard_ux.spec.ts
+++ b/src/ui/next/src/e2e/dashboard_ux.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 import { currentAppSmoke } from '../../../../e2e/current_app_smoke';
 import { test as base } from '../../../../e2e/fixtures';
 

--- a/src/ui/next/src/e2e/documentation_features.spec.ts
+++ b/src/ui/next/src/e2e/documentation_features.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Documentation Features', () => {
 

--- a/src/ui/next/src/e2e/embeddable-storefront.spec.ts
+++ b/src/ui/next/src/e2e/embeddable-storefront.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Embeddable Storefront Widget Growth Loop', () => {
     test('dashboard shows the embed storefront widget and copies HTML', async ({ page }) => {

--- a/src/ui/next/src/e2e/exit-intent-builder.spec.ts
+++ b/src/ui/next/src/e2e/exit-intent-builder.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Exit-Intent Pop-up Builder', () => {
   test.use({ bypassCSP: true });

--- a/src/ui/next/src/e2e/growth_loops.spec.ts
+++ b/src/ui/next/src/e2e/growth_loops.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Growth & Referral Features', () => {
   test('GrowthReferralWidget renders successfully and can generate an invite link', async ({ page }) => {

--- a/src/ui/next/src/e2e/help_components.spec.ts
+++ b/src/ui/next/src/e2e/help_components.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Help Components', () => {
   test('Help Center page loads with articles', async ({ page }) => {

--- a/src/ui/next/src/e2e/hyperlocal-lead-gen.spec.ts
+++ b/src/ui/next/src/e2e/hyperlocal-lead-gen.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 import { adminPage } from '../../../../e2e/fixtures';
 
 test.describe('Hyperlocal Lead Gen CUJ', () => {

--- a/src/ui/next/src/e2e/integrations.spec.ts
+++ b/src/ui/next/src/e2e/integrations.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Integrations Loop', () => {
     test('Integrations loop connects Mercado Pago and Zoom', async ({ page }) => {

--- a/src/ui/next/src/e2e/interactive-quote.spec.ts
+++ b/src/ui/next/src/e2e/interactive-quote.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Interactive Quote Widget Growth Loop', () => {
     test('generator page renders correctly, preview updates, and public widget functions properly with viral loop link', async ({ page }) => {

--- a/src/ui/next/src/e2e/interactive_poll.spec.ts
+++ b/src/ui/next/src/e2e/interactive_poll.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Interactive Poll Generator E2E', () => {
   test('should allow creating a poll and viewing embed modal', async ({ page }) => {

--- a/src/ui/next/src/e2e/inventory_sync.spec.ts
+++ b/src/ui/next/src/e2e/inventory_sync.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Dynamic Centralized Inventory & POS Sync', () => {
   const tenantId = 'test-inventory-tenant';

--- a/src/ui/next/src/e2e/invoice.spec.ts
+++ b/src/ui/next/src/e2e/invoice.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Agentic Invoicing System E2E', () => {
   test('should verify invoice generator page renders properly', async ({ page }) => {

--- a/src/ui/next/src/e2e/kds.spec.ts
+++ b/src/ui/next/src/e2e/kds.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('KDS Offline & Multilingual', () => {
   test.describe.configure({ mode: 'serial' });

--- a/src/ui/next/src/e2e/kitchen-offline.spec.ts
+++ b/src/ui/next/src/e2e/kitchen-offline.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Kitchen Command Center Offline Sync', () => {
   test.describe.configure({ mode: 'serial' });

--- a/src/ui/next/src/e2e/knowledge-documents.spec.ts
+++ b/src/ui/next/src/e2e/knowledge-documents.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Knowledge & Documents Sync UX', () => {
   test('should display syncing status and update when complete', async ({ page }) => {

--- a/src/ui/next/src/e2e/langgraph.spec.ts
+++ b/src/ui/next/src/e2e/langgraph.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('LangGraph State Machine', () => {
   test('should execute a task via LangGraph mechanics and trigger tool node routing from sidebar', async ({ page }) => {

--- a/src/ui/next/src/e2e/link-in-bio.spec.ts
+++ b/src/ui/next/src/e2e/link-in-bio.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Link-in-Bio Generator Growth Loop', () => {
     test('generator page renders correctly, saves data, and public page works with footer', async ({ page }) => {

--- a/src/ui/next/src/e2e/link_in_bio.spec.ts
+++ b/src/ui/next/src/e2e/link_in_bio.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Link-in-Bio Generator E2E', () => {
   test('User can create and publish link in bio, then view it publicly', async ({ page }) => {

--- a/src/ui/next/src/e2e/loyalty-program.spec.ts
+++ b/src/ui/next/src/e2e/loyalty-program.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 
 test.describe('Automated Loyalty Campaign Growth Loop', () => {

--- a/src/ui/next/src/e2e/milestone-loop.spec.ts
+++ b/src/ui/next/src/e2e/milestone-loop.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Milestone Celebration Growth Loop', () => {
     test('displays milestone modal and correct links after login', async ({ page }) => {

--- a/src/ui/next/src/e2e/milestones.spec.ts
+++ b/src/ui/next/src/e2e/milestones.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Milestones Page UI', () => {
   // We navigate naturally through the frontend to reach the page.

--- a/src/ui/next/src/e2e/morning-briefing.spec.ts
+++ b/src/ui/next/src/e2e/morning-briefing.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Morning Briefing & Insight Chat Dashboard Integration', () => {
   test('should display the morning briefing and allow chatting', async ({ page }) => {

--- a/src/ui/next/src/e2e/multilingual_walkup.spec.ts
+++ b/src/ui/next/src/e2e/multilingual_walkup.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Multilingual Order Interceptor Walk-up', () => {
   test.beforeEach(async ({ page, context }) => {

--- a/src/ui/next/src/e2e/omni_inbox.spec.ts
+++ b/src/ui/next/src/e2e/omni_inbox.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Omnichannel Inbox UI', () => {
   test('Owner sees sender id and known customer in inbox', async ({ page }) => {

--- a/src/ui/next/src/e2e/onboarding.spec.ts
+++ b/src/ui/next/src/e2e/onboarding.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('OnboardingWizard CUJ', () => {
   test.beforeEach(async ({ page }) => {

--- a/src/ui/next/src/e2e/onboarding_error_banner.spec.ts
+++ b/src/ui/next/src/e2e/onboarding_error_banner.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Onboarding Error Banner UI', () => {
 

--- a/src/ui/next/src/e2e/owner-dashboard-booking.spec.ts
+++ b/src/ui/next/src/e2e/owner-dashboard-booking.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Owner Dashboard Bookings', () => {
   test('Owner can navigate to bookings management view and see AI suggestions context', async ({ page }) => {

--- a/src/ui/next/src/e2e/plan.spec.ts
+++ b/src/ui/next/src/e2e/plan.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 // NOTE: This test requires a docker-sandbox fix to run properly in CI
 // due to pgvector pull permissions in the Bazel test sandbox environment.

--- a/src/ui/next/src/e2e/pos-inventory-sync-optimistic.spec.ts
+++ b/src/ui/next/src/e2e/pos-inventory-sync-optimistic.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('POS Inventory Sync - Optimistic UI', () => {
   test('POS terminal immediately updates stock UI on charge before API returns', async ({ page }) => {

--- a/src/ui/next/src/e2e/pos-inventory-sync.spec.ts
+++ b/src/ui/next/src/e2e/pos-inventory-sync.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('POS Inventory Sync - E2E Race Condition', () => {
   test('POS terminal applies lock and prevents double booking online', async ({ page }) => {

--- a/src/ui/next/src/e2e/post-purchase-share.spec.ts
+++ b/src/ui/next/src/e2e/post-purchase-share.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 import { e2eTestTenant } from './fixtures';
 
 test.describe('Post-Purchase Share Widget Generator', () => {

--- a/src/ui/next/src/e2e/pricing.spec.ts
+++ b/src/ui/next/src/e2e/pricing.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Pricing Page Loop', () => {
   test('Pricing page loads and displays tiers correctly', async ({ page }) => {

--- a/src/ui/next/src/e2e/project-showcase.spec.ts
+++ b/src/ui/next/src/e2e/project-showcase.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Project Showcase Generator (Growth Loop)', () => {
     test.beforeEach(async ({ page }) => {

--- a/src/ui/next/src/e2e/pydantic-validation.spec.ts
+++ b/src/ui/next/src/e2e/pydantic-validation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Pydantic-First Tool Schema Validation', () => {
   test('should successfully validate correct tool payload', async ({ page }) => {

--- a/src/ui/next/src/e2e/qr-code-generator.spec.ts
+++ b/src/ui/next/src/e2e/qr-code-generator.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('QR Code Generation Widget', () => {
     test('renders correctly and generates QR code', async ({ page }) => {

--- a/src/ui/next/src/e2e/ralph-loop.spec.ts
+++ b/src/ui/next/src/e2e/ralph-loop.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('The Ralph Loop UI E2E', () => {
   test('Owner can navigate to Ralph Loop, enter task, and see execution', async ({ page }) => {

--- a/src/ui/next/src/e2e/real_estate_onboarding.spec.ts
+++ b/src/ui/next/src/e2e/real_estate_onboarding.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 import { e2eUrl } from './fixtures';
 
 test.describe('Real Estate Onboarding CUJ', () => {

--- a/src/ui/next/src/e2e/receipt-campaign.spec.ts
+++ b/src/ui/next/src/e2e/receipt-campaign.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Automated Receipt Campaign Growth Loop', () => {
     test('generate receipt endpoint returns 502 when backend is unavailable', async ({ request }) => {

--- a/src/ui/next/src/e2e/returns.spec.ts
+++ b/src/ui/next/src/e2e/returns.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Omnichannel Returns & Exchange Flow', () => {
   test('Customer initiates return and Owner approves it', async ({ page }) => {

--- a/src/ui/next/src/e2e/review-campaign.spec.ts
+++ b/src/ui/next/src/e2e/review-campaign.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('AI Review Campaign Builder', () => {
   test('should generate an AI review request campaign draft', async ({ page }) => {

--- a/src/ui/next/src/e2e/shift_reassignment.spec.ts
+++ b/src/ui/next/src/e2e/shift_reassignment.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 import { Pool } from 'pg';
 
 test.describe('Shift Reassignment Work Triage CUJ', () => {

--- a/src/ui/next/src/e2e/staff-mesh.spec.ts
+++ b/src/ui/next/src/e2e/staff-mesh.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Universal Autonomous Staff & Shift Management Mesh', () => {
   test('CUJ: Manager creates staff, staff logs in offline via PIN', async ({ page }) => {

--- a/src/ui/next/src/e2e/staff_manager.spec.ts
+++ b/src/ui/next/src/e2e/staff_manager.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test('Staff Manager handles data format correctly without crashing', async ({ page }) => {
   // Mock the /api/staff endpoint to return the format the backend uses

--- a/src/ui/next/src/e2e/staff_task_assignment.spec.ts
+++ b/src/ui/next/src/e2e/staff_task_assignment.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 import { Pool } from 'pg';
 
 test.describe('Staff AI Task & Summaries', () => {

--- a/src/ui/next/src/e2e/store-wrapped.spec.ts
+++ b/src/ui/next/src/e2e/store-wrapped.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Store Wrapped Growth Loop', () => {
     test('dashboard shows the Store Wrapped section and navigates to the wrapped page', async ({ page }) => {

--- a/src/ui/next/src/e2e/subscription_box.spec.ts
+++ b/src/ui/next/src/e2e/subscription_box.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Autonomous Subscription Box Lifecycle', () => {
 

--- a/src/ui/next/src/e2e/supply_chain.spec.ts
+++ b/src/ui/next/src/e2e/supply_chain.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Autonomous Supply Chain', () => {
   test('shows database-backed inventory state', async ({ page }) => {

--- a/src/ui/next/src/e2e/test_git_checkpointing.spec.ts
+++ b/src/ui/next/src/e2e/test_git_checkpointing.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Agent Protocol Git Checkpointing (SOTA Harness)', () => {
   test('creates task, executes steps, and verifies checkpoints can be restored via real stack', async ({ page }) => {

--- a/src/ui/next/src/e2e/test_glassmorphism.spec.ts
+++ b/src/ui/next/src/e2e/test_glassmorphism.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Premium Aesthetics Verification', () => {
   test.beforeEach(async ({ page }) => {

--- a/src/ui/next/src/e2e/test_observation_masking.spec.ts
+++ b/src/ui/next/src/e2e/test_observation_masking.spec.ts
@@ -1,5 +1,5 @@
 
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Observation Masking UI Settings', () => {
   test('Owner can toggle observation masking', async ({ page }) => {

--- a/src/ui/next/src/e2e/test_styled_pages.spec.ts
+++ b/src/ui/next/src/e2e/test_styled_pages.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Styled Pages Verification', () => {
   test.beforeEach(async ({ page }) => {

--- a/src/ui/next/src/e2e/tip-jar.spec.ts
+++ b/src/ui/next/src/e2e/tip-jar.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Tip Jar Widget Growth Loop', () => {
     test('renders the builder and viral branding loop correctly', async ({ page }) => {

--- a/src/ui/next/src/e2e/translucent_glass_ui.spec.ts
+++ b/src/ui/next/src/e2e/translucent_glass_ui.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Translucent Glass UI Aesthetics Verification', () => {
   test.beforeEach(async ({ page }) => {

--- a/src/ui/next/src/e2e/trial_extension.spec.ts
+++ b/src/ui/next/src/e2e/trial_extension.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Interactive Trial Extension', () => {
   test('should allow user to claim 7 extra days of pro by sharing on X', async ({ page, context }) => {

--- a/src/ui/next/src/e2e/verify-ui.spec.ts
+++ b/src/ui/next/src/e2e/verify-ui.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test('Verify onboarding UI', async ({ page }) => {
   // Mock external API responses to eliminate backend dependencies

--- a/src/ui/next/src/e2e/viral-agent-paywall.spec.ts
+++ b/src/ui/next/src/e2e/viral-agent-paywall.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Viral Agent Paywall Growth Loop', () => {
     test('intercepts advanced skill toggle and displays trial extension offer', async ({ page }) => {

--- a/src/ui/next/src/e2e/viral-loop-dashboard.spec.ts
+++ b/src/ui/next/src/e2e/viral-loop-dashboard.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Viral Loop Dashboard Widget', () => {
     test('dashboard surfaces viral loop metrics correctly and increments on invite generation', async ({ page }) => {

--- a/src/ui/next/src/e2e/viral-post-generator.spec.ts
+++ b/src/ui/next/src/e2e/viral-post-generator.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Viral Post Generator Soft Paywall', () => {
     test('should show soft paywall modal when attempting to remove branding', async ({ page }) => {

--- a/src/ui/next/src/e2e/viral_affiliate_marketing.spec.ts
+++ b/src/ui/next/src/e2e/viral_affiliate_marketing.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Autonomous Influencer and Affiliate Marketing Engine', () => {
     test('customer signs up as an affiliate via checkout success, and commission is tracked in owner dashboard', async ({ page, browser }) => {

--- a/src/ui/next/src/e2e/viral_job_board.spec.ts
+++ b/src/ui/next/src/e2e/viral_job_board.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Viral Job Board Generator', () => {
   test('should render the generator and preview correctly', async ({ page }) => {

--- a/src/ui/next/src/e2e/viral_pre_order_waitlist.spec.ts
+++ b/src/ui/next/src/e2e/viral_pre_order_waitlist.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Pre-Order Waitlist Engine', () => {
   test('should load the dashboard and click the waitlist link', async ({ page }) => {

--- a/src/ui/next/src/e2e/visual-workflow.spec.ts
+++ b/src/ui/next/src/e2e/visual-workflow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Visual Workflow Builder E2E', () => {
   test('should allow creating and running a visual workflow', async ({ page }) => {

--- a/src/ui/next/src/e2e/voice_assistant.spec.ts
+++ b/src/ui/next/src/e2e/voice_assistant.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Voice Assistant Mobile Command Center', () => {
   test('should process voice command and add Approval Card to Unified Agent Feed', async ({ page }) => {

--- a/src/ui/next/src/e2e/walkthrough.spec.ts
+++ b/src/ui/next/src/e2e/walkthrough.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Interactive Walkthroughs', () => {
 

--- a/src/ui/next/src/e2e/whatsapp-flow.spec.ts
+++ b/src/ui/next/src/e2e/whatsapp-flow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('WhatsApp Flow CUJ', () => {
   test('Owner connects WhatsApp via Meta Embedded Signup', async ({ page, request }) => {

--- a/src/ui/next/src/e2e/whatsapp-link-generator.spec.ts
+++ b/src/ui/next/src/e2e/whatsapp-link-generator.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('WhatsApp Link Generator Growth Loop', () => {
     test('renders the builder and viral branding loop correctly', async ({ page }) => {

--- a/src/ui/next/src/e2e/whatsapp-twilio-flow.spec.ts
+++ b/src/ui/next/src/e2e/whatsapp-twilio-flow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Twilio WhatsApp Flow CUJ', () => {
   test.beforeEach(async ({ page }) => {

--- a/src/ui/next/src/e2e/work_intake_widget.spec.ts
+++ b/src/ui/next/src/e2e/work_intake_widget.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Embeddable Work-Intake Widget Growth Loop', () => {
     test('dashboard shows the embed work intake widget and generates correct HTML', async ({ page }) => {

--- a/src/ui/next/src/e2e/zero-click-builder.spec.ts
+++ b/src/ui/next/src/e2e/zero-click-builder.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../../../e2e/fixtures';
 
 test.describe('Zero Click Builder Mobile Onboarding', () => {
   test.use({ viewport: { width: 375, height: 812 } }); // Mobile-first constraint


### PR DESCRIPTION
Removed hardcoded mock image URL in the Inbox implementation and replaced it with a hidden file input that reads local images as base64 Data URLs, enabling real interaction. Replaced direct `@playwright/test` imports in `src/ui/next/src/e2e/*.spec.ts` with local fixture imports `../../../../e2e/fixtures` to fix timeouts and hermetic execution issues during Bazel E2E tests.

---
*PR created automatically by Jules for task [833392470017542618](https://jules.google.com/task/833392470017542618) started by @ql-owo-lp*