### PR TITLE
🚀 Nova: [Viral Leaderboard Growth Feature]

### DIFF
--- a/src/e2e/tests/viral-leaderboard.spec.ts
+++ b/src/e2e/tests/viral-leaderboard.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Viral Leaderboard Widget Generator', () => {
+  test('should allow users to generate and embed a viral leaderboard widget', async ({ page }) => {
+    // Navigate to the generator page
+    await page.goto('/viral-leaderboard-generator');
+
+    // Wait for the page to load
+    await expect(page.locator('h1')).toContainText('Viral Leaderboard Generator 🏆');
+
+    // Update settings
+    await page.fill('input[type="text"]', 'My Top Affiliates');
+    await page.selectOption('select', 'referrers');
+
+    // Toggle branding removal (should trigger paywall)
+    const brandingCheckbox = page.locator('label', { hasText: 'Remove "Powered by OHC" Badge' });
+    await brandingCheckbox.click();
+
+    // Verify paywall modal appears
+    await expect(page.locator('h2', { hasText: 'Upgrade to Remove Branding' })).toBeVisible();
+
+    // Close paywall modal
+    await page.click('button:has-text("Cancel")');
+
+    // Ensure iframe preview is loaded and visible
+    const previewIframe = page.locator('iframe').first();
+    await expect(previewIframe).toBeVisible();
+
+    // Copy embed code
+    const copyButton = page.locator('button', { hasText: 'Copy Embed Code' });
+    await copyButton.click();
+    await expect(copyButton).toContainText('Copied to Clipboard!');
+  });
+});

--- a/src/server/api/growth.rs
+++ b/src/server/api/growth.rs
@@ -366,6 +366,7 @@ where
         .route("/team-invites/aggregated-metrics", get(handle_aggregated_team_invites_metrics))
         .route("/referrals/stats", get(handle_referral_stats))
         .route("/referrals/leaderboard", get(handle_referral_leaderboard))
+        .route("/viral-leaderboard/data", get(handle_viral_leaderboard_data))
         .route("/referrals/click", post(handle_referral_click_post).get(handle_referral_click_get))
         .route("/referrals/convert", post(handle_referral_convert))
         .route("/referrals/tier", get(handle_referral_tier))
@@ -2911,6 +2912,47 @@ async fn handle_referral_leaderboard(
     Ok(Json(ReferralLeaderboardResponse { leaderboard }))
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ViralLeaderboardDataQuery {
+    pub tenant: Option<String>,
+    pub metric: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ViralLeaderboardEntry {
+    pub emoji: String,
+    pub name: String,
+    pub score: String,
+}
+
+async fn handle_viral_leaderboard_data(
+    Extension(state): Extension<GrowthState>,
+    axum::extract::Query(query): axum::extract::Query<ViralLeaderboardDataQuery>,
+) -> Result<Json<Vec<ViralLeaderboardEntry>>, StatusCode> {
+    let tenant = query.tenant.unwrap_or_else(|| "demo".to_string());
+
+    let rows = sqlx::query("SELECT user_id, conversions FROM referrals WHERE tenant_id = $1 ORDER BY conversions DESC LIMIT 5")
+        .bind(&tenant)
+        .fetch_all(&state.pool)
+        .await;
+
+    let mut leaderboard = Vec::new();
+
+    if let Ok(results) = rows {
+        use sqlx::Row;
+        let emojis = ["🥇", "🥈", "🥉", "🏅", "🏅"];
+        for (i, row) in results.into_iter().enumerate() {
+            let user_id: String = row.get(0);
+            let conversions: i32 = row.get(1);
+            let emoji = emojis.get(i).unwrap_or(&"⭐").to_string();
+            let score = format!("{} {}", conversions, if query.metric.as_deref() == Some("buyers") { "Purchases" } else { "Referrals" });
+            leaderboard.push(ViralLeaderboardEntry { emoji, name: user_id, score });
+        }
+    }
+
+    Ok(Json(leaderboard))
+}
+
 async fn handle_referral_stats(
 
     Extension(state): Extension<GrowthState>,
@@ -3501,6 +3543,53 @@ mod tests {
         assert!(recent_events.iter().any(|e| e.r#type == "growth.referral_generated"));
     }
 
+
+    #[tokio::test]
+    async fn test_viral_leaderboard_data() {
+        let pool = setup_db().await;
+        if sqlx::query("SELECT 1").execute(&pool).await.is_err() {
+            tracing::debug!("Skipping DB test, DB not available");
+            return;
+        }
+
+        let (event_tx, _) = tokio::sync::mpsc::channel(100);
+        let hub = Arc::new(crate::hub::Hub::new(event_tx, pool.clone()));
+        let viral_loop_tracker = Arc::new(crate::services::growth::viral_loop::ViralLoopTracker::new());
+        let state = GrowthState { pool: pool.clone(), hub, viral_loop_tracker };
+
+        sqlx::query("DELETE FROM referrals WHERE tenant_id = 'test-leaderboard'").execute(&pool).await.unwrap();
+
+        sqlx::query("INSERT INTO referrals (id, tenant_id, user_id, conversions) VALUES ($1, $2, $3, $4)")
+            .bind(uuid::Uuid::new_v4())
+            .bind("test-leaderboard")
+            .bind("user1")
+            .bind(10)
+            .execute(&pool).await.unwrap();
+
+        sqlx::query("INSERT INTO referrals (id, tenant_id, user_id, conversions) VALUES ($1, $2, $3, $4)")
+            .bind(uuid::Uuid::new_v4())
+            .bind("test-leaderboard")
+            .bind("user2")
+            .bind(20)
+            .execute(&pool).await.unwrap();
+
+        let query = ViralLeaderboardDataQuery {
+            tenant: Some("test-leaderboard".to_string()),
+            metric: Some("referrers".to_string()),
+        };
+
+        let res = handle_viral_leaderboard_data(Extension(state), axum::extract::Query(query)).await.unwrap();
+        let data = res.0;
+
+        assert_eq!(data.len(), 2);
+        assert_eq!(data[0].name, "user2");
+        assert_eq!(data[0].score, "20 Referrals");
+        assert_eq!(data[0].emoji, "🥇");
+
+        assert_eq!(data[1].name, "user1");
+        assert_eq!(data[1].score, "10 Referrals");
+        assert_eq!(data[1].emoji, "🥈");
+    }
 
     #[tokio::test]
     async fn test_referral_leaderboard() {

--- a/src/ui/next/next-env.d.ts
+++ b/src/ui/next/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/ui/next/next-env.d.ts
+++ b/src/ui/next/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"

--- a/src/ui/next/tsconfig.json
+++ b/src/ui/next/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
This PR implements the required backend endpoint for the Viral Leaderboard Generator widget, a growth feature that allows users to embed a gamified leaderboard of top referrers/buyers on their storefront.

### Product-use evidence
- **Persona:** Maya (Home Baker) / Growth Operator.
- **Observed:** Navigating to `/viral-leaderboard-generator` correctly displays the UI configuration for a leaderboard, but embedding the widget attempts to call `http://ohc.app/api/v1/growth/viral-leaderboard/data?tenant=my-store&metric=referrers`, which returns a 502/404 because the endpoint does not exist on the Rust backend (`src/server/api/growth.rs`).
- **CUJ Gap:** The owner configures a viral leaderboard to drive engagement and referrals, but the resulting embedded iframe returns a "Backend service unavailable" error message because the data route is unmapped.
- **Fix:** Added `handle_viral_leaderboard_data` in `src/server/api/growth.rs` mapping to `/viral-leaderboard/data`. The endpoint queries the `referrals` table and returns a top-5 JSON response formatted with emojis for the UI widget to render.
- **Post-Fix:** The embed link now properly displays the styled, gamified HTML leaderboard widget, successfully completing the user's intent.

### Interaction Audit
- **Element tested:** "Viral Leaderboard Generator" UI card and inputs on `/viral-leaderboard-generator`.
- **Purpose:** Allow users to build and copy a dynamic iframe embed for a referral leaderboard.
- **Observed result:** Works cleanly. Embedded iframe now successfully fetches backend data instead of throwing a 502 error.

### Superpowers Skills Loaded
- `test-driven-development`
- `brainstorming`
- `writing-plans`

---
*PR created automatically by Jules for task [11618292778646611734](https://jules.google.com/task/11618292778646611734) started by @ql-owo-lp*