### PR TITLE
fix(onboarding): resolve cross-device state sync conflicts

### DIFF
--- a/src/e2e/setup.spec.ts
+++ b/src/e2e/setup.spec.ts
@@ -117,6 +117,51 @@ test.describe.serial('OHC Setup Wizard Flow', () => {
     const btnBox = await page.locator('.next-step-btn').first().boundingBox();
     expect(btnBox?.height).toBeGreaterThanOrEqual(44);
   });
+  test('should prioritize backend state if updated_at is newer', async ({ page }) => {
+    const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
+    await page.route('**/setup.html', async route => {
+        const htmlContent = (() => {
+            try {
+                return fs.readFileSync(path.join(tauriUiDir, 'setup.html'), 'utf-8');
+            } catch(e) {
+                return fs.readFileSync(path.join(process.env.TEST_SRCDIR || '', process.env.TEST_WORKSPACE || '', 'src/ui/tauri/src/ui', 'setup.html'), 'utf-8');
+            }
+        })();
+        await route.fulfill({ contentType: 'text/html', body: htmlContent });
+    });
+    // intercept tooltips
+    await page.route('**/api/tooltips', async route => {
+      await route.fulfill({ status: 200, body: JSON.stringify({}) });
+    });
+
+    // Mock backend returning a newer state
+    await page.route('**/api/onboarding/draft', async route => {
+       await route.fulfill({ status: 200, body: JSON.stringify({
+           step: 4,
+           businessName: 'Backend Bakery',
+           categories: 'Home Baker',
+           updated_at: Date.now() + 10000 // Future timestamp
+       }) });
+    });
+
+    await page.goto('http://mock/setup.html');
+
+    // Skip to template step (mock localStorage with an older state)
+    await page.evaluate(() => {
+        localStorage.setItem('onboardingState', JSON.stringify({
+            step: 2,
+            businessName: 'Local Bakery',
+            categories: 'Home Baker',
+            updated_at: Date.now() - 10000 // Past timestamp
+        }));
+    });
+
+    await page.reload();
+
+    // Backend state should win
+    await expect(page.getByTestId('business-name')).toHaveValue('Backend Bakery');
+  });
+
   test('should auto-save progress and clear it on success', async ({ page }) => {
     const tauriUiDir = path.join(process.cwd(), 'src/ui/tauri/src/ui');
     await page.route('**/setup.html', async route => {

--- a/src/server/services/onboarding/onboarding_agent.rs
+++ b/src/server/services/onboarding/onboarding_agent.rs
@@ -442,7 +442,7 @@ Your response:",
         use sqlx::Row;
 
         let row = sqlx::query(
-            "SELECT current_step, state_json FROM onboarding_state WHERE tenant_id = $1 AND user_id = $2"
+            "SELECT current_step, state_json, updated_at FROM onboarding_state WHERE tenant_id = $1 AND user_id = $2"
         )
         .bind(tenant_id)
         .bind(user_id)
@@ -455,6 +455,11 @@ Your response:",
             let current_step: i32 = record.get("current_step");
             if let Some(obj) = state.as_object_mut() {
                 obj.insert("step".to_string(), serde_json::json!(current_step));
+
+                // Add updated_at from DB
+                if let Ok(updated_at) = record.try_get::<chrono::DateTime<chrono::Utc>, _>("updated_at") {
+                    obj.insert("updated_at".to_string(), serde_json::json!(updated_at.timestamp_millis()));
+                }
             }
             state
         } else {

--- a/src/ui/tauri/src/ui/setup.html
+++ b/src/ui/tauri/src/ui/setup.html
@@ -2886,29 +2886,42 @@
           }
         }
 
-        // Merge from localStorage as fallback
+        // Compare updated_at from backend and localStorage to prioritize the most recent
         const stored = localStorage.getItem("onboardingState");
+        let parsedStored = null;
         if (stored) {
-          const parsed = JSON.parse(stored);
-          state = { ...state, ...parsed };
-          if (parsed.businessName && !parsed.business_name) {
-            state.business_name = parsed.businessName;
-          }
-          if (parsed.business_name && !parsed.businessName) {
-            state.businessName = parsed.business_name;
-          }
+          parsedStored = JSON.parse(stored);
         }
 
-        // Merge backend state, taking priority if it has advanced further or exists
+        // Default to merging backend state if it exists
         if (loadedState && Object.keys(loadedState).length > 0) {
-          if (!state.step || (loadedState.step && loadedState.step >= state.step)) {
-              state = { ...state, ...loadedState };
+          // Compare updated_at timestamps
+          const backendUpdatedAt = loadedState.updated_at || 0;
+          const localUpdatedAt = parsedStored ? (parsedStored.updated_at || 0) : 0;
+
+          if (localUpdatedAt > backendUpdatedAt) {
+             // Local is newer, so start with backend and override with local
+             state = { ...state, ...loadedState, ...parsedStored };
+          } else {
+             // Backend is newer or equal, so start with local and override with backend
+             if (parsedStored) {
+                 state = { ...state, ...parsedStored };
+             }
+             state = { ...state, ...loadedState };
           }
-          if (loadedState.businessName && !loadedState.business_name) {
-             state.business_name = loadedState.businessName;
-          }
-          localStorage.setItem("onboardingState", JSON.stringify(state));
+        } else if (parsedStored) {
+          // No backend state, just use local
+          state = { ...state, ...parsedStored };
         }
+
+        // Ensure business name consistency
+        if (state.businessName && !state.business_name) {
+            state.business_name = state.businessName;
+        }
+        if (state.business_name && !state.businessName) {
+            state.businessName = state.business_name;
+        }
+        localStorage.setItem("onboardingState", JSON.stringify(state));
 
         populateForm();
 
@@ -3111,6 +3124,7 @@
 
       var saveStateTimer = null;
       function saveCurrentState() {
+        state.updated_at = Date.now();
         state.categories = inputs.categories.value;
         state.business_name = inputs.name.value;
         state.businessName = inputs.name.value; // Sync for E2E


### PR DESCRIPTION
Fixes cross-device onboarding state sync issues by relying on `updated_at` timestamps to perform an intelligent merge, preventing an older local state from overriding a newer backend state.

---
*PR created automatically by Jules for task [8196805488108346375](https://jules.google.com/task/8196805488108346375) started by @ql-owo-lp*