### PR TITLE
feat: Implement Unified Agentic Work Feed & Triage System (#34044)

### DIFF
--- a/src/e2e/playwright/daily_work_generation.spec.ts
+++ b/src/e2e/playwright/daily_work_generation.spec.ts
@@ -23,10 +23,10 @@ test.describe('Autonomous AI Work Triage and Daily Work Generation', () => {
     const workItemId = result.id;
 
     // 2. Navigate to Daily Work Feed at mobile resolution
-    await page.goto('/dashboard/daily-work');
+    await page.goto('/dashboard.html');
 
     // Wait for the feed to load
-    await expect(page.locator('text=Loading your work feed...')).not.toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=Loading Agent Proposals...')).not.toBeVisible({ timeout: 10000 });
 
     // 3. Verify the surfaced actionable card
     const card = page.locator(`[data-testid="daily-work-card-${workItemId}"]`);

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -3469,35 +3469,6 @@ pub async fn simulate_ui_triage_item_handler(
             };
 
             if let Err(e) = sqlx::query(
-                "INSERT INTO triage_items (id, tenant_id, customer_id, source, priority, context, status) VALUES ($1, $2, $3, $4, $5, $6, 'pending')"
-            )
-            .bind(&item_id)
-            .bind(&tenant_id)
-            .bind("12345")
-            .bind("Instagram DM")
-            .bind("High")
-            .bind("Do you have vegan chocolate cake available this weekend?")
-            .execute(&mut *tx)
-            .await {
-                tracing::error!("Failed to insert triage_items: {:?}", e);
-                return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({ "success": false, "error": e.to_string() }))).into_response();
-            }
-
-            if let Err(e) = sqlx::query(
-                "INSERT INTO triage_proposed_actions (id, triage_item_id, tenant_id, action_type, payload) VALUES ($1, $2, $3, $4, $5)"
-            )
-            .bind(&action_id)
-            .bind(&item_id)
-            .bind(&tenant_id)
-            .bind("Draft Reply")
-            .bind(r#"{"feature_type": "instagram_dm", "draft_reply": "Hi! Yes, we have 2 vegan chocolate cakes left for this weekend. Would you like me to hold one for you? [Link to $20 deposit]", "customer_message": "Do you have vegan chocolate cake available this weekend?"}"#)
-            .execute(&mut *tx)
-            .await {
-                tracing::error!("Failed to insert triage_proposed_actions: {:?}", e);
-                return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({ "success": false, "error": e.to_string() }))).into_response();
-            }
-
-            if let Err(e) = sqlx::query(
                 "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, 'PENDING_APPROVAL', NOW(), NOW())"
             )
             .bind(&item_id)
@@ -3524,35 +3495,6 @@ pub async fn simulate_ui_triage_item_handler(
                     return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({"error": e.to_string()}))).into_response();
                 }
             };
-
-            if let Err(e) = sqlx::query(
-                "INSERT INTO triage_items (id, tenant_id, customer_id, source, priority, context, status) VALUES (?, ?, ?, ?, ?, ?, 'pending')"
-            )
-            .bind(&item_id)
-            .bind(&tenant_id)
-            .bind("12345")
-            .bind("Instagram DM")
-            .bind("High")
-            .bind("Do you have vegan chocolate cake available this weekend?")
-            .execute(&mut *tx)
-            .await {
-                tracing::error!("Failed to insert triage_items: {:?}", e);
-                return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({ "success": false, "error": e.to_string() }))).into_response();
-            }
-
-            if let Err(e) = sqlx::query(
-                "INSERT INTO triage_proposed_actions (id, triage_item_id, tenant_id, action_type, payload) VALUES (?, ?, ?, ?, ?)"
-            )
-            .bind(&action_id)
-            .bind(&item_id)
-            .bind(&tenant_id)
-            .bind("Draft Reply")
-            .bind(r#"{"feature_type": "instagram_dm", "draft_reply": "Hi! Yes, we have 2 vegan chocolate cakes left for this weekend. Would you like me to hold one for you? [Link to $20 deposit]", "customer_message": "Do you have vegan chocolate cake available this weekend?"}"#)
-            .execute(&mut *tx)
-            .await {
-                tracing::error!("Failed to insert triage_proposed_actions: {:?}", e);
-                return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, axum::Json(serde_json::json!({ "success": false, "error": e.to_string() }))).into_response();
-            }
 
             if let Err(e) = sqlx::query(
                 "INSERT INTO agent_feed_items (id, tenant_id, event_source, context_payload, proposed_action, lifecycle_state, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'PENDING_APPROVAL', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"

--- a/src/ui/tauri/src/ui/dashboard.html
+++ b/src/ui/tauri/src/ui/dashboard.html
@@ -2350,7 +2350,7 @@
             let proposedAction = item.proposed_action || {};
             let draftReply = proposedAction.draft_reply || parsedPayload.draft_reply || '';
             return `
-              <div class="triage-item glassmorphism" data-testid="instagram-dm-card" id="triage-${item.id}" style="background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(40px) saturate(220%); -webkit-backdrop-filter: blur(40px) saturate(220%); border-radius: 16px; padding: 16px; border: 1px solid rgba(255, 255, 255, 0.4); box-sizing: border-box; width: 100%;">
+              <div class="triage-item glassmorphism" data-testid="daily-work-card-${item.id}" id="triage-${item.id}" style="background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(40px) saturate(220%); -webkit-backdrop-filter: blur(40px) saturate(220%); border-radius: 16px; padding: 16px; border: 1px solid rgba(255, 255, 255, 0.4); box-sizing: border-box; width: 100%;">
                 <div class="triage-header" style="margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center;">
                   <div class="triage-source" style="display: flex; align-items: center; gap: 8px; font-weight: 600;">
                     <span style="font-size: 18px;">💬</span> <strong style="color: #1D1D1F; font-family: Outfit, sans-serif;">Instagram DM</strong>
@@ -2365,8 +2365,8 @@
                   ${draftReply}
                 </div>
                 <div class="triage-controls" style="display: flex; gap: 8px;">
-                  <button class="triage-btn-approve min-h-[44px] min-w-[44px]" data-testid="feed-approve-btn" data-testid="feed-approve-btn" onclick="handleTriageAction('${item.id}', 'APPROVED')" style="min-height: 44px; min-width: 44px; flex: 1; min-height: 44px; min-width: 44px; background: #0066FF; color: white; padding: 12px; border-radius: 8px; font-weight: 600; border: none; box-shadow: 0 4px 12px rgba(0,102,255,0.3); cursor: pointer; display: flex; align-items: center; justify-content: center; transition: opacity 0.2s;">Approve & Send</button>
-                  <button class="triage-btn-dismiss" data-testid="feed-dismiss-btn" onclick="handleTriageAction('${item.id}', 'DISMISSED')" style="min-height: 44px; min-width: 44px; flex: 1; min-height: 44px; min-width: 44px; background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(40px) saturate(220%); -webkit-backdrop-filter: blur(40px) saturate(220%); border: 1px solid rgba(255, 255, 255, 0.4); border-radius: 8px; color: #1d1d1f; padding: 12px; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: background 0.2s;">Dismiss</button>
+                  <button class="triage-btn-approve min-h-[44px] min-w-[44px]" data-testid="approve-${item.id}" onclick="handleTriageAction('${item.id}', 'APPROVED')" style="min-height: 44px; min-width: 44px; flex: 1; min-height: 44px; min-width: 44px; background: #0066FF; color: white; padding: 12px; border-radius: 8px; font-weight: 600; border: none; box-shadow: 0 4px 12px rgba(0,102,255,0.3); cursor: pointer; display: flex; align-items: center; justify-content: center; transition: opacity 0.2s;">Approve & Send</button>
+                  <button class="triage-btn-dismiss" data-testid="dismiss-${item.id}" onclick="handleTriageAction('${item.id}', 'DISMISSED')" style="min-height: 44px; min-width: 44px; flex: 1; min-height: 44px; min-width: 44px; background: rgba(255, 255, 255, 0.65); backdrop-filter: blur(40px) saturate(220%); -webkit-backdrop-filter: blur(40px) saturate(220%); border: 1px solid rgba(255, 255, 255, 0.4); border-radius: 8px; color: #1d1d1f; padding: 12px; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: background 0.2s;">Dismiss</button>
                 </div>
               </div>
             `;


### PR DESCRIPTION
Resolves #34044 by updating the mocked signal endpoint `/api/dev/simulate-triage-item` to insert directly into `agent_feed_items` instead of legacy tables, and updating `dashboard.html` to support the rendering of this agent feed format (such as an Instagram DM simulation action card).

It also updates the corresponding E2E test to fetch from the newly updated `/dashboard.html` UI rather than the legacy dashboard route.

---
*PR created automatically by Jules for task [18332451549667513767](https://jules.google.com/task/18332451549667513767) started by @ql-owo-lp*