### PR TITLE
fix: implement Centralized Inventory & Distributed POS Architecture lock

### DIFF
--- a/src/ui/next/src/app/feed/page.tsx
+++ b/src/ui/next/src/app/feed/page.tsx
@@ -42,20 +42,6 @@ export default function FeedPage() {
     }
   };
 
-  const simulateInvoiceDraft = async () => {
-    try {
-      setLoading(true);
-      await fetch('/api/agents/approvals/simulate-invoice-draft', { method: 'POST' });
-      const res = await fetch('/api/agent-feed');
-      const data = await res.json();
-      setItems((data.items || []).filter((i: any) => i.lifecycle_state !== "APPROVED" && i.lifecycle_state !== "DISMISSED"));
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   const simulateInvoiceFollowup = async () => {
     try {
       setLoading(true);

--- a/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
+++ b/src/ui/next/src/app/pos/terminal/StripeTerminalClient.tsx
@@ -151,6 +151,29 @@ export default function StripeTerminalClient({ amount, productId, cart, tenantId
        return;
     }
 
+    // Reserve inventory via Redlock before intent
+    if (productId && productId !== 'custom-charge') {
+        setStatus('Reserving inventory...');
+        try {
+            const qty = cart && cart.length > 0 ? cart.find(c => c.product.id === productId)?.quantity || 1 : 1;
+            const reserveRes = await fetch('/api/v1/payments/terminal/reserve', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ tenant_id: tenantId, product_id: productId, quantity: qty, ttl_seconds: 15 })
+            });
+            const reserveData = await reserveRes.json();
+            if (!reserveRes.ok || !reserveData.success) {
+                setStatus('Failed to reserve inventory: Item is currently being checked out by another customer.');
+                if (onOptimisticRollback) onOptimisticRollback();
+                return;
+            }
+        } catch (e) {
+            setStatus('Failed to connect to reservation service');
+            if (onOptimisticRollback) onOptimisticRollback();
+            return;
+        }
+    }
+
     setStatus('Waiting for card tap...');
 
     // We must create an intent first by calling the backend

--- a/src/ui/next/src/app/pos/terminal/page.tsx
+++ b/src/ui/next/src/app/pos/terminal/page.tsx
@@ -256,6 +256,8 @@ export default function POSTerminal() {
       }
       return p;
     }));
+    setCart(prev => prev.filter(item => item.product.id !== productId));
+    setOrderStatus('Item just sold out. Please select another item.');
   };
 
   const handleOptimisticRollback = (productId: string) => {


### PR DESCRIPTION
### Description
The issue described double-booking from simultaneous checkouts due to a lack of distributed POS locking mechanism across offline/POS clients and online stores.

The backend `InventoryService` already implemented the Redis Redlock reservation logic under `reserve_inventory`, which prevents double booking if two threads attempt to acquire it at the same time. The issue was that the POS Terminal UI inside `StripeTerminalClient.tsx` didn't execute this reservation early before grabbing the card payment intent, so conflicts could be triggered *after* authorization or double bookings could bypass early checks.

### Changes
*   Added an explicit call to `/api/v1/payments/terminal/reserve` in `StripeTerminalClient.tsx`'s `processPayment` method.
*   Implemented early abortion in `StripeTerminalClient` if the backend's Redlock fails to acquire the lock (due to it being locked by another concurrent checkout).
*   Added `onOptimisticRollback` UI behaviors in `page.tsx` that clear the failed item from the POS cart and display a safe error message (`Item just sold out.`).
*   Cleared out a build error causing NextJS to fail building `feed/page.tsx` (duplicate `simulateInvoiceDraft`).

---
*PR created automatically by Jules for task [9772143895583741648](https://jules.google.com/task/9772143895583741648) started by @ql-owo-lp*

Resolves #34061